### PR TITLE
Adding an (abstract) interface for FStar.Ident

### DIFF
--- a/src/basic/FStar.Ident.fs
+++ b/src/basic/FStar.Ident.fs
@@ -80,9 +80,7 @@ let lid_add_suffix l s =
 let ml_path_of_lid lid =
     String.concat "_" <| (path_of_ns lid.ns)@[text_of_id lid.ident]
 
-(* JP: I don't understand why a lid has both a str and a semantic list of
- * namespaces followed by a lowercase identifiers... *)
-let string_of_lid lid = text_of_path (path_of_lid lid)
+let string_of_lid lid = lid.str
 
 let qual_id lid id =
     set_lid_range (lid_of_ids (lid.ns @ [lid.ident;id])) (range_of_id id)

--- a/src/basic/FStar.Ident.fsi
+++ b/src/basic/FStar.Ident.fsi
@@ -1,49 +1,116 @@
 #light "off"
 module FStar.Ident
-open Prims
-open FStar.ST
-open FStar.All
+
 open FStar.Range
 
-type ident = {idText:string;
-              idRange:Range.range}
-type lident = {ns:list<ident>; //["FStar"; "Basic"]
-               ident:ident;    //"lident"
-               nsstr:string; // Cached version of the namespace
-               str:string} // Cached version of string_of_lid
+(** A (short) identifier for a local name.
+ *  e.g. x in `fun x -> ...` *)
+type ident
 
+(** A module path *)
 type path = list<string>
-type lid = lident
 
-val mk_ident            : (string * Range.range) -> ident
-val reserved_prefix     : string
-val reset_gensym        : unit -> unit
-val next_id             : unit -> int
-val gen'                : string -> Range.range -> ident
-val gen                 : Range.range -> ident
+(** A module path, as idents *)
+type ipath = list<ident>
+
+(** Create an ident *)
+val mk_ident            : (string * range) -> ident
+
+(** Obtain the range of an ident *)
+val range_of_id         : ident -> range
+
+(** Create an ident with a dummyRange (avoid if possible) *)
 val id_of_text          : string -> ident
 
-val text_of_id          : ident -> string
-val text_of_path        : path -> string
-val path_of_text        : string -> path
-val path_of_ns          : list<ident> -> path
-val path_of_lid         : lident -> path
-val ids_of_lid          : lident -> list<ident>
-val range_of_id         : ident -> Range.range
+(** The prefix for reserved identifiers *)
+val reserved_prefix     : string
 
-val lid_of_ns_and_id    : list<ident> -> ident -> lident
-val lid_of_ids          : list<ident> -> lident
-val lid_of_str          : string -> lident
-val lid_of_path         : path -> Range.range -> lident
+(** Set the range on an ident *)
+val set_id_range        : range -> ident -> ident
 
-val text_of_lid         : lident -> string
-
-val lid_equals          : lident -> lident -> bool
+(** Equality of idents *)
 val ident_equals        : ident -> ident -> bool
-val range_of_lid        : lident -> Range.range
-val set_lid_range       : lident -> Range.range -> lident
+
+(** Print an ident *)
+val text_of_id          : ident -> string
+
+
+
+
+
+(** Gensym, generating fresh names *)
+val reset_gensym        : unit -> unit
+val next_id             : unit -> int
+val gen'                : string -> range -> ident
+val gen                 : range -> ident
+
+(** Turn a string of shape A.B.C into a path *)
+val path_of_text        : string -> path
+
+(** Turn a namespace, a list of idents, into a path *)
+val path_of_ns          : ipath -> path
+
+
+
+
+
+(** A long identifier for top-level, fully-qualified names.
+    e.g. Prims.string. Essentially a list of idents where
+    the last one denotes a name, and all the others denote a
+    module path that qualifies the name. *)
+type lident
+type lid = lident
+
+(** Obtain the range of an lid *)
+val range_of_lid        : lident -> range
+
+(* Return the name in an lid *)
+val ident_of_lid        : lident -> ident
+
+(** Equality of lidents *)
+val lid_equals          : lident -> lident -> bool
+
+(** Turn an lid into a path *)
+val path_of_lid         : lident -> path
+
+(** Return an lid as a path (containing the name itself).
+    e.g. ids_of_lid Prims.string = [Prims; string] *)
+val ids_of_lid          : lident -> ipath
+
+(** Return the namespace of an lid (not including its name).
+    e.g. ns_of_lid Prims.string = [Prims] *)
+val ns_of_lid           : lident -> ipath
+
+(** Create an lid from a ipath and a name *)
+val lid_of_ns_and_id    : ipath -> ident -> lident
+
+(** Create an lid from a ipath (last ident is the name) *)
+val lid_of_ids          : ipath -> lident
+
+(** Create an lid from a string, separating it by "." *)
+val lid_of_str          : string -> lident
+
+(** Create an lid from a (string) path and a range *)
+val lid_of_path         : path -> range -> lident
+
+(** Set the range on an lid *)
+val set_lid_range       : lident -> range -> lident
+
+(** Add a component to an lid *)
 val lid_add_suffix      : lident -> string -> lident
 
-val ml_path_of_lid      : lident -> string
-val string_of_ident     : ident -> string
+(** Qualify an ident by a module. Similar to lid_add_suffix, but the
+    range is taken from the ident instead. *)
+val qual_id             : lident -> ident -> lident
+
+(** Print an lid. This is O(1). *)
 val string_of_lid       : lident -> string
+
+(** Print the namespace portion of an lid. This is O(1). *)
+val nsstr               : lident -> string
+
+(** Print a path as A.B.C *)
+val text_of_path        : path -> string
+
+(* Similar to string_of_lid, but separates with "_" instead of "." *)
+val ml_path_of_lid      : lident -> string

--- a/src/extraction/FStar.Extraction.ML.Modul.fs
+++ b/src/extraction/FStar.Extraction.ML.Modul.fs
@@ -656,7 +656,7 @@ let extract_iface (g:env_t) modul =
     let g, iface =
       if Options.debug_any()
       then FStar.Util.measure_execution_time
-             (BU.format1 "Extracted interface of %s" modul.name.str)
+             (BU.format1 "Extracted interface of %s" (string_of_lid modul.name))
              (fun () -> extract_iface' g modul)
       else extract_iface' g modul
     in
@@ -677,7 +677,7 @@ let extract_bundle env se =
         let steps = [ Env.Inlining; Env.UnfoldUntil S.delta_constant; Env.EraseUniverses; Env.AllowUnboundUniverses ] in
         let names = match (SS.compress (N.normalize steps (tcenv_of_uenv env_iparams) ctor.dtyp)).n with
           | Tm_arrow (bs, _) ->
-              List.map (fun ({ ppname = ppname }, _) -> ppname.idText) bs
+              List.map (fun ({ ppname = ppname }, _) -> (text_of_id ppname)) bs
           | _ ->
               []
         in
@@ -960,7 +960,7 @@ let extract' (g:uenv) (m:modul) : uenv * option<mllib> =
   let g, sigs =
     BU.fold_map
         (fun g se ->
-            if Options.debug_module m.name.str
+            if Options.debug_module (string_of_lid m.name)
             then let nm = FStar.Syntax.Util.lids_of_sigelt se |> List.map Ident.string_of_lid |> String.concat ", " in
                  BU.print1 "+++About to extract {%s}\n" nm;
                  FStar.Util.measure_execution_time
@@ -970,7 +970,7 @@ let extract' (g:uenv) (m:modul) : uenv * option<mllib> =
         g m.declarations in
   let mlm : mlmodule = List.flatten sigs in
   let is_kremlin = Options.codegen () = Some Options.Kremlin in
-  if m.name.str <> "Prims"
+  if string_of_lid m.name <> "Prims"
   && (is_kremlin || not m.is_interface)
   then begin
     if not (Options.silent()) then (BU.print1 "Extracted module %s\n" (string_of_lid m.name));
@@ -980,7 +980,7 @@ let extract' (g:uenv) (m:modul) : uenv * option<mllib> =
 
 let extract (g:uenv) (m:modul) =
   ignore <| Options.restore_cmd_line_options true;
-  if not (Options.should_extract m.name.str)
+  if not (Options.should_extract (string_of_lid m.name))
   then failwith (BU.format1 "Extract called on a module %s that should not be extracted" (Ident.string_of_lid m.name));
   if Options.interactive() then g, None else
   let g, mllib =

--- a/src/extraction/FStar.Extraction.ML.Term.fs
+++ b/src/extraction/FStar.Extraction.ML.Term.fs
@@ -109,13 +109,13 @@ let err_unexpected_eff env t ty f0 f1 =
 let effect_as_etag =
     let cache = BU.smap_create 20 in
     let rec delta_norm_eff g (l:lident) =
-        match BU.smap_try_find cache l.str with
+        match BU.smap_try_find cache (string_of_lid l) with
             | Some l -> l
             | None ->
                 let res = match TypeChecker.Env.lookup_effect_abbrev (tcenv_of_uenv g) [S.U_zero] l with
                 | None -> l
                 | Some (_, c) -> delta_norm_eff g (U.comp_effect_name c) in
-                BU.smap_add cache l.str res;
+                BU.smap_add cache (string_of_lid l) res;
                 res in
     fun g l ->
         let l = delta_norm_eff g l in
@@ -810,7 +810,7 @@ let resugar_pat g q p = match p with
         | _ ->
           match q with
           | Some (Record_ctor (ty, fns)) ->
-              let path = List.map text_of_id ty.ns in
+              let path = List.map text_of_id (ns_of_lid ty) in
               let fs = record_fields g ty fns pats in
               MLP_Record(path, fs)
           | _ -> p
@@ -956,7 +956,7 @@ let maybe_eta_data_and_project_record (g:uenv) (qual : option<fv_qual>) (residua
     let as_record qual e =
       match e.expr, qual with
       | MLE_CTor(_, args), Some (Record_ctor(tyname, fields)) ->
-        let path = List.map text_of_id tyname.ns in
+        let path = List.map text_of_id (ns_of_lid tyname) in
         let fields = record_fields g tyname fields args in
         with_ty e.mlty <| MLE_Record(path, fields)
       | _ -> e

--- a/src/extraction/FStar.Extraction.ML.Util.fs
+++ b/src/extraction/FStar.Extraction.ML.Util.fs
@@ -286,11 +286,11 @@ let resugar_exp e = match e.expr with
 
 let record_field_path = function
     | f::_ ->
-        let ns, _ = BU.prefix f.ns in
-        ns |> List.map (fun id -> id.idText)
+        let ns, _ = BU.prefix (ns_of_lid f) in
+        ns |> List.map (fun id -> (text_of_id id))
     | _ -> failwith "impos"
 
-let record_fields fs vs = List.map2 (fun (f:lident) e -> f.ident.idText, e) fs vs
+let record_fields fs vs = List.map2 (fun (f:lident) e -> (text_of_id (ident_of_lid f)), e) fs vs
 //
 //let resugar_pat q p = match p with
 //    | MLP_CTor(d, pats) ->
@@ -330,7 +330,7 @@ let flatten_mlpath (ns, n) =
     then String.concat "." (ns@[n])
     else String.concat "_" (ns@[n])
 let ml_module_name_of_lid (l:lident) =
-  let mlp = l.ns |> List.map (fun i -> i.idText),  l.ident.idText in
+  let mlp = l |> ns_of_lid |> List.map text_of_id,  text_of_id (ident_of_lid l) in
   flatten_mlpath mlp
 
 
@@ -555,7 +555,7 @@ let interpret_plugin_as_term_fun (env:UEnv.uenv) (fv:fv) (t:typ) (arity_opt:opti
                 args
                 |> List.map (fun (t, _) -> mk_embedding l env t)
             in
-            let nm = fv.fv_name.v.ident.idText in
+            let nm = text_of_id (ident_of_lid fv.fv_name.v) in
             let (_, t_arity, _trepr_head), loc_embedding =
                 BU.find_opt
                     (fun ((x, _, _), _) -> fv_eq_lid fv x)

--- a/src/fstar/FStar.Interactive.Ide.fs
+++ b/src/fstar/FStar.Interactive.Ide.fs
@@ -923,7 +923,7 @@ let sc_fvars tcenv sc = // Memoized version of fc_vars
 
 let json_of_search_result tcenv sc =
   let typ_str = term_to_string tcenv (sc_typ tcenv sc) in
-  JsonAssoc [("lid", JsonStr (DsEnv.shorten_lid tcenv.dsenv sc.sc_lid).str);
+  JsonAssoc [("lid", JsonStr (string_of_lid (DsEnv.shorten_lid tcenv.dsenv sc.sc_lid)));
              ("type", JsonStr typ_str)]
 
 exception InvalidSearch of string
@@ -935,7 +935,7 @@ let run_search st search_str =
   let st_matches candidate term =
     let found =
       match term.st_term with
-      | NameContainsStr str -> Util.contains candidate.sc_lid.str str
+      | NameContainsStr str -> Util.contains (string_of_lid candidate.sc_lid) str
       | TypeContainsLid lid -> set_mem lid (sc_fvars tcenv candidate) in
     found <> term.st_negate in
 
@@ -970,7 +970,7 @@ let run_search st search_str =
     (if term.st_negate then "-" else "")
     ^ (match term.st_term with
        | NameContainsStr s -> Util.format1 "\"%s\"" s
-       | TypeContainsLid l -> Util.format1 "%s" l.str) in
+       | TypeContainsLid l -> Util.format1 "%s" (string_of_lid l)) in
 
   let results =
     try
@@ -978,7 +978,7 @@ let run_search st search_str =
       let all_lidents = TcEnv.lidents tcenv in
       let all_candidates = List.map sc_of_lid all_lidents in
       let matches_all candidate = List.for_all (st_matches candidate) terms in
-      let cmp r1 r2 = Util.compare r1.sc_lid.str r2.sc_lid.str in
+      let cmp r1 r2 = Util.compare (string_of_lid r1.sc_lid) (string_of_lid r2.sc_lid) in
       let results = List.filter matches_all all_candidates in
       let sorted = Util.sort_with cmp results in
       let js = List.map (json_of_search_result tcenv) sorted in

--- a/src/fstar/FStar.Interactive.Legacy.fs
+++ b/src/fstar/FStar.Interactive.Legacy.fs
@@ -433,7 +433,7 @@ let rec go (line_col:(int*int))
             Util.map_option (fun (prefix, matched, len) -> (hc :: prefix, matched, len)) in
     let str_of_ids ids = Util.concat_l "." (List.map FStar.Ident.text_of_id ids) in
     let match_lident_against needle lident =
-        locate_match needle (lident.ns @ [lident.ident])
+        locate_match needle (ns_of_lid lident @ [ident_of_lid lident])
     in
     let shorten_namespace (prefix, matched, match_len) =
       let naked_match = match matched with [_] -> true | _ -> false in
@@ -469,7 +469,7 @@ let rec go (line_col:(int*int))
             List.filter_map (fun n ->
             if Util.starts_with n id
             then let lid = Ident.lid_of_ns_and_id (Ident.ids_of_lid m) (Ident.id_of_text n) in
-                 Option.map (fun fqn -> [], (List.map Ident.id_of_text orig_ns)@[fqn.ident], matched_length)
+                 Option.map (fun fqn -> [], (List.map Ident.id_of_text orig_ns)@[ident_of_lid fqn], matched_length)
                             (DsEnv.resolve_to_fully_qualified_name env.dsenv lid)
             else None)
         in

--- a/src/fstar/FStar.Interactive.PushHelper.fs
+++ b/src/fstar/FStar.Interactive.PushHelper.fs
@@ -187,10 +187,10 @@ let query_of_ids (ids: list<ident>) : CTable.query =
   List.map text_of_id ids
 
 let query_of_lid (lid: lident) : CTable.query =
-  query_of_ids (lid.ns @ [lid.ident])
+  query_of_ids (ns_of_lid lid @ [ident_of_lid lid])
 
 let update_names_from_event cur_mod_str table evt =
-  let is_cur_mod lid = lid.str = cur_mod_str in
+  let is_cur_mod lid = (string_of_lid lid) = cur_mod_str in
   match evt with
   | NTAlias (host, id, included) ->
     if is_cur_mod host then
@@ -215,15 +215,15 @@ let update_names_from_event cur_mod_str table evt =
       | _ -> [] in
     List.fold_left
       (fun tbl lid ->
-         let ns_query = if lid.nsstr = cur_mod_str then []
-                        else query_of_ids lid.ns in
+         let ns_query = if nsstr lid = cur_mod_str then []
+                        else query_of_ids (ns_of_lid lid) in
          CTable.insert
-           tbl ns_query (text_of_id lid.ident) lid)
+           tbl ns_query (text_of_id (ident_of_lid lid)) lid)
       table lids
 
 let commit_name_tracking' cur_mod names name_events =
   let cur_mod_str = match cur_mod with
-                    | None -> "" | Some md -> (SS.mod_name md).str in
+                    | None -> "" | Some md -> string_of_lid (SS.mod_name md) in
   let updater = update_names_from_event cur_mod_str in
   List.fold_left updater names name_events
 

--- a/src/fstar/FStar.Main.fs
+++ b/src/fstar/FStar.Main.fs
@@ -41,8 +41,8 @@ let finished_message fmods errs =
   if not (Options.silent()) then begin
     fmods |> List.iter (fun (iface, name) ->
                 let tag = if iface then "i'face (or impl+i'face)" else "module" in
-                if Options.should_print_message name.str
-                then print_to (Util.format2 "Verified %s: %s\n" tag (Ident.text_of_lid name)));
+                if Options.should_print_message (string_of_lid name)
+                then print_to (Util.format2 "Verified %s: %s\n" tag (Ident.string_of_lid name)));
     if errs > 0
     then if errs = 1
          then Util.print_error "1 error was reported (see above)\n"

--- a/src/fstar/FStar.Universal.fs
+++ b/src/fstar/FStar.Universal.fs
@@ -277,7 +277,7 @@ let tc_one_file
   in
   let maybe_extract_mldefs tcmod env =
       if Options.codegen() = None
-      || not (Options.should_extract tcmod.name.str)
+      || not (Options.should_extract (string_of_lid tcmod.name))
       then None, 0
       else
         FStar.Util.record_time (fun () ->
@@ -321,7 +321,7 @@ let tc_one_file
 
           let ((tcmod, smt_decls), env) =
             Profiling.profile (fun () -> check env)
-                              (Some fmod.name.str)
+                              (Some (string_of_lid fmod.name))
                               "FStar.Universal.tc_source_file"
           in
 
@@ -339,7 +339,7 @@ let tc_one_file
           extracted_defs,
           env
       in
-      if (Options.should_verify fmod.name.str //if we're verifying this module
+      if (Options.should_verify (string_of_lid fmod.name) //if we're verifying this module
             && (FStar.Options.record_hints() //and if we're recording or using hints
                 || FStar.Options.use_hints()))
       then SMT.with_hints_db (Pars.find_file fn) check_mod
@@ -364,7 +364,7 @@ let tc_one_file
 
         if FStar.Errors.get_err_count() = 0
         && (Options.lax()  //we'll write out a .checked.lax file
-            || Options.should_verify tc_result.checked_module.name.str) //we'll write out a .checked file
+            || Options.should_verify (string_of_lid tc_result.checked_module.name)) //we'll write out a .checked file
         //but we will not write out a .checked file for an unverified dependence
         //of some file that should be checked
         //(i.e. we DO write .checked.lax files for dependencies even if not provided as an argument)
@@ -374,7 +374,7 @@ let tc_one_file
       | Some tc_result ->
         let tcmod = tc_result.checked_module in
         let smt_decls = tc_result.smt_decls in
-        if Options.dump_module tcmod.name.str
+        if Options.dump_module (string_of_lid tcmod.name)
         then BU.print1 "Module after type checking:\n%s\n" (FStar.Syntax.Print.modul_to_string tcmod);
 
         let extend_tcenv tcmod tcenv =
@@ -406,7 +406,7 @@ let tc_one_file
         (* If we have to extract this module, then do it first *)
         let mllib =
             if Options.codegen()<>None
-            && Options.should_extract tcmod.name.str
+            && Options.should_extract (string_of_lid tcmod.name)
             && (not tcmod.is_interface || Options.codegen()=Some Options.Kremlin)
             then
                  let extracted_defs, _extraction_time = maybe_extract_mldefs tcmod env in

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -1478,16 +1478,16 @@ let (extract_iface :
         if uu____4208
         then
           let uu____4215 =
-            FStar_Util.format1 "Extracted interface of %s"
-              (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
-             in
+            let uu____4217 =
+              FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name  in
+            FStar_Util.format1 "Extracted interface of %s" uu____4217  in
           FStar_Util.measure_execution_time uu____4215
-            (fun uu____4223  -> extract_iface' g modul)
+            (fun uu____4225  -> extract_iface' g modul)
         else extract_iface' g modul  in
       match uu____4203 with
       | (g1,iface1) ->
-          let uu____4232 = FStar_Extraction_ML_UEnv.exit_module g1  in
-          (uu____4232, iface1)
+          let uu____4234 = FStar_Extraction_ML_UEnv.exit_module g1  in
+          (uu____4234, iface1)
   
 let (extract_bundle :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1499,10 +1499,10 @@ let (extract_bundle :
     fun se  ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____4310 =
+          let uu____4312 =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp  in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____4310
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____4312
            in
         let steps =
           [FStar_TypeChecker_Env.Inlining;
@@ -1511,124 +1511,124 @@ let (extract_bundle :
           FStar_TypeChecker_Env.EraseUniverses;
           FStar_TypeChecker_Env.AllowUnboundUniverses]  in
         let names =
-          let uu____4318 =
-            let uu____4319 =
-              let uu____4322 =
-                let uu____4323 =
+          let uu____4320 =
+            let uu____4321 =
+              let uu____4324 =
+                let uu____4325 =
                   FStar_Extraction_ML_UEnv.tcenv_of_uenv env_iparams  in
-                FStar_TypeChecker_Normalize.normalize steps uu____4323
+                FStar_TypeChecker_Normalize.normalize steps uu____4325
                   ctor.dtyp
                  in
-              FStar_Syntax_Subst.compress uu____4322  in
-            uu____4319.FStar_Syntax_Syntax.n  in
-          match uu____4318 with
-          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____4328) ->
+              FStar_Syntax_Subst.compress uu____4324  in
+            uu____4321.FStar_Syntax_Syntax.n  in
+          match uu____4320 with
+          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____4330) ->
               FStar_List.map
-                (fun uu____4361  ->
-                   match uu____4361 with
+                (fun uu____4363  ->
+                   match uu____4363 with
                    | ({ FStar_Syntax_Syntax.ppname = ppname;
-                        FStar_Syntax_Syntax.index = uu____4370;
-                        FStar_Syntax_Syntax.sort = uu____4371;_},uu____4372)
-                       -> ppname.FStar_Ident.idText) bs
-          | uu____4380 -> []  in
+                        FStar_Syntax_Syntax.index = uu____4372;
+                        FStar_Syntax_Syntax.sort = uu____4373;_},uu____4374)
+                       -> FStar_Ident.text_of_id ppname) bs
+          | uu____4382 -> []  in
         let tys = (ml_tyvars, mlt)  in
         let fvv =
           FStar_Syntax_Syntax.lid_as_fv ctor.dname
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        let uu____4388 =
+        let uu____4390 =
           FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false  in
-        match uu____4388 with
-        | (env2,mls,uu____4415) ->
-            let uu____4418 =
-              let uu____4431 =
-                let uu____4439 = FStar_Extraction_ML_Util.argTypes mlt  in
-                FStar_List.zip names uu____4439  in
-              (mls, uu____4431)  in
-            (env2, uu____4418)
+        match uu____4390 with
+        | (env2,mls,uu____4417) ->
+            let uu____4420 =
+              let uu____4433 =
+                let uu____4441 = FStar_Extraction_ML_Util.argTypes mlt  in
+                FStar_List.zip names uu____4441  in
+              (mls, uu____4433)  in
+            (env2, uu____4420)
          in
       let extract_one_family env1 ind =
-        let uu____4500 = binders_as_mlty_binders env1 ind.iparams  in
-        match uu____4500 with
+        let uu____4502 = binders_as_mlty_binders env1 ind.iparams  in
+        match uu____4502 with
         | (env_iparams,vars) ->
-            let uu____4544 =
+            let uu____4546 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1)
                in
-            (match uu____4544 with
+            (match uu____4546 with
              | (env2,ctors) ->
-                 let uu____4651 = FStar_Syntax_Util.arrow_formals ind.ityp
+                 let uu____4653 = FStar_Syntax_Util.arrow_formals ind.ityp
                     in
-                 (match uu____4651 with
-                  | (indices,uu____4685) ->
+                 (match uu____4653 with
+                  | (indices,uu____4687) ->
                       let ml_params =
-                        let uu____4694 =
+                        let uu____4696 =
                           FStar_All.pipe_right indices
                             (FStar_List.mapi
                                (fun i  ->
-                                  fun uu____4720  ->
-                                    let uu____4728 =
+                                  fun uu____4722  ->
+                                    let uu____4730 =
                                       FStar_Util.string_of_int i  in
-                                    Prims.op_Hat "'dummyV" uu____4728))
+                                    Prims.op_Hat "'dummyV" uu____4730))
                            in
-                        FStar_List.append vars uu____4694  in
-                      let uu____4732 =
-                        let uu____4737 =
+                        FStar_List.append vars uu____4696  in
+                      let uu____4734 =
+                        let uu____4739 =
                           FStar_Util.find_opt
-                            (fun uu___7_4742  ->
-                               match uu___7_4742 with
-                               | FStar_Syntax_Syntax.RecordType uu____4744 ->
+                            (fun uu___7_4744  ->
+                               match uu___7_4744 with
+                               | FStar_Syntax_Syntax.RecordType uu____4746 ->
                                    true
-                               | uu____4754 -> false) ind.iquals
+                               | uu____4756 -> false) ind.iquals
                            in
-                        match uu____4737 with
+                        match uu____4739 with
                         | FStar_Pervasives_Native.Some
                             (FStar_Syntax_Syntax.RecordType (ns,ids)) ->
-                            let uu____4770 = FStar_List.hd ctors  in
-                            (match uu____4770 with
-                             | (uu____4799,c_ty) ->
-                                 let uu____4818 =
+                            let uu____4772 = FStar_List.hd ctors  in
+                            (match uu____4772 with
+                             | (uu____4801,c_ty) ->
+                                 let uu____4820 =
                                    FStar_List.fold_right2
                                      (fun id  ->
-                                        fun uu____4857  ->
-                                          fun uu____4858  ->
-                                            match (uu____4857, uu____4858)
+                                        fun uu____4859  ->
+                                          fun uu____4860  ->
+                                            match (uu____4859, uu____4860)
                                             with
-                                            | ((uu____4902,ty),(fields,g)) ->
-                                                let uu____4938 =
+                                            | ((uu____4904,ty),(fields,g)) ->
+                                                let uu____4940 =
                                                   FStar_Extraction_ML_UEnv.extend_record_field_name
                                                     g ((ind.iname), id)
                                                    in
-                                                (match uu____4938 with
+                                                (match uu____4940 with
                                                  | (mlp,g1) ->
                                                      ((((FStar_Pervasives_Native.snd
                                                            mlp), ty) ::
                                                        fields), g1))) ids
                                      c_ty ([], env2)
                                     in
-                                 (match uu____4818 with
+                                 (match uu____4820 with
                                   | (fields,g) ->
                                       ((FStar_Extraction_ML_Syntax.MLTD_Record
                                           fields), g)))
-                        | uu____5005 ->
+                        | uu____5007 ->
                             ((FStar_Extraction_ML_Syntax.MLTD_DType ctors),
                               env2)
                          in
-                      (match uu____4732 with
+                      (match uu____4734 with
                        | (tbody,env3) ->
-                           let uu____5036 =
-                             let uu____5059 =
-                               let uu____5061 =
+                           let uu____5038 =
+                             let uu____5061 =
+                               let uu____5063 =
                                  FStar_Extraction_ML_UEnv.mlpath_of_lident
                                    env3 ind.iname
                                   in
-                               FStar_Pervasives_Native.snd uu____5061  in
-                             (false, uu____5059,
+                               FStar_Pervasives_Native.snd uu____5063  in
+                             (false, uu____5061,
                                FStar_Pervasives_Native.None, ml_params,
                                (ind.imetadata),
                                (FStar_Pervasives_Native.Some tbody))
                               in
-                           (env3, uu____5036))))
+                           (env3, uu____5038))))
          in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
@@ -1636,34 +1636,34 @@ let (extract_bundle :
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l,uu____5117,t,uu____5119,uu____5120,uu____5121);
-            FStar_Syntax_Syntax.sigrng = uu____5122;
-            FStar_Syntax_Syntax.sigquals = uu____5123;
-            FStar_Syntax_Syntax.sigmeta = uu____5124;
-            FStar_Syntax_Syntax.sigattrs = uu____5125;
-            FStar_Syntax_Syntax.sigopts = uu____5126;_}::[],uu____5127),(FStar_Syntax_Syntax.ExceptionConstructor
+              (l,uu____5119,t,uu____5121,uu____5122,uu____5123);
+            FStar_Syntax_Syntax.sigrng = uu____5124;
+            FStar_Syntax_Syntax.sigquals = uu____5125;
+            FStar_Syntax_Syntax.sigmeta = uu____5126;
+            FStar_Syntax_Syntax.sigattrs = uu____5127;
+            FStar_Syntax_Syntax.sigopts = uu____5128;_}::[],uu____5129),(FStar_Syntax_Syntax.ExceptionConstructor
          )::[]) ->
-          let uu____5148 = extract_ctor env [] env { dname = l; dtyp = t }
+          let uu____5150 = extract_ctor env [] env { dname = l; dtyp = t }
              in
-          (match uu____5148 with
+          (match uu____5150 with
            | (env1,ctor) -> (env1, [FStar_Extraction_ML_Syntax.MLM_Exn ctor]))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____5201),quals) ->
-          let uu____5215 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____5203),quals) ->
+          let uu____5217 =
             FStar_Syntax_Util.has_attribute se.FStar_Syntax_Syntax.sigattrs
               FStar_Parser_Const.erasable_attr
              in
-          if uu____5215
+          if uu____5217
           then (env, [])
           else
-            (let uu____5228 = bundle_as_inductive_families env ses quals  in
-             match uu____5228 with
+            (let uu____5230 = bundle_as_inductive_families env ses quals  in
+             match uu____5230 with
              | (env1,ifams) ->
-                 let uu____5247 =
+                 let uu____5249 =
                    FStar_Util.fold_map extract_one_family env1 ifams  in
-                 (match uu____5247 with
+                 (match uu____5249 with
                   | (env2,td) ->
                       (env2, [FStar_Extraction_ML_Syntax.MLM_Ty td])))
-      | uu____5356 -> failwith "Unexpected signature element"
+      | uu____5358 -> failwith "Unexpected signature element"
   
 let (maybe_register_plugin :
   env_t ->
@@ -1679,43 +1679,43 @@ let (maybe_register_plugin :
       let plugin_with_arity attrs =
         FStar_Util.find_map attrs
           (fun t  ->
-             let uu____5414 = FStar_Syntax_Util.head_and_args t  in
-             match uu____5414 with
+             let uu____5416 = FStar_Syntax_Util.head_and_args t  in
+             match uu____5416 with
              | (head,args) ->
-                 let uu____5462 =
-                   let uu____5464 =
+                 let uu____5464 =
+                   let uu____5466 =
                      FStar_Syntax_Util.is_fvar FStar_Parser_Const.plugin_attr
                        head
                       in
-                   Prims.op_Negation uu____5464  in
-                 if uu____5462
+                   Prims.op_Negation uu____5466  in
+                 if uu____5464
                  then FStar_Pervasives_Native.None
                  else
                    (match args with
                     | ({
                          FStar_Syntax_Syntax.n =
                            FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_int (s,uu____5483));
-                         FStar_Syntax_Syntax.pos = uu____5484;
-                         FStar_Syntax_Syntax.vars = uu____5485;_},uu____5486)::[]
+                           (FStar_Const.Const_int (s,uu____5485));
+                         FStar_Syntax_Syntax.pos = uu____5486;
+                         FStar_Syntax_Syntax.vars = uu____5487;_},uu____5488)::[]
                         ->
-                        let uu____5525 =
-                          let uu____5529 = FStar_Util.int_of_string s  in
-                          FStar_Pervasives_Native.Some uu____5529  in
-                        FStar_Pervasives_Native.Some uu____5525
-                    | uu____5535 ->
+                        let uu____5527 =
+                          let uu____5531 = FStar_Util.int_of_string s  in
+                          FStar_Pervasives_Native.Some uu____5531  in
+                        FStar_Pervasives_Native.Some uu____5527
+                    | uu____5537 ->
                         FStar_Pervasives_Native.Some
                           FStar_Pervasives_Native.None))
          in
-      let uu____5550 =
-        let uu____5552 = FStar_Options.codegen ()  in
-        uu____5552 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
-      if uu____5550
+      let uu____5552 =
+        let uu____5554 = FStar_Options.codegen ()  in
+        uu____5554 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
+      if uu____5552
       then []
       else
-        (let uu____5562 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
+        (let uu____5564 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
             in
-         match uu____5562 with
+         match uu____5564 with
          | FStar_Pervasives_Native.None  -> []
          | FStar_Pervasives_Native.Some arity_opt ->
              (match se.FStar_Syntax_Syntax.sigel with
@@ -1728,18 +1728,18 @@ let (maybe_register_plugin :
                        in
                     let fv_t = lb.FStar_Syntax_Syntax.lbtyp  in
                     let ml_name_str =
-                      let uu____5604 =
-                        let uu____5605 = FStar_Ident.string_of_lid fv_lid  in
-                        FStar_Extraction_ML_Syntax.MLC_String uu____5605  in
-                      FStar_Extraction_ML_Syntax.MLE_Const uu____5604  in
-                    let uu____5607 =
+                      let uu____5606 =
+                        let uu____5607 = FStar_Ident.string_of_lid fv_lid  in
+                        FStar_Extraction_ML_Syntax.MLC_String uu____5607  in
+                      FStar_Extraction_ML_Syntax.MLE_Const uu____5606  in
+                    let uu____5609 =
                       FStar_Extraction_ML_Util.interpret_plugin_as_term_fun g
                         fv fv_t arity_opt ml_name_str
                        in
-                    match uu____5607 with
+                    match uu____5609 with
                     | FStar_Pervasives_Native.Some
                         (interp,nbe_interp,arity,plugin) ->
-                        let uu____5640 =
+                        let uu____5642 =
                           if plugin
                           then
                             ((["FStar_Tactics_Native"], "register_plugin"),
@@ -1748,7 +1748,7 @@ let (maybe_register_plugin :
                             ((["FStar_Tactics_Native"], "register_tactic"),
                               [interp])
                            in
-                        (match uu____5640 with
+                        (match uu____5642 with
                          | (register,args) ->
                              let h =
                                FStar_All.pipe_left
@@ -1758,17 +1758,17 @@ let (maybe_register_plugin :
                                     register)
                                 in
                              let arity1 =
-                               let uu____5686 =
-                                 let uu____5687 =
-                                   let uu____5699 =
+                               let uu____5688 =
+                                 let uu____5689 =
+                                   let uu____5701 =
                                      FStar_Util.string_of_int arity  in
-                                   (uu____5699, FStar_Pervasives_Native.None)
+                                   (uu____5701, FStar_Pervasives_Native.None)
                                     in
                                  FStar_Extraction_ML_Syntax.MLC_Int
-                                   uu____5687
+                                   uu____5689
                                   in
                                FStar_Extraction_ML_Syntax.MLE_Const
-                                 uu____5686
+                                 uu____5688
                                 in
                              let app =
                                FStar_All.pipe_left
@@ -1783,7 +1783,7 @@ let (maybe_register_plugin :
                     | FStar_Pervasives_Native.None  -> []  in
                   FStar_List.collect mk_registration
                     (FStar_Pervasives_Native.snd lbs)
-              | uu____5728 -> []))
+              | uu____5730 -> []))
   
 let rec (extract_sig :
   env_t ->
@@ -1794,61 +1794,61 @@ let rec (extract_sig :
     fun se  ->
       FStar_Extraction_ML_UEnv.debug g
         (fun u  ->
-           let uu____5756 = FStar_Syntax_Print.sigelt_to_string se  in
-           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5756);
+           let uu____5758 = FStar_Syntax_Print.sigelt_to_string se  in
+           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5758);
       (match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_bundle uu____5765 -> extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5774 ->
+       | FStar_Syntax_Syntax.Sig_bundle uu____5767 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5776 ->
            extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_datacon uu____5791 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_datacon uu____5793 -> extract_bundle g se
        | FStar_Syntax_Syntax.Sig_new_effect ed when
-           let uu____5808 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-           FStar_TypeChecker_Env.is_reifiable_effect uu____5808
+           let uu____5810 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
+           FStar_TypeChecker_Env.is_reifiable_effect uu____5810
              ed.FStar_Syntax_Syntax.mname
            ->
-           let uu____5809 = extract_reifiable_effect g ed  in
-           (match uu____5809 with | (env,_iface,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_splice uu____5833 ->
+           let uu____5811 = extract_reifiable_effect g ed  in
+           (match uu____5811 with | (env,_iface,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_splice uu____5835 ->
            failwith "impossible: trying to extract splice"
-       | FStar_Syntax_Syntax.Sig_fail uu____5847 ->
+       | FStar_Syntax_Syntax.Sig_fail uu____5849 ->
            failwith "impossible: trying to extract Sig_fail"
-       | FStar_Syntax_Syntax.Sig_new_effect uu____5867 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_new_effect uu____5869 -> (g, [])
        | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs,t) when
            FStar_Extraction_ML_Term.is_arity g t ->
-           let uu____5873 =
+           let uu____5875 =
              extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs univs t
               in
-           (match uu____5873 with | (env,uu____5889,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5898) when
+           (match uu____5875 with | (env,uu____5891,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5900) when
            FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
            ->
-           let uu____5907 =
+           let uu____5909 =
              extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs lb
               in
-           (match uu____5907 with | (env,uu____5923,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____5932) when
+           (match uu____5909 with | (env,uu____5925,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____5934) when
            FStar_Util.for_some
              (fun lb  ->
                 FStar_Extraction_ML_Term.is_arity g
                   lb.FStar_Syntax_Syntax.lbtyp) lbs
            ->
-           let uu____5945 = extract_let_rec_types se g lbs  in
-           (match uu____5945 with | (env,uu____5961,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let (lbs,uu____5970) ->
+           let uu____5947 = extract_let_rec_types se g lbs  in
+           (match uu____5947 with | (env,uu____5963,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let (lbs,uu____5972) ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs  in
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____5981 =
-             let uu____5990 =
+           let uu____5983 =
+             let uu____5992 =
                FStar_Syntax_Util.extract_attr'
                  FStar_Parser_Const.postprocess_extr_with attrs
                 in
-             match uu____5990 with
+             match uu____5992 with
              | FStar_Pervasives_Native.None  ->
                  (attrs, FStar_Pervasives_Native.None)
              | FStar_Pervasives_Native.Some
-                 (ats,(tau,FStar_Pervasives_Native.None )::uu____6019) ->
+                 (ats,(tau,FStar_Pervasives_Native.None )::uu____6021) ->
                  (ats, (FStar_Pervasives_Native.Some tau))
              | FStar_Pervasives_Native.Some (ats,args) ->
                  (FStar_Errors.log_issue se.FStar_Syntax_Syntax.sigrng
@@ -1856,34 +1856,34 @@ let rec (extract_sig :
                       "Ill-formed application of `postprocess_for_extraction_with`");
                   (attrs, FStar_Pervasives_Native.None))
               in
-           (match uu____5981 with
+           (match uu____5983 with
             | (attrs1,post_tau) ->
                 let postprocess_lb tau lb =
                   let lbdef =
-                    let uu____6105 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+                    let uu____6107 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                        in
-                    FStar_TypeChecker_Env.postprocess uu____6105 tau
+                    FStar_TypeChecker_Env.postprocess uu____6107 tau
                       lb.FStar_Syntax_Syntax.lbtyp
                       lb.FStar_Syntax_Syntax.lbdef
                      in
-                  let uu___909_6106 = lb  in
+                  let uu___909_6108 = lb  in
                   {
                     FStar_Syntax_Syntax.lbname =
-                      (uu___909_6106.FStar_Syntax_Syntax.lbname);
+                      (uu___909_6108.FStar_Syntax_Syntax.lbname);
                     FStar_Syntax_Syntax.lbunivs =
-                      (uu___909_6106.FStar_Syntax_Syntax.lbunivs);
+                      (uu___909_6108.FStar_Syntax_Syntax.lbunivs);
                     FStar_Syntax_Syntax.lbtyp =
-                      (uu___909_6106.FStar_Syntax_Syntax.lbtyp);
+                      (uu___909_6108.FStar_Syntax_Syntax.lbtyp);
                     FStar_Syntax_Syntax.lbeff =
-                      (uu___909_6106.FStar_Syntax_Syntax.lbeff);
+                      (uu___909_6108.FStar_Syntax_Syntax.lbeff);
                     FStar_Syntax_Syntax.lbdef = lbdef;
                     FStar_Syntax_Syntax.lbattrs =
-                      (uu___909_6106.FStar_Syntax_Syntax.lbattrs);
+                      (uu___909_6108.FStar_Syntax_Syntax.lbattrs);
                     FStar_Syntax_Syntax.lbpos =
-                      (uu___909_6106.FStar_Syntax_Syntax.lbpos)
+                      (uu___909_6108.FStar_Syntax_Syntax.lbpos)
                   }  in
                 let lbs1 =
-                  let uu____6115 =
+                  let uu____6117 =
                     match post_tau with
                     | FStar_Pervasives_Native.Some tau ->
                         FStar_List.map (postprocess_lb tau)
@@ -1891,338 +1891,338 @@ let rec (extract_sig :
                     | FStar_Pervasives_Native.None  ->
                         FStar_Pervasives_Native.snd lbs
                      in
-                  ((FStar_Pervasives_Native.fst lbs), uu____6115)  in
-                let uu____6133 =
-                  let uu____6140 =
+                  ((FStar_Pervasives_Native.fst lbs), uu____6117)  in
+                let uu____6135 =
+                  let uu____6142 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_let
                          (lbs1, FStar_Syntax_Util.exp_false_bool))
                       FStar_Pervasives_Native.None
                       se.FStar_Syntax_Syntax.sigrng
                      in
-                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____6140  in
-                (match uu____6133 with
-                 | (ml_let,uu____6157,uu____6158) ->
+                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____6142  in
+                (match uu____6135 with
+                 | (ml_let,uu____6159,uu____6160) ->
                      (match ml_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((flavor,bindings),uu____6167) ->
+                          ((flavor,bindings),uu____6169) ->
                           let flags = FStar_List.choose flag_of_qual quals
                              in
                           let flags' = extract_metadata attrs1  in
-                          let uu____6184 =
+                          let uu____6186 =
                             FStar_List.fold_left2
-                              (fun uu____6210  ->
+                              (fun uu____6212  ->
                                  fun ml_lb  ->
-                                   fun uu____6212  ->
-                                     match (uu____6210, uu____6212) with
+                                   fun uu____6214  ->
+                                     match (uu____6212, uu____6214) with
                                      | ((env,ml_lbs),{
                                                        FStar_Syntax_Syntax.lbname
                                                          = lbname;
                                                        FStar_Syntax_Syntax.lbunivs
-                                                         = uu____6234;
+                                                         = uu____6236;
                                                        FStar_Syntax_Syntax.lbtyp
                                                          = t;
                                                        FStar_Syntax_Syntax.lbeff
-                                                         = uu____6236;
-                                                       FStar_Syntax_Syntax.lbdef
-                                                         = uu____6237;
-                                                       FStar_Syntax_Syntax.lbattrs
                                                          = uu____6238;
+                                                       FStar_Syntax_Syntax.lbdef
+                                                         = uu____6239;
+                                                       FStar_Syntax_Syntax.lbattrs
+                                                         = uu____6240;
                                                        FStar_Syntax_Syntax.lbpos
-                                                         = uu____6239;_})
+                                                         = uu____6241;_})
                                          ->
-                                         let uu____6264 =
+                                         let uu____6266 =
                                            FStar_All.pipe_right
                                              ml_lb.FStar_Extraction_ML_Syntax.mllb_meta
                                              (FStar_List.contains
                                                 FStar_Extraction_ML_Syntax.Erased)
                                             in
-                                         if uu____6264
+                                         if uu____6266
                                          then (env, ml_lbs)
                                          else
                                            (let lb_lid =
-                                              let uu____6281 =
-                                                let uu____6284 =
+                                              let uu____6283 =
+                                                let uu____6286 =
                                                   FStar_Util.right lbname  in
-                                                uu____6284.FStar_Syntax_Syntax.fv_name
+                                                uu____6286.FStar_Syntax_Syntax.fv_name
                                                  in
-                                              uu____6281.FStar_Syntax_Syntax.v
+                                              uu____6283.FStar_Syntax_Syntax.v
                                                in
                                             let flags'' =
-                                              let uu____6288 =
-                                                let uu____6289 =
+                                              let uu____6290 =
+                                                let uu____6291 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____6289.FStar_Syntax_Syntax.n
+                                                uu____6291.FStar_Syntax_Syntax.n
                                                  in
-                                              match uu____6288 with
+                                              match uu____6290 with
                                               | FStar_Syntax_Syntax.Tm_arrow
-                                                  (uu____6294,{
+                                                  (uu____6296,{
                                                                 FStar_Syntax_Syntax.n
                                                                   =
                                                                   FStar_Syntax_Syntax.Comp
                                                                   {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____6295;
+                                                                    uu____6297;
                                                                     FStar_Syntax_Syntax.effect_name
                                                                     = e;
                                                                     FStar_Syntax_Syntax.result_typ
                                                                     =
-                                                                    uu____6297;
+                                                                    uu____6299;
                                                                     FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____6298;
+                                                                    uu____6300;
                                                                     FStar_Syntax_Syntax.flags
                                                                     =
-                                                                    uu____6299;_};
+                                                                    uu____6301;_};
                                                                 FStar_Syntax_Syntax.pos
                                                                   =
-                                                                  uu____6300;
+                                                                  uu____6302;
                                                                 FStar_Syntax_Syntax.vars
                                                                   =
-                                                                  uu____6301;_})
+                                                                  uu____6303;_})
                                                   when
-                                                  let uu____6336 =
+                                                  let uu____6338 =
                                                     FStar_Ident.string_of_lid
                                                       e
                                                      in
-                                                  uu____6336 =
+                                                  uu____6338 =
                                                     "FStar.HyperStack.ST.StackInline"
                                                   ->
                                                   [FStar_Extraction_ML_Syntax.StackInline]
-                                              | uu____6340 -> []  in
+                                              | uu____6342 -> []  in
                                             let meta =
                                               FStar_List.append flags
                                                 (FStar_List.append flags'
                                                    flags'')
                                                in
                                             let ml_lb1 =
-                                              let uu___957_6345 = ml_lb  in
+                                              let uu___957_6347 = ml_lb  in
                                               {
                                                 FStar_Extraction_ML_Syntax.mllb_name
                                                   =
-                                                  (uu___957_6345.FStar_Extraction_ML_Syntax.mllb_name);
+                                                  (uu___957_6347.FStar_Extraction_ML_Syntax.mllb_name);
                                                 FStar_Extraction_ML_Syntax.mllb_tysc
                                                   =
-                                                  (uu___957_6345.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                  (uu___957_6347.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                 FStar_Extraction_ML_Syntax.mllb_add_unit
                                                   =
-                                                  (uu___957_6345.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                  (uu___957_6347.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                 FStar_Extraction_ML_Syntax.mllb_def
                                                   =
-                                                  (uu___957_6345.FStar_Extraction_ML_Syntax.mllb_def);
+                                                  (uu___957_6347.FStar_Extraction_ML_Syntax.mllb_def);
                                                 FStar_Extraction_ML_Syntax.mllb_meta
                                                   = meta;
                                                 FStar_Extraction_ML_Syntax.print_typ
                                                   =
-                                                  (uu___957_6345.FStar_Extraction_ML_Syntax.print_typ)
+                                                  (uu___957_6347.FStar_Extraction_ML_Syntax.print_typ)
                                               }  in
-                                            let uu____6346 =
-                                              let uu____6351 =
+                                            let uu____6348 =
+                                              let uu____6353 =
                                                 FStar_All.pipe_right quals
                                                   (FStar_Util.for_some
-                                                     (fun uu___8_6358  ->
-                                                        match uu___8_6358
+                                                     (fun uu___8_6360  ->
+                                                        match uu___8_6360
                                                         with
                                                         | FStar_Syntax_Syntax.Projector
-                                                            uu____6360 ->
+                                                            uu____6362 ->
                                                             true
-                                                        | uu____6366 -> false))
+                                                        | uu____6368 -> false))
                                                  in
-                                              if uu____6351
+                                              if uu____6353
                                               then
-                                                let uu____6373 =
-                                                  let uu____6381 =
+                                                let uu____6375 =
+                                                  let uu____6383 =
                                                     FStar_Util.right lbname
                                                      in
-                                                  let uu____6382 =
+                                                  let uu____6384 =
                                                     FStar_Util.must
                                                       ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                      in
                                                   FStar_Extraction_ML_UEnv.extend_fv
-                                                    env uu____6381 uu____6382
+                                                    env uu____6383 uu____6384
                                                     ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                    in
-                                                match uu____6373 with
-                                                | (env1,mls,uu____6389) ->
+                                                match uu____6375 with
+                                                | (env1,mls,uu____6391) ->
                                                     (env1,
-                                                      (let uu___969_6393 =
+                                                      (let uu___969_6395 =
                                                          ml_lb1  in
                                                        {
                                                          FStar_Extraction_ML_Syntax.mllb_name
                                                            = mls;
                                                          FStar_Extraction_ML_Syntax.mllb_tysc
                                                            =
-                                                           (uu___969_6393.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                           (uu___969_6395.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                          FStar_Extraction_ML_Syntax.mllb_add_unit
                                                            =
-                                                           (uu___969_6393.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                           (uu___969_6395.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                          FStar_Extraction_ML_Syntax.mllb_def
                                                            =
-                                                           (uu___969_6393.FStar_Extraction_ML_Syntax.mllb_def);
+                                                           (uu___969_6395.FStar_Extraction_ML_Syntax.mllb_def);
                                                          FStar_Extraction_ML_Syntax.mllb_meta
                                                            =
-                                                           (uu___969_6393.FStar_Extraction_ML_Syntax.mllb_meta);
+                                                           (uu___969_6395.FStar_Extraction_ML_Syntax.mllb_meta);
                                                          FStar_Extraction_ML_Syntax.print_typ
                                                            =
-                                                           (uu___969_6393.FStar_Extraction_ML_Syntax.print_typ)
+                                                           (uu___969_6395.FStar_Extraction_ML_Syntax.print_typ)
                                                        }))
                                               else
-                                                (let uu____6396 =
-                                                   let uu____6404 =
+                                                (let uu____6398 =
+                                                   let uu____6406 =
                                                      FStar_Util.must
                                                        ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                       in
                                                    FStar_Extraction_ML_UEnv.extend_lb
-                                                     env lbname t uu____6404
+                                                     env lbname t uu____6406
                                                      ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                     in
-                                                 match uu____6396 with
-                                                 | (env1,uu____6410,uu____6411)
+                                                 match uu____6398 with
+                                                 | (env1,uu____6412,uu____6413)
                                                      -> (env1, ml_lb1))
                                                in
-                                            match uu____6346 with
+                                            match uu____6348 with
                                             | (g1,ml_lb2) ->
                                                 (g1, (ml_lb2 :: ml_lbs))))
                               (g, []) bindings
                               (FStar_Pervasives_Native.snd lbs1)
                              in
-                          (match uu____6184 with
+                          (match uu____6186 with
                            | (g1,ml_lbs') ->
-                               let uu____6441 =
-                                 let uu____6444 =
-                                   let uu____6447 =
-                                     let uu____6448 =
+                               let uu____6443 =
+                                 let uu____6446 =
+                                   let uu____6449 =
+                                     let uu____6450 =
                                        FStar_Extraction_ML_Util.mlloc_of_range
                                          se.FStar_Syntax_Syntax.sigrng
                                         in
                                      FStar_Extraction_ML_Syntax.MLM_Loc
-                                       uu____6448
+                                       uu____6450
                                       in
-                                   [uu____6447;
+                                   [uu____6449;
                                    FStar_Extraction_ML_Syntax.MLM_Let
                                      (flavor, (FStar_List.rev ml_lbs'))]
                                     in
-                                 let uu____6451 = maybe_register_plugin g1 se
+                                 let uu____6453 = maybe_register_plugin g1 se
                                     in
-                                 FStar_List.append uu____6444 uu____6451  in
-                               (g1, uu____6441))
-                      | uu____6456 ->
-                          let uu____6457 =
-                            let uu____6459 =
-                              let uu____6461 =
+                                 FStar_List.append uu____6446 uu____6453  in
+                               (g1, uu____6443))
+                      | uu____6458 ->
+                          let uu____6459 =
+                            let uu____6461 =
+                              let uu____6463 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g
                                  in
                               FStar_Extraction_ML_Code.string_of_mlexpr
-                                uu____6461 ml_let
+                                uu____6463 ml_let
                                in
                             FStar_Util.format1
                               "Impossible: Translated a let to a non-let: %s"
-                              uu____6459
+                              uu____6461
                              in
-                          failwith uu____6457)))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____6470,t) ->
+                          failwith uu____6459)))
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____6472,t) ->
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____6475 =
+           let uu____6477 =
              (FStar_All.pipe_right quals
                 (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                &&
-               (let uu____6481 =
-                  let uu____6483 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+               (let uu____6483 =
+                  let uu____6485 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                      in
-                  FStar_TypeChecker_Util.must_erase_for_extraction uu____6483
+                  FStar_TypeChecker_Util.must_erase_for_extraction uu____6485
                     t
                    in
-                Prims.op_Negation uu____6481)
+                Prims.op_Negation uu____6483)
               in
-           if uu____6475
+           if uu____6477
            then
              let always_fail1 =
-               let uu___989_6492 = se  in
-               let uu____6493 =
-                 let uu____6494 =
-                   let uu____6501 =
-                     let uu____6502 =
-                       let uu____6505 = always_fail lid t  in [uu____6505]
+               let uu___989_6494 = se  in
+               let uu____6495 =
+                 let uu____6496 =
+                   let uu____6503 =
+                     let uu____6504 =
+                       let uu____6507 = always_fail lid t  in [uu____6507]
                         in
-                     (false, uu____6502)  in
-                   (uu____6501, [])  in
-                 FStar_Syntax_Syntax.Sig_let uu____6494  in
+                     (false, uu____6504)  in
+                   (uu____6503, [])  in
+                 FStar_Syntax_Syntax.Sig_let uu____6496  in
                {
-                 FStar_Syntax_Syntax.sigel = uu____6493;
+                 FStar_Syntax_Syntax.sigel = uu____6495;
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___989_6492.FStar_Syntax_Syntax.sigrng);
+                   (uu___989_6494.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___989_6492.FStar_Syntax_Syntax.sigquals);
+                   (uu___989_6494.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___989_6492.FStar_Syntax_Syntax.sigmeta);
+                   (uu___989_6494.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___989_6492.FStar_Syntax_Syntax.sigattrs);
+                   (uu___989_6494.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___989_6492.FStar_Syntax_Syntax.sigopts)
+                   (uu___989_6494.FStar_Syntax_Syntax.sigopts)
                }  in
-             let uu____6512 = extract_sig g always_fail1  in
-             (match uu____6512 with
+             let uu____6514 = extract_sig g always_fail1  in
+             (match uu____6514 with
               | (g1,mlm) ->
-                  let uu____6531 =
+                  let uu____6533 =
                     FStar_Util.find_map quals
-                      (fun uu___9_6536  ->
-                         match uu___9_6536 with
+                      (fun uu___9_6538  ->
+                         match uu___9_6538 with
                          | FStar_Syntax_Syntax.Discriminator l ->
                              FStar_Pervasives_Native.Some l
-                         | uu____6540 -> FStar_Pervasives_Native.None)
+                         | uu____6542 -> FStar_Pervasives_Native.None)
                      in
-                  (match uu____6531 with
+                  (match uu____6533 with
                    | FStar_Pervasives_Native.Some l ->
-                       let uu____6548 =
-                         let uu____6551 =
-                           let uu____6552 =
+                       let uu____6550 =
+                         let uu____6553 =
+                           let uu____6554 =
                              FStar_Extraction_ML_Util.mlloc_of_range
                                se.FStar_Syntax_Syntax.sigrng
                               in
-                           FStar_Extraction_ML_Syntax.MLM_Loc uu____6552  in
-                         let uu____6553 =
-                           let uu____6556 =
+                           FStar_Extraction_ML_Syntax.MLM_Loc uu____6554  in
+                         let uu____6555 =
+                           let uu____6558 =
                              FStar_Extraction_ML_Term.ind_discriminator_body
                                g1 lid l
                               in
-                           [uu____6556]  in
-                         uu____6551 :: uu____6553  in
-                       (g1, uu____6548)
-                   | uu____6559 ->
-                       let uu____6562 =
+                           [uu____6558]  in
+                         uu____6553 :: uu____6555  in
+                       (g1, uu____6550)
+                   | uu____6561 ->
+                       let uu____6564 =
                          FStar_Util.find_map quals
-                           (fun uu___10_6568  ->
-                              match uu___10_6568 with
-                              | FStar_Syntax_Syntax.Projector (l,uu____6572)
+                           (fun uu___10_6570  ->
+                              match uu___10_6570 with
+                              | FStar_Syntax_Syntax.Projector (l,uu____6574)
                                   -> FStar_Pervasives_Native.Some l
-                              | uu____6573 -> FStar_Pervasives_Native.None)
+                              | uu____6575 -> FStar_Pervasives_Native.None)
                           in
-                       (match uu____6562 with
-                        | FStar_Pervasives_Native.Some uu____6580 -> (g1, [])
-                        | uu____6583 -> (g1, mlm))))
+                       (match uu____6564 with
+                        | FStar_Pervasives_Native.Some uu____6582 -> (g1, [])
+                        | uu____6585 -> (g1, mlm))))
            else (g, [])
        | FStar_Syntax_Syntax.Sig_main e ->
-           let uu____6593 = FStar_Extraction_ML_Term.term_as_mlexpr g e  in
-           (match uu____6593 with
-            | (ml_main,uu____6607,uu____6608) ->
-                let uu____6609 =
-                  let uu____6612 =
-                    let uu____6613 =
+           let uu____6595 = FStar_Extraction_ML_Term.term_as_mlexpr g e  in
+           (match uu____6595 with
+            | (ml_main,uu____6609,uu____6610) ->
+                let uu____6611 =
+                  let uu____6614 =
+                    let uu____6615 =
                       FStar_Extraction_ML_Util.mlloc_of_range
                         se.FStar_Syntax_Syntax.sigrng
                        in
-                    FStar_Extraction_ML_Syntax.MLM_Loc uu____6613  in
-                  [uu____6612; FStar_Extraction_ML_Syntax.MLM_Top ml_main]
+                    FStar_Extraction_ML_Syntax.MLM_Loc uu____6615  in
+                  [uu____6614; FStar_Extraction_ML_Syntax.MLM_Top ml_main]
                    in
-                (g, uu____6609))
-       | FStar_Syntax_Syntax.Sig_assume uu____6616 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_sub_effect uu____6625 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6628 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____6643 -> (g, [])
+                (g, uu____6611))
+       | FStar_Syntax_Syntax.Sig_assume uu____6618 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_sub_effect uu____6627 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6630 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____6645 -> (g, [])
        | FStar_Syntax_Syntax.Sig_pragma p ->
            (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
             (g, [])))
@@ -2235,70 +2235,75 @@ let (extract' :
   =
   fun g  ->
     fun m  ->
-      let uu____6683 = FStar_Options.restore_cmd_line_options true  in
-      let uu____6685 =
+      let uu____6685 = FStar_Options.restore_cmd_line_options true  in
+      let uu____6687 =
         FStar_Extraction_ML_UEnv.extend_with_module_name g
           m.FStar_Syntax_Syntax.name
          in
-      match uu____6685 with
+      match uu____6687 with
       | (name,g1) ->
           let g2 =
-            let uu____6699 =
-              let uu____6700 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1  in
-              FStar_TypeChecker_Env.set_current_module uu____6700
+            let uu____6701 =
+              let uu____6702 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1  in
+              FStar_TypeChecker_Env.set_current_module uu____6702
                 m.FStar_Syntax_Syntax.name
                in
-            FStar_Extraction_ML_UEnv.set_tcenv g1 uu____6699  in
+            FStar_Extraction_ML_UEnv.set_tcenv g1 uu____6701  in
           let g3 = FStar_Extraction_ML_UEnv.set_current_module g2 name  in
-          let uu____6702 =
+          let uu____6704 =
             FStar_Util.fold_map
               (fun g4  ->
                  fun se  ->
-                   let uu____6721 =
-                     FStar_Options.debug_module
-                       (m.FStar_Syntax_Syntax.name).FStar_Ident.str
-                      in
-                   if uu____6721
+                   let uu____6723 =
+                     let uu____6725 =
+                       FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
+                        in
+                     FStar_Options.debug_module uu____6725  in
+                   if uu____6723
                    then
                      let nm =
-                       let uu____6732 =
+                       let uu____6736 =
                          FStar_All.pipe_right
                            (FStar_Syntax_Util.lids_of_sigelt se)
                            (FStar_List.map FStar_Ident.string_of_lid)
                           in
-                       FStar_All.pipe_right uu____6732
+                       FStar_All.pipe_right uu____6736
                          (FStar_String.concat ", ")
                         in
                      (FStar_Util.print1 "+++About to extract {%s}\n" nm;
-                      (let uu____6749 =
+                      (let uu____6753 =
                          FStar_Util.format1 "---Extracted {%s}" nm  in
-                       FStar_Util.measure_execution_time uu____6749
-                         (fun uu____6759  -> extract_sig g4 se)))
+                       FStar_Util.measure_execution_time uu____6753
+                         (fun uu____6763  -> extract_sig g4 se)))
                    else extract_sig g4 se) g3
               m.FStar_Syntax_Syntax.declarations
              in
-          (match uu____6702 with
+          (match uu____6704 with
            | (g4,sigs) ->
                let mlm = FStar_List.flatten sigs  in
                let is_kremlin =
-                 let uu____6781 = FStar_Options.codegen ()  in
-                 uu____6781 =
+                 let uu____6785 = FStar_Options.codegen ()  in
+                 uu____6785 =
                    (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
                   in
-               if
-                 ((m.FStar_Syntax_Syntax.name).FStar_Ident.str <> "Prims") &&
+               let uu____6790 =
+                 (let uu____6794 =
+                    FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
+                  uu____6794 <> "Prims") &&
                    (is_kremlin ||
                       (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface))
+                  in
+               if uu____6790
                then
-                 ((let uu____6796 =
-                     let uu____6798 = FStar_Options.silent ()  in
-                     Prims.op_Negation uu____6798  in
-                   if uu____6796
+                 ((let uu____6806 =
+                     let uu____6808 = FStar_Options.silent ()  in
+                     Prims.op_Negation uu____6808  in
+                   if uu____6806
                    then
-                     let uu____6801 =
+                     let uu____6811 =
                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
                         in
-                     FStar_Util.print1 "Extracted module %s\n" uu____6801
+                     FStar_Util.print1 "Extracted module %s\n" uu____6811
                    else ());
                   (g4,
                     (FStar_Pervasives_Native.Some
@@ -2315,46 +2320,46 @@ let (extract :
   =
   fun g  ->
     fun m  ->
-      (let uu____6876 = FStar_Options.restore_cmd_line_options true  in
-       FStar_All.pipe_left (fun uu____6878  -> ()) uu____6876);
-      (let uu____6880 =
-         let uu____6882 =
-           FStar_Options.should_extract
-             (m.FStar_Syntax_Syntax.name).FStar_Ident.str
-            in
-         Prims.op_Negation uu____6882  in
-       if uu____6880
+      (let uu____6886 = FStar_Options.restore_cmd_line_options true  in
+       FStar_All.pipe_left (fun uu____6888  -> ()) uu____6886);
+      (let uu____6890 =
+         let uu____6892 =
+           let uu____6894 =
+             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
+           FStar_Options.should_extract uu____6894  in
+         Prims.op_Negation uu____6892  in
+       if uu____6890
        then
-         let uu____6885 =
-           let uu____6887 =
+         let uu____6897 =
+           let uu____6899 =
              FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
            FStar_Util.format1
              "Extract called on a module %s that should not be extracted"
-             uu____6887
+             uu____6899
             in
-         failwith uu____6885
+         failwith uu____6897
        else ());
-      (let uu____6892 = FStar_Options.interactive ()  in
-       if uu____6892
+      (let uu____6904 = FStar_Options.interactive ()  in
+       if uu____6904
        then (g, FStar_Pervasives_Native.None)
        else
-         (let uu____6905 =
-            let uu____6912 = FStar_Options.debug_any ()  in
-            if uu____6912
+         (let uu____6917 =
+            let uu____6924 = FStar_Options.debug_any ()  in
+            if uu____6924
             then
               let msg =
-                let uu____6923 =
+                let uu____6935 =
                   FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name
                    in
-                FStar_Util.format1 "Extracting module %s" uu____6923  in
+                FStar_Util.format1 "Extracting module %s" uu____6935  in
               FStar_Util.measure_execution_time msg
-                (fun uu____6933  -> extract' g m)
+                (fun uu____6945  -> extract' g m)
             else extract' g m  in
-          match uu____6905 with
+          match uu____6917 with
           | (g1,mllib) ->
-              ((let uu____6949 = FStar_Options.restore_cmd_line_options true
+              ((let uu____6961 = FStar_Options.restore_cmd_line_options true
                    in
-                FStar_All.pipe_left (fun uu____6951  -> ()) uu____6949);
-               (let uu____6952 = FStar_Extraction_ML_UEnv.exit_module g1  in
-                (uu____6952, mllib)))))
+                FStar_All.pipe_left (fun uu____6963  -> ()) uu____6961);
+               (let uu____6964 = FStar_Extraction_ML_UEnv.exit_module g1  in
+                (uu____6964, mllib)))))
   

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -157,48 +157,52 @@ let (effect_as_etag :
   =
   let cache = FStar_Util.smap_create (Prims.of_int (20))  in
   let rec delta_norm_eff g l =
-    let uu____346 = FStar_Util.smap_try_find cache l.FStar_Ident.str  in
+    let uu____346 =
+      let uu____349 = FStar_Ident.string_of_lid l  in
+      FStar_Util.smap_try_find cache uu____349  in
     match uu____346 with
     | FStar_Pervasives_Native.Some l1 -> l1
     | FStar_Pervasives_Native.None  ->
         let res =
-          let uu____351 =
-            let uu____358 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-            FStar_TypeChecker_Env.lookup_effect_abbrev uu____358
+          let uu____353 =
+            let uu____360 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
+            FStar_TypeChecker_Env.lookup_effect_abbrev uu____360
               [FStar_Syntax_Syntax.U_zero] l
              in
-          match uu____351 with
+          match uu____353 with
           | FStar_Pervasives_Native.None  -> l
-          | FStar_Pervasives_Native.Some (uu____363,c) ->
+          | FStar_Pervasives_Native.Some (uu____365,c) ->
               delta_norm_eff g (FStar_Syntax_Util.comp_effect_name c)
            in
-        (FStar_Util.smap_add cache l.FStar_Ident.str res; res)
+        ((let uu____372 = FStar_Ident.string_of_lid l  in
+          FStar_Util.smap_add cache uu____372 res);
+         res)
      in
   fun g  ->
     fun l  ->
       let l1 = delta_norm_eff g l  in
-      let uu____373 =
+      let uu____377 =
         FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_PURE_lid  in
-      if uu____373
+      if uu____377
       then FStar_Extraction_ML_Syntax.E_PURE
       else
-        (let uu____378 =
+        (let uu____382 =
            FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GHOST_lid  in
-         if uu____378
+         if uu____382
          then FStar_Extraction_ML_Syntax.E_GHOST
          else
            (let ed_opt =
-              let uu____392 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-              FStar_TypeChecker_Env.effect_decl_opt uu____392 l1  in
+              let uu____396 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
+              FStar_TypeChecker_Env.effect_decl_opt uu____396 l1  in
             match ed_opt with
             | FStar_Pervasives_Native.Some (ed,qualifiers) ->
-                let uu____405 =
-                  let uu____407 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+                let uu____409 =
+                  let uu____411 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                      in
-                  FStar_TypeChecker_Env.is_reifiable_effect uu____407
+                  FStar_TypeChecker_Env.is_reifiable_effect uu____411
                     ed.FStar_Syntax_Syntax.mname
                    in
-                if uu____405
+                if uu____409
                 then FStar_Extraction_ML_Syntax.E_PURE
                 else FStar_Extraction_ML_Syntax.E_IMPURE
             | FStar_Pervasives_Native.None  ->
@@ -209,49 +213,49 @@ let rec (is_arity :
   fun env  ->
     fun t  ->
       let t1 = FStar_Syntax_Util.unmeta t  in
-      let uu____430 =
-        let uu____431 = FStar_Syntax_Subst.compress t1  in
-        uu____431.FStar_Syntax_Syntax.n  in
-      match uu____430 with
+      let uu____434 =
+        let uu____435 = FStar_Syntax_Subst.compress t1  in
+        uu____435.FStar_Syntax_Syntax.n  in
+      match uu____434 with
       | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____437 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_ascribed uu____454 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_meta uu____483 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____441 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_ascribed uu____458 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_meta uu____487 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____493 = FStar_Syntax_Util.unfold_lazy i  in
-          is_arity env uu____493
-      | FStar_Syntax_Syntax.Tm_uvar uu____494 -> false
-      | FStar_Syntax_Syntax.Tm_constant uu____508 -> false
-      | FStar_Syntax_Syntax.Tm_name uu____510 -> false
-      | FStar_Syntax_Syntax.Tm_quoted uu____512 -> false
-      | FStar_Syntax_Syntax.Tm_bvar uu____520 -> false
-      | FStar_Syntax_Syntax.Tm_type uu____522 -> true
-      | FStar_Syntax_Syntax.Tm_arrow (uu____524,c) ->
+          let uu____497 = FStar_Syntax_Util.unfold_lazy i  in
+          is_arity env uu____497
+      | FStar_Syntax_Syntax.Tm_uvar uu____498 -> false
+      | FStar_Syntax_Syntax.Tm_constant uu____512 -> false
+      | FStar_Syntax_Syntax.Tm_name uu____514 -> false
+      | FStar_Syntax_Syntax.Tm_quoted uu____516 -> false
+      | FStar_Syntax_Syntax.Tm_bvar uu____524 -> false
+      | FStar_Syntax_Syntax.Tm_type uu____526 -> true
+      | FStar_Syntax_Syntax.Tm_arrow (uu____528,c) ->
           is_arity env (FStar_Syntax_Util.comp_result c)
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let topt =
-            let uu____554 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
+            let uu____558 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Unfold
-                 FStar_Syntax_Syntax.delta_constant] uu____554
+                 FStar_Syntax_Syntax.delta_constant] uu____558
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
           (match topt with
            | FStar_Pervasives_Native.None  -> false
-           | FStar_Pervasives_Native.Some (uu____561,t2) -> is_arity env t2)
-      | FStar_Syntax_Syntax.Tm_app uu____567 ->
-          let uu____584 = FStar_Syntax_Util.head_and_args t1  in
-          (match uu____584 with | (head,uu____603) -> is_arity env head)
-      | FStar_Syntax_Syntax.Tm_uinst (head,uu____629) -> is_arity env head
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____635) ->
+           | FStar_Pervasives_Native.Some (uu____565,t2) -> is_arity env t2)
+      | FStar_Syntax_Syntax.Tm_app uu____571 ->
+          let uu____588 = FStar_Syntax_Util.head_and_args t1  in
+          (match uu____588 with | (head,uu____607) -> is_arity env head)
+      | FStar_Syntax_Syntax.Tm_uinst (head,uu____633) -> is_arity env head
+      | FStar_Syntax_Syntax.Tm_refine (x,uu____639) ->
           is_arity env x.FStar_Syntax_Syntax.sort
-      | FStar_Syntax_Syntax.Tm_abs (uu____640,body,uu____642) ->
+      | FStar_Syntax_Syntax.Tm_abs (uu____644,body,uu____646) ->
           is_arity env body
-      | FStar_Syntax_Syntax.Tm_let (uu____667,body) -> is_arity env body
-      | FStar_Syntax_Syntax.Tm_match (uu____687,branches) ->
+      | FStar_Syntax_Syntax.Tm_let (uu____671,body) -> is_arity env body
+      | FStar_Syntax_Syntax.Tm_match (uu____691,branches) ->
           (match branches with
-           | (uu____726,uu____727,e)::uu____729 -> is_arity env e
-           | uu____776 -> false)
+           | (uu____730,uu____731,e)::uu____733 -> is_arity env e
+           | uu____780 -> false)
   
 let rec (is_type_aux :
   FStar_Extraction_ML_UEnv.uenv -> FStar_Syntax_Syntax.term -> Prims.bool) =
@@ -259,110 +263,110 @@ let rec (is_type_aux :
     fun t  ->
       let t1 = FStar_Syntax_Subst.compress t  in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____808 ->
-          let uu____823 =
-            let uu____825 = FStar_Syntax_Print.tag_of_term t1  in
-            FStar_Util.format1 "Impossible: %s" uu____825  in
-          failwith uu____823
+      | FStar_Syntax_Syntax.Tm_delayed uu____812 ->
+          let uu____827 =
+            let uu____829 = FStar_Syntax_Print.tag_of_term t1  in
+            FStar_Util.format1 "Impossible: %s" uu____829  in
+          failwith uu____827
       | FStar_Syntax_Syntax.Tm_unknown  ->
-          let uu____829 =
-            let uu____831 = FStar_Syntax_Print.tag_of_term t1  in
-            FStar_Util.format1 "Impossible: %s" uu____831  in
-          failwith uu____829
+          let uu____833 =
+            let uu____835 = FStar_Syntax_Print.tag_of_term t1  in
+            FStar_Util.format1 "Impossible: %s" uu____835  in
+          failwith uu____833
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____836 = FStar_Syntax_Util.unfold_lazy i  in
-          is_type_aux env uu____836
-      | FStar_Syntax_Syntax.Tm_constant uu____837 -> false
-      | FStar_Syntax_Syntax.Tm_type uu____839 -> true
-      | FStar_Syntax_Syntax.Tm_refine uu____841 -> true
-      | FStar_Syntax_Syntax.Tm_arrow uu____849 -> true
+          let uu____840 = FStar_Syntax_Util.unfold_lazy i  in
+          is_type_aux env uu____840
+      | FStar_Syntax_Syntax.Tm_constant uu____841 -> false
+      | FStar_Syntax_Syntax.Tm_type uu____843 -> true
+      | FStar_Syntax_Syntax.Tm_refine uu____845 -> true
+      | FStar_Syntax_Syntax.Tm_arrow uu____853 -> true
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.failwith_lid ->
           false
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           FStar_Extraction_ML_UEnv.is_type_name env fv
       | FStar_Syntax_Syntax.Tm_uvar
-          ({ FStar_Syntax_Syntax.ctx_uvar_head = uu____868;
-             FStar_Syntax_Syntax.ctx_uvar_gamma = uu____869;
-             FStar_Syntax_Syntax.ctx_uvar_binders = uu____870;
+          ({ FStar_Syntax_Syntax.ctx_uvar_head = uu____872;
+             FStar_Syntax_Syntax.ctx_uvar_gamma = uu____873;
+             FStar_Syntax_Syntax.ctx_uvar_binders = uu____874;
              FStar_Syntax_Syntax.ctx_uvar_typ = t2;
-             FStar_Syntax_Syntax.ctx_uvar_reason = uu____872;
-             FStar_Syntax_Syntax.ctx_uvar_should_check = uu____873;
-             FStar_Syntax_Syntax.ctx_uvar_range = uu____874;
-             FStar_Syntax_Syntax.ctx_uvar_meta = uu____875;_},s)
+             FStar_Syntax_Syntax.ctx_uvar_reason = uu____876;
+             FStar_Syntax_Syntax.ctx_uvar_should_check = uu____877;
+             FStar_Syntax_Syntax.ctx_uvar_range = uu____878;
+             FStar_Syntax_Syntax.ctx_uvar_meta = uu____879;_},s)
           ->
-          let uu____924 = FStar_Syntax_Subst.subst' s t2  in
-          is_arity env uu____924
+          let uu____928 = FStar_Syntax_Subst.subst' s t2  in
+          is_arity env uu____928
       | FStar_Syntax_Syntax.Tm_bvar
-          { FStar_Syntax_Syntax.ppname = uu____925;
-            FStar_Syntax_Syntax.index = uu____926;
+          { FStar_Syntax_Syntax.ppname = uu____929;
+            FStar_Syntax_Syntax.index = uu____930;
             FStar_Syntax_Syntax.sort = t2;_}
           -> is_arity env t2
       | FStar_Syntax_Syntax.Tm_name
-          { FStar_Syntax_Syntax.ppname = uu____931;
-            FStar_Syntax_Syntax.index = uu____932;
+          { FStar_Syntax_Syntax.ppname = uu____935;
+            FStar_Syntax_Syntax.index = uu____936;
             FStar_Syntax_Syntax.sort = t2;_}
           -> is_arity env t2
-      | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____938,uu____939) ->
+      | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____942,uu____943) ->
           is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_uinst (t2,uu____981) -> is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____988) ->
-          let uu____1013 = FStar_Syntax_Subst.open_term bs body  in
-          (match uu____1013 with
-           | (uu____1019,body1) -> is_type_aux env body1)
+      | FStar_Syntax_Syntax.Tm_uinst (t2,uu____985) -> is_type_aux env t2
+      | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____992) ->
+          let uu____1017 = FStar_Syntax_Subst.open_term bs body  in
+          (match uu____1017 with
+           | (uu____1023,body1) -> is_type_aux env body1)
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
           let x = FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-          let uu____1039 =
-            let uu____1044 =
-              let uu____1045 = FStar_Syntax_Syntax.mk_binder x  in
-              [uu____1045]  in
-            FStar_Syntax_Subst.open_term uu____1044 body  in
-          (match uu____1039 with
-           | (uu____1065,body1) -> is_type_aux env body1)
-      | FStar_Syntax_Syntax.Tm_let ((uu____1067,lbs),body) ->
-          let uu____1087 = FStar_Syntax_Subst.open_let_rec lbs body  in
-          (match uu____1087 with
-           | (uu____1095,body1) -> is_type_aux env body1)
-      | FStar_Syntax_Syntax.Tm_match (uu____1101,branches) ->
+          let uu____1043 =
+            let uu____1048 =
+              let uu____1049 = FStar_Syntax_Syntax.mk_binder x  in
+              [uu____1049]  in
+            FStar_Syntax_Subst.open_term uu____1048 body  in
+          (match uu____1043 with
+           | (uu____1069,body1) -> is_type_aux env body1)
+      | FStar_Syntax_Syntax.Tm_let ((uu____1071,lbs),body) ->
+          let uu____1091 = FStar_Syntax_Subst.open_let_rec lbs body  in
+          (match uu____1091 with
+           | (uu____1099,body1) -> is_type_aux env body1)
+      | FStar_Syntax_Syntax.Tm_match (uu____1105,branches) ->
           (match branches with
-           | b::uu____1141 ->
-               let uu____1186 = FStar_Syntax_Subst.open_branch b  in
-               (match uu____1186 with
-                | (uu____1188,uu____1189,e) -> is_type_aux env e)
-           | uu____1207 -> false)
-      | FStar_Syntax_Syntax.Tm_quoted uu____1225 -> false
-      | FStar_Syntax_Syntax.Tm_meta (t2,uu____1234) -> is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_app (head,uu____1240) -> is_type_aux env head
+           | b::uu____1145 ->
+               let uu____1190 = FStar_Syntax_Subst.open_branch b  in
+               (match uu____1190 with
+                | (uu____1192,uu____1193,e) -> is_type_aux env e)
+           | uu____1211 -> false)
+      | FStar_Syntax_Syntax.Tm_quoted uu____1229 -> false
+      | FStar_Syntax_Syntax.Tm_meta (t2,uu____1238) -> is_type_aux env t2
+      | FStar_Syntax_Syntax.Tm_app (head,uu____1244) -> is_type_aux env head
   
 let (is_type :
   FStar_Extraction_ML_UEnv.uenv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env  ->
     fun t  ->
       FStar_Extraction_ML_UEnv.debug env
-        (fun uu____1281  ->
-           let uu____1282 = FStar_Syntax_Print.tag_of_term t  in
-           let uu____1284 = FStar_Syntax_Print.term_to_string t  in
-           FStar_Util.print2 "checking is_type (%s) %s\n" uu____1282
-             uu____1284);
+        (fun uu____1285  ->
+           let uu____1286 = FStar_Syntax_Print.tag_of_term t  in
+           let uu____1288 = FStar_Syntax_Print.term_to_string t  in
+           FStar_Util.print2 "checking is_type (%s) %s\n" uu____1286
+             uu____1288);
       (let b = is_type_aux env t  in
        FStar_Extraction_ML_UEnv.debug env
-         (fun uu____1293  ->
+         (fun uu____1297  ->
             if b
             then
-              let uu____1295 = FStar_Syntax_Print.term_to_string t  in
-              let uu____1297 = FStar_Syntax_Print.tag_of_term t  in
-              FStar_Util.print2 "yes, is_type %s (%s)\n" uu____1295
-                uu____1297
+              let uu____1299 = FStar_Syntax_Print.term_to_string t  in
+              let uu____1301 = FStar_Syntax_Print.tag_of_term t  in
+              FStar_Util.print2 "yes, is_type %s (%s)\n" uu____1299
+                uu____1301
             else
-              (let uu____1302 = FStar_Syntax_Print.term_to_string t  in
-               let uu____1304 = FStar_Syntax_Print.tag_of_term t  in
-               FStar_Util.print2 "not a type %s (%s)\n" uu____1302 uu____1304));
+              (let uu____1306 = FStar_Syntax_Print.term_to_string t  in
+               let uu____1308 = FStar_Syntax_Print.tag_of_term t  in
+               FStar_Util.print2 "not a type %s (%s)\n" uu____1306 uu____1308));
        b)
   
 let is_type_binder :
-  'uuuuuu1314 .
+  'uuuuuu1318 .
     FStar_Extraction_ML_UEnv.uenv ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu1314) -> Prims.bool
+      (FStar_Syntax_Syntax.bv * 'uuuuuu1318) -> Prims.bool
   =
   fun env  ->
     fun x  ->
@@ -370,67 +374,67 @@ let is_type_binder :
   
 let (is_constructor : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____1341 =
-      let uu____1342 = FStar_Syntax_Subst.compress t  in
-      uu____1342.FStar_Syntax_Syntax.n  in
-    match uu____1341 with
+    let uu____1345 =
+      let uu____1346 = FStar_Syntax_Subst.compress t  in
+      uu____1346.FStar_Syntax_Syntax.n  in
+    match uu____1345 with
     | FStar_Syntax_Syntax.Tm_fvar
-        { FStar_Syntax_Syntax.fv_name = uu____1346;
-          FStar_Syntax_Syntax.fv_delta = uu____1347;
+        { FStar_Syntax_Syntax.fv_name = uu____1350;
+          FStar_Syntax_Syntax.fv_delta = uu____1351;
           FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
             (FStar_Syntax_Syntax.Data_ctor );_}
         -> true
     | FStar_Syntax_Syntax.Tm_fvar
-        { FStar_Syntax_Syntax.fv_name = uu____1349;
-          FStar_Syntax_Syntax.fv_delta = uu____1350;
+        { FStar_Syntax_Syntax.fv_name = uu____1353;
+          FStar_Syntax_Syntax.fv_delta = uu____1354;
           FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
-            (FStar_Syntax_Syntax.Record_ctor uu____1351);_}
+            (FStar_Syntax_Syntax.Record_ctor uu____1355);_}
         -> true
-    | uu____1359 -> false
+    | uu____1363 -> false
   
 let rec (is_fstar_value : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____1368 =
-      let uu____1369 = FStar_Syntax_Subst.compress t  in
-      uu____1369.FStar_Syntax_Syntax.n  in
-    match uu____1368 with
-    | FStar_Syntax_Syntax.Tm_constant uu____1373 -> true
-    | FStar_Syntax_Syntax.Tm_bvar uu____1375 -> true
-    | FStar_Syntax_Syntax.Tm_fvar uu____1377 -> true
-    | FStar_Syntax_Syntax.Tm_abs uu____1379 -> true
+    let uu____1372 =
+      let uu____1373 = FStar_Syntax_Subst.compress t  in
+      uu____1373.FStar_Syntax_Syntax.n  in
+    match uu____1372 with
+    | FStar_Syntax_Syntax.Tm_constant uu____1377 -> true
+    | FStar_Syntax_Syntax.Tm_bvar uu____1379 -> true
+    | FStar_Syntax_Syntax.Tm_fvar uu____1381 -> true
+    | FStar_Syntax_Syntax.Tm_abs uu____1383 -> true
     | FStar_Syntax_Syntax.Tm_app (head,args) ->
-        let uu____1425 = is_constructor head  in
-        if uu____1425
+        let uu____1429 = is_constructor head  in
+        if uu____1429
         then
           FStar_All.pipe_right args
             (FStar_List.for_all
-               (fun uu____1447  ->
-                  match uu____1447 with
-                  | (te,uu____1456) -> is_fstar_value te))
+               (fun uu____1451  ->
+                  match uu____1451 with
+                  | (te,uu____1460) -> is_fstar_value te))
         else false
-    | FStar_Syntax_Syntax.Tm_meta (t1,uu____1465) -> is_fstar_value t1
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____1471,uu____1472) ->
+    | FStar_Syntax_Syntax.Tm_meta (t1,uu____1469) -> is_fstar_value t1
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____1475,uu____1476) ->
         is_fstar_value t1
-    | uu____1513 -> false
+    | uu____1517 -> false
   
 let rec (is_ml_value : FStar_Extraction_ML_Syntax.mlexpr -> Prims.bool) =
   fun e  ->
     match e.FStar_Extraction_ML_Syntax.expr with
-    | FStar_Extraction_ML_Syntax.MLE_Const uu____1523 -> true
-    | FStar_Extraction_ML_Syntax.MLE_Var uu____1525 -> true
-    | FStar_Extraction_ML_Syntax.MLE_Name uu____1528 -> true
-    | FStar_Extraction_ML_Syntax.MLE_Fun uu____1530 -> true
-    | FStar_Extraction_ML_Syntax.MLE_CTor (uu____1543,exps) ->
+    | FStar_Extraction_ML_Syntax.MLE_Const uu____1527 -> true
+    | FStar_Extraction_ML_Syntax.MLE_Var uu____1529 -> true
+    | FStar_Extraction_ML_Syntax.MLE_Name uu____1532 -> true
+    | FStar_Extraction_ML_Syntax.MLE_Fun uu____1534 -> true
+    | FStar_Extraction_ML_Syntax.MLE_CTor (uu____1547,exps) ->
         FStar_Util.for_all is_ml_value exps
     | FStar_Extraction_ML_Syntax.MLE_Tuple exps ->
         FStar_Util.for_all is_ml_value exps
-    | FStar_Extraction_ML_Syntax.MLE_Record (uu____1552,fields) ->
+    | FStar_Extraction_ML_Syntax.MLE_Record (uu____1556,fields) ->
         FStar_Util.for_all
-          (fun uu____1582  ->
-             match uu____1582 with | (uu____1589,e1) -> is_ml_value e1)
+          (fun uu____1586  ->
+             match uu____1586 with | (uu____1593,e1) -> is_ml_value e1)
           fields
-    | FStar_Extraction_ML_Syntax.MLE_TApp (h,uu____1594) -> is_ml_value h
-    | uu____1599 -> false
+    | FStar_Extraction_ML_Syntax.MLE_TApp (h,uu____1598) -> is_ml_value h
+    | uu____1603 -> false
   
 let (normalize_abs : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t0  ->
@@ -439,22 +443,22 @@ let (normalize_abs : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_abs (bs',body,copt1) ->
           aux (FStar_List.append bs bs') body copt1
-      | uu____1681 ->
+      | uu____1685 ->
           let e' = FStar_Syntax_Util.unascribe t1  in
-          let uu____1683 = FStar_Syntax_Util.is_fun e'  in
-          if uu____1683
+          let uu____1687 = FStar_Syntax_Util.is_fun e'  in
+          if uu____1687
           then aux bs e' copt
           else FStar_Syntax_Util.abs bs e' copt
        in
     aux [] t0 FStar_Pervasives_Native.None
   
 let (unit_binder : unit -> FStar_Syntax_Syntax.binder) =
-  fun uu____1701  ->
-    let uu____1702 =
+  fun uu____1705  ->
+    let uu____1706 =
       FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
         FStar_Syntax_Syntax.t_unit
        in
-    FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____1702
+    FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____1706
   
 let (check_pats_for_ite :
   (FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.term
@@ -468,13 +472,13 @@ let (check_pats_for_ite :
     if (FStar_List.length l) <> (Prims.of_int (2))
     then def
     else
-      (let uu____1793 = FStar_List.hd l  in
-       match uu____1793 with
+      (let uu____1797 = FStar_List.hd l  in
+       match uu____1797 with
        | (p1,w1,e1) ->
-           let uu____1828 =
-             let uu____1837 = FStar_List.tl l  in FStar_List.hd uu____1837
+           let uu____1832 =
+             let uu____1841 = FStar_List.tl l  in FStar_List.hd uu____1841
               in
-           (match uu____1828 with
+           (match uu____1832 with
             | (p2,w2,e2) ->
                 (match (w1, w2, (p1.FStar_Syntax_Syntax.v),
                          (p2.FStar_Syntax_Syntax.v))
@@ -493,7 +497,7 @@ let (check_pats_for_ite :
                     (FStar_Const.Const_bool (true ))) ->
                      (true, (FStar_Pervasives_Native.Some e2),
                        (FStar_Pervasives_Native.Some e1))
-                 | uu____1921 -> def)))
+                 | uu____1925 -> def)))
   
 let (instantiate_tyscheme :
   FStar_Extraction_ML_Syntax.mltyscheme ->
@@ -508,18 +512,18 @@ let (fresh_mlidents :
   =
   fun ts  ->
     fun g  ->
-      let uu____1986 =
+      let uu____1990 =
         FStar_List.fold_right
           (fun t  ->
-             fun uu____2017  ->
-               match uu____2017 with
+             fun uu____2021  ->
+               match uu____2021 with
                | (uenv,vs) ->
-                   let uu____2056 = FStar_Extraction_ML_UEnv.new_mlident uenv
+                   let uu____2060 = FStar_Extraction_ML_UEnv.new_mlident uenv
                       in
-                   (match uu____2056 with
+                   (match uu____2060 with
                     | (uenv1,v) -> (uenv1, ((v, t) :: vs)))) ts (g, [])
          in
-      match uu____1986 with | (g1,vs_ts) -> (vs_ts, g1)
+      match uu____1990 with | (g1,vs_ts) -> (vs_ts, g1)
   
 let (instantiate_maybe_partial :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -534,8 +538,8 @@ let (instantiate_maybe_partial :
     fun e  ->
       fun s  ->
         fun tyargs  ->
-          let uu____2173 = s  in
-          match uu____2173 with
+          let uu____2177 = s  in
+          match uu____2177 with
           | (vars,t) ->
               let n_vars = FStar_List.length vars  in
               let n_args = FStar_List.length tyargs  in
@@ -546,37 +550,37 @@ let (instantiate_maybe_partial :
                  else
                    (let ts = instantiate_tyscheme (vars, t) tyargs  in
                     let tapp =
-                      let uu___372_2205 = e  in
+                      let uu___372_2209 = e  in
                       {
                         FStar_Extraction_ML_Syntax.expr =
                           (FStar_Extraction_ML_Syntax.MLE_TApp (e, tyargs));
                         FStar_Extraction_ML_Syntax.mlty = ts;
                         FStar_Extraction_ML_Syntax.loc =
-                          (uu___372_2205.FStar_Extraction_ML_Syntax.loc)
+                          (uu___372_2209.FStar_Extraction_ML_Syntax.loc)
                       }  in
                     (tapp, FStar_Extraction_ML_Syntax.E_PURE, ts)))
               else
                 if n_args < n_vars
                 then
                   (let extra_tyargs =
-                     let uu____2220 = FStar_Util.first_N n_args vars  in
-                     match uu____2220 with
-                     | (uu____2234,rest_vars) ->
+                     let uu____2224 = FStar_Util.first_N n_args vars  in
+                     match uu____2224 with
+                     | (uu____2238,rest_vars) ->
                          FStar_All.pipe_right rest_vars
                            (FStar_List.map
-                              (fun uu____2255  ->
+                              (fun uu____2259  ->
                                  FStar_Extraction_ML_Syntax.MLTY_Erased))
                       in
                    let tyargs1 = FStar_List.append tyargs extra_tyargs  in
                    let ts = instantiate_tyscheme (vars, t) tyargs1  in
                    let tapp =
-                     let uu___383_2262 = e  in
+                     let uu___383_2266 = e  in
                      {
                        FStar_Extraction_ML_Syntax.expr =
                          (FStar_Extraction_ML_Syntax.MLE_TApp (e, tyargs1));
                        FStar_Extraction_ML_Syntax.mlty = ts;
                        FStar_Extraction_ML_Syntax.loc =
-                         (uu___383_2262.FStar_Extraction_ML_Syntax.loc)
+                         (uu___383_2266.FStar_Extraction_ML_Syntax.loc)
                      }  in
                    let t1 =
                      FStar_List.fold_left
@@ -586,8 +590,8 @@ let (instantiate_maybe_partial :
                               (t1, FStar_Extraction_ML_Syntax.E_PURE, out))
                        ts extra_tyargs
                       in
-                   let uu____2270 = fresh_mlidents extra_tyargs g  in
-                   match uu____2270 with
+                   let uu____2274 = fresh_mlidents extra_tyargs g  in
+                   match uu____2274 with
                    | (vs_ts,g1) ->
                        let f =
                          FStar_All.pipe_left
@@ -607,19 +611,19 @@ let (eta_expand :
   fun g  ->
     fun t  ->
       fun e  ->
-        let uu____2337 = FStar_Extraction_ML_Util.doms_and_cod t  in
-        match uu____2337 with
+        let uu____2341 = FStar_Extraction_ML_Util.doms_and_cod t  in
+        match uu____2341 with
         | (ts,r) ->
             if ts = []
             then e
             else
-              (let uu____2355 = fresh_mlidents ts g  in
-               match uu____2355 with
+              (let uu____2359 = fresh_mlidents ts g  in
+               match uu____2359 with
                | (vs_ts,g1) ->
                    let vs_es =
                      FStar_List.map
-                       (fun uu____2394  ->
-                          match uu____2394 with
+                       (fun uu____2398  ->
+                          match uu____2398 with
                           | (v,t1) ->
                               FStar_Extraction_ML_Syntax.with_ty t1
                                 (FStar_Extraction_ML_Syntax.MLE_Var v)) vs_ts
@@ -638,14 +642,14 @@ let (default_value_for_ty :
   =
   fun g  ->
     fun t  ->
-      let uu____2425 = FStar_Extraction_ML_Util.doms_and_cod t  in
-      match uu____2425 with
+      let uu____2429 = FStar_Extraction_ML_Util.doms_and_cod t  in
+      match uu____2429 with
       | (ts,r) ->
           let body r1 =
             let r2 =
-              let uu____2445 = FStar_Extraction_ML_Util.udelta_unfold g r1
+              let uu____2449 = FStar_Extraction_ML_Util.udelta_unfold g r1
                  in
-              match uu____2445 with
+              match uu____2449 with
               | FStar_Pervasives_Native.None  -> r1
               | FStar_Pervasives_Native.Some r2 -> r2  in
             match r2 with
@@ -655,7 +659,7 @@ let (default_value_for_ty :
                 FStar_Extraction_ML_Syntax.apply_obj_repr
                   FStar_Extraction_ML_Syntax.ml_unit
                   FStar_Extraction_ML_Syntax.MLTY_Erased
-            | uu____2449 ->
+            | uu____2453 ->
                 FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty r2)
                   (FStar_Extraction_ML_Syntax.MLE_Coerce
                      (FStar_Extraction_ML_Syntax.ml_unit,
@@ -664,15 +668,15 @@ let (default_value_for_ty :
           if ts = []
           then body r
           else
-            (let uu____2455 = fresh_mlidents ts g  in
-             match uu____2455 with
+            (let uu____2459 = fresh_mlidents ts g  in
+             match uu____2459 with
              | (vs_ts,g1) ->
-                 let uu____2483 =
-                   let uu____2484 =
-                     let uu____2496 = body r  in (vs_ts, uu____2496)  in
-                   FStar_Extraction_ML_Syntax.MLE_Fun uu____2484  in
+                 let uu____2487 =
+                   let uu____2488 =
+                     let uu____2500 = body r  in (vs_ts, uu____2500)  in
+                   FStar_Extraction_ML_Syntax.MLE_Fun uu____2488  in
                  FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty t)
-                   uu____2483)
+                   uu____2487)
   
 let (maybe_eta_expand :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -682,13 +686,13 @@ let (maybe_eta_expand :
   fun g  ->
     fun expect  ->
       fun e  ->
-        let uu____2520 =
+        let uu____2524 =
           (FStar_Options.ml_no_eta_expand_coertions ()) ||
-            (let uu____2523 = FStar_Options.codegen ()  in
-             uu____2523 =
+            (let uu____2527 = FStar_Options.codegen ()  in
+             uu____2527 =
                (FStar_Pervasives_Native.Some FStar_Options.Kremlin))
            in
-        if uu____2520 then e else eta_expand g expect e
+        if uu____2524 then e else eta_expand g expect e
   
 let (apply_coercion :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -705,54 +709,54 @@ let (apply_coercion :
             | FStar_Extraction_ML_Syntax.MLE_Fun (binders,body1) ->
                 FStar_Extraction_ML_Syntax.MLE_Fun
                   ((binder :: binders), body1)
-            | uu____2601 ->
+            | uu____2605 ->
                 FStar_Extraction_ML_Syntax.MLE_Fun ([binder], body)
              in
           let rec aux e1 ty1 expect1 =
-            let coerce_branch uu____2656 =
-              match uu____2656 with
+            let coerce_branch uu____2660 =
+              match uu____2660 with
               | (pat,w,b) ->
-                  let uu____2680 = aux b ty1 expect1  in (pat, w, uu____2680)
+                  let uu____2684 = aux b ty1 expect1  in (pat, w, uu____2684)
                in
             match ((e1.FStar_Extraction_ML_Syntax.expr), ty1, expect1) with
             | (FStar_Extraction_ML_Syntax.MLE_Fun
                (arg::rest,body),FStar_Extraction_ML_Syntax.MLTY_Fun
-               (t0,uu____2687,t1),FStar_Extraction_ML_Syntax.MLTY_Fun
-               (s0,uu____2690,s1)) ->
+               (t0,uu____2691,t1),FStar_Extraction_ML_Syntax.MLTY_Fun
+               (s0,uu____2694,s1)) ->
                 let body1 =
                   match rest with
                   | [] -> body
-                  | uu____2722 ->
+                  | uu____2726 ->
                       FStar_Extraction_ML_Syntax.with_ty t1
                         (FStar_Extraction_ML_Syntax.MLE_Fun (rest, body))
                    in
                 let body2 = aux body1 t1 s1  in
-                let uu____2738 = type_leq g s0 t0  in
-                if uu____2738
+                let uu____2742 = type_leq g s0 t0  in
+                if uu____2742
                 then
                   FStar_Extraction_ML_Syntax.with_ty expect1
                     (mk_fun arg body2)
                 else
                   (let lb =
-                     let uu____2744 =
-                       let uu____2745 =
-                         let uu____2746 =
-                           let uu____2753 =
+                     let uu____2748 =
+                       let uu____2749 =
+                         let uu____2750 =
+                           let uu____2757 =
                              FStar_All.pipe_left
                                (FStar_Extraction_ML_Syntax.with_ty s0)
                                (FStar_Extraction_ML_Syntax.MLE_Var
                                   (FStar_Pervasives_Native.fst arg))
                               in
-                           (uu____2753, s0, t0)  in
-                         FStar_Extraction_ML_Syntax.MLE_Coerce uu____2746  in
-                       FStar_Extraction_ML_Syntax.with_ty t0 uu____2745  in
+                           (uu____2757, s0, t0)  in
+                         FStar_Extraction_ML_Syntax.MLE_Coerce uu____2750  in
+                       FStar_Extraction_ML_Syntax.with_ty t0 uu____2749  in
                      {
                        FStar_Extraction_ML_Syntax.mllb_name =
                          (FStar_Pervasives_Native.fst arg);
                        FStar_Extraction_ML_Syntax.mllb_tysc =
                          (FStar_Pervasives_Native.Some ([], t0));
                        FStar_Extraction_ML_Syntax.mllb_add_unit = false;
-                       FStar_Extraction_ML_Syntax.mllb_def = uu____2744;
+                       FStar_Extraction_ML_Syntax.mllb_def = uu____2748;
                        FStar_Extraction_ML_Syntax.mllb_meta = [];
                        FStar_Extraction_ML_Syntax.print_typ = false
                      }  in
@@ -765,71 +769,71 @@ let (apply_coercion :
                    FStar_Extraction_ML_Syntax.with_ty expect1
                      (mk_fun ((FStar_Pervasives_Native.fst arg), s0) body3))
             | (FStar_Extraction_ML_Syntax.MLE_Let
-               (lbs,body),uu____2772,uu____2773) ->
-                let uu____2786 =
-                  let uu____2787 =
-                    let uu____2798 = aux body ty1 expect1  in
-                    (lbs, uu____2798)  in
-                  FStar_Extraction_ML_Syntax.MLE_Let uu____2787  in
+               (lbs,body),uu____2776,uu____2777) ->
+                let uu____2790 =
+                  let uu____2791 =
+                    let uu____2802 = aux body ty1 expect1  in
+                    (lbs, uu____2802)  in
+                  FStar_Extraction_ML_Syntax.MLE_Let uu____2791  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2786
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2790
             | (FStar_Extraction_ML_Syntax.MLE_Match
-               (s,branches),uu____2807,uu____2808) ->
-                let uu____2829 =
-                  let uu____2830 =
-                    let uu____2845 = FStar_List.map coerce_branch branches
+               (s,branches),uu____2811,uu____2812) ->
+                let uu____2833 =
+                  let uu____2834 =
+                    let uu____2849 = FStar_List.map coerce_branch branches
                        in
-                    (s, uu____2845)  in
-                  FStar_Extraction_ML_Syntax.MLE_Match uu____2830  in
+                    (s, uu____2849)  in
+                  FStar_Extraction_ML_Syntax.MLE_Match uu____2834  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2829
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2833
             | (FStar_Extraction_ML_Syntax.MLE_If
-               (s,b1,b2_opt),uu____2885,uu____2886) ->
-                let uu____2891 =
-                  let uu____2892 =
-                    let uu____2901 = aux b1 ty1 expect1  in
-                    let uu____2902 =
+               (s,b1,b2_opt),uu____2889,uu____2890) ->
+                let uu____2895 =
+                  let uu____2896 =
+                    let uu____2905 = aux b1 ty1 expect1  in
+                    let uu____2906 =
                       FStar_Util.map_opt b2_opt
                         (fun b2  -> aux b2 ty1 expect1)
                        in
-                    (s, uu____2901, uu____2902)  in
-                  FStar_Extraction_ML_Syntax.MLE_If uu____2892  in
+                    (s, uu____2905, uu____2906)  in
+                  FStar_Extraction_ML_Syntax.MLE_If uu____2896  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2891
-            | (FStar_Extraction_ML_Syntax.MLE_Seq es,uu____2910,uu____2911)
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2895
+            | (FStar_Extraction_ML_Syntax.MLE_Seq es,uu____2914,uu____2915)
                 ->
-                let uu____2914 = FStar_Util.prefix es  in
-                (match uu____2914 with
+                let uu____2918 = FStar_Util.prefix es  in
+                (match uu____2918 with
                  | (prefix,last) ->
-                     let uu____2927 =
-                       let uu____2928 =
-                         let uu____2931 =
-                           let uu____2934 = aux last ty1 expect1  in
-                           [uu____2934]  in
-                         FStar_List.append prefix uu____2931  in
-                       FStar_Extraction_ML_Syntax.MLE_Seq uu____2928  in
+                     let uu____2931 =
+                       let uu____2932 =
+                         let uu____2935 =
+                           let uu____2938 = aux last ty1 expect1  in
+                           [uu____2938]  in
+                         FStar_List.append prefix uu____2935  in
+                       FStar_Extraction_ML_Syntax.MLE_Seq uu____2932  in
                      FStar_All.pipe_left
                        (FStar_Extraction_ML_Syntax.with_ty expect1)
-                       uu____2927)
+                       uu____2931)
             | (FStar_Extraction_ML_Syntax.MLE_Try
-               (s,branches),uu____2937,uu____2938) ->
-                let uu____2959 =
-                  let uu____2960 =
-                    let uu____2975 = FStar_List.map coerce_branch branches
+               (s,branches),uu____2941,uu____2942) ->
+                let uu____2963 =
+                  let uu____2964 =
+                    let uu____2979 = FStar_List.map coerce_branch branches
                        in
-                    (s, uu____2975)  in
-                  FStar_Extraction_ML_Syntax.MLE_Try uu____2960  in
+                    (s, uu____2979)  in
+                  FStar_Extraction_ML_Syntax.MLE_Try uu____2964  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2959
-            | uu____3012 ->
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2963
+            | uu____3016 ->
                 FStar_Extraction_ML_Syntax.with_ty expect1
                   (FStar_Extraction_ML_Syntax.MLE_Coerce (e1, ty1, expect1))
              in
           aux e ty expect
   
 let maybe_coerce :
-  'uuuuuu3032 .
-    'uuuuuu3032 ->
+  'uuuuuu3036 .
+    'uuuuuu3036 ->
       FStar_Extraction_ML_UEnv.uenv ->
         FStar_Extraction_ML_Syntax.mlexpr ->
           FStar_Extraction_ML_Syntax.mlty ->
@@ -842,81 +846,81 @@ let maybe_coerce :
         fun ty  ->
           fun expect  ->
             let ty1 = eraseTypeDeep g ty  in
-            let uu____3059 =
+            let uu____3063 =
               type_leq_c g (FStar_Pervasives_Native.Some e) ty1 expect  in
-            match uu____3059 with
+            match uu____3063 with
             | (true ,FStar_Pervasives_Native.Some e') -> e'
-            | uu____3072 ->
+            | uu____3076 ->
                 (match ty1 with
                  | FStar_Extraction_ML_Syntax.MLTY_Erased  ->
                      default_value_for_ty g expect
-                 | uu____3080 ->
-                     let uu____3081 =
-                       let uu____3083 =
+                 | uu____3084 ->
+                     let uu____3085 =
+                       let uu____3087 =
                          FStar_Extraction_ML_Util.erase_effect_annotations
                            ty1
                           in
-                       let uu____3084 =
+                       let uu____3088 =
                          FStar_Extraction_ML_Util.erase_effect_annotations
                            expect
                           in
-                       type_leq g uu____3083 uu____3084  in
-                     if uu____3081
+                       type_leq g uu____3087 uu____3088  in
+                     if uu____3085
                      then
                        (FStar_Extraction_ML_UEnv.debug g
-                          (fun uu____3090  ->
-                             let uu____3091 =
-                               let uu____3093 =
+                          (fun uu____3094  ->
+                             let uu____3095 =
+                               let uu____3097 =
                                  FStar_Extraction_ML_UEnv.current_module_of_uenv
                                    g
                                   in
                                FStar_Extraction_ML_Code.string_of_mlexpr
-                                 uu____3093 e
+                                 uu____3097 e
                                 in
-                             let uu____3094 =
-                               let uu____3096 =
+                             let uu____3098 =
+                               let uu____3100 =
                                  FStar_Extraction_ML_UEnv.current_module_of_uenv
                                    g
                                   in
                                FStar_Extraction_ML_Code.string_of_mlty
-                                 uu____3096 ty1
+                                 uu____3100 ty1
                                 in
                              FStar_Util.print2
                                "\n Effect mismatch on type of %s : %s\n"
-                               uu____3091 uu____3094);
+                               uu____3095 uu____3098);
                         e)
                      else
                        (FStar_Extraction_ML_UEnv.debug g
-                          (fun uu____3105  ->
-                             let uu____3106 =
-                               let uu____3108 =
+                          (fun uu____3109  ->
+                             let uu____3110 =
+                               let uu____3112 =
                                  FStar_Extraction_ML_UEnv.current_module_of_uenv
                                    g
                                   in
                                FStar_Extraction_ML_Code.string_of_mlexpr
-                                 uu____3108 e
+                                 uu____3112 e
                                 in
-                             let uu____3109 =
-                               let uu____3111 =
+                             let uu____3113 =
+                               let uu____3115 =
                                  FStar_Extraction_ML_UEnv.current_module_of_uenv
                                    g
                                   in
                                FStar_Extraction_ML_Code.string_of_mlty
-                                 uu____3111 ty1
+                                 uu____3115 ty1
                                 in
-                             let uu____3112 =
-                               let uu____3114 =
+                             let uu____3116 =
+                               let uu____3118 =
                                  FStar_Extraction_ML_UEnv.current_module_of_uenv
                                    g
                                   in
                                FStar_Extraction_ML_Code.string_of_mlty
-                                 uu____3114 expect
+                                 uu____3118 expect
                                 in
                              FStar_Util.print3
                                "\n (*needed to coerce expression \n %s \n of type \n %s \n to type \n %s *) \n"
-                               uu____3106 uu____3109 uu____3112);
-                        (let uu____3116 = apply_coercion g e ty1 expect  in
-                         maybe_eta_expand g expect uu____3116)))
+                               uu____3110 uu____3113 uu____3116);
+                        (let uu____3120 = apply_coercion g e ty1 expect  in
+                         maybe_eta_expand g expect uu____3120)))
   
 let (bv_as_mlty :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -924,10 +928,10 @@ let (bv_as_mlty :
   =
   fun g  ->
     fun bv  ->
-      let uu____3128 = FStar_Extraction_ML_UEnv.lookup_bv g bv  in
-      match uu____3128 with
+      let uu____3132 = FStar_Extraction_ML_UEnv.lookup_bv g bv  in
+      match uu____3132 with
       | FStar_Util.Inl ty_b -> ty_b.FStar_Extraction_ML_UEnv.ty_b_ty
-      | uu____3130 -> FStar_Extraction_ML_Syntax.MLTY_Top
+      | uu____3134 -> FStar_Extraction_ML_Syntax.MLTY_Top
   
 let (extraction_norm_steps_core : FStar_TypeChecker_Env.step Prims.list) =
   [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -941,9 +945,9 @@ let (extraction_norm_steps_core : FStar_TypeChecker_Env.step Prims.list) =
 let (extraction_norm_steps_nbe : FStar_TypeChecker_Env.step Prims.list) =
   FStar_TypeChecker_Env.NBE :: extraction_norm_steps_core 
 let (extraction_norm_steps : unit -> FStar_TypeChecker_Env.step Prims.list) =
-  fun uu____3144  ->
-    let uu____3145 = FStar_Options.use_nbe_for_extraction ()  in
-    if uu____3145
+  fun uu____3148  ->
+    let uu____3149 = FStar_Options.use_nbe_for_extraction ()  in
+    if uu____3149
     then extraction_norm_steps_nbe
     else extraction_norm_steps_core
   
@@ -953,42 +957,42 @@ let (comp_no_args :
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____3166 -> c
-    | FStar_Syntax_Syntax.GTotal uu____3175 -> c
+    | FStar_Syntax_Syntax.Total uu____3170 -> c
+    | FStar_Syntax_Syntax.GTotal uu____3179 -> c
     | FStar_Syntax_Syntax.Comp ct ->
         let effect_args =
           FStar_List.map
-            (fun uu____3211  ->
-               match uu____3211 with
-               | (uu____3226,aq) -> (FStar_Syntax_Syntax.t_unit, aq))
+            (fun uu____3215  ->
+               match uu____3215 with
+               | (uu____3230,aq) -> (FStar_Syntax_Syntax.t_unit, aq))
             ct.FStar_Syntax_Syntax.effect_args
            in
         let ct1 =
-          let uu___550_3239 = ct  in
+          let uu___550_3243 = ct  in
           {
             FStar_Syntax_Syntax.comp_univs =
-              (uu___550_3239.FStar_Syntax_Syntax.comp_univs);
+              (uu___550_3243.FStar_Syntax_Syntax.comp_univs);
             FStar_Syntax_Syntax.effect_name =
-              (uu___550_3239.FStar_Syntax_Syntax.effect_name);
+              (uu___550_3243.FStar_Syntax_Syntax.effect_name);
             FStar_Syntax_Syntax.result_typ =
-              (uu___550_3239.FStar_Syntax_Syntax.result_typ);
+              (uu___550_3243.FStar_Syntax_Syntax.result_typ);
             FStar_Syntax_Syntax.effect_args = effect_args;
             FStar_Syntax_Syntax.flags =
-              (uu___550_3239.FStar_Syntax_Syntax.flags)
+              (uu___550_3243.FStar_Syntax_Syntax.flags)
           }  in
         let c1 =
-          let uu___553_3243 = c  in
+          let uu___553_3247 = c  in
           {
             FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
-            FStar_Syntax_Syntax.pos = (uu___553_3243.FStar_Syntax_Syntax.pos);
+            FStar_Syntax_Syntax.pos = (uu___553_3247.FStar_Syntax_Syntax.pos);
             FStar_Syntax_Syntax.vars =
-              (uu___553_3243.FStar_Syntax_Syntax.vars)
+              (uu___553_3247.FStar_Syntax_Syntax.vars)
           }  in
         c1
   
 let maybe_reify_comp :
-  'uuuuuu3255 .
-    'uuuuuu3255 ->
+  'uuuuuu3259 .
+    'uuuuuu3259 ->
       FStar_TypeChecker_Env.env ->
         FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.term
   =
@@ -996,17 +1000,17 @@ let maybe_reify_comp :
     fun env  ->
       fun c  ->
         let c1 = comp_no_args c  in
-        let uu____3274 =
-          let uu____3276 =
-            let uu____3277 =
+        let uu____3278 =
+          let uu____3280 =
+            let uu____3281 =
               FStar_All.pipe_right c1 FStar_Syntax_Util.comp_effect_name  in
-            FStar_All.pipe_right uu____3277
+            FStar_All.pipe_right uu____3281
               (FStar_TypeChecker_Env.norm_eff_name env)
              in
-          FStar_All.pipe_right uu____3276
+          FStar_All.pipe_right uu____3280
             (FStar_TypeChecker_Env.is_reifiable_effect env)
            in
-        if uu____3274
+        if uu____3278
         then
           FStar_TypeChecker_Env.reify_comp env c1
             FStar_Syntax_Syntax.U_unknown
@@ -1018,54 +1022,54 @@ let rec (translate_term_to_mlty :
   =
   fun g  ->
     fun t0  ->
-      let arg_as_mlty g1 uu____3330 =
-        match uu____3330 with
-        | (a,uu____3338) ->
-            let uu____3343 = is_type g1 a  in
-            if uu____3343
+      let arg_as_mlty g1 uu____3334 =
+        match uu____3334 with
+        | (a,uu____3342) ->
+            let uu____3347 = is_type g1 a  in
+            if uu____3347
             then translate_term_to_mlty g1 a
             else FStar_Extraction_ML_Syntax.MLTY_Erased
          in
       let fv_app_as_mlty g1 fv args =
-        let uu____3364 =
-          let uu____3366 = FStar_Extraction_ML_UEnv.is_fv_type g1 fv  in
-          Prims.op_Negation uu____3366  in
-        if uu____3364
+        let uu____3368 =
+          let uu____3370 = FStar_Extraction_ML_UEnv.is_fv_type g1 fv  in
+          Prims.op_Negation uu____3370  in
+        if uu____3368
         then FStar_Extraction_ML_Syntax.MLTY_Top
         else
-          (let uu____3371 =
-             let uu____3378 =
-               let uu____3387 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1  in
-               FStar_TypeChecker_Env.lookup_lid uu____3387
+          (let uu____3375 =
+             let uu____3382 =
+               let uu____3391 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1  in
+               FStar_TypeChecker_Env.lookup_lid uu____3391
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                 in
-             match uu____3378 with
-             | ((uu____3394,fvty),uu____3396) ->
+             match uu____3382 with
+             | ((uu____3398,fvty),uu____3400) ->
                  let fvty1 =
-                   let uu____3402 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1
+                   let uu____3406 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1
                       in
                    FStar_TypeChecker_Normalize.normalize
                      [FStar_TypeChecker_Env.UnfoldUntil
-                        FStar_Syntax_Syntax.delta_constant] uu____3402 fvty
+                        FStar_Syntax_Syntax.delta_constant] uu____3406 fvty
                     in
                  FStar_Syntax_Util.arrow_formals fvty1
               in
-           match uu____3371 with
-           | (formals,uu____3404) ->
+           match uu____3375 with
+           | (formals,uu____3408) ->
                let mlargs = FStar_List.map (arg_as_mlty g1) args  in
                let mlargs1 =
                  let n_args = FStar_List.length args  in
                  if (FStar_List.length formals) > n_args
                  then
-                   let uu____3441 = FStar_Util.first_N n_args formals  in
-                   match uu____3441 with
-                   | (uu____3470,rest) ->
-                       let uu____3504 =
+                   let uu____3445 = FStar_Util.first_N n_args formals  in
+                   match uu____3445 with
+                   | (uu____3474,rest) ->
+                       let uu____3508 =
                          FStar_List.map
-                           (fun uu____3514  ->
+                           (fun uu____3518  ->
                               FStar_Extraction_ML_Syntax.MLTY_Erased) rest
                           in
-                       FStar_List.append mlargs uu____3504
+                       FStar_List.append mlargs uu____3508
                  else mlargs  in
                let nm =
                  FStar_Extraction_ML_UEnv.mlpath_of_lident g1
@@ -1076,124 +1080,124 @@ let rec (translate_term_to_mlty :
       let aux env t =
         let t1 = FStar_Syntax_Subst.compress t  in
         match t1.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_type uu____3538 ->
+        | FStar_Syntax_Syntax.Tm_type uu____3542 ->
             FStar_Extraction_ML_Syntax.MLTY_Erased
-        | FStar_Syntax_Syntax.Tm_bvar uu____3539 ->
-            let uu____3540 =
-              let uu____3542 = FStar_Syntax_Print.term_to_string t1  in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3542
+        | FStar_Syntax_Syntax.Tm_bvar uu____3543 ->
+            let uu____3544 =
+              let uu____3546 = FStar_Syntax_Print.term_to_string t1  in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3546
                in
-            failwith uu____3540
-        | FStar_Syntax_Syntax.Tm_delayed uu____3545 ->
-            let uu____3560 =
-              let uu____3562 = FStar_Syntax_Print.term_to_string t1  in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3562
+            failwith uu____3544
+        | FStar_Syntax_Syntax.Tm_delayed uu____3549 ->
+            let uu____3564 =
+              let uu____3566 = FStar_Syntax_Print.term_to_string t1  in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3566
                in
-            failwith uu____3560
+            failwith uu____3564
         | FStar_Syntax_Syntax.Tm_unknown  ->
-            let uu____3565 =
-              let uu____3567 = FStar_Syntax_Print.term_to_string t1  in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3567
+            let uu____3569 =
+              let uu____3571 = FStar_Syntax_Print.term_to_string t1  in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3571
                in
-            failwith uu____3565
+            failwith uu____3569
         | FStar_Syntax_Syntax.Tm_lazy i ->
-            let uu____3571 = FStar_Syntax_Util.unfold_lazy i  in
-            translate_term_to_mlty env uu____3571
-        | FStar_Syntax_Syntax.Tm_constant uu____3572 ->
+            let uu____3575 = FStar_Syntax_Util.unfold_lazy i  in
+            translate_term_to_mlty env uu____3575
+        | FStar_Syntax_Syntax.Tm_constant uu____3576 ->
             FStar_Extraction_ML_Syntax.MLTY_Top
-        | FStar_Syntax_Syntax.Tm_quoted uu____3573 ->
+        | FStar_Syntax_Syntax.Tm_quoted uu____3577 ->
             FStar_Extraction_ML_Syntax.MLTY_Top
-        | FStar_Syntax_Syntax.Tm_uvar uu____3580 ->
+        | FStar_Syntax_Syntax.Tm_uvar uu____3584 ->
             FStar_Extraction_ML_Syntax.MLTY_Top
-        | FStar_Syntax_Syntax.Tm_meta (t2,uu____3594) ->
+        | FStar_Syntax_Syntax.Tm_meta (t2,uu____3598) ->
             translate_term_to_mlty env t2
         | FStar_Syntax_Syntax.Tm_refine
-            ({ FStar_Syntax_Syntax.ppname = uu____3599;
-               FStar_Syntax_Syntax.index = uu____3600;
-               FStar_Syntax_Syntax.sort = t2;_},uu____3602)
+            ({ FStar_Syntax_Syntax.ppname = uu____3603;
+               FStar_Syntax_Syntax.index = uu____3604;
+               FStar_Syntax_Syntax.sort = t2;_},uu____3606)
             -> translate_term_to_mlty env t2
-        | FStar_Syntax_Syntax.Tm_uinst (t2,uu____3611) ->
+        | FStar_Syntax_Syntax.Tm_uinst (t2,uu____3615) ->
             translate_term_to_mlty env t2
-        | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____3617,uu____3618) ->
+        | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____3621,uu____3622) ->
             translate_term_to_mlty env t2
         | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
         | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv []
         | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-            let uu____3691 = FStar_Syntax_Subst.open_comp bs c  in
-            (match uu____3691 with
+            let uu____3695 = FStar_Syntax_Subst.open_comp bs c  in
+            (match uu____3695 with
              | (bs1,c1) ->
-                 let uu____3698 = binders_as_ml_binders env bs1  in
-                 (match uu____3698 with
+                 let uu____3702 = binders_as_ml_binders env bs1  in
+                 (match uu____3702 with
                   | (mlbs,env1) ->
                       let t_ret =
-                        let uu____3727 =
-                          let uu____3728 =
+                        let uu____3731 =
+                          let uu____3732 =
                             FStar_Extraction_ML_UEnv.tcenv_of_uenv env1  in
-                          maybe_reify_comp env1 uu____3728 c1  in
-                        translate_term_to_mlty env1 uu____3727  in
+                          maybe_reify_comp env1 uu____3732 c1  in
+                        translate_term_to_mlty env1 uu____3731  in
                       let erase =
                         effect_as_etag env1
                           (FStar_Syntax_Util.comp_effect_name c1)
                          in
-                      let uu____3730 =
+                      let uu____3734 =
                         FStar_List.fold_right
-                          (fun uu____3750  ->
-                             fun uu____3751  ->
-                               match (uu____3750, uu____3751) with
-                               | ((uu____3774,t2),(tag,t')) ->
+                          (fun uu____3754  ->
+                             fun uu____3755  ->
+                               match (uu____3754, uu____3755) with
+                               | ((uu____3778,t2),(tag,t')) ->
                                    (FStar_Extraction_ML_Syntax.E_PURE,
                                      (FStar_Extraction_ML_Syntax.MLTY_Fun
                                         (t2, tag, t')))) mlbs (erase, t_ret)
                          in
-                      (match uu____3730 with | (uu____3789,t2) -> t2)))
+                      (match uu____3734 with | (uu____3793,t2) -> t2)))
         | FStar_Syntax_Syntax.Tm_app (head,args) ->
             let res =
-              let uu____3818 =
-                let uu____3819 = FStar_Syntax_Util.un_uinst head  in
-                uu____3819.FStar_Syntax_Syntax.n  in
-              match uu____3818 with
+              let uu____3822 =
+                let uu____3823 = FStar_Syntax_Util.un_uinst head  in
+                uu____3823.FStar_Syntax_Syntax.n  in
+              match uu____3822 with
               | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
               | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv args
               | FStar_Syntax_Syntax.Tm_app (head1,args') ->
-                  let uu____3850 =
+                  let uu____3854 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_app
                          (head1, (FStar_List.append args' args)))
                       FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
                      in
-                  translate_term_to_mlty env uu____3850
-              | uu____3871 -> FStar_Extraction_ML_Syntax.MLTY_Top  in
+                  translate_term_to_mlty env uu____3854
+              | uu____3875 -> FStar_Extraction_ML_Syntax.MLTY_Top  in
             res
-        | FStar_Syntax_Syntax.Tm_abs (bs,ty,uu____3874) ->
-            let uu____3899 = FStar_Syntax_Subst.open_term bs ty  in
-            (match uu____3899 with
+        | FStar_Syntax_Syntax.Tm_abs (bs,ty,uu____3878) ->
+            let uu____3903 = FStar_Syntax_Subst.open_term bs ty  in
+            (match uu____3903 with
              | (bs1,ty1) ->
-                 let uu____3906 = binders_as_ml_binders env bs1  in
-                 (match uu____3906 with
+                 let uu____3910 = binders_as_ml_binders env bs1  in
+                 (match uu____3910 with
                   | (bts,env1) -> translate_term_to_mlty env1 ty1))
-        | FStar_Syntax_Syntax.Tm_let uu____3934 ->
+        | FStar_Syntax_Syntax.Tm_let uu____3938 ->
             FStar_Extraction_ML_Syntax.MLTY_Top
-        | FStar_Syntax_Syntax.Tm_match uu____3948 ->
+        | FStar_Syntax_Syntax.Tm_match uu____3952 ->
             FStar_Extraction_ML_Syntax.MLTY_Top
          in
       let rec is_top_ty t =
         match t with
         | FStar_Extraction_ML_Syntax.MLTY_Top  -> true
-        | FStar_Extraction_ML_Syntax.MLTY_Named uu____3980 ->
-            let uu____3987 = FStar_Extraction_ML_Util.udelta_unfold g t  in
-            (match uu____3987 with
+        | FStar_Extraction_ML_Syntax.MLTY_Named uu____3984 ->
+            let uu____3991 = FStar_Extraction_ML_Util.udelta_unfold g t  in
+            (match uu____3991 with
              | FStar_Pervasives_Native.None  -> false
              | FStar_Pervasives_Native.Some t1 -> is_top_ty t1)
-        | uu____3993 -> false  in
-      let uu____3995 =
-        let uu____3997 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-        FStar_TypeChecker_Util.must_erase_for_extraction uu____3997 t0  in
-      if uu____3995
+        | uu____3997 -> false  in
+      let uu____3999 =
+        let uu____4001 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
+        FStar_TypeChecker_Util.must_erase_for_extraction uu____4001 t0  in
+      if uu____3999
       then FStar_Extraction_ML_Syntax.MLTY_Erased
       else
         (let mlt = aux g t0  in
-         let uu____4002 = is_top_ty mlt  in
-         if uu____4002 then FStar_Extraction_ML_Syntax.MLTY_Top else mlt)
+         let uu____4006 = is_top_ty mlt  in
+         if uu____4006 then FStar_Extraction_ML_Syntax.MLTY_Top else mlt)
 
 and (binders_as_ml_binders :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1203,23 +1207,23 @@ and (binders_as_ml_binders :
   =
   fun g  ->
     fun bs  ->
-      let uu____4020 =
+      let uu____4024 =
         FStar_All.pipe_right bs
           (FStar_List.fold_left
-             (fun uu____4077  ->
+             (fun uu____4081  ->
                 fun b  ->
-                  match uu____4077 with
+                  match uu____4081 with
                   | (ml_bs,env) ->
-                      let uu____4123 = is_type_binder g b  in
-                      if uu____4123
+                      let uu____4127 = is_type_binder g b  in
+                      if uu____4127
                       then
                         let b1 = FStar_Pervasives_Native.fst b  in
                         let env1 =
                           FStar_Extraction_ML_UEnv.extend_ty env b1 true  in
                         let ml_b =
-                          let uu____4146 =
+                          let uu____4150 =
                             FStar_Extraction_ML_UEnv.lookup_ty env1 b1  in
-                          uu____4146.FStar_Extraction_ML_UEnv.ty_b_name  in
+                          uu____4150.FStar_Extraction_ML_UEnv.ty_b_name  in
                         let ml_b1 =
                           (ml_b, FStar_Extraction_ML_Syntax.ml_unit_ty)  in
                         ((ml_b1 :: ml_bs), env1)
@@ -1229,16 +1233,16 @@ and (binders_as_ml_binders :
                            translate_term_to_mlty env
                              b1.FStar_Syntax_Syntax.sort
                             in
-                         let uu____4172 =
+                         let uu____4176 =
                            FStar_Extraction_ML_UEnv.extend_bv env b1 
                              ([], t) false false
                             in
-                         match uu____4172 with
-                         | (env1,b2,uu____4196) ->
+                         match uu____4176 with
+                         | (env1,b2,uu____4200) ->
                              let ml_b = (b2, t)  in ((ml_b :: ml_bs), env1)))
              ([], g))
          in
-      match uu____4020 with | (ml_bs,env) -> ((FStar_List.rev ml_bs), env)
+      match uu____4024 with | (ml_bs,env) -> ((FStar_List.rev ml_bs), env)
 
 let (term_as_mlty :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1247,9 +1251,9 @@ let (term_as_mlty :
   fun g  ->
     fun t0  ->
       let t =
-        let uu____4281 = extraction_norm_steps ()  in
-        let uu____4282 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-        FStar_TypeChecker_Normalize.normalize uu____4281 uu____4282 t0  in
+        let uu____4285 = extraction_norm_steps ()  in
+        let uu____4286 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
+        FStar_TypeChecker_Normalize.normalize uu____4285 uu____4286 t0  in
       translate_term_to_mlty g t
   
 let (mk_MLE_Seq :
@@ -1264,11 +1268,11 @@ let (mk_MLE_Seq :
       | (FStar_Extraction_ML_Syntax.MLE_Seq
          es1,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (FStar_List.append es1 es2)
-      | (FStar_Extraction_ML_Syntax.MLE_Seq es1,uu____4301) ->
+      | (FStar_Extraction_ML_Syntax.MLE_Seq es1,uu____4305) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (FStar_List.append es1 [e2])
-      | (uu____4304,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
+      | (uu____4308,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (e1 :: es2)
-      | uu____4308 -> FStar_Extraction_ML_Syntax.MLE_Seq [e1; e2]
+      | uu____4312 -> FStar_Extraction_ML_Syntax.MLE_Seq [e1; e2]
   
 let (mk_MLE_Let :
   Prims.bool ->
@@ -1294,16 +1298,16 @@ let (mk_MLE_Let :
                     | FStar_Extraction_ML_Syntax.MLE_Var x when
                         x = lb.FStar_Extraction_ML_Syntax.mllb_name ->
                         (lb.FStar_Extraction_ML_Syntax.mllb_def).FStar_Extraction_ML_Syntax.expr
-                    | uu____4342 when
+                    | uu____4346 when
                         (lb.FStar_Extraction_ML_Syntax.mllb_def).FStar_Extraction_ML_Syntax.expr
                           =
                           FStar_Extraction_ML_Syntax.ml_unit.FStar_Extraction_ML_Syntax.expr
                         -> body.FStar_Extraction_ML_Syntax.expr
-                    | uu____4343 ->
+                    | uu____4347 ->
                         mk_MLE_Seq lb.FStar_Extraction_ML_Syntax.mllb_def
                           body)
-             | uu____4344 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body))
-        | uu____4353 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body)
+             | uu____4348 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body))
+        | uu____4357 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body)
   
 let record_fields :
   'a .
@@ -1324,8 +1328,8 @@ let record_fields :
               fns
              in
           FStar_List.map2
-            (fun uu____4429  ->
-               fun x  -> match uu____4429 with | (p,s) -> (s, x)) fns1 xs
+            (fun uu____4433  ->
+               fun x  -> match uu____4433 with | (p,s) -> (s, x)) fns1 xs
   
 let (resugar_pat :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1338,22 +1342,21 @@ let (resugar_pat :
       fun p  ->
         match p with
         | FStar_Extraction_ML_Syntax.MLP_CTor (d,pats) ->
-            let uu____4481 = FStar_Extraction_ML_Util.is_xtuple d  in
-            (match uu____4481 with
+            let uu____4485 = FStar_Extraction_ML_Util.is_xtuple d  in
+            (match uu____4485 with
              | FStar_Pervasives_Native.Some n ->
                  FStar_Extraction_ML_Syntax.MLP_Tuple pats
-             | uu____4488 ->
+             | uu____4492 ->
                  (match q with
                   | FStar_Pervasives_Native.Some
                       (FStar_Syntax_Syntax.Record_ctor (ty,fns)) ->
                       let path =
-                        FStar_List.map FStar_Ident.text_of_id
-                          ty.FStar_Ident.ns
-                         in
+                        let uu____4506 = FStar_Ident.ns_of_lid ty  in
+                        FStar_List.map FStar_Ident.text_of_id uu____4506  in
                       let fs = record_fields g ty fns pats  in
                       FStar_Extraction_ML_Syntax.MLP_Record (path, fs)
-                  | uu____4521 -> p))
-        | uu____4524 -> p
+                  | uu____4528 -> p))
+        | uu____4531 -> p
   
 let rec (extract_one_pat :
   Prims.bool ->
@@ -1384,200 +1387,200 @@ let rec (extract_one_pat :
                   (if Prims.op_Negation ok
                    then
                      FStar_Extraction_ML_UEnv.debug g
-                       (fun uu____4626  ->
-                          let uu____4627 =
-                            let uu____4629 =
+                       (fun uu____4633  ->
+                          let uu____4634 =
+                            let uu____4636 =
                               FStar_Extraction_ML_UEnv.current_module_of_uenv
                                 g
                                in
                             FStar_Extraction_ML_Code.string_of_mlty
-                              uu____4629 t'
+                              uu____4636 t'
                              in
-                          let uu____4630 =
-                            let uu____4632 =
+                          let uu____4637 =
+                            let uu____4639 =
                               FStar_Extraction_ML_UEnv.current_module_of_uenv
                                 g
                                in
                             FStar_Extraction_ML_Code.string_of_mlty
-                              uu____4632 t
+                              uu____4639 t
                              in
                           FStar_Util.print2
                             "Expected pattern type %s; got pattern type %s\n"
-                            uu____4627 uu____4630)
+                            uu____4634 uu____4637)
                    else ();
                    ok)
                in
             match p.FStar_Syntax_Syntax.v with
             | FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_int
                 (c,swopt)) when
-                let uu____4667 = FStar_Options.codegen ()  in
-                uu____4667 <>
+                let uu____4674 = FStar_Options.codegen ()  in
+                uu____4674 <>
                   (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
                 ->
-                let uu____4672 =
+                let uu____4679 =
                   match swopt with
                   | FStar_Pervasives_Native.None  ->
-                      let uu____4685 =
-                        let uu____4686 =
-                          let uu____4687 =
+                      let uu____4692 =
+                        let uu____4693 =
+                          let uu____4694 =
                             FStar_Extraction_ML_Util.mlconst_of_const
                               p.FStar_Syntax_Syntax.p
                               (FStar_Const.Const_int
                                  (c, FStar_Pervasives_Native.None))
                              in
-                          FStar_Extraction_ML_Syntax.MLE_Const uu____4687  in
+                          FStar_Extraction_ML_Syntax.MLE_Const uu____4694  in
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.ml_int_ty) uu____4686
+                             FStar_Extraction_ML_Syntax.ml_int_ty) uu____4693
                          in
-                      (uu____4685, FStar_Extraction_ML_Syntax.ml_int_ty)
+                      (uu____4692, FStar_Extraction_ML_Syntax.ml_int_ty)
                   | FStar_Pervasives_Native.Some sw ->
                       let source_term =
-                        let uu____4709 =
-                          let uu____4710 =
+                        let uu____4716 =
+                          let uu____4717 =
                             FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-                          uu____4710.FStar_TypeChecker_Env.dsenv  in
+                          uu____4717.FStar_TypeChecker_Env.dsenv  in
                         FStar_ToSyntax_ToSyntax.desugar_machine_integer
-                          uu____4709 c sw FStar_Range.dummyRange
+                          uu____4716 c sw FStar_Range.dummyRange
                          in
-                      let uu____4711 = term_as_mlexpr g source_term  in
-                      (match uu____4711 with
-                       | (mlterm,uu____4723,mlty) -> (mlterm, mlty))
+                      let uu____4718 = term_as_mlexpr g source_term  in
+                      (match uu____4718 with
+                       | (mlterm,uu____4730,mlty) -> (mlterm, mlty))
                    in
-                (match uu____4672 with
+                (match uu____4679 with
                  | (mlc,ml_ty) ->
-                     let uu____4742 = FStar_Extraction_ML_UEnv.new_mlident g
+                     let uu____4749 = FStar_Extraction_ML_UEnv.new_mlident g
                         in
-                     (match uu____4742 with
+                     (match uu____4749 with
                       | (g1,x) ->
                           let when_clause =
-                            let uu____4768 =
-                              let uu____4769 =
-                                let uu____4776 =
-                                  let uu____4779 =
+                            let uu____4775 =
+                              let uu____4776 =
+                                let uu____4783 =
+                                  let uu____4786 =
                                     FStar_All.pipe_left
                                       (FStar_Extraction_ML_Syntax.with_ty
                                          ml_ty)
                                       (FStar_Extraction_ML_Syntax.MLE_Var x)
                                      in
-                                  [uu____4779; mlc]  in
+                                  [uu____4786; mlc]  in
                                 (FStar_Extraction_ML_Util.prims_op_equality,
-                                  uu____4776)
+                                  uu____4783)
                                  in
-                              FStar_Extraction_ML_Syntax.MLE_App uu____4769
+                              FStar_Extraction_ML_Syntax.MLE_App uu____4776
                                in
                             FStar_All.pipe_left
                               (FStar_Extraction_ML_Syntax.with_ty
                                  FStar_Extraction_ML_Syntax.ml_bool_ty)
-                              uu____4768
+                              uu____4775
                              in
-                          let uu____4782 = ok ml_ty  in
+                          let uu____4789 = ok ml_ty  in
                           (g1,
                             (FStar_Pervasives_Native.Some
                                ((FStar_Extraction_ML_Syntax.MLP_Var x),
-                                 [when_clause])), uu____4782)))
+                                 [when_clause])), uu____4789)))
             | FStar_Syntax_Syntax.Pat_constant s ->
                 let t =
-                  let uu____4803 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+                  let uu____4810 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                      in
-                  FStar_TypeChecker_TcTerm.tc_constant uu____4803
+                  FStar_TypeChecker_TcTerm.tc_constant uu____4810
                     FStar_Range.dummyRange s
                    in
                 let mlty = term_as_mlty g t  in
-                let uu____4805 =
-                  let uu____4814 =
-                    let uu____4821 =
-                      let uu____4822 =
+                let uu____4812 =
+                  let uu____4821 =
+                    let uu____4828 =
+                      let uu____4829 =
                         FStar_Extraction_ML_Util.mlconst_of_const
                           p.FStar_Syntax_Syntax.p s
                          in
-                      FStar_Extraction_ML_Syntax.MLP_Const uu____4822  in
-                    (uu____4821, [])  in
-                  FStar_Pervasives_Native.Some uu____4814  in
-                let uu____4831 = ok mlty  in (g, uu____4805, uu____4831)
+                      FStar_Extraction_ML_Syntax.MLP_Const uu____4829  in
+                    (uu____4828, [])  in
+                  FStar_Pervasives_Native.Some uu____4821  in
+                let uu____4838 = ok mlty  in (g, uu____4812, uu____4838)
             | FStar_Syntax_Syntax.Pat_var x ->
                 let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort  in
-                let uu____4844 =
+                let uu____4851 =
                   FStar_Extraction_ML_UEnv.extend_bv g x ([], mlty) false imp
                    in
-                (match uu____4844 with
-                 | (g1,x1,uu____4871) ->
-                     let uu____4874 = ok mlty  in
+                (match uu____4851 with
+                 | (g1,x1,uu____4878) ->
+                     let uu____4881 = ok mlty  in
                      (g1,
                        (if imp
                         then FStar_Pervasives_Native.None
                         else
                           FStar_Pervasives_Native.Some
                             ((FStar_Extraction_ML_Syntax.MLP_Var x1), [])),
-                       uu____4874))
+                       uu____4881))
             | FStar_Syntax_Syntax.Pat_wild x ->
                 let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort  in
-                let uu____4912 =
+                let uu____4919 =
                   FStar_Extraction_ML_UEnv.extend_bv g x ([], mlty) false imp
                    in
-                (match uu____4912 with
-                 | (g1,x1,uu____4939) ->
-                     let uu____4942 = ok mlty  in
+                (match uu____4919 with
+                 | (g1,x1,uu____4946) ->
+                     let uu____4949 = ok mlty  in
                      (g1,
                        (if imp
                         then FStar_Pervasives_Native.None
                         else
                           FStar_Pervasives_Native.Some
                             ((FStar_Extraction_ML_Syntax.MLP_Var x1), [])),
-                       uu____4942))
-            | FStar_Syntax_Syntax.Pat_dot_term uu____4978 ->
+                       uu____4949))
+            | FStar_Syntax_Syntax.Pat_dot_term uu____4985 ->
                 (g, FStar_Pervasives_Native.None, true)
             | FStar_Syntax_Syntax.Pat_cons (f,pats) ->
-                let uu____5021 =
-                  let uu____5030 = FStar_Extraction_ML_UEnv.lookup_fv g f  in
-                  match uu____5030 with
-                  | { FStar_Extraction_ML_UEnv.exp_b_name = uu____5039;
+                let uu____5028 =
+                  let uu____5037 = FStar_Extraction_ML_UEnv.lookup_fv g f  in
+                  match uu____5037 with
+                  | { FStar_Extraction_ML_UEnv.exp_b_name = uu____5046;
                       FStar_Extraction_ML_UEnv.exp_b_expr =
                         {
                           FStar_Extraction_ML_Syntax.expr =
                             FStar_Extraction_ML_Syntax.MLE_Name n;
-                          FStar_Extraction_ML_Syntax.mlty = uu____5041;
-                          FStar_Extraction_ML_Syntax.loc = uu____5042;_};
+                          FStar_Extraction_ML_Syntax.mlty = uu____5048;
+                          FStar_Extraction_ML_Syntax.loc = uu____5049;_};
                       FStar_Extraction_ML_UEnv.exp_b_tscheme = ttys;_} ->
                       (n, ttys)
-                  | uu____5049 -> failwith "Expected a constructor"  in
-                (match uu____5021 with
+                  | uu____5056 -> failwith "Expected a constructor"  in
+                (match uu____5028 with
                  | (d,tys) ->
                      let nTyVars =
                        FStar_List.length (FStar_Pervasives_Native.fst tys)
                         in
-                     let uu____5086 = FStar_Util.first_N nTyVars pats  in
-                     (match uu____5086 with
+                     let uu____5093 = FStar_Util.first_N nTyVars pats  in
+                     (match uu____5093 with
                       | (tysVarPats,restPats) ->
                           let f_ty_opt =
                             try
-                              (fun uu___852_5190  ->
+                              (fun uu___852_5197  ->
                                  match () with
                                  | () ->
                                      let mlty_args =
                                        FStar_All.pipe_right tysVarPats
                                          (FStar_List.map
-                                            (fun uu____5221  ->
-                                               match uu____5221 with
-                                               | (p1,uu____5228) ->
+                                            (fun uu____5228  ->
+                                               match uu____5228 with
+                                               | (p1,uu____5235) ->
                                                    (match p1.FStar_Syntax_Syntax.v
                                                     with
                                                     | FStar_Syntax_Syntax.Pat_dot_term
-                                                        (uu____5231,t) ->
+                                                        (uu____5238,t) ->
                                                         term_as_mlty g t
-                                                    | uu____5237 ->
+                                                    | uu____5244 ->
                                                         (FStar_Extraction_ML_UEnv.debug
                                                            g
-                                                           (fun uu____5241 
+                                                           (fun uu____5248 
                                                               ->
-                                                              let uu____5242
+                                                              let uu____5249
                                                                 =
                                                                 FStar_Syntax_Print.pat_to_string
                                                                   p1
                                                                  in
                                                               FStar_Util.print1
                                                                 "Pattern %s is not extractable"
-                                                                uu____5242);
+                                                                uu____5249);
                                                          FStar_Exn.raise
                                                            Un_extractable))))
                                         in
@@ -1585,39 +1588,39 @@ let rec (extract_one_pat :
                                        FStar_Extraction_ML_Util.subst tys
                                          mlty_args
                                         in
-                                     let uu____5246 =
+                                     let uu____5253 =
                                        FStar_Extraction_ML_Util.uncurry_mlty_fun
                                          f_ty
                                         in
-                                     FStar_Pervasives_Native.Some uu____5246)
+                                     FStar_Pervasives_Native.Some uu____5253)
                                 ()
                             with
                             | Un_extractable  -> FStar_Pervasives_Native.None
                              in
-                          let uu____5275 =
+                          let uu____5282 =
                             FStar_Util.fold_map
                               (fun g1  ->
-                                 fun uu____5312  ->
-                                   match uu____5312 with
+                                 fun uu____5319  ->
+                                   match uu____5319 with
                                    | (p1,imp1) ->
-                                       let uu____5334 =
+                                       let uu____5341 =
                                          extract_one_pat true g1 p1
                                            FStar_Pervasives_Native.None
                                            term_as_mlexpr
                                           in
-                                       (match uu____5334 with
-                                        | (g2,p2,uu____5365) -> (g2, p2))) g
+                                       (match uu____5341 with
+                                        | (g2,p2,uu____5372) -> (g2, p2))) g
                               tysVarPats
                              in
-                          (match uu____5275 with
+                          (match uu____5282 with
                            | (g1,tyMLPats) ->
-                               let uu____5429 =
+                               let uu____5436 =
                                  FStar_Util.fold_map
-                                   (fun uu____5494  ->
-                                      fun uu____5495  ->
-                                        match (uu____5494, uu____5495) with
+                                   (fun uu____5501  ->
+                                      fun uu____5502  ->
+                                        match (uu____5501, uu____5502) with
                                         | ((g2,f_ty_opt1),(p1,imp1)) ->
-                                            let uu____5593 =
+                                            let uu____5600 =
                                               match f_ty_opt1 with
                                               | FStar_Pervasives_Native.Some
                                                   (hd::rest,res) ->
@@ -1625,64 +1628,64 @@ let rec (extract_one_pat :
                                                       (rest, res)),
                                                     (FStar_Pervasives_Native.Some
                                                        hd))
-                                              | uu____5653 ->
+                                              | uu____5660 ->
                                                   (FStar_Pervasives_Native.None,
                                                     FStar_Pervasives_Native.None)
                                                in
-                                            (match uu____5593 with
+                                            (match uu____5600 with
                                              | (f_ty_opt2,expected_ty) ->
-                                                 let uu____5724 =
+                                                 let uu____5731 =
                                                    extract_one_pat false g2
                                                      p1 expected_ty
                                                      term_as_mlexpr
                                                     in
-                                                 (match uu____5724 with
-                                                  | (g3,p2,uu____5767) ->
+                                                 (match uu____5731 with
+                                                  | (g3,p2,uu____5774) ->
                                                       ((g3, f_ty_opt2), p2))))
                                    (g1, f_ty_opt) restPats
                                   in
-                               (match uu____5429 with
+                               (match uu____5436 with
                                 | ((g2,f_ty_opt1),restMLPats) ->
-                                    let uu____5888 =
-                                      let uu____5899 =
+                                    let uu____5895 =
+                                      let uu____5906 =
                                         FStar_All.pipe_right
                                           (FStar_List.append tyMLPats
                                              restMLPats)
                                           (FStar_List.collect
-                                             (fun uu___0_5950  ->
-                                                match uu___0_5950 with
+                                             (fun uu___0_5957  ->
+                                                match uu___0_5957 with
                                                 | FStar_Pervasives_Native.Some
                                                     x -> [x]
-                                                | uu____5992 -> []))
+                                                | uu____5999 -> []))
                                          in
-                                      FStar_All.pipe_right uu____5899
+                                      FStar_All.pipe_right uu____5906
                                         FStar_List.split
                                        in
-                                    (match uu____5888 with
+                                    (match uu____5895 with
                                      | (mlPats,when_clauses) ->
                                          let pat_ty_compat =
                                            match f_ty_opt1 with
                                            | FStar_Pervasives_Native.Some
                                                ([],t) -> ok t
-                                           | uu____6068 -> false  in
-                                         let uu____6078 =
-                                           let uu____6087 =
-                                             let uu____6094 =
+                                           | uu____6075 -> false  in
+                                         let uu____6085 =
+                                           let uu____6094 =
+                                             let uu____6101 =
                                                resugar_pat g2
                                                  f.FStar_Syntax_Syntax.fv_qual
                                                  (FStar_Extraction_ML_Syntax.MLP_CTor
                                                     (d, mlPats))
                                                 in
-                                             let uu____6097 =
+                                             let uu____6104 =
                                                FStar_All.pipe_right
                                                  when_clauses
                                                  FStar_List.flatten
                                                 in
-                                             (uu____6094, uu____6097)  in
+                                             (uu____6101, uu____6104)  in
                                            FStar_Pervasives_Native.Some
-                                             uu____6087
+                                             uu____6094
                                             in
-                                         (g2, uu____6078, pat_ty_compat))))))
+                                         (g2, uu____6085, pat_ty_compat))))))
   
 let (extract_pat :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1704,26 +1707,26 @@ let (extract_pat :
       fun expected_t  ->
         fun term_as_mlexpr  ->
           let extract_one_pat1 g1 p1 expected_t1 =
-            let uu____6229 =
+            let uu____6236 =
               extract_one_pat false g1 p1 expected_t1 term_as_mlexpr  in
-            match uu____6229 with
+            match uu____6236 with
             | (g2,FStar_Pervasives_Native.Some (x,v),b) -> (g2, (x, v), b)
-            | uu____6292 ->
+            | uu____6299 ->
                 failwith "Impossible: Unable to translate pattern"
              in
           let mk_when_clause whens =
             match whens with
             | [] -> FStar_Pervasives_Native.None
             | hd::tl ->
-                let uu____6340 =
+                let uu____6347 =
                   FStar_List.fold_left FStar_Extraction_ML_Util.conjoin hd tl
                    in
-                FStar_Pervasives_Native.Some uu____6340
+                FStar_Pervasives_Native.Some uu____6347
              in
-          let uu____6341 =
+          let uu____6348 =
             extract_one_pat1 g p (FStar_Pervasives_Native.Some expected_t)
              in
-          match uu____6341 with
+          match uu____6348 with
           | (g1,(p1,whens),b) ->
               let when_clause = mk_when_clause whens  in
               (g1, [(p1, when_clause)], b)
@@ -1741,72 +1744,72 @@ let (maybe_eta_data_and_project_record :
         fun mlAppExpr  ->
           let rec eta_args g1 more_args t =
             match t with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun (t0,uu____6506,t1) ->
-                let uu____6508 = FStar_Extraction_ML_UEnv.new_mlident g1  in
-                (match uu____6508 with
+            | FStar_Extraction_ML_Syntax.MLTY_Fun (t0,uu____6513,t1) ->
+                let uu____6515 = FStar_Extraction_ML_UEnv.new_mlident g1  in
+                (match uu____6515 with
                  | (g2,x) ->
-                     let uu____6533 =
-                       let uu____6545 =
-                         let uu____6555 =
+                     let uu____6540 =
+                       let uu____6552 =
+                         let uu____6562 =
                            FStar_All.pipe_left
                              (FStar_Extraction_ML_Syntax.with_ty t0)
                              (FStar_Extraction_ML_Syntax.MLE_Var x)
                             in
-                         ((x, t0), uu____6555)  in
-                       uu____6545 :: more_args  in
-                     eta_args g2 uu____6533 t1)
-            | FStar_Extraction_ML_Syntax.MLTY_Named (uu____6571,uu____6572)
+                         ((x, t0), uu____6562)  in
+                       uu____6552 :: more_args  in
+                     eta_args g2 uu____6540 t1)
+            | FStar_Extraction_ML_Syntax.MLTY_Named (uu____6578,uu____6579)
                 -> ((FStar_List.rev more_args), t)
-            | uu____6597 ->
-                let uu____6598 =
-                  let uu____6600 =
-                    let uu____6602 =
+            | uu____6604 ->
+                let uu____6605 =
+                  let uu____6607 =
+                    let uu____6609 =
                       FStar_Extraction_ML_UEnv.current_module_of_uenv g1  in
-                    FStar_Extraction_ML_Code.string_of_mlexpr uu____6602
+                    FStar_Extraction_ML_Code.string_of_mlexpr uu____6609
                       mlAppExpr
                      in
-                  let uu____6603 =
-                    let uu____6605 =
+                  let uu____6610 =
+                    let uu____6612 =
                       FStar_Extraction_ML_UEnv.current_module_of_uenv g1  in
-                    FStar_Extraction_ML_Code.string_of_mlty uu____6605 t  in
+                    FStar_Extraction_ML_Code.string_of_mlty uu____6612 t  in
                   FStar_Util.format2
                     "Impossible: Head type is not an arrow: (%s : %s)"
-                    uu____6600 uu____6603
+                    uu____6607 uu____6610
                    in
-                failwith uu____6598
+                failwith uu____6605
              in
           let as_record qual1 e =
             match ((e.FStar_Extraction_ML_Syntax.expr), qual1) with
             | (FStar_Extraction_ML_Syntax.MLE_CTor
-               (uu____6639,args),FStar_Pervasives_Native.Some
+               (uu____6646,args),FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Record_ctor (tyname,fields))) ->
                 let path =
-                  FStar_List.map FStar_Ident.text_of_id tyname.FStar_Ident.ns
-                   in
+                  let uu____6664 = FStar_Ident.ns_of_lid tyname  in
+                  FStar_List.map FStar_Ident.text_of_id uu____6664  in
                 let fields1 = record_fields g tyname fields args  in
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      e.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_Record (path, fields1))
-            | uu____6676 -> e  in
+            | uu____6686 -> e  in
           let resugar_and_maybe_eta qual1 e =
-            let uu____6698 = eta_args g [] residualType  in
-            match uu____6698 with
+            let uu____6708 = eta_args g [] residualType  in
+            match uu____6708 with
             | (eargs,tres) ->
                 (match eargs with
                  | [] ->
-                     let uu____6756 = as_record qual1 e  in
-                     FStar_Extraction_ML_Util.resugar_exp uu____6756
-                 | uu____6757 ->
-                     let uu____6769 = FStar_List.unzip eargs  in
-                     (match uu____6769 with
+                     let uu____6766 = as_record qual1 e  in
+                     FStar_Extraction_ML_Util.resugar_exp uu____6766
+                 | uu____6767 ->
+                     let uu____6779 = FStar_List.unzip eargs  in
+                     (match uu____6779 with
                       | (binders,eargs1) ->
                           (match e.FStar_Extraction_ML_Syntax.expr with
                            | FStar_Extraction_ML_Syntax.MLE_CTor (head,args)
                                ->
                                let body =
-                                 let uu____6815 =
-                                   let uu____6816 =
+                                 let uu____6825 =
+                                   let uu____6826 =
                                      FStar_All.pipe_left
                                        (FStar_Extraction_ML_Syntax.with_ty
                                           tres)
@@ -1815,54 +1818,54 @@ let (maybe_eta_data_and_project_record :
                                             (FStar_List.append args eargs1)))
                                       in
                                    FStar_All.pipe_left (as_record qual1)
-                                     uu____6816
+                                     uu____6826
                                     in
                                  FStar_All.pipe_left
                                    FStar_Extraction_ML_Util.resugar_exp
-                                   uu____6815
+                                   uu____6825
                                   in
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty
                                     e.FStar_Extraction_ML_Syntax.mlty)
                                  (FStar_Extraction_ML_Syntax.MLE_Fun
                                     (binders, body))
-                           | uu____6826 ->
+                           | uu____6836 ->
                                failwith "Impossible: Not a constructor")))
              in
           match ((mlAppExpr.FStar_Extraction_ML_Syntax.expr), qual) with
-          | (uu____6830,FStar_Pervasives_Native.None ) -> mlAppExpr
+          | (uu____6840,FStar_Pervasives_Native.None ) -> mlAppExpr
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6834;
-                FStar_Extraction_ML_Syntax.loc = uu____6835;_},mle::args),FStar_Pervasives_Native.Some
+                FStar_Extraction_ML_Syntax.mlty = uu____6844;
+                FStar_Extraction_ML_Syntax.loc = uu____6845;_},mle::args),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Record_projector (constrname,f))) ->
               let fn =
-                let uu____6847 =
-                  let uu____6852 =
-                    let uu____6853 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+                let uu____6857 =
+                  let uu____6862 =
+                    let uu____6863 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                        in
-                    FStar_TypeChecker_Env.typ_of_datacon uu____6853
+                    FStar_TypeChecker_Env.typ_of_datacon uu____6863
                       constrname
                      in
-                  (uu____6852, f)  in
+                  (uu____6862, f)  in
                 FStar_Extraction_ML_UEnv.lookup_record_field_name g
-                  uu____6847
+                  uu____6857
                  in
               let proj = FStar_Extraction_ML_Syntax.MLE_Proj (mle, fn)  in
               let e =
                 match args with
                 | [] -> proj
-                | uu____6856 ->
-                    let uu____6859 =
-                      let uu____6866 =
+                | uu____6866 ->
+                    let uu____6869 =
+                      let uu____6876 =
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
                              FStar_Extraction_ML_Syntax.MLTY_Top) proj
                          in
-                      (uu____6866, args)  in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____6859
+                      (uu____6876, args)  in
+                    FStar_Extraction_ML_Syntax.MLE_App uu____6869
                  in
               FStar_Extraction_ML_Syntax.with_ty
                 mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
@@ -1873,36 +1876,36 @@ let (maybe_eta_data_and_project_record :
                   ({
                      FStar_Extraction_ML_Syntax.expr =
                        FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                     FStar_Extraction_ML_Syntax.mlty = uu____6870;
-                     FStar_Extraction_ML_Syntax.loc = uu____6871;_},uu____6872);
-                FStar_Extraction_ML_Syntax.mlty = uu____6873;
-                FStar_Extraction_ML_Syntax.loc = uu____6874;_},mle::args),FStar_Pervasives_Native.Some
+                     FStar_Extraction_ML_Syntax.mlty = uu____6880;
+                     FStar_Extraction_ML_Syntax.loc = uu____6881;_},uu____6882);
+                FStar_Extraction_ML_Syntax.mlty = uu____6883;
+                FStar_Extraction_ML_Syntax.loc = uu____6884;_},mle::args),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Record_projector (constrname,f))) ->
               let fn =
-                let uu____6890 =
-                  let uu____6895 =
-                    let uu____6896 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+                let uu____6900 =
+                  let uu____6905 =
+                    let uu____6906 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                        in
-                    FStar_TypeChecker_Env.typ_of_datacon uu____6896
+                    FStar_TypeChecker_Env.typ_of_datacon uu____6906
                       constrname
                      in
-                  (uu____6895, f)  in
+                  (uu____6905, f)  in
                 FStar_Extraction_ML_UEnv.lookup_record_field_name g
-                  uu____6890
+                  uu____6900
                  in
               let proj = FStar_Extraction_ML_Syntax.MLE_Proj (mle, fn)  in
               let e =
                 match args with
                 | [] -> proj
-                | uu____6899 ->
-                    let uu____6902 =
-                      let uu____6909 =
+                | uu____6909 ->
+                    let uu____6912 =
+                      let uu____6919 =
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
                              FStar_Extraction_ML_Syntax.MLTY_Top) proj
                          in
-                      (uu____6909, args)  in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____6902
+                      (uu____6919, args)  in
+                    FStar_Extraction_ML_Syntax.MLE_App uu____6912
                  in
               FStar_Extraction_ML_Syntax.with_ty
                 mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
@@ -1910,30 +1913,30 @@ let (maybe_eta_data_and_project_record :
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6913;
-                FStar_Extraction_ML_Syntax.loc = uu____6914;_},mlargs),FStar_Pervasives_Native.Some
+                FStar_Extraction_ML_Syntax.mlty = uu____6923;
+                FStar_Extraction_ML_Syntax.loc = uu____6924;_},mlargs),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Data_ctor )) ->
-              let uu____6922 =
+              let uu____6932 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6922
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6932
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6926;
-                FStar_Extraction_ML_Syntax.loc = uu____6927;_},mlargs),FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____6929)) ->
-              let uu____6942 =
+                FStar_Extraction_ML_Syntax.mlty = uu____6936;
+                FStar_Extraction_ML_Syntax.loc = uu____6937;_},mlargs),FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Record_ctor uu____6939)) ->
+              let uu____6952 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6942
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6952
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -1941,18 +1944,18 @@ let (maybe_eta_data_and_project_record :
                   ({
                      FStar_Extraction_ML_Syntax.expr =
                        FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                     FStar_Extraction_ML_Syntax.mlty = uu____6946;
-                     FStar_Extraction_ML_Syntax.loc = uu____6947;_},uu____6948);
-                FStar_Extraction_ML_Syntax.mlty = uu____6949;
-                FStar_Extraction_ML_Syntax.loc = uu____6950;_},mlargs),FStar_Pervasives_Native.Some
+                     FStar_Extraction_ML_Syntax.mlty = uu____6956;
+                     FStar_Extraction_ML_Syntax.loc = uu____6957;_},uu____6958);
+                FStar_Extraction_ML_Syntax.mlty = uu____6959;
+                FStar_Extraction_ML_Syntax.loc = uu____6960;_},mlargs),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Data_ctor )) ->
-              let uu____6962 =
+              let uu____6972 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6962
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6972
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -1960,67 +1963,67 @@ let (maybe_eta_data_and_project_record :
                   ({
                      FStar_Extraction_ML_Syntax.expr =
                        FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                     FStar_Extraction_ML_Syntax.mlty = uu____6966;
-                     FStar_Extraction_ML_Syntax.loc = uu____6967;_},uu____6968);
-                FStar_Extraction_ML_Syntax.mlty = uu____6969;
-                FStar_Extraction_ML_Syntax.loc = uu____6970;_},mlargs),FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____6972)) ->
-              let uu____6989 =
+                     FStar_Extraction_ML_Syntax.mlty = uu____6976;
+                     FStar_Extraction_ML_Syntax.loc = uu____6977;_},uu____6978);
+                FStar_Extraction_ML_Syntax.mlty = uu____6979;
+                FStar_Extraction_ML_Syntax.loc = uu____6980;_},mlargs),FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Record_ctor uu____6982)) ->
+              let uu____6999 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6989
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6999
           | (FStar_Extraction_ML_Syntax.MLE_Name
              mlp,FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor
              )) ->
-              let uu____6995 =
+              let uu____7005 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6995
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____7005
           | (FStar_Extraction_ML_Syntax.MLE_Name
              mlp,FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____6999)) ->
-              let uu____7008 =
+             (FStar_Syntax_Syntax.Record_ctor uu____7009)) ->
+              let uu____7018 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____7008
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____7018
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____7012;
-                FStar_Extraction_ML_Syntax.loc = uu____7013;_},uu____7014),FStar_Pervasives_Native.Some
+                FStar_Extraction_ML_Syntax.mlty = uu____7022;
+                FStar_Extraction_ML_Syntax.loc = uu____7023;_},uu____7024),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Data_ctor )) ->
-              let uu____7021 =
+              let uu____7031 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____7021
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____7031
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____7025;
-                FStar_Extraction_ML_Syntax.loc = uu____7026;_},uu____7027),FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____7028)) ->
-              let uu____7041 =
+                FStar_Extraction_ML_Syntax.mlty = uu____7035;
+                FStar_Extraction_ML_Syntax.loc = uu____7036;_},uu____7037),FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Record_ctor uu____7038)) ->
+              let uu____7051 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____7041
-          | uu____7044 -> mlAppExpr
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____7051
+          | uu____7054 -> mlAppExpr
   
 let (maybe_promote_effect :
   FStar_Extraction_ML_Syntax.mlexpr ->
@@ -2041,7 +2044,7 @@ let (maybe_promote_effect :
            ,FStar_Extraction_ML_Syntax.MLTY_Erased ) ->
             (FStar_Extraction_ML_Syntax.ml_unit,
               FStar_Extraction_ML_Syntax.E_PURE)
-        | uu____7075 -> (ml_e, tag)
+        | uu____7085 -> (ml_e, tag)
   
 let (extract_lb_sig :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -2053,27 +2056,27 @@ let (extract_lb_sig :
   =
   fun g  ->
     fun lbs  ->
-      let maybe_generalize uu____7136 =
-        match uu____7136 with
+      let maybe_generalize uu____7146 =
+        match uu____7146 with
         | { FStar_Syntax_Syntax.lbname = lbname_;
-            FStar_Syntax_Syntax.lbunivs = uu____7157;
+            FStar_Syntax_Syntax.lbunivs = uu____7167;
             FStar_Syntax_Syntax.lbtyp = lbtyp;
             FStar_Syntax_Syntax.lbeff = lbeff;
             FStar_Syntax_Syntax.lbdef = lbdef;
             FStar_Syntax_Syntax.lbattrs = lbattrs;
-            FStar_Syntax_Syntax.lbpos = uu____7162;_} ->
+            FStar_Syntax_Syntax.lbpos = uu____7172;_} ->
             let f_e = effect_as_etag g lbeff  in
             let lbtyp1 = FStar_Syntax_Subst.compress lbtyp  in
-            let no_gen uu____7243 =
+            let no_gen uu____7253 =
               let expected_t = term_as_mlty g lbtyp1  in
               (lbname_, f_e, (lbtyp1, ([], ([], expected_t))), false, lbdef)
                in
-            let uu____7320 =
-              let uu____7322 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-              FStar_TypeChecker_Util.must_erase_for_extraction uu____7322
+            let uu____7330 =
+              let uu____7332 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
+              FStar_TypeChecker_Util.must_erase_for_extraction uu____7332
                 lbtyp1
                in
-            if uu____7320
+            if uu____7330
             then
               (lbname_, f_e,
                 (lbtyp1, ([], ([], FStar_Extraction_ML_Syntax.MLTY_Erased))),
@@ -2081,71 +2084,71 @@ let (extract_lb_sig :
             else
               (match lbtyp1.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_arrow (bs,c) when
-                   let uu____7407 = FStar_List.hd bs  in
-                   FStar_All.pipe_right uu____7407 (is_type_binder g) ->
-                   let uu____7429 = FStar_Syntax_Subst.open_comp bs c  in
-                   (match uu____7429 with
+                   let uu____7417 = FStar_List.hd bs  in
+                   FStar_All.pipe_right uu____7417 (is_type_binder g) ->
+                   let uu____7439 = FStar_Syntax_Subst.open_comp bs c  in
+                   (match uu____7439 with
                     | (bs1,c1) ->
-                        let uu____7455 =
-                          let uu____7468 =
+                        let uu____7465 =
+                          let uu____7478 =
                             FStar_Util.prefix_until
                               (fun x  ->
-                                 let uu____7514 = is_type_binder g x  in
-                                 Prims.op_Negation uu____7514) bs1
+                                 let uu____7524 = is_type_binder g x  in
+                                 Prims.op_Negation uu____7524) bs1
                              in
-                          match uu____7468 with
+                          match uu____7478 with
                           | FStar_Pervasives_Native.None  ->
                               (bs1, (FStar_Syntax_Util.comp_result c1))
                           | FStar_Pervasives_Native.Some (bs2,b,rest) ->
-                              let uu____7641 =
+                              let uu____7651 =
                                 FStar_Syntax_Util.arrow (b :: rest) c1  in
-                              (bs2, uu____7641)
+                              (bs2, uu____7651)
                            in
-                        (match uu____7455 with
+                        (match uu____7465 with
                          | (tbinders,tbody) ->
                              let n_tbinders = FStar_List.length tbinders  in
                              let lbdef1 =
-                               let uu____7703 = normalize_abs lbdef  in
-                               FStar_All.pipe_right uu____7703
+                               let uu____7713 = normalize_abs lbdef  in
+                               FStar_All.pipe_right uu____7713
                                  FStar_Syntax_Util.unmeta
                                 in
                              (match lbdef1.FStar_Syntax_Syntax.n with
                               | FStar_Syntax_Syntax.Tm_abs (bs2,body,copt) ->
-                                  let uu____7752 =
+                                  let uu____7762 =
                                     FStar_Syntax_Subst.open_term bs2 body  in
-                                  (match uu____7752 with
+                                  (match uu____7762 with
                                    | (bs3,body1) ->
                                        if
                                          n_tbinders <=
                                            (FStar_List.length bs3)
                                        then
-                                         let uu____7804 =
+                                         let uu____7814 =
                                            FStar_Util.first_N n_tbinders bs3
                                             in
-                                         (match uu____7804 with
+                                         (match uu____7814 with
                                           | (targs,rest_args) ->
                                               let expected_source_ty =
                                                 let s =
                                                   FStar_List.map2
-                                                    (fun uu____7907  ->
-                                                       fun uu____7908  ->
-                                                         match (uu____7907,
-                                                                 uu____7908)
+                                                    (fun uu____7917  ->
+                                                       fun uu____7918  ->
+                                                         match (uu____7917,
+                                                                 uu____7918)
                                                          with
-                                                         | ((x,uu____7934),
-                                                            (y,uu____7936))
+                                                         | ((x,uu____7944),
+                                                            (y,uu____7946))
                                                              ->
-                                                             let uu____7957 =
-                                                               let uu____7964
+                                                             let uu____7967 =
+                                                               let uu____7974
                                                                  =
                                                                  FStar_Syntax_Syntax.bv_to_name
                                                                    y
                                                                   in
                                                                (x,
-                                                                 uu____7964)
+                                                                 uu____7974)
                                                                 in
                                                              FStar_Syntax_Syntax.NT
-                                                               uu____7957)
+                                                               uu____7967)
                                                     tbinders targs
                                                    in
                                                 FStar_Syntax_Subst.subst s
@@ -2154,9 +2157,9 @@ let (extract_lb_sig :
                                               let env =
                                                 FStar_List.fold_left
                                                   (fun env  ->
-                                                     fun uu____7981  ->
-                                                       match uu____7981 with
-                                                       | (a,uu____7989) ->
+                                                     fun uu____7991  ->
+                                                       match uu____7991 with
+                                                       | (a,uu____7999) ->
                                                            FStar_Extraction_ML_UEnv.extend_ty
                                                              env a false) g
                                                   targs
@@ -2166,43 +2169,43 @@ let (extract_lb_sig :
                                                   expected_source_ty
                                                  in
                                               let polytype =
-                                                let uu____8001 =
+                                                let uu____8011 =
                                                   FStar_All.pipe_right targs
                                                     (FStar_List.map
-                                                       (fun uu____8021  ->
-                                                          match uu____8021
+                                                       (fun uu____8031  ->
+                                                          match uu____8031
                                                           with
-                                                          | (x,uu____8030) ->
-                                                              let uu____8035
+                                                          | (x,uu____8040) ->
+                                                              let uu____8045
                                                                 =
                                                                 FStar_Extraction_ML_UEnv.lookup_ty
                                                                   env x
                                                                  in
-                                                              uu____8035.FStar_Extraction_ML_UEnv.ty_b_name))
+                                                              uu____8045.FStar_Extraction_ML_UEnv.ty_b_name))
                                                    in
-                                                (uu____8001, expected_t)  in
+                                                (uu____8011, expected_t)  in
                                               let add_unit =
                                                 match rest_args with
                                                 | [] ->
-                                                    (let uu____8047 =
+                                                    (let uu____8057 =
                                                        is_fstar_value body1
                                                         in
                                                      Prims.op_Negation
-                                                       uu____8047)
+                                                       uu____8057)
                                                       ||
-                                                      (let uu____8050 =
+                                                      (let uu____8060 =
                                                          FStar_Syntax_Util.is_pure_comp
                                                            c1
                                                           in
                                                        Prims.op_Negation
-                                                         uu____8050)
-                                                | uu____8052 -> false  in
+                                                         uu____8060)
+                                                | uu____8062 -> false  in
                                               let rest_args1 =
                                                 if add_unit
                                                 then
-                                                  let uu____8064 =
+                                                  let uu____8074 =
                                                     unit_binder ()  in
-                                                  uu____8064 :: rest_args
+                                                  uu____8074 :: rest_args
                                                 else rest_args  in
                                               let polytype1 =
                                                 if add_unit
@@ -2219,43 +2222,43 @@ let (extract_lb_sig :
                                                 add_unit, body2))
                                        else
                                          failwith "Not enough type binders")
-                              | FStar_Syntax_Syntax.Tm_uinst uu____8121 ->
+                              | FStar_Syntax_Syntax.Tm_uinst uu____8131 ->
                                   let env =
                                     FStar_List.fold_left
                                       (fun env  ->
-                                         fun uu____8140  ->
-                                           match uu____8140 with
-                                           | (a,uu____8148) ->
+                                         fun uu____8150  ->
+                                           match uu____8150 with
+                                           | (a,uu____8158) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
                                                  env a false) g tbinders
                                      in
                                   let expected_t = term_as_mlty env tbody  in
                                   let polytype =
-                                    let uu____8160 =
+                                    let uu____8170 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____8180  ->
-                                              match uu____8180 with
-                                              | (x,uu____8189) ->
-                                                  let uu____8194 =
+                                           (fun uu____8190  ->
+                                              match uu____8190 with
+                                              | (x,uu____8199) ->
+                                                  let uu____8204 =
                                                     FStar_Extraction_ML_UEnv.lookup_ty
                                                       env x
                                                      in
-                                                  uu____8194.FStar_Extraction_ML_UEnv.ty_b_name))
+                                                  uu____8204.FStar_Extraction_ML_UEnv.ty_b_name))
                                        in
-                                    (uu____8160, expected_t)  in
+                                    (uu____8170, expected_t)  in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____8234  ->
-                                            match uu____8234 with
-                                            | (bv,uu____8242) ->
-                                                let uu____8247 =
+                                         (fun uu____8244  ->
+                                            match uu____8244 with
+                                            | (bv,uu____8252) ->
+                                                let uu____8257 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____8247
+                                                  uu____8257
                                                   FStar_Syntax_Syntax.as_arg))
                                      in
                                   let e =
@@ -2267,43 +2270,43 @@ let (extract_lb_sig :
                                      in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | FStar_Syntax_Syntax.Tm_fvar uu____8277 ->
+                              | FStar_Syntax_Syntax.Tm_fvar uu____8287 ->
                                   let env =
                                     FStar_List.fold_left
                                       (fun env  ->
-                                         fun uu____8290  ->
-                                           match uu____8290 with
-                                           | (a,uu____8298) ->
+                                         fun uu____8300  ->
+                                           match uu____8300 with
+                                           | (a,uu____8308) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
                                                  env a false) g tbinders
                                      in
                                   let expected_t = term_as_mlty env tbody  in
                                   let polytype =
-                                    let uu____8310 =
+                                    let uu____8320 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____8330  ->
-                                              match uu____8330 with
-                                              | (x,uu____8339) ->
-                                                  let uu____8344 =
+                                           (fun uu____8340  ->
+                                              match uu____8340 with
+                                              | (x,uu____8349) ->
+                                                  let uu____8354 =
                                                     FStar_Extraction_ML_UEnv.lookup_ty
                                                       env x
                                                      in
-                                                  uu____8344.FStar_Extraction_ML_UEnv.ty_b_name))
+                                                  uu____8354.FStar_Extraction_ML_UEnv.ty_b_name))
                                        in
-                                    (uu____8310, expected_t)  in
+                                    (uu____8320, expected_t)  in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____8384  ->
-                                            match uu____8384 with
-                                            | (bv,uu____8392) ->
-                                                let uu____8397 =
+                                         (fun uu____8394  ->
+                                            match uu____8394 with
+                                            | (bv,uu____8402) ->
+                                                let uu____8407 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____8397
+                                                  uu____8407
                                                   FStar_Syntax_Syntax.as_arg))
                                      in
                                   let e =
@@ -2315,43 +2318,43 @@ let (extract_lb_sig :
                                      in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | FStar_Syntax_Syntax.Tm_name uu____8427 ->
+                              | FStar_Syntax_Syntax.Tm_name uu____8437 ->
                                   let env =
                                     FStar_List.fold_left
                                       (fun env  ->
-                                         fun uu____8440  ->
-                                           match uu____8440 with
-                                           | (a,uu____8448) ->
+                                         fun uu____8450  ->
+                                           match uu____8450 with
+                                           | (a,uu____8458) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
                                                  env a false) g tbinders
                                      in
                                   let expected_t = term_as_mlty env tbody  in
                                   let polytype =
-                                    let uu____8460 =
+                                    let uu____8470 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____8480  ->
-                                              match uu____8480 with
-                                              | (x,uu____8489) ->
-                                                  let uu____8494 =
+                                           (fun uu____8490  ->
+                                              match uu____8490 with
+                                              | (x,uu____8499) ->
+                                                  let uu____8504 =
                                                     FStar_Extraction_ML_UEnv.lookup_ty
                                                       env x
                                                      in
-                                                  uu____8494.FStar_Extraction_ML_UEnv.ty_b_name))
+                                                  uu____8504.FStar_Extraction_ML_UEnv.ty_b_name))
                                        in
-                                    (uu____8460, expected_t)  in
+                                    (uu____8470, expected_t)  in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____8534  ->
-                                            match uu____8534 with
-                                            | (bv,uu____8542) ->
-                                                let uu____8547 =
+                                         (fun uu____8544  ->
+                                            match uu____8544 with
+                                            | (bv,uu____8552) ->
+                                                let uu____8557 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____8547
+                                                  uu____8557
                                                   FStar_Syntax_Syntax.as_arg))
                                      in
                                   let e =
@@ -2363,8 +2366,8 @@ let (extract_lb_sig :
                                      in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | uu____8577 -> err_value_restriction lbdef1)))
-               | uu____8597 -> no_gen ())
+                              | uu____8587 -> err_value_restriction lbdef1)))
+               | uu____8607 -> no_gen ())
          in
       FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
         (FStar_List.map maybe_generalize)
@@ -2385,19 +2388,19 @@ let (extract_lb_iface :
       let lbs1 = extract_lb_sig g lbs  in
       FStar_Util.fold_map
         (fun env  ->
-           fun uu____8748  ->
-             match uu____8748 with
+           fun uu____8758  ->
+             match uu____8758 with
              | (lbname,e_tag,(typ,(binders,mltyscheme)),add_unit,_body) ->
-                 let uu____8809 =
+                 let uu____8819 =
                    FStar_Extraction_ML_UEnv.extend_lb env lbname typ
                      mltyscheme add_unit
                     in
-                 (match uu____8809 with
-                  | (env1,uu____8826,exp_binding) ->
-                      let uu____8830 =
-                        let uu____8835 = FStar_Util.right lbname  in
-                        (uu____8835, exp_binding)  in
-                      (env1, uu____8830))) g lbs1
+                 (match uu____8819 with
+                  | (env1,uu____8836,exp_binding) ->
+                      let uu____8840 =
+                        let uu____8845 = FStar_Util.right lbname  in
+                        (uu____8845, exp_binding)  in
+                      (env1, uu____8840))) g lbs1
   
 let rec (check_term_as_mlexpr :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -2412,52 +2415,52 @@ let rec (check_term_as_mlexpr :
       fun f  ->
         fun ty  ->
           FStar_Extraction_ML_UEnv.debug g
-            (fun uu____8902  ->
-               let uu____8903 = FStar_Syntax_Print.term_to_string e  in
-               let uu____8905 =
-                 let uu____8907 =
+            (fun uu____8912  ->
+               let uu____8913 = FStar_Syntax_Print.term_to_string e  in
+               let uu____8915 =
+                 let uu____8917 =
                    FStar_Extraction_ML_UEnv.current_module_of_uenv g  in
-                 FStar_Extraction_ML_Code.string_of_mlty uu____8907 ty  in
-               let uu____8908 = FStar_Extraction_ML_Util.eff_to_string f  in
+                 FStar_Extraction_ML_Code.string_of_mlty uu____8917 ty  in
+               let uu____8918 = FStar_Extraction_ML_Util.eff_to_string f  in
                FStar_Util.print3 "Checking %s at type %s and eff %s\n"
-                 uu____8903 uu____8905 uu____8908);
+                 uu____8913 uu____8915 uu____8918);
           (match (f, ty) with
-           | (FStar_Extraction_ML_Syntax.E_GHOST ,uu____8915) ->
+           | (FStar_Extraction_ML_Syntax.E_GHOST ,uu____8925) ->
                (FStar_Extraction_ML_Syntax.ml_unit,
                  FStar_Extraction_ML_Syntax.MLTY_Erased)
            | (FStar_Extraction_ML_Syntax.E_PURE
               ,FStar_Extraction_ML_Syntax.MLTY_Erased ) ->
                (FStar_Extraction_ML_Syntax.ml_unit,
                  FStar_Extraction_ML_Syntax.MLTY_Erased)
-           | uu____8916 ->
-               let uu____8921 = term_as_mlexpr g e  in
-               (match uu____8921 with
+           | uu____8926 ->
+               let uu____8931 = term_as_mlexpr g e  in
+               (match uu____8931 with
                 | (ml_e,tag,t) ->
-                    let uu____8935 = FStar_Extraction_ML_Util.eff_leq tag f
+                    let uu____8945 = FStar_Extraction_ML_Util.eff_leq tag f
                        in
-                    if uu____8935
+                    if uu____8945
                     then
-                      let uu____8942 =
+                      let uu____8952 =
                         maybe_coerce e.FStar_Syntax_Syntax.pos g ml_e t ty
                          in
-                      (uu____8942, ty)
+                      (uu____8952, ty)
                     else
                       (match (tag, f, ty) with
                        | (FStar_Extraction_ML_Syntax.E_GHOST
                           ,FStar_Extraction_ML_Syntax.E_PURE
                           ,FStar_Extraction_ML_Syntax.MLTY_Erased ) ->
-                           let uu____8949 =
+                           let uu____8959 =
                              maybe_coerce e.FStar_Syntax_Syntax.pos g ml_e t
                                ty
                               in
-                           (uu____8949, ty)
-                       | uu____8950 ->
+                           (uu____8959, ty)
+                       | uu____8960 ->
                            (err_unexpected_eff g e ty f tag;
-                            (let uu____8958 =
+                            (let uu____8968 =
                                maybe_coerce e.FStar_Syntax_Syntax.pos g ml_e
                                  t ty
                                 in
-                             (uu____8958, ty))))))
+                             (uu____8968, ty))))))
 
 and (term_as_mlexpr :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -2467,11 +2470,11 @@ and (term_as_mlexpr :
   =
   fun g  ->
     fun e  ->
-      let uu____8967 = term_as_mlexpr' g e  in
-      match uu____8967 with
+      let uu____8977 = term_as_mlexpr' g e  in
+      match uu____8977 with
       | (e1,f,t) ->
-          let uu____8983 = maybe_promote_effect e1 f t  in
-          (match uu____8983 with | (e2,f1) -> (e2, f1, t))
+          let uu____8993 = maybe_promote_effect e1 f t  in
+          (match uu____8993 with | (e2,f1) -> (e2, f1, t))
 
 and (term_as_mlexpr' :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -2484,117 +2487,117 @@ and (term_as_mlexpr' :
       let top1 = FStar_Syntax_Subst.compress top  in
       FStar_Extraction_ML_UEnv.debug g
         (fun u  ->
-           let uu____9009 =
-             let uu____9011 =
+           let uu____9019 =
+             let uu____9021 =
                FStar_Range.string_of_range top1.FStar_Syntax_Syntax.pos  in
-             let uu____9013 = FStar_Syntax_Print.tag_of_term top1  in
-             let uu____9015 = FStar_Syntax_Print.term_to_string top1  in
+             let uu____9023 = FStar_Syntax_Print.tag_of_term top1  in
+             let uu____9025 = FStar_Syntax_Print.term_to_string top1  in
              FStar_Util.format3 "%s: term_as_mlexpr' (%s) :  %s \n"
-               uu____9011 uu____9013 uu____9015
+               uu____9021 uu____9023 uu____9025
               in
-           FStar_Util.print_string uu____9009);
+           FStar_Util.print_string uu____9019);
       (let is_match t =
-         let uu____9025 =
-           let uu____9026 =
-             let uu____9029 =
+         let uu____9035 =
+           let uu____9036 =
+             let uu____9039 =
                FStar_All.pipe_right t FStar_Syntax_Subst.compress  in
-             FStar_All.pipe_right uu____9029 FStar_Syntax_Util.unascribe  in
-           uu____9026.FStar_Syntax_Syntax.n  in
-         match uu____9025 with
-         | FStar_Syntax_Syntax.Tm_match uu____9033 -> true
-         | uu____9057 -> false  in
+             FStar_All.pipe_right uu____9039 FStar_Syntax_Util.unascribe  in
+           uu____9036.FStar_Syntax_Syntax.n  in
+         match uu____9035 with
+         | FStar_Syntax_Syntax.Tm_match uu____9043 -> true
+         | uu____9067 -> false  in
        let should_apply_to_match_branches =
          FStar_List.for_all
-           (fun uu____9076  ->
-              match uu____9076 with
-              | (t,uu____9085) ->
-                  let uu____9090 =
-                    let uu____9091 =
+           (fun uu____9086  ->
+              match uu____9086 with
+              | (t,uu____9095) ->
+                  let uu____9100 =
+                    let uu____9101 =
                       FStar_All.pipe_right t FStar_Syntax_Subst.compress  in
-                    uu____9091.FStar_Syntax_Syntax.n  in
-                  (match uu____9090 with
-                   | FStar_Syntax_Syntax.Tm_name uu____9097 -> true
-                   | FStar_Syntax_Syntax.Tm_fvar uu____9099 -> true
-                   | FStar_Syntax_Syntax.Tm_constant uu____9101 -> true
-                   | uu____9103 -> false))
+                    uu____9101.FStar_Syntax_Syntax.n  in
+                  (match uu____9100 with
+                   | FStar_Syntax_Syntax.Tm_name uu____9107 -> true
+                   | FStar_Syntax_Syntax.Tm_fvar uu____9109 -> true
+                   | FStar_Syntax_Syntax.Tm_constant uu____9111 -> true
+                   | uu____9113 -> false))
           in
        let apply_to_match_branches head args =
-         let uu____9142 =
-           let uu____9143 =
-             let uu____9146 =
+         let uu____9152 =
+           let uu____9153 =
+             let uu____9156 =
                FStar_All.pipe_right head FStar_Syntax_Subst.compress  in
-             FStar_All.pipe_right uu____9146 FStar_Syntax_Util.unascribe  in
-           uu____9143.FStar_Syntax_Syntax.n  in
-         match uu____9142 with
+             FStar_All.pipe_right uu____9156 FStar_Syntax_Util.unascribe  in
+           uu____9153.FStar_Syntax_Syntax.n  in
+         match uu____9152 with
          | FStar_Syntax_Syntax.Tm_match (scrutinee,branches) ->
              let branches1 =
                FStar_All.pipe_right branches
                  (FStar_List.map
-                    (fun uu____9270  ->
-                       match uu____9270 with
+                    (fun uu____9280  ->
+                       match uu____9280 with
                        | (pat,when_opt,body) ->
                            (pat, when_opt,
-                             (let uu___1319_9327 = body  in
+                             (let uu___1319_9337 = body  in
                               {
                                 FStar_Syntax_Syntax.n =
                                   (FStar_Syntax_Syntax.Tm_app (body, args));
                                 FStar_Syntax_Syntax.pos =
-                                  (uu___1319_9327.FStar_Syntax_Syntax.pos);
+                                  (uu___1319_9337.FStar_Syntax_Syntax.pos);
                                 FStar_Syntax_Syntax.vars =
-                                  (uu___1319_9327.FStar_Syntax_Syntax.vars)
+                                  (uu___1319_9337.FStar_Syntax_Syntax.vars)
                               }))))
                 in
-             let uu___1322_9342 = head  in
+             let uu___1322_9352 = head  in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.Tm_match (scrutinee, branches1));
                FStar_Syntax_Syntax.pos =
-                 (uu___1322_9342.FStar_Syntax_Syntax.pos);
+                 (uu___1322_9352.FStar_Syntax_Syntax.pos);
                FStar_Syntax_Syntax.vars =
-                 (uu___1322_9342.FStar_Syntax_Syntax.vars)
+                 (uu___1322_9352.FStar_Syntax_Syntax.vars)
              }
-         | uu____9363 ->
+         | uu____9373 ->
              failwith
                "Impossible! cannot apply args to match branches if head is not a match"
           in
        let t = FStar_Syntax_Subst.compress top1  in
        match t.FStar_Syntax_Syntax.n with
        | FStar_Syntax_Syntax.Tm_unknown  ->
-           let uu____9374 =
-             let uu____9376 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____9376
+           let uu____9384 =
+             let uu____9386 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____9386
               in
-           failwith uu____9374
-       | FStar_Syntax_Syntax.Tm_delayed uu____9385 ->
-           let uu____9400 =
-             let uu____9402 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____9402
+           failwith uu____9384
+       | FStar_Syntax_Syntax.Tm_delayed uu____9395 ->
+           let uu____9410 =
+             let uu____9412 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____9412
               in
-           failwith uu____9400
-       | FStar_Syntax_Syntax.Tm_uvar uu____9411 ->
-           let uu____9424 =
-             let uu____9426 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____9426
+           failwith uu____9410
+       | FStar_Syntax_Syntax.Tm_uvar uu____9421 ->
+           let uu____9434 =
+             let uu____9436 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____9436
               in
-           failwith uu____9424
-       | FStar_Syntax_Syntax.Tm_bvar uu____9435 ->
-           let uu____9436 =
-             let uu____9438 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____9438
+           failwith uu____9434
+       | FStar_Syntax_Syntax.Tm_bvar uu____9445 ->
+           let uu____9446 =
+             let uu____9448 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____9448
               in
-           failwith uu____9436
+           failwith uu____9446
        | FStar_Syntax_Syntax.Tm_lazy i ->
-           let uu____9448 = FStar_Syntax_Util.unfold_lazy i  in
-           term_as_mlexpr g uu____9448
-       | FStar_Syntax_Syntax.Tm_type uu____9449 ->
+           let uu____9458 = FStar_Syntax_Util.unfold_lazy i  in
+           term_as_mlexpr g uu____9458
+       | FStar_Syntax_Syntax.Tm_type uu____9459 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
-       | FStar_Syntax_Syntax.Tm_refine uu____9450 ->
+       | FStar_Syntax_Syntax.Tm_refine uu____9460 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
-       | FStar_Syntax_Syntax.Tm_arrow uu____9457 ->
+       | FStar_Syntax_Syntax.Tm_arrow uu____9467 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
@@ -2602,24 +2605,24 @@ and (term_as_mlexpr' :
            (qt,{
                  FStar_Syntax_Syntax.qkind =
                    FStar_Syntax_Syntax.Quote_dynamic ;
-                 FStar_Syntax_Syntax.antiquotes = uu____9473;_})
+                 FStar_Syntax_Syntax.antiquotes = uu____9483;_})
            ->
-           let uu____9486 =
-             let uu____9487 =
+           let uu____9496 =
+             let uu____9497 =
                FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.failwith_lid
                  FStar_Syntax_Syntax.delta_constant
                  FStar_Pervasives_Native.None
                 in
-             FStar_Extraction_ML_UEnv.lookup_fv g uu____9487  in
-           (match uu____9486 with
-            | { FStar_Extraction_ML_UEnv.exp_b_name = uu____9494;
+             FStar_Extraction_ML_UEnv.lookup_fv g uu____9497  in
+           (match uu____9496 with
+            | { FStar_Extraction_ML_UEnv.exp_b_name = uu____9504;
                 FStar_Extraction_ML_UEnv.exp_b_expr = fw;
-                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu____9496;_} ->
-                let uu____9498 =
-                  let uu____9499 =
-                    let uu____9500 =
-                      let uu____9507 =
-                        let uu____9510 =
+                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu____9506;_} ->
+                let uu____9508 =
+                  let uu____9509 =
+                    let uu____9510 =
+                      let uu____9517 =
+                        let uu____9520 =
                           FStar_All.pipe_left
                             (FStar_Extraction_ML_Syntax.with_ty
                                FStar_Extraction_ML_Syntax.ml_string_ty)
@@ -2627,127 +2630,127 @@ and (term_as_mlexpr' :
                                (FStar_Extraction_ML_Syntax.MLC_String
                                   "Cannot evaluate open quotation at runtime"))
                            in
-                        [uu____9510]  in
-                      (fw, uu____9507)  in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____9500  in
+                        [uu____9520]  in
+                      (fw, uu____9517)  in
+                    FStar_Extraction_ML_Syntax.MLE_App uu____9510  in
                   FStar_All.pipe_left
                     (FStar_Extraction_ML_Syntax.with_ty
-                       FStar_Extraction_ML_Syntax.ml_int_ty) uu____9499
+                       FStar_Extraction_ML_Syntax.ml_int_ty) uu____9509
                    in
-                (uu____9498, FStar_Extraction_ML_Syntax.E_PURE,
+                (uu____9508, FStar_Extraction_ML_Syntax.E_PURE,
                   FStar_Extraction_ML_Syntax.ml_int_ty))
        | FStar_Syntax_Syntax.Tm_quoted
            (qt,{
                  FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_static ;
                  FStar_Syntax_Syntax.antiquotes = aqs;_})
            ->
-           let uu____9528 = FStar_Reflection_Basic.inspect_ln qt  in
-           (match uu____9528 with
+           let uu____9538 = FStar_Reflection_Basic.inspect_ln qt  in
+           (match uu____9538 with
             | FStar_Reflection_Data.Tv_Var bv ->
-                let uu____9536 = FStar_Syntax_Syntax.lookup_aq bv aqs  in
-                (match uu____9536 with
+                let uu____9546 = FStar_Syntax_Syntax.lookup_aq bv aqs  in
+                (match uu____9546 with
                  | FStar_Pervasives_Native.Some tm -> term_as_mlexpr g tm
                  | FStar_Pervasives_Native.None  ->
                      let tv =
-                       let uu____9547 =
-                         let uu____9554 =
+                       let uu____9557 =
+                         let uu____9564 =
                            FStar_Reflection_Embeddings.e_term_view_aq aqs  in
-                         FStar_Syntax_Embeddings.embed uu____9554
+                         FStar_Syntax_Embeddings.embed uu____9564
                            (FStar_Reflection_Data.Tv_Var bv)
                           in
-                       uu____9547 t.FStar_Syntax_Syntax.pos
+                       uu____9557 t.FStar_Syntax_Syntax.pos
                          FStar_Pervasives_Native.None
                          FStar_Syntax_Embeddings.id_norm_cb
                         in
                      let t1 =
-                       let uu____9562 =
-                         let uu____9573 = FStar_Syntax_Syntax.as_arg tv  in
-                         [uu____9573]  in
+                       let uu____9572 =
+                         let uu____9583 = FStar_Syntax_Syntax.as_arg tv  in
+                         [uu____9583]  in
                        FStar_Syntax_Util.mk_app
                          (FStar_Reflection_Data.refl_constant_term
                             FStar_Reflection_Data.fstar_refl_pack_ln)
-                         uu____9562
+                         uu____9572
                         in
                      term_as_mlexpr g t1)
             | tv ->
                 let tv1 =
-                  let uu____9600 =
-                    let uu____9607 =
+                  let uu____9610 =
+                    let uu____9617 =
                       FStar_Reflection_Embeddings.e_term_view_aq aqs  in
-                    FStar_Syntax_Embeddings.embed uu____9607 tv  in
-                  uu____9600 t.FStar_Syntax_Syntax.pos
+                    FStar_Syntax_Embeddings.embed uu____9617 tv  in
+                  uu____9610 t.FStar_Syntax_Syntax.pos
                     FStar_Pervasives_Native.None
                     FStar_Syntax_Embeddings.id_norm_cb
                    in
                 let t1 =
-                  let uu____9615 =
-                    let uu____9626 = FStar_Syntax_Syntax.as_arg tv1  in
-                    [uu____9626]  in
+                  let uu____9625 =
+                    let uu____9636 = FStar_Syntax_Syntax.as_arg tv1  in
+                    [uu____9636]  in
                   FStar_Syntax_Util.mk_app
                     (FStar_Reflection_Data.refl_constant_term
-                       FStar_Reflection_Data.fstar_refl_pack_ln) uu____9615
+                       FStar_Reflection_Data.fstar_refl_pack_ln) uu____9625
                    in
                 term_as_mlexpr g t1)
        | FStar_Syntax_Syntax.Tm_meta
-           (t1,FStar_Syntax_Syntax.Meta_monadic (m,uu____9653)) ->
+           (t1,FStar_Syntax_Syntax.Meta_monadic (m,uu____9663)) ->
            let t2 = FStar_Syntax_Subst.compress t1  in
            (match t2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) when
                 FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname ->
-                let uu____9686 =
-                  let uu____9693 =
-                    let uu____9702 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+                let uu____9696 =
+                  let uu____9703 =
+                    let uu____9712 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                        in
-                    FStar_TypeChecker_Env.effect_decl_opt uu____9702 m  in
-                  FStar_Util.must uu____9693  in
-                (match uu____9686 with
+                    FStar_TypeChecker_Env.effect_decl_opt uu____9712 m  in
+                  FStar_Util.must uu____9703  in
+                (match uu____9696 with
                  | (ed,qualifiers) ->
-                     let uu____9721 =
-                       let uu____9723 =
-                         let uu____9725 =
+                     let uu____9731 =
+                       let uu____9733 =
+                         let uu____9735 =
                            FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-                         FStar_TypeChecker_Env.is_reifiable_effect uu____9725
+                         FStar_TypeChecker_Env.is_reifiable_effect uu____9735
                            ed.FStar_Syntax_Syntax.mname
                           in
-                       Prims.op_Negation uu____9723  in
-                     if uu____9721
+                       Prims.op_Negation uu____9733  in
+                     if uu____9731
                      then term_as_mlexpr g t2
                      else
                        failwith
                          "This should not happen (should have been handled at Tm_abs level)")
-            | uu____9742 -> term_as_mlexpr g t2)
-       | FStar_Syntax_Syntax.Tm_meta (t1,uu____9744) -> term_as_mlexpr g t1
-       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____9750) -> term_as_mlexpr g t1
+            | uu____9752 -> term_as_mlexpr g t2)
+       | FStar_Syntax_Syntax.Tm_meta (t1,uu____9754) -> term_as_mlexpr g t1
+       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____9760) -> term_as_mlexpr g t1
        | FStar_Syntax_Syntax.Tm_constant c ->
-           let uu____9756 =
-             let uu____9763 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-             FStar_TypeChecker_TcTerm.type_of_tot_term uu____9763 t  in
-           (match uu____9756 with
-            | (uu____9770,ty,uu____9772) ->
+           let uu____9766 =
+             let uu____9773 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
+             FStar_TypeChecker_TcTerm.type_of_tot_term uu____9773 t  in
+           (match uu____9766 with
+            | (uu____9780,ty,uu____9782) ->
                 let ml_ty = term_as_mlty g ty  in
-                let uu____9774 =
-                  let uu____9775 =
+                let uu____9784 =
+                  let uu____9785 =
                     FStar_Extraction_ML_Util.mlexpr_of_const
                       t.FStar_Syntax_Syntax.pos c
                      in
-                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu____9775  in
-                (uu____9774, FStar_Extraction_ML_Syntax.E_PURE, ml_ty))
-       | FStar_Syntax_Syntax.Tm_name uu____9776 ->
-           let uu____9777 = is_type g t  in
-           if uu____9777
+                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu____9785  in
+                (uu____9784, FStar_Extraction_ML_Syntax.E_PURE, ml_ty))
+       | FStar_Syntax_Syntax.Tm_name uu____9786 ->
+           let uu____9787 = is_type g t  in
+           if uu____9787
            then
              (FStar_Extraction_ML_Syntax.ml_unit,
                FStar_Extraction_ML_Syntax.E_PURE,
                FStar_Extraction_ML_Syntax.ml_unit_ty)
            else
-             (let uu____9788 = FStar_Extraction_ML_UEnv.lookup_term g t  in
-              match uu____9788 with
-              | (FStar_Util.Inl uu____9801,uu____9802) ->
+             (let uu____9798 = FStar_Extraction_ML_UEnv.lookup_term g t  in
+              match uu____9798 with
+              | (FStar_Util.Inl uu____9811,uu____9812) ->
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.ml_unit_ty)
               | (FStar_Util.Inr
-                 { FStar_Extraction_ML_UEnv.exp_b_name = uu____9807;
+                 { FStar_Extraction_ML_UEnv.exp_b_name = uu____9817;
                    FStar_Extraction_ML_UEnv.exp_b_expr = x;
                    FStar_Extraction_ML_UEnv.exp_b_tscheme = mltys;_},qual)
                   ->
@@ -2757,160 +2760,160 @@ and (term_as_mlexpr' :
                        (FStar_Extraction_ML_Syntax.ml_unit,
                          FStar_Extraction_ML_Syntax.E_PURE, t1)
                    | ([],t1) ->
-                       let uu____9826 =
+                       let uu____9836 =
                          maybe_eta_data_and_project_record g qual t1 x  in
-                       (uu____9826, FStar_Extraction_ML_Syntax.E_PURE, t1)
-                   | uu____9827 -> instantiate_maybe_partial g x mltys []))
+                       (uu____9836, FStar_Extraction_ML_Syntax.E_PURE, t1)
+                   | uu____9837 -> instantiate_maybe_partial g x mltys []))
        | FStar_Syntax_Syntax.Tm_fvar fv ->
-           let uu____9829 = is_type g t  in
-           if uu____9829
+           let uu____9839 = is_type g t  in
+           if uu____9839
            then
              (FStar_Extraction_ML_Syntax.ml_unit,
                FStar_Extraction_ML_Syntax.E_PURE,
                FStar_Extraction_ML_Syntax.ml_unit_ty)
            else
-             (let uu____9840 = FStar_Extraction_ML_UEnv.try_lookup_fv g fv
+             (let uu____9850 = FStar_Extraction_ML_UEnv.try_lookup_fv g fv
                  in
-              match uu____9840 with
+              match uu____9850 with
               | FStar_Pervasives_Native.None  ->
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.MLTY_Erased)
               | FStar_Pervasives_Native.Some
-                  { FStar_Extraction_ML_UEnv.exp_b_name = uu____9849;
+                  { FStar_Extraction_ML_UEnv.exp_b_name = uu____9859;
                     FStar_Extraction_ML_UEnv.exp_b_expr = x;
                     FStar_Extraction_ML_UEnv.exp_b_tscheme = mltys;_}
                   ->
                   (FStar_Extraction_ML_UEnv.debug g
-                     (fun uu____9858  ->
-                        let uu____9859 = FStar_Syntax_Print.fv_to_string fv
+                     (fun uu____9868  ->
+                        let uu____9869 = FStar_Syntax_Print.fv_to_string fv
                            in
-                        let uu____9861 =
-                          let uu____9863 =
+                        let uu____9871 =
+                          let uu____9873 =
                             FStar_Extraction_ML_UEnv.current_module_of_uenv g
                              in
                           FStar_Extraction_ML_Code.string_of_mlexpr
-                            uu____9863 x
+                            uu____9873 x
                            in
-                        let uu____9864 =
-                          let uu____9866 =
+                        let uu____9874 =
+                          let uu____9876 =
                             FStar_Extraction_ML_UEnv.current_module_of_uenv g
                              in
-                          FStar_Extraction_ML_Code.string_of_mlty uu____9866
+                          FStar_Extraction_ML_Code.string_of_mlty uu____9876
                             (FStar_Pervasives_Native.snd mltys)
                            in
                         FStar_Util.print3 "looked up %s: got %s at %s \n"
-                          uu____9859 uu____9861 uu____9864);
+                          uu____9869 uu____9871 uu____9874);
                    (match mltys with
                     | ([],t1) when t1 = FStar_Extraction_ML_Syntax.ml_unit_ty
                         ->
                         (FStar_Extraction_ML_Syntax.ml_unit,
                           FStar_Extraction_ML_Syntax.E_PURE, t1)
                     | ([],t1) ->
-                        let uu____9878 =
+                        let uu____9888 =
                           maybe_eta_data_and_project_record g
                             fv.FStar_Syntax_Syntax.fv_qual t1 x
                            in
-                        (uu____9878, FStar_Extraction_ML_Syntax.E_PURE, t1)
-                    | uu____9879 -> instantiate_maybe_partial g x mltys [])))
+                        (uu____9888, FStar_Extraction_ML_Syntax.E_PURE, t1)
+                    | uu____9889 -> instantiate_maybe_partial g x mltys [])))
        | FStar_Syntax_Syntax.Tm_abs (bs,body,rcopt) ->
-           let uu____9907 = FStar_Syntax_Subst.open_term bs body  in
-           (match uu____9907 with
+           let uu____9917 = FStar_Syntax_Subst.open_term bs body  in
+           (match uu____9917 with
             | (bs1,body1) ->
-                let uu____9920 = binders_as_ml_binders g bs1  in
-                (match uu____9920 with
+                let uu____9930 = binders_as_ml_binders g bs1  in
+                (match uu____9930 with
                  | (ml_bs,env) ->
                      let body2 =
                        match rcopt with
                        | FStar_Pervasives_Native.Some rc ->
-                           let uu____9956 =
-                             let uu____9958 =
+                           let uu____9966 =
+                             let uu____9968 =
                                FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
-                             FStar_TypeChecker_Env.is_reifiable_rc uu____9958
+                             FStar_TypeChecker_Env.is_reifiable_rc uu____9968
                                rc
                               in
-                           if uu____9956
+                           if uu____9966
                            then
-                             let uu____9960 =
+                             let uu____9970 =
                                FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
-                             FStar_TypeChecker_Util.reify_body uu____9960
+                             FStar_TypeChecker_Util.reify_body uu____9970
                                [FStar_TypeChecker_Env.Inlining;
                                FStar_TypeChecker_Env.Unascribe] body1
                            else body1
                        | FStar_Pervasives_Native.None  ->
                            (FStar_Extraction_ML_UEnv.debug g
-                              (fun uu____9966  ->
-                                 let uu____9967 =
+                              (fun uu____9976  ->
+                                 let uu____9977 =
                                    FStar_Syntax_Print.term_to_string body1
                                     in
                                  FStar_Util.print1
-                                   "No computation type for: %s\n" uu____9967);
+                                   "No computation type for: %s\n" uu____9977);
                             body1)
                         in
-                     let uu____9970 = term_as_mlexpr env body2  in
-                     (match uu____9970 with
+                     let uu____9980 = term_as_mlexpr env body2  in
+                     (match uu____9980 with
                       | (ml_body,f,t1) ->
-                          let uu____9986 =
+                          let uu____9996 =
                             FStar_List.fold_right
-                              (fun uu____10006  ->
-                                 fun uu____10007  ->
-                                   match (uu____10006, uu____10007) with
-                                   | ((uu____10030,targ),(f1,t2)) ->
+                              (fun uu____10016  ->
+                                 fun uu____10017  ->
+                                   match (uu____10016, uu____10017) with
+                                   | ((uu____10040,targ),(f1,t2)) ->
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          (FStar_Extraction_ML_Syntax.MLTY_Fun
                                             (targ, f1, t2)))) ml_bs (f, t1)
                              in
-                          (match uu____9986 with
+                          (match uu____9996 with
                            | (f1,tfun) ->
-                               let uu____10053 =
+                               let uu____10063 =
                                  FStar_All.pipe_left
                                    (FStar_Extraction_ML_Syntax.with_ty tfun)
                                    (FStar_Extraction_ML_Syntax.MLE_Fun
                                       (ml_bs, ml_body))
                                   in
-                               (uu____10053, f1, tfun)))))
+                               (uu____10063, f1, tfun)))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of );
-              FStar_Syntax_Syntax.pos = uu____10061;
-              FStar_Syntax_Syntax.vars = uu____10062;_},(a1,uu____10064)::[])
+              FStar_Syntax_Syntax.pos = uu____10071;
+              FStar_Syntax_Syntax.vars = uu____10072;_},(a1,uu____10074)::[])
            ->
            let ty =
-             let uu____10104 =
+             let uu____10114 =
                FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid  in
-             term_as_mlty g uu____10104  in
-           let uu____10105 =
-             let uu____10106 =
+             term_as_mlty g uu____10114  in
+           let uu____10115 =
+             let uu____10116 =
                FStar_Extraction_ML_Util.mlexpr_of_range
                  a1.FStar_Syntax_Syntax.pos
                 in
              FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty ty)
-               uu____10106
+               uu____10116
               in
-           (uu____10105, FStar_Extraction_ML_Syntax.E_PURE, ty)
+           (uu____10115, FStar_Extraction_ML_Syntax.E_PURE, ty)
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of );
-              FStar_Syntax_Syntax.pos = uu____10107;
-              FStar_Syntax_Syntax.vars = uu____10108;_},(t1,uu____10110)::
-            (r,uu____10112)::[])
+              FStar_Syntax_Syntax.pos = uu____10117;
+              FStar_Syntax_Syntax.vars = uu____10118;_},(t1,uu____10120)::
+            (r,uu____10122)::[])
            -> term_as_mlexpr g t1
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect uu____10167);
-              FStar_Syntax_Syntax.pos = uu____10168;
-              FStar_Syntax_Syntax.vars = uu____10169;_},uu____10170)
+                (FStar_Const.Const_reflect uu____10177);
+              FStar_Syntax_Syntax.pos = uu____10178;
+              FStar_Syntax_Syntax.vars = uu____10179;_},uu____10180)
            -> failwith "Unreachable? Tm_app Const_reflect"
        | FStar_Syntax_Syntax.Tm_app (head,args) when
            (is_match head) &&
              (FStar_All.pipe_right args should_apply_to_match_branches)
            ->
-           let uu____10229 =
+           let uu____10239 =
              FStar_All.pipe_right args (apply_to_match_branches head)  in
-           FStar_All.pipe_right uu____10229 (term_as_mlexpr g)
+           FStar_All.pipe_right uu____10239 (term_as_mlexpr g)
        | FStar_Syntax_Syntax.Tm_app (head,args) ->
            let is_total rc =
              (FStar_Ident.lid_equals rc.FStar_Syntax_Syntax.residual_effect
@@ -2918,23 +2921,23 @@ and (term_as_mlexpr' :
                ||
                (FStar_All.pipe_right rc.FStar_Syntax_Syntax.residual_flags
                   (FStar_List.existsb
-                     (fun uu___1_10283  ->
-                        match uu___1_10283 with
+                     (fun uu___1_10293  ->
+                        match uu___1_10293 with
                         | FStar_Syntax_Syntax.TOTAL  -> true
-                        | uu____10286 -> false)))
+                        | uu____10296 -> false)))
               in
-           let uu____10288 =
-             let uu____10289 =
-               let uu____10292 =
+           let uu____10298 =
+             let uu____10299 =
+               let uu____10302 =
                  FStar_All.pipe_right head FStar_Syntax_Subst.compress  in
-               FStar_All.pipe_right uu____10292 FStar_Syntax_Util.unascribe
+               FStar_All.pipe_right uu____10302 FStar_Syntax_Util.unascribe
                 in
-             uu____10289.FStar_Syntax_Syntax.n  in
-           (match uu____10288 with
-            | FStar_Syntax_Syntax.Tm_abs (bs,uu____10302,_rc) ->
-                let uu____10328 =
-                  let uu____10329 =
-                    let uu____10334 =
+             uu____10299.FStar_Syntax_Syntax.n  in
+           (match uu____10298 with
+            | FStar_Syntax_Syntax.Tm_abs (bs,uu____10312,_rc) ->
+                let uu____10338 =
+                  let uu____10339 =
+                    let uu____10344 =
                       FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
                     FStar_TypeChecker_Normalize.normalize
                       [FStar_TypeChecker_Env.Beta;
@@ -2942,35 +2945,35 @@ and (term_as_mlexpr' :
                       FStar_TypeChecker_Env.Zeta;
                       FStar_TypeChecker_Env.EraseUniverses;
                       FStar_TypeChecker_Env.AllowUnboundUniverses]
-                      uu____10334
+                      uu____10344
                      in
-                  FStar_All.pipe_right t uu____10329  in
-                FStar_All.pipe_right uu____10328 (term_as_mlexpr g)
+                  FStar_All.pipe_right t uu____10339  in
+                FStar_All.pipe_right uu____10338 (term_as_mlexpr g)
             | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify ) ->
                 let e =
-                  let uu____10342 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+                  let uu____10352 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                      in
-                  let uu____10343 = FStar_List.hd args  in
-                  FStar_TypeChecker_Util.reify_body_with_arg uu____10342
+                  let uu____10353 = FStar_List.hd args  in
+                  FStar_TypeChecker_Util.reify_body_with_arg uu____10352
                     [FStar_TypeChecker_Env.Inlining;
-                    FStar_TypeChecker_Env.Unascribe] head uu____10343
+                    FStar_TypeChecker_Env.Unascribe] head uu____10353
                    in
                 let tm =
-                  let uu____10355 =
-                    let uu____10360 = FStar_TypeChecker_Util.remove_reify e
+                  let uu____10365 =
+                    let uu____10370 = FStar_TypeChecker_Util.remove_reify e
                        in
-                    let uu____10361 = FStar_List.tl args  in
-                    FStar_Syntax_Syntax.mk_Tm_app uu____10360 uu____10361  in
-                  uu____10355 FStar_Pervasives_Native.None
+                    let uu____10371 = FStar_List.tl args  in
+                    FStar_Syntax_Syntax.mk_Tm_app uu____10370 uu____10371  in
+                  uu____10365 FStar_Pervasives_Native.None
                     t.FStar_Syntax_Syntax.pos
                    in
                 term_as_mlexpr g tm
-            | uu____10370 ->
-                let rec extract_app is_data uu____10419 uu____10420 restArgs
+            | uu____10380 ->
+                let rec extract_app is_data uu____10429 uu____10430 restArgs
                   =
-                  match (uu____10419, uu____10420) with
+                  match (uu____10429, uu____10430) with
                   | ((mlhead,mlargs_f),(f,t1)) ->
-                      let mk_head uu____10501 =
+                      let mk_head uu____10511 =
                         let mlargs =
                           FStar_All.pipe_right (FStar_List.rev mlargs_f)
                             (FStar_List.map FStar_Pervasives_Native.fst)
@@ -2981,89 +2984,89 @@ and (term_as_mlexpr' :
                              (mlhead, mlargs))
                          in
                       (FStar_Extraction_ML_UEnv.debug g
-                         (fun uu____10528  ->
-                            let uu____10529 =
-                              let uu____10531 =
+                         (fun uu____10538  ->
+                            let uu____10539 =
+                              let uu____10541 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g
                                  in
-                              let uu____10532 = mk_head ()  in
+                              let uu____10542 = mk_head ()  in
                               FStar_Extraction_ML_Code.string_of_mlexpr
-                                uu____10531 uu____10532
+                                uu____10541 uu____10542
                                in
-                            let uu____10533 =
-                              let uu____10535 =
+                            let uu____10543 =
+                              let uu____10545 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g
                                  in
                               FStar_Extraction_ML_Code.string_of_mlty
-                                uu____10535 t1
+                                uu____10545 t1
                                in
-                            let uu____10536 =
+                            let uu____10546 =
                               match restArgs with
                               | [] -> "none"
-                              | (hd,uu____10547)::uu____10548 ->
+                              | (hd,uu____10557)::uu____10558 ->
                                   FStar_Syntax_Print.term_to_string hd
                                in
                             FStar_Util.print3
                               "extract_app ml_head=%s type of head = %s, next arg = %s\n"
-                              uu____10529 uu____10533 uu____10536);
+                              uu____10539 uu____10543 uu____10546);
                        (match (restArgs, t1) with
-                        | ([],uu____10582) ->
+                        | ([],uu____10592) ->
                             let app =
-                              let uu____10598 = mk_head ()  in
+                              let uu____10608 = mk_head ()  in
                               maybe_eta_data_and_project_record g is_data t1
-                                uu____10598
+                                uu____10608
                                in
                             (app, f, t1)
-                        | ((arg,uu____10600)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
+                        | ((arg,uu____10610)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
                            (formal_t,f',t2)) when
                             (is_type g arg) &&
                               (type_leq g formal_t
                                  FStar_Extraction_ML_Syntax.ml_unit_ty)
                             ->
-                            let uu____10631 =
-                              let uu____10636 =
+                            let uu____10641 =
+                              let uu____10646 =
                                 FStar_Extraction_ML_Util.join
                                   arg.FStar_Syntax_Syntax.pos f f'
                                  in
-                              (uu____10636, t2)  in
+                              (uu____10646, t2)  in
                             extract_app is_data
                               (mlhead,
                                 ((FStar_Extraction_ML_Syntax.ml_unit,
                                    FStar_Extraction_ML_Syntax.E_PURE) ::
-                                mlargs_f)) uu____10631 rest
-                        | ((e0,uu____10648)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
+                                mlargs_f)) uu____10641 rest
+                        | ((e0,uu____10658)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
                            (tExpected,f',t2)) ->
                             let r = e0.FStar_Syntax_Syntax.pos  in
                             let expected_effect =
-                              let uu____10681 =
+                              let uu____10691 =
                                 (FStar_Options.lax ()) &&
                                   (FStar_TypeChecker_Util.short_circuit_head
                                      head)
                                  in
-                              if uu____10681
+                              if uu____10691
                               then FStar_Extraction_ML_Syntax.E_IMPURE
                               else FStar_Extraction_ML_Syntax.E_PURE  in
-                            let uu____10686 =
+                            let uu____10696 =
                               check_term_as_mlexpr g e0 expected_effect
                                 tExpected
                                in
-                            (match uu____10686 with
+                            (match uu____10696 with
                              | (e01,tInferred) ->
-                                 let uu____10699 =
-                                   let uu____10704 =
+                                 let uu____10709 =
+                                   let uu____10714 =
                                      FStar_Extraction_ML_Util.join_l r
                                        [f; f']
                                       in
-                                   (uu____10704, t2)  in
+                                   (uu____10714, t2)  in
                                  extract_app is_data
                                    (mlhead, ((e01, expected_effect) ::
-                                     mlargs_f)) uu____10699 rest)
-                        | uu____10715 ->
-                            let uu____10728 =
+                                     mlargs_f)) uu____10709 rest)
+                        | uu____10725 ->
+                            let uu____10738 =
                               FStar_Extraction_ML_Util.udelta_unfold g t1  in
-                            (match uu____10728 with
+                            (match uu____10738 with
                              | FStar_Pervasives_Native.Some t2 ->
                                  extract_app is_data (mlhead, mlargs_f)
                                    (f, t2) restArgs
@@ -3107,7 +3110,7 @@ and (term_as_mlexpr' :
                                          in
                                       extract_app is_data (mlhead1, [])
                                         (f, t2) restArgs
-                                  | uu____10800 ->
+                                  | uu____10810 ->
                                       let mlhead1 =
                                         let mlargs =
                                           FStar_All.pipe_right
@@ -3131,128 +3134,128 @@ and (term_as_mlexpr' :
                                       err_ill_typed_application g top1
                                         mlhead1 restArgs t1))))
                    in
-                let extract_app_maybe_projector is_data mlhead uu____10871
+                let extract_app_maybe_projector is_data mlhead uu____10881
                   args1 =
-                  match uu____10871 with
+                  match uu____10881 with
                   | (f,t1) ->
                       (match is_data with
                        | FStar_Pervasives_Native.Some
-                           (FStar_Syntax_Syntax.Record_projector uu____10901)
+                           (FStar_Syntax_Syntax.Record_projector uu____10911)
                            ->
                            let rec remove_implicits args2 f1 t2 =
                              match (args2, t2) with
                              | ((a0,FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Implicit uu____10985))::args3,FStar_Extraction_ML_Syntax.MLTY_Fun
-                                (uu____10987,f',t3)) ->
-                                 let uu____11025 =
+                                 (FStar_Syntax_Syntax.Implicit uu____10995))::args3,FStar_Extraction_ML_Syntax.MLTY_Fun
+                                (uu____10997,f',t3)) ->
+                                 let uu____11035 =
                                    FStar_Extraction_ML_Util.join
                                      a0.FStar_Syntax_Syntax.pos f1 f'
                                     in
-                                 remove_implicits args3 uu____11025 t3
-                             | uu____11026 -> (args2, f1, t2)  in
-                           let uu____11051 = remove_implicits args1 f t1  in
-                           (match uu____11051 with
+                                 remove_implicits args3 uu____11035 t3
+                             | uu____11036 -> (args2, f1, t2)  in
+                           let uu____11061 = remove_implicits args1 f t1  in
+                           (match uu____11061 with
                             | (args2,f1,t2) ->
                                 extract_app is_data (mlhead, []) (f1, t2)
                                   args2)
-                       | uu____11107 ->
+                       | uu____11117 ->
                            extract_app is_data (mlhead, []) (f, t1) args1)
                    in
-                let extract_app_with_instantiations uu____11131 =
+                let extract_app_with_instantiations uu____11141 =
                   let head1 = FStar_Syntax_Util.un_uinst head  in
                   match head1.FStar_Syntax_Syntax.n with
-                  | FStar_Syntax_Syntax.Tm_name uu____11139 ->
-                      let uu____11140 =
-                        let uu____11155 =
+                  | FStar_Syntax_Syntax.Tm_name uu____11149 ->
+                      let uu____11150 =
+                        let uu____11165 =
                           FStar_Extraction_ML_UEnv.lookup_term g head1  in
-                        match uu____11155 with
+                        match uu____11165 with
                         | (FStar_Util.Inr exp_b,q) ->
                             (FStar_Extraction_ML_UEnv.debug g
-                               (fun uu____11187  ->
-                                  let uu____11188 =
+                               (fun uu____11197  ->
+                                  let uu____11198 =
                                     FStar_Syntax_Print.term_to_string head1
                                      in
-                                  let uu____11190 =
-                                    let uu____11192 =
+                                  let uu____11200 =
+                                    let uu____11202 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g
                                        in
                                     FStar_Extraction_ML_Code.string_of_mlexpr
-                                      uu____11192
+                                      uu____11202
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_expr
                                      in
-                                  let uu____11193 =
-                                    let uu____11195 =
+                                  let uu____11203 =
+                                    let uu____11205 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g
                                        in
                                     FStar_Extraction_ML_Code.string_of_mlty
-                                      uu____11195
+                                      uu____11205
                                       (FStar_Pervasives_Native.snd
                                          exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)
                                      in
                                   FStar_Util.print3
                                     "@@@looked up %s: got %s at %s\n"
-                                    uu____11188 uu____11190 uu____11193);
+                                    uu____11198 uu____11200 uu____11203);
                              (((exp_b.FStar_Extraction_ML_UEnv.exp_b_expr),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)),
                                q))
-                        | uu____11211 -> failwith "FIXME Ty"  in
-                      (match uu____11140 with
+                        | uu____11221 -> failwith "FIXME Ty"  in
+                      (match uu____11150 with
                        | ((head_ml,(vars,t1)),qual) ->
                            let has_typ_apps =
                              match args with
-                             | (a,uu____11263)::uu____11264 -> is_type g a
-                             | uu____11291 -> false  in
-                           let uu____11303 =
+                             | (a,uu____11273)::uu____11274 -> is_type g a
+                             | uu____11301 -> false  in
+                           let uu____11313 =
                              let n = FStar_List.length vars  in
-                             let uu____11320 =
+                             let uu____11330 =
                                if (FStar_List.length args) <= n
                                then
-                                 let uu____11358 =
+                                 let uu____11368 =
                                    FStar_List.map
-                                     (fun uu____11370  ->
-                                        match uu____11370 with
-                                        | (x,uu____11378) -> term_as_mlty g x)
+                                     (fun uu____11380  ->
+                                        match uu____11380 with
+                                        | (x,uu____11388) -> term_as_mlty g x)
                                      args
                                     in
-                                 (uu____11358, [])
+                                 (uu____11368, [])
                                else
-                                 (let uu____11401 = FStar_Util.first_N n args
+                                 (let uu____11411 = FStar_Util.first_N n args
                                      in
-                                  match uu____11401 with
+                                  match uu____11411 with
                                   | (prefix,rest) ->
-                                      let uu____11490 =
+                                      let uu____11500 =
                                         FStar_List.map
-                                          (fun uu____11502  ->
-                                             match uu____11502 with
-                                             | (x,uu____11510) ->
+                                          (fun uu____11512  ->
+                                             match uu____11512 with
+                                             | (x,uu____11520) ->
                                                  term_as_mlty g x) prefix
                                          in
-                                      (uu____11490, rest))
+                                      (uu____11500, rest))
                                 in
-                             match uu____11320 with
+                             match uu____11330 with
                              | (provided_type_args,rest) ->
-                                 let uu____11561 =
+                                 let uu____11571 =
                                    match head_ml.FStar_Extraction_ML_Syntax.expr
                                    with
                                    | FStar_Extraction_ML_Syntax.MLE_Name
-                                       uu____11570 ->
-                                       let uu____11571 =
+                                       uu____11580 ->
+                                       let uu____11581 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____11571 with
-                                        | (head2,uu____11583,t2) ->
+                                       (match uu____11581 with
+                                        | (head2,uu____11593,t2) ->
                                             (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_Var
-                                       uu____11585 ->
-                                       let uu____11587 =
+                                       uu____11595 ->
+                                       let uu____11597 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____11587 with
-                                        | (head2,uu____11599,t2) ->
+                                       (match uu____11597 with
+                                        | (head2,uu____11609,t2) ->
                                             (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_App
                                        (head2,{
@@ -3262,17 +3265,17 @@ and (term_as_mlexpr' :
                                                   (FStar_Extraction_ML_Syntax.MLC_Unit
                                                   );
                                                 FStar_Extraction_ML_Syntax.mlty
-                                                  = uu____11602;
+                                                  = uu____11612;
                                                 FStar_Extraction_ML_Syntax.loc
-                                                  = uu____11603;_}::[])
+                                                  = uu____11613;_}::[])
                                        ->
-                                       let uu____11606 =
+                                       let uu____11616 =
                                          instantiate_maybe_partial g head2
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____11606 with
-                                        | (head3,uu____11618,t2) ->
-                                            let uu____11620 =
+                                       (match uu____11616 with
+                                        | (head3,uu____11628,t2) ->
+                                            let uu____11630 =
                                               FStar_All.pipe_right
                                                 (FStar_Extraction_ML_Syntax.MLE_App
                                                    (head3,
@@ -3280,122 +3283,122 @@ and (term_as_mlexpr' :
                                                 (FStar_Extraction_ML_Syntax.with_ty
                                                    t2)
                                                in
-                                            (uu____11620, t2))
-                                   | uu____11623 ->
+                                            (uu____11630, t2))
+                                   | uu____11633 ->
                                        failwith
                                          "Impossible: Unexpected head term"
                                     in
-                                 (match uu____11561 with
+                                 (match uu____11571 with
                                   | (head2,t2) -> (head2, t2, rest))
                               in
-                           (match uu____11303 with
+                           (match uu____11313 with
                             | (head_ml1,head_t,args1) ->
                                 (match args1 with
                                  | [] ->
-                                     let uu____11690 =
+                                     let uu____11700 =
                                        maybe_eta_data_and_project_record g
                                          qual head_t head_ml1
                                         in
-                                     (uu____11690,
+                                     (uu____11700,
                                        FStar_Extraction_ML_Syntax.E_PURE,
                                        head_t)
-                                 | uu____11691 ->
+                                 | uu____11701 ->
                                      extract_app_maybe_projector qual
                                        head_ml1
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          head_t) args1)))
-                  | FStar_Syntax_Syntax.Tm_fvar uu____11700 ->
-                      let uu____11701 =
-                        let uu____11716 =
+                  | FStar_Syntax_Syntax.Tm_fvar uu____11710 ->
+                      let uu____11711 =
+                        let uu____11726 =
                           FStar_Extraction_ML_UEnv.lookup_term g head1  in
-                        match uu____11716 with
+                        match uu____11726 with
                         | (FStar_Util.Inr exp_b,q) ->
                             (FStar_Extraction_ML_UEnv.debug g
-                               (fun uu____11748  ->
-                                  let uu____11749 =
+                               (fun uu____11758  ->
+                                  let uu____11759 =
                                     FStar_Syntax_Print.term_to_string head1
                                      in
-                                  let uu____11751 =
-                                    let uu____11753 =
+                                  let uu____11761 =
+                                    let uu____11763 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g
                                        in
                                     FStar_Extraction_ML_Code.string_of_mlexpr
-                                      uu____11753
+                                      uu____11763
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_expr
                                      in
-                                  let uu____11754 =
-                                    let uu____11756 =
+                                  let uu____11764 =
+                                    let uu____11766 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g
                                        in
                                     FStar_Extraction_ML_Code.string_of_mlty
-                                      uu____11756
+                                      uu____11766
                                       (FStar_Pervasives_Native.snd
                                          exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)
                                      in
                                   FStar_Util.print3
                                     "@@@looked up %s: got %s at %s\n"
-                                    uu____11749 uu____11751 uu____11754);
+                                    uu____11759 uu____11761 uu____11764);
                              (((exp_b.FStar_Extraction_ML_UEnv.exp_b_expr),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)),
                                q))
-                        | uu____11772 -> failwith "FIXME Ty"  in
-                      (match uu____11701 with
+                        | uu____11782 -> failwith "FIXME Ty"  in
+                      (match uu____11711 with
                        | ((head_ml,(vars,t1)),qual) ->
                            let has_typ_apps =
                              match args with
-                             | (a,uu____11824)::uu____11825 -> is_type g a
-                             | uu____11852 -> false  in
-                           let uu____11864 =
+                             | (a,uu____11834)::uu____11835 -> is_type g a
+                             | uu____11862 -> false  in
+                           let uu____11874 =
                              let n = FStar_List.length vars  in
-                             let uu____11881 =
+                             let uu____11891 =
                                if (FStar_List.length args) <= n
                                then
-                                 let uu____11919 =
+                                 let uu____11929 =
                                    FStar_List.map
-                                     (fun uu____11931  ->
-                                        match uu____11931 with
-                                        | (x,uu____11939) -> term_as_mlty g x)
+                                     (fun uu____11941  ->
+                                        match uu____11941 with
+                                        | (x,uu____11949) -> term_as_mlty g x)
                                      args
                                     in
-                                 (uu____11919, [])
+                                 (uu____11929, [])
                                else
-                                 (let uu____11962 = FStar_Util.first_N n args
+                                 (let uu____11972 = FStar_Util.first_N n args
                                      in
-                                  match uu____11962 with
+                                  match uu____11972 with
                                   | (prefix,rest) ->
-                                      let uu____12051 =
+                                      let uu____12061 =
                                         FStar_List.map
-                                          (fun uu____12063  ->
-                                             match uu____12063 with
-                                             | (x,uu____12071) ->
+                                          (fun uu____12073  ->
+                                             match uu____12073 with
+                                             | (x,uu____12081) ->
                                                  term_as_mlty g x) prefix
                                          in
-                                      (uu____12051, rest))
+                                      (uu____12061, rest))
                                 in
-                             match uu____11881 with
+                             match uu____11891 with
                              | (provided_type_args,rest) ->
-                                 let uu____12122 =
+                                 let uu____12132 =
                                    match head_ml.FStar_Extraction_ML_Syntax.expr
                                    with
                                    | FStar_Extraction_ML_Syntax.MLE_Name
-                                       uu____12131 ->
-                                       let uu____12132 =
+                                       uu____12141 ->
+                                       let uu____12142 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____12132 with
-                                        | (head2,uu____12144,t2) ->
+                                       (match uu____12142 with
+                                        | (head2,uu____12154,t2) ->
                                             (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_Var
-                                       uu____12146 ->
-                                       let uu____12148 =
+                                       uu____12156 ->
+                                       let uu____12158 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____12148 with
-                                        | (head2,uu____12160,t2) ->
+                                       (match uu____12158 with
+                                        | (head2,uu____12170,t2) ->
                                             (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_App
                                        (head2,{
@@ -3405,17 +3408,17 @@ and (term_as_mlexpr' :
                                                   (FStar_Extraction_ML_Syntax.MLC_Unit
                                                   );
                                                 FStar_Extraction_ML_Syntax.mlty
-                                                  = uu____12163;
+                                                  = uu____12173;
                                                 FStar_Extraction_ML_Syntax.loc
-                                                  = uu____12164;_}::[])
+                                                  = uu____12174;_}::[])
                                        ->
-                                       let uu____12167 =
+                                       let uu____12177 =
                                          instantiate_maybe_partial g head2
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____12167 with
-                                        | (head3,uu____12179,t2) ->
-                                            let uu____12181 =
+                                       (match uu____12177 with
+                                        | (head3,uu____12189,t2) ->
+                                            let uu____12191 =
                                               FStar_All.pipe_right
                                                 (FStar_Extraction_ML_Syntax.MLE_App
                                                    (head3,
@@ -3423,93 +3426,93 @@ and (term_as_mlexpr' :
                                                 (FStar_Extraction_ML_Syntax.with_ty
                                                    t2)
                                                in
-                                            (uu____12181, t2))
-                                   | uu____12184 ->
+                                            (uu____12191, t2))
+                                   | uu____12194 ->
                                        failwith
                                          "Impossible: Unexpected head term"
                                     in
-                                 (match uu____12122 with
+                                 (match uu____12132 with
                                   | (head2,t2) -> (head2, t2, rest))
                               in
-                           (match uu____11864 with
+                           (match uu____11874 with
                             | (head_ml1,head_t,args1) ->
                                 (match args1 with
                                  | [] ->
-                                     let uu____12251 =
+                                     let uu____12261 =
                                        maybe_eta_data_and_project_record g
                                          qual head_t head_ml1
                                         in
-                                     (uu____12251,
+                                     (uu____12261,
                                        FStar_Extraction_ML_Syntax.E_PURE,
                                        head_t)
-                                 | uu____12252 ->
+                                 | uu____12262 ->
                                      extract_app_maybe_projector qual
                                        head_ml1
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          head_t) args1)))
-                  | uu____12261 ->
-                      let uu____12262 = term_as_mlexpr g head1  in
-                      (match uu____12262 with
+                  | uu____12271 ->
+                      let uu____12272 = term_as_mlexpr g head1  in
+                      (match uu____12272 with
                        | (head2,f,t1) ->
                            extract_app_maybe_projector
                              FStar_Pervasives_Native.None head2 (f, t1) args)
                    in
-                let uu____12278 = is_type g t  in
-                if uu____12278
+                let uu____12288 = is_type g t  in
+                if uu____12288
                 then
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.ml_unit_ty)
                 else
-                  (let uu____12289 =
-                     let uu____12290 = FStar_Syntax_Util.un_uinst head  in
-                     uu____12290.FStar_Syntax_Syntax.n  in
-                   match uu____12289 with
+                  (let uu____12299 =
+                     let uu____12300 = FStar_Syntax_Util.un_uinst head  in
+                     uu____12300.FStar_Syntax_Syntax.n  in
+                   match uu____12299 with
                    | FStar_Syntax_Syntax.Tm_fvar fv ->
-                       let uu____12300 =
+                       let uu____12310 =
                          FStar_Extraction_ML_UEnv.try_lookup_fv g fv  in
-                       (match uu____12300 with
+                       (match uu____12310 with
                         | FStar_Pervasives_Native.None  ->
                             (FStar_Extraction_ML_Syntax.ml_unit,
                               FStar_Extraction_ML_Syntax.E_PURE,
                               FStar_Extraction_ML_Syntax.MLTY_Erased)
-                        | uu____12309 -> extract_app_with_instantiations ())
-                   | uu____12312 -> extract_app_with_instantiations ()))
-       | FStar_Syntax_Syntax.Tm_ascribed (e0,(tc,uu____12315),f) ->
+                        | uu____12319 -> extract_app_with_instantiations ())
+                   | uu____12322 -> extract_app_with_instantiations ()))
+       | FStar_Syntax_Syntax.Tm_ascribed (e0,(tc,uu____12325),f) ->
            let t1 =
              match tc with
              | FStar_Util.Inl t1 -> term_as_mlty g t1
              | FStar_Util.Inr c ->
-                 let uu____12380 =
-                   let uu____12381 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+                 let uu____12390 =
+                   let uu____12391 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                       in
-                   maybe_reify_comp g uu____12381 c  in
-                 term_as_mlty g uu____12380
+                   maybe_reify_comp g uu____12391 c  in
+                 term_as_mlty g uu____12390
               in
            let f1 =
              match f with
              | FStar_Pervasives_Native.None  ->
                  failwith "Ascription node with an empty effect label"
              | FStar_Pervasives_Native.Some l -> effect_as_etag g l  in
-           let uu____12385 = check_term_as_mlexpr g e0 f1 t1  in
-           (match uu____12385 with | (e,t2) -> (e, f1, t2))
+           let uu____12395 = check_term_as_mlexpr g e0 f1 t1  in
+           (match uu____12395 with | (e,t2) -> (e, f1, t2))
        | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e') when
-           (let uu____12417 = FStar_Syntax_Syntax.is_top_level [lb]  in
-            Prims.op_Negation uu____12417) &&
-             (let uu____12420 =
+           (let uu____12427 = FStar_Syntax_Syntax.is_top_level [lb]  in
+            Prims.op_Negation uu____12427) &&
+             (let uu____12430 =
                 FStar_Syntax_Util.get_attribute
                   FStar_Parser_Const.rename_let_attr
                   lb.FStar_Syntax_Syntax.lbattrs
                  in
-              FStar_Util.is_some uu____12420)
+              FStar_Util.is_some uu____12430)
            ->
            let b =
-             let uu____12430 = FStar_Util.left lb.FStar_Syntax_Syntax.lbname
+             let uu____12440 = FStar_Util.left lb.FStar_Syntax_Syntax.lbname
                 in
-             (uu____12430, FStar_Pervasives_Native.None)  in
-           let uu____12433 = FStar_Syntax_Subst.open_term_1 b e'  in
-           (match uu____12433 with
-            | ((x,uu____12445),body) ->
+             (uu____12440, FStar_Pervasives_Native.None)  in
+           let uu____12443 = FStar_Syntax_Subst.open_term_1 b e'  in
+           (match uu____12443 with
+            | ((x,uu____12455),body) ->
                 let suggested_name =
                   let attr =
                     FStar_Syntax_Util.get_attribute
@@ -3517,19 +3520,19 @@ and (term_as_mlexpr' :
                       lb.FStar_Syntax_Syntax.lbattrs
                      in
                   match attr with
-                  | FStar_Pervasives_Native.Some ((str,uu____12460)::[]) ->
-                      let uu____12485 =
-                        let uu____12486 = FStar_Syntax_Subst.compress str  in
-                        uu____12486.FStar_Syntax_Syntax.n  in
-                      (match uu____12485 with
+                  | FStar_Pervasives_Native.Some ((str,uu____12470)::[]) ->
+                      let uu____12495 =
+                        let uu____12496 = FStar_Syntax_Subst.compress str  in
+                        uu____12496.FStar_Syntax_Syntax.n  in
+                      (match uu____12495 with
                        | FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_string (s,uu____12492)) ->
+                           (FStar_Const.Const_string (s,uu____12502)) ->
                            let id =
-                             let uu____12496 =
-                               let uu____12502 =
+                             let uu____12506 =
+                               let uu____12512 =
                                  FStar_Syntax_Syntax.range_of_bv x  in
-                               (s, uu____12502)  in
-                             FStar_Ident.mk_ident uu____12496  in
+                               (s, uu____12512)  in
+                             FStar_Ident.mk_ident uu____12506  in
                            let bv =
                              {
                                FStar_Syntax_Syntax.ppname = id;
@@ -3539,8 +3542,8 @@ and (term_as_mlexpr' :
                              }  in
                            let bv1 = FStar_Syntax_Syntax.freshen_bv bv  in
                            FStar_Pervasives_Native.Some bv1
-                       | uu____12507 -> FStar_Pervasives_Native.None)
-                  | FStar_Pervasives_Native.Some uu____12508 ->
+                       | uu____12517 -> FStar_Pervasives_Native.None)
+                  | FStar_Pervasives_Native.Some uu____12518 ->
                       (FStar_Errors.log_issue top1.FStar_Syntax_Syntax.pos
                          (FStar_Errors.Warning_UnrecognizedAttribute,
                            "Ill-formed application of `rename_let`");
@@ -3549,18 +3552,18 @@ and (term_as_mlexpr' :
                       FStar_Pervasives_Native.None
                    in
                 let remove_attr attrs =
-                  let uu____12528 =
+                  let uu____12538 =
                     FStar_List.partition
                       (fun attr  ->
-                         let uu____12540 =
+                         let uu____12550 =
                            FStar_Syntax_Util.get_attribute
                              FStar_Parser_Const.rename_let_attr [attr]
                             in
-                         FStar_Util.is_some uu____12540)
+                         FStar_Util.is_some uu____12550)
                       lb.FStar_Syntax_Syntax.lbattrs
                      in
-                  match uu____12528 with
-                  | (uu____12545,other_attrs) -> other_attrs  in
+                  match uu____12538 with
+                  | (uu____12555,other_attrs) -> other_attrs  in
                 let maybe_rewritten_let =
                   match suggested_name with
                   | FStar_Pervasives_Native.None  ->
@@ -3568,98 +3571,98 @@ and (term_as_mlexpr' :
                         remove_attr lb.FStar_Syntax_Syntax.lbattrs  in
                       FStar_Syntax_Syntax.Tm_let
                         ((false,
-                           [(let uu___1774_12573 = lb  in
+                           [(let uu___1774_12583 = lb  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___1774_12573.FStar_Syntax_Syntax.lbname);
+                                 (uu___1774_12583.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___1774_12573.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___1774_12583.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___1774_12573.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___1774_12583.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1774_12573.FStar_Syntax_Syntax.lbeff);
+                                 (uu___1774_12583.FStar_Syntax_Syntax.lbeff);
                                FStar_Syntax_Syntax.lbdef =
-                                 (uu___1774_12573.FStar_Syntax_Syntax.lbdef);
+                                 (uu___1774_12583.FStar_Syntax_Syntax.lbdef);
                                FStar_Syntax_Syntax.lbattrs = other_attrs;
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1774_12573.FStar_Syntax_Syntax.lbpos)
+                                 (uu___1774_12583.FStar_Syntax_Syntax.lbpos)
                              })]), e')
                   | FStar_Pervasives_Native.Some y ->
                       let other_attrs =
                         remove_attr lb.FStar_Syntax_Syntax.lbattrs  in
                       let rename =
-                        let uu____12581 =
-                          let uu____12582 =
-                            let uu____12589 =
+                        let uu____12591 =
+                          let uu____12592 =
+                            let uu____12599 =
                               FStar_Syntax_Syntax.bv_to_name y  in
-                            (x, uu____12589)  in
-                          FStar_Syntax_Syntax.NT uu____12582  in
-                        [uu____12581]  in
+                            (x, uu____12599)  in
+                          FStar_Syntax_Syntax.NT uu____12592  in
+                        [uu____12591]  in
                       let body1 =
-                        let uu____12595 =
+                        let uu____12605 =
                           FStar_Syntax_Subst.subst rename body  in
                         FStar_Syntax_Subst.close
-                          [(y, FStar_Pervasives_Native.None)] uu____12595
+                          [(y, FStar_Pervasives_Native.None)] uu____12605
                          in
                       let lb1 =
-                        let uu___1781_12611 = lb  in
+                        let uu___1781_12621 = lb  in
                         {
                           FStar_Syntax_Syntax.lbname = (FStar_Util.Inl y);
                           FStar_Syntax_Syntax.lbunivs =
-                            (uu___1781_12611.FStar_Syntax_Syntax.lbunivs);
+                            (uu___1781_12621.FStar_Syntax_Syntax.lbunivs);
                           FStar_Syntax_Syntax.lbtyp =
-                            (uu___1781_12611.FStar_Syntax_Syntax.lbtyp);
+                            (uu___1781_12621.FStar_Syntax_Syntax.lbtyp);
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___1781_12611.FStar_Syntax_Syntax.lbeff);
+                            (uu___1781_12621.FStar_Syntax_Syntax.lbeff);
                           FStar_Syntax_Syntax.lbdef =
-                            (uu___1781_12611.FStar_Syntax_Syntax.lbdef);
+                            (uu___1781_12621.FStar_Syntax_Syntax.lbdef);
                           FStar_Syntax_Syntax.lbattrs = other_attrs;
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___1781_12611.FStar_Syntax_Syntax.lbpos)
+                            (uu___1781_12621.FStar_Syntax_Syntax.lbpos)
                         }  in
                       FStar_Syntax_Syntax.Tm_let ((false, [lb1]), body1)
                    in
                 let top2 =
-                  let uu___1785_12628 = top1  in
+                  let uu___1785_12638 = top1  in
                   {
                     FStar_Syntax_Syntax.n = maybe_rewritten_let;
                     FStar_Syntax_Syntax.pos =
-                      (uu___1785_12628.FStar_Syntax_Syntax.pos);
+                      (uu___1785_12638.FStar_Syntax_Syntax.pos);
                     FStar_Syntax_Syntax.vars =
-                      (uu___1785_12628.FStar_Syntax_Syntax.vars)
+                      (uu___1785_12638.FStar_Syntax_Syntax.vars)
                   }  in
                 term_as_mlexpr' g top2)
        | FStar_Syntax_Syntax.Tm_let ((is_rec,lbs),e') ->
            let top_level = FStar_Syntax_Syntax.is_top_level lbs  in
-           let uu____12651 =
+           let uu____12661 =
              if is_rec
              then FStar_Syntax_Subst.open_let_rec lbs e'
              else
-               (let uu____12667 = FStar_Syntax_Syntax.is_top_level lbs  in
-                if uu____12667
+               (let uu____12677 = FStar_Syntax_Syntax.is_top_level lbs  in
+                if uu____12677
                 then (lbs, e')
                 else
                   (let lb = FStar_List.hd lbs  in
                    let x =
-                     let uu____12682 =
+                     let uu____12692 =
                        FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                     FStar_Syntax_Syntax.freshen_bv uu____12682  in
+                     FStar_Syntax_Syntax.freshen_bv uu____12692  in
                    let lb1 =
-                     let uu___1799_12684 = lb  in
+                     let uu___1799_12694 = lb  in
                      {
                        FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
                        FStar_Syntax_Syntax.lbunivs =
-                         (uu___1799_12684.FStar_Syntax_Syntax.lbunivs);
+                         (uu___1799_12694.FStar_Syntax_Syntax.lbunivs);
                        FStar_Syntax_Syntax.lbtyp =
-                         (uu___1799_12684.FStar_Syntax_Syntax.lbtyp);
+                         (uu___1799_12694.FStar_Syntax_Syntax.lbtyp);
                        FStar_Syntax_Syntax.lbeff =
-                         (uu___1799_12684.FStar_Syntax_Syntax.lbeff);
+                         (uu___1799_12694.FStar_Syntax_Syntax.lbeff);
                        FStar_Syntax_Syntax.lbdef =
-                         (uu___1799_12684.FStar_Syntax_Syntax.lbdef);
+                         (uu___1799_12694.FStar_Syntax_Syntax.lbdef);
                        FStar_Syntax_Syntax.lbattrs =
-                         (uu___1799_12684.FStar_Syntax_Syntax.lbattrs);
+                         (uu___1799_12694.FStar_Syntax_Syntax.lbattrs);
                        FStar_Syntax_Syntax.lbpos =
-                         (uu___1799_12684.FStar_Syntax_Syntax.lbpos)
+                         (uu___1799_12694.FStar_Syntax_Syntax.lbpos)
                      }  in
                    let e'1 =
                      FStar_Syntax_Subst.subst
@@ -3667,57 +3670,57 @@ and (term_as_mlexpr' :
                       in
                    ([lb1], e'1)))
               in
-           (match uu____12651 with
+           (match uu____12661 with
             | (lbs1,e'1) ->
                 let lbs2 =
                   if top_level
                   then
                     let tcenv =
-                      let uu____12709 =
+                      let uu____12719 =
                         FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-                      let uu____12710 =
-                        let uu____12711 =
-                          let uu____12712 =
-                            let uu____12716 =
+                      let uu____12720 =
+                        let uu____12721 =
+                          let uu____12722 =
+                            let uu____12726 =
                               FStar_Extraction_ML_UEnv.current_module_of_uenv
                                 g
                                in
-                            FStar_Pervasives_Native.fst uu____12716  in
-                          let uu____12729 =
-                            let uu____12733 =
-                              let uu____12735 =
+                            FStar_Pervasives_Native.fst uu____12726  in
+                          let uu____12739 =
+                            let uu____12743 =
+                              let uu____12745 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g
                                  in
-                              FStar_Pervasives_Native.snd uu____12735  in
-                            [uu____12733]  in
-                          FStar_List.append uu____12712 uu____12729  in
-                        FStar_Ident.lid_of_path uu____12711
+                              FStar_Pervasives_Native.snd uu____12745  in
+                            [uu____12743]  in
+                          FStar_List.append uu____12722 uu____12739  in
+                        FStar_Ident.lid_of_path uu____12721
                           FStar_Range.dummyRange
                          in
-                      FStar_TypeChecker_Env.set_current_module uu____12709
-                        uu____12710
+                      FStar_TypeChecker_Env.set_current_module uu____12719
+                        uu____12720
                        in
                     FStar_All.pipe_right lbs1
                       (FStar_List.map
                          (fun lb  ->
                             let lbdef =
-                              let uu____12762 = FStar_Options.ml_ish ()  in
-                              if uu____12762
+                              let uu____12772 = FStar_Options.ml_ish ()  in
+                              if uu____12772
                               then lb.FStar_Syntax_Syntax.lbdef
                               else
-                                (let norm_call uu____12774 =
-                                   let uu____12775 =
-                                     let uu____12776 =
+                                (let norm_call uu____12784 =
+                                   let uu____12785 =
+                                     let uu____12786 =
                                        extraction_norm_steps ()  in
                                      FStar_TypeChecker_Env.PureSubtermsWithinComputations
-                                       :: uu____12776
+                                       :: uu____12786
                                       in
                                    FStar_TypeChecker_Normalize.normalize
-                                     uu____12775 tcenv
+                                     uu____12785 tcenv
                                      lb.FStar_Syntax_Syntax.lbdef
                                     in
-                                 let uu____12779 =
+                                 let uu____12789 =
                                    (FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug tcenv)
                                       (FStar_Options.Other "Extraction"))
@@ -3726,69 +3729,69 @@ and (term_as_mlexpr' :
                                         (FStar_TypeChecker_Env.debug tcenv)
                                         (FStar_Options.Other "ExtractNorm"))
                                     in
-                                 if uu____12779
+                                 if uu____12789
                                  then
-                                   ((let uu____12789 =
+                                   ((let uu____12799 =
                                        FStar_Syntax_Print.lbname_to_string
                                          lb.FStar_Syntax_Syntax.lbname
                                         in
                                      FStar_Util.print1
                                        "Starting to normalize top-level let %s\n"
-                                       uu____12789);
+                                       uu____12799);
                                     (let a =
-                                       let uu____12795 =
-                                         let uu____12797 =
+                                       let uu____12805 =
+                                         let uu____12807 =
                                            FStar_Syntax_Print.lbname_to_string
                                              lb.FStar_Syntax_Syntax.lbname
                                             in
                                          FStar_Util.format1
                                            "###(Time to normalize top-level let %s)"
-                                           uu____12797
+                                           uu____12807
                                           in
                                        FStar_Util.measure_execution_time
-                                         uu____12795 norm_call
+                                         uu____12805 norm_call
                                         in
                                      a))
                                  else norm_call ())
                                in
-                            let uu___1816_12804 = lb  in
+                            let uu___1816_12814 = lb  in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___1816_12804.FStar_Syntax_Syntax.lbname);
+                                (uu___1816_12814.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___1816_12804.FStar_Syntax_Syntax.lbunivs);
+                                (uu___1816_12814.FStar_Syntax_Syntax.lbunivs);
                               FStar_Syntax_Syntax.lbtyp =
-                                (uu___1816_12804.FStar_Syntax_Syntax.lbtyp);
+                                (uu___1816_12814.FStar_Syntax_Syntax.lbtyp);
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___1816_12804.FStar_Syntax_Syntax.lbeff);
+                                (uu___1816_12814.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef = lbdef;
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___1816_12804.FStar_Syntax_Syntax.lbattrs);
+                                (uu___1816_12814.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___1816_12804.FStar_Syntax_Syntax.lbpos)
+                                (uu___1816_12814.FStar_Syntax_Syntax.lbpos)
                             }))
                   else lbs1  in
-                let check_lb env uu____12857 =
-                  match uu____12857 with
+                let check_lb env uu____12867 =
+                  match uu____12867 with
                   | (nm,(_lbname,f,(_t,(targs,polytype)),add_unit,e)) ->
                       let env1 =
                         FStar_List.fold_left
                           (fun env1  ->
-                             fun uu____13013  ->
-                               match uu____13013 with
-                               | (a,uu____13021) ->
+                             fun uu____13023  ->
+                               match uu____13023 with
+                               | (a,uu____13031) ->
                                    FStar_Extraction_ML_UEnv.extend_ty env1 a
                                      false) env targs
                          in
                       let expected_t = FStar_Pervasives_Native.snd polytype
                          in
-                      let uu____13028 =
+                      let uu____13038 =
                         check_term_as_mlexpr env1 e f expected_t  in
-                      (match uu____13028 with
+                      (match uu____13038 with
                        | (e1,ty) ->
-                           let uu____13039 =
+                           let uu____13049 =
                              maybe_promote_effect e1 f expected_t  in
-                           (match uu____13039 with
+                           (match uu____13049 with
                             | (e2,f1) ->
                                 let meta =
                                   match (f1, ty) with
@@ -3798,7 +3801,7 @@ and (term_as_mlexpr' :
                                   | (FStar_Extraction_ML_Syntax.E_GHOST
                                      ,FStar_Extraction_ML_Syntax.MLTY_Erased
                                      ) -> [FStar_Extraction_ML_Syntax.Erased]
-                                  | uu____13051 -> []  in
+                                  | uu____13061 -> []  in
                                 (f1,
                                   {
                                     FStar_Extraction_ML_Syntax.mllb_name = nm;
@@ -3814,26 +3817,26 @@ and (term_as_mlexpr' :
                                   })))
                    in
                 let lbs3 = extract_lb_sig g (is_rec, lbs2)  in
-                let uu____13082 =
+                let uu____13092 =
                   FStar_List.fold_right
                     (fun lb  ->
-                       fun uu____13179  ->
-                         match uu____13179 with
+                       fun uu____13189  ->
+                         match uu____13189 with
                          | (env,lbs4) ->
-                             let uu____13313 = lb  in
-                             (match uu____13313 with
-                              | (lbname,uu____13364,(t1,(uu____13366,polytype)),add_unit,uu____13369)
+                             let uu____13323 = lb  in
+                             (match uu____13323 with
+                              | (lbname,uu____13374,(t1,(uu____13376,polytype)),add_unit,uu____13379)
                                   ->
-                                  let uu____13384 =
+                                  let uu____13394 =
                                     FStar_Extraction_ML_UEnv.extend_lb env
                                       lbname t1 polytype add_unit
                                      in
-                                  (match uu____13384 with
-                                   | (env1,nm,uu____13424) ->
+                                  (match uu____13394 with
+                                   | (env1,nm,uu____13434) ->
                                        (env1, ((nm, lb) :: lbs4))))) lbs3
                     (g, [])
                    in
-                (match uu____13082 with
+                (match uu____13092 with
                  | (env_body,lbs4) ->
                      let env_def = if is_rec then env_body else g  in
                      let lbs5 =
@@ -3841,46 +3844,46 @@ and (term_as_mlexpr' :
                          (FStar_List.map (check_lb env_def))
                         in
                      let e'_rng = e'1.FStar_Syntax_Syntax.pos  in
-                     let uu____13703 = term_as_mlexpr env_body e'1  in
-                     (match uu____13703 with
+                     let uu____13713 = term_as_mlexpr env_body e'1  in
+                     (match uu____13713 with
                       | (e'2,f',t') ->
                           let f =
-                            let uu____13720 =
-                              let uu____13723 =
+                            let uu____13730 =
+                              let uu____13733 =
                                 FStar_List.map FStar_Pervasives_Native.fst
                                   lbs5
                                  in
-                              f' :: uu____13723  in
+                              f' :: uu____13733  in
                             FStar_Extraction_ML_Util.join_l e'_rng
-                              uu____13720
+                              uu____13730
                              in
                           let is_rec1 =
                             if is_rec = true
                             then FStar_Extraction_ML_Syntax.Rec
                             else FStar_Extraction_ML_Syntax.NonRec  in
-                          let uu____13736 =
-                            let uu____13737 =
-                              let uu____13738 =
-                                let uu____13739 =
+                          let uu____13746 =
+                            let uu____13747 =
+                              let uu____13748 =
+                                let uu____13749 =
                                   FStar_List.map FStar_Pervasives_Native.snd
                                     lbs5
                                    in
-                                (is_rec1, uu____13739)  in
-                              mk_MLE_Let top_level uu____13738 e'2  in
-                            let uu____13748 =
+                                (is_rec1, uu____13749)  in
+                              mk_MLE_Let top_level uu____13748 e'2  in
+                            let uu____13758 =
                               FStar_Extraction_ML_Util.mlloc_of_range
                                 t.FStar_Syntax_Syntax.pos
                                in
                             FStar_Extraction_ML_Syntax.with_ty_loc t'
-                              uu____13737 uu____13748
+                              uu____13747 uu____13758
                              in
-                          (uu____13736, f, t'))))
+                          (uu____13746, f, t'))))
        | FStar_Syntax_Syntax.Tm_match (scrutinee,pats) ->
-           let uu____13787 = term_as_mlexpr g scrutinee  in
-           (match uu____13787 with
+           let uu____13797 = term_as_mlexpr g scrutinee  in
+           (match uu____13797 with
             | (e,f_e,t_e) ->
-                let uu____13803 = check_pats_for_ite pats  in
-                (match uu____13803 with
+                let uu____13813 = check_pats_for_ite pats  in
+                (match uu____13813 with
                  | (b,then_e,else_e) ->
                      let no_lift x t1 = x  in
                      if b
@@ -3888,80 +3891,80 @@ and (term_as_mlexpr' :
                        (match (then_e, else_e) with
                         | (FStar_Pervasives_Native.Some
                            then_e1,FStar_Pervasives_Native.Some else_e1) ->
-                            let uu____13868 = term_as_mlexpr g then_e1  in
-                            (match uu____13868 with
+                            let uu____13878 = term_as_mlexpr g then_e1  in
+                            (match uu____13878 with
                              | (then_mle,f_then,t_then) ->
-                                 let uu____13884 = term_as_mlexpr g else_e1
+                                 let uu____13894 = term_as_mlexpr g else_e1
                                     in
-                                 (match uu____13884 with
+                                 (match uu____13894 with
                                   | (else_mle,f_else,t_else) ->
-                                      let uu____13900 =
-                                        let uu____13911 =
+                                      let uu____13910 =
+                                        let uu____13921 =
                                           type_leq g t_then t_else  in
-                                        if uu____13911
+                                        if uu____13921
                                         then (t_else, no_lift)
                                         else
-                                          (let uu____13932 =
+                                          (let uu____13942 =
                                              type_leq g t_else t_then  in
-                                           if uu____13932
+                                           if uu____13942
                                            then (t_then, no_lift)
                                            else
                                              (FStar_Extraction_ML_Syntax.MLTY_Top,
                                                FStar_Extraction_ML_Syntax.apply_obj_repr))
                                          in
-                                      (match uu____13900 with
+                                      (match uu____13910 with
                                        | (t_branch,maybe_lift) ->
-                                           let uu____13979 =
-                                             let uu____13980 =
-                                               let uu____13981 =
-                                                 let uu____13990 =
+                                           let uu____13989 =
+                                             let uu____13990 =
+                                               let uu____13991 =
+                                                 let uu____14000 =
                                                    maybe_lift then_mle t_then
                                                     in
-                                                 let uu____13991 =
-                                                   let uu____13994 =
+                                                 let uu____14001 =
+                                                   let uu____14004 =
                                                      maybe_lift else_mle
                                                        t_else
                                                       in
                                                    FStar_Pervasives_Native.Some
-                                                     uu____13994
+                                                     uu____14004
                                                     in
-                                                 (e, uu____13990,
-                                                   uu____13991)
+                                                 (e, uu____14000,
+                                                   uu____14001)
                                                   in
                                                FStar_Extraction_ML_Syntax.MLE_If
-                                                 uu____13981
+                                                 uu____13991
                                                 in
                                              FStar_All.pipe_left
                                                (FStar_Extraction_ML_Syntax.with_ty
-                                                  t_branch) uu____13980
+                                                  t_branch) uu____13990
                                               in
-                                           let uu____13997 =
+                                           let uu____14007 =
                                              FStar_Extraction_ML_Util.join
                                                then_e1.FStar_Syntax_Syntax.pos
                                                f_then f_else
                                               in
-                                           (uu____13979, uu____13997,
+                                           (uu____13989, uu____14007,
                                              t_branch))))
-                        | uu____13998 ->
+                        | uu____14008 ->
                             failwith
                               "ITE pats matched but then and else expressions not found?")
                      else
-                       (let uu____14016 =
+                       (let uu____14026 =
                           FStar_All.pipe_right pats
                             (FStar_Util.fold_map
                                (fun compat  ->
                                   fun br  ->
-                                    let uu____14115 =
+                                    let uu____14125 =
                                       FStar_Syntax_Subst.open_branch br  in
-                                    match uu____14115 with
+                                    match uu____14125 with
                                     | (pat,when_opt,branch) ->
-                                        let uu____14160 =
+                                        let uu____14170 =
                                           extract_pat g pat t_e
                                             term_as_mlexpr
                                            in
-                                        (match uu____14160 with
+                                        (match uu____14170 with
                                          | (env,p,pat_t_compat) ->
-                                             let uu____14222 =
+                                             let uu____14232 =
                                                match when_opt with
                                                | FStar_Pervasives_Native.None
                                                     ->
@@ -3972,9 +3975,9 @@ and (term_as_mlexpr' :
                                                    let w_pos =
                                                      w.FStar_Syntax_Syntax.pos
                                                       in
-                                                   let uu____14245 =
+                                                   let uu____14255 =
                                                      term_as_mlexpr env w  in
-                                                   (match uu____14245 with
+                                                   (match uu____14255 with
                                                     | (w1,f_w,t_w) ->
                                                         let w2 =
                                                           maybe_coerce w_pos
@@ -3984,22 +3987,22 @@ and (term_as_mlexpr' :
                                                         ((FStar_Pervasives_Native.Some
                                                             w2), f_w))
                                                 in
-                                             (match uu____14222 with
+                                             (match uu____14232 with
                                               | (when_opt1,f_when) ->
-                                                  let uu____14295 =
+                                                  let uu____14305 =
                                                     term_as_mlexpr env branch
                                                      in
-                                                  (match uu____14295 with
+                                                  (match uu____14305 with
                                                    | (mlbranch,f_branch,t_branch)
                                                        ->
-                                                       let uu____14330 =
+                                                       let uu____14340 =
                                                          FStar_All.pipe_right
                                                            p
                                                            (FStar_List.map
                                                               (fun
-                                                                 uu____14407 
+                                                                 uu____14417 
                                                                  ->
-                                                                 match uu____14407
+                                                                 match uu____14417
                                                                  with
                                                                  | (p1,wopt)
                                                                     ->
@@ -4018,10 +4021,10 @@ and (term_as_mlexpr' :
                                                           in
                                                        ((compat &&
                                                            pat_t_compat),
-                                                         uu____14330)))))
+                                                         uu____14340)))))
                                true)
                            in
-                        match uu____14016 with
+                        match uu____14026 with
                         | (pat_t_compat,mlbranches) ->
                             let mlbranches1 = FStar_List.flatten mlbranches
                                in
@@ -4030,26 +4033,26 @@ and (term_as_mlexpr' :
                               then e
                               else
                                 (FStar_Extraction_ML_UEnv.debug g
-                                   (fun uu____14578  ->
-                                      let uu____14579 =
-                                        let uu____14581 =
+                                   (fun uu____14588  ->
+                                      let uu____14589 =
+                                        let uu____14591 =
                                           FStar_Extraction_ML_UEnv.current_module_of_uenv
                                             g
                                            in
                                         FStar_Extraction_ML_Code.string_of_mlexpr
-                                          uu____14581 e
+                                          uu____14591 e
                                          in
-                                      let uu____14582 =
-                                        let uu____14584 =
+                                      let uu____14592 =
+                                        let uu____14594 =
                                           FStar_Extraction_ML_UEnv.current_module_of_uenv
                                             g
                                            in
                                         FStar_Extraction_ML_Code.string_of_mlty
-                                          uu____14584 t_e
+                                          uu____14594 t_e
                                          in
                                       FStar_Util.print2
                                         "Coercing scrutinee %s from type %s because pattern type is incompatible\n"
-                                        uu____14579 uu____14582);
+                                        uu____14589 uu____14592);
                                  FStar_All.pipe_left
                                    (FStar_Extraction_ML_Syntax.with_ty t_e)
                                    (FStar_Extraction_ML_Syntax.MLE_Coerce
@@ -4058,30 +4061,30 @@ and (term_as_mlexpr' :
                                in
                             (match mlbranches1 with
                              | [] ->
-                                 let uu____14610 =
-                                   let uu____14611 =
+                                 let uu____14620 =
+                                   let uu____14621 =
                                      FStar_Syntax_Syntax.lid_as_fv
                                        FStar_Parser_Const.failwith_lid
                                        FStar_Syntax_Syntax.delta_constant
                                        FStar_Pervasives_Native.None
                                       in
                                    FStar_Extraction_ML_UEnv.lookup_fv g
-                                     uu____14611
+                                     uu____14621
                                     in
-                                 (match uu____14610 with
+                                 (match uu____14620 with
                                   | {
                                       FStar_Extraction_ML_UEnv.exp_b_name =
-                                        uu____14618;
+                                        uu____14628;
                                       FStar_Extraction_ML_UEnv.exp_b_expr =
                                         fw;
                                       FStar_Extraction_ML_UEnv.exp_b_tscheme
-                                        = uu____14620;_}
+                                        = uu____14630;_}
                                       ->
-                                      let uu____14622 =
-                                        let uu____14623 =
-                                          let uu____14624 =
-                                            let uu____14631 =
-                                              let uu____14634 =
+                                      let uu____14632 =
+                                        let uu____14633 =
+                                          let uu____14634 =
+                                            let uu____14641 =
+                                              let uu____14644 =
                                                 FStar_All.pipe_left
                                                   (FStar_Extraction_ML_Syntax.with_ty
                                                      FStar_Extraction_ML_Syntax.ml_string_ty)
@@ -4089,29 +4092,29 @@ and (term_as_mlexpr' :
                                                      (FStar_Extraction_ML_Syntax.MLC_String
                                                         "unreachable"))
                                                  in
-                                              [uu____14634]  in
-                                            (fw, uu____14631)  in
+                                              [uu____14644]  in
+                                            (fw, uu____14641)  in
                                           FStar_Extraction_ML_Syntax.MLE_App
-                                            uu____14624
+                                            uu____14634
                                            in
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              FStar_Extraction_ML_Syntax.ml_int_ty)
-                                          uu____14623
+                                          uu____14633
                                          in
-                                      (uu____14622,
+                                      (uu____14632,
                                         FStar_Extraction_ML_Syntax.E_PURE,
                                         FStar_Extraction_ML_Syntax.ml_int_ty))
-                             | (uu____14638,uu____14639,(uu____14640,f_first,t_first))::rest
+                             | (uu____14648,uu____14649,(uu____14650,f_first,t_first))::rest
                                  ->
-                                 let uu____14700 =
+                                 let uu____14710 =
                                    FStar_List.fold_left
-                                     (fun uu____14742  ->
-                                        fun uu____14743  ->
-                                          match (uu____14742, uu____14743)
+                                     (fun uu____14752  ->
+                                        fun uu____14753  ->
+                                          match (uu____14752, uu____14753)
                                           with
-                                          | ((topt,f),(uu____14800,uu____14801,
-                                                       (uu____14802,f_branch,t_branch)))
+                                          | ((topt,f),(uu____14810,uu____14811,
+                                                       (uu____14812,f_branch,t_branch)))
                                               ->
                                               let f1 =
                                                 FStar_Extraction_ML_Util.join
@@ -4125,19 +4128,19 @@ and (term_as_mlexpr' :
                                                     FStar_Pervasives_Native.None
                                                 | FStar_Pervasives_Native.Some
                                                     t1 ->
-                                                    let uu____14858 =
+                                                    let uu____14868 =
                                                       type_leq g t1 t_branch
                                                        in
-                                                    if uu____14858
+                                                    if uu____14868
                                                     then
                                                       FStar_Pervasives_Native.Some
                                                         t_branch
                                                     else
-                                                      (let uu____14865 =
+                                                      (let uu____14875 =
                                                          type_leq g t_branch
                                                            t1
                                                           in
-                                                       if uu____14865
+                                                       if uu____14875
                                                        then
                                                          FStar_Pervasives_Native.Some
                                                            t1
@@ -4148,15 +4151,15 @@ and (term_as_mlexpr' :
                                      ((FStar_Pervasives_Native.Some t_first),
                                        f_first) rest
                                     in
-                                 (match uu____14700 with
+                                 (match uu____14710 with
                                   | (topt,f_match) ->
                                       let mlbranches2 =
                                         FStar_All.pipe_right mlbranches1
                                           (FStar_List.map
-                                             (fun uu____14963  ->
-                                                match uu____14963 with
-                                                | (p,(wopt,uu____14992),
-                                                   (b1,uu____14994,t1)) ->
+                                             (fun uu____14973  ->
+                                                match uu____14973 with
+                                                | (p,(wopt,uu____15002),
+                                                   (b1,uu____15004,t1)) ->
                                                     let b2 =
                                                       match topt with
                                                       | FStar_Pervasives_Native.None
@@ -4164,7 +4167,7 @@ and (term_as_mlexpr' :
                                                           FStar_Extraction_ML_Syntax.apply_obj_repr
                                                             b1 t1
                                                       | FStar_Pervasives_Native.Some
-                                                          uu____15013 -> b1
+                                                          uu____15023 -> b1
                                                        in
                                                     (p, wopt, b2)))
                                          in
@@ -4175,14 +4178,14 @@ and (term_as_mlexpr' :
                                         | FStar_Pervasives_Native.Some t1 ->
                                             t1
                                          in
-                                      let uu____15018 =
+                                      let uu____15028 =
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              t_match)
                                           (FStar_Extraction_ML_Syntax.MLE_Match
                                              (e1, mlbranches2))
                                          in
-                                      (uu____15018, f_match, t_match)))))))
+                                      (uu____15028, f_match, t_match)))))))
 
 let (ind_discriminator_body :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -4192,79 +4195,79 @@ let (ind_discriminator_body :
   fun env  ->
     fun discName  ->
       fun constrName  ->
-        let uu____15045 =
-          let uu____15050 =
-            let uu____15059 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
-            FStar_TypeChecker_Env.lookup_lid uu____15059 discName  in
-          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____15050  in
-        match uu____15045 with
-        | (uu____15076,fstar_disc_type) ->
-            let uu____15078 =
-              let uu____15090 =
-                let uu____15091 = FStar_Syntax_Subst.compress fstar_disc_type
+        let uu____15055 =
+          let uu____15060 =
+            let uu____15069 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
+            FStar_TypeChecker_Env.lookup_lid uu____15069 discName  in
+          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____15060  in
+        match uu____15055 with
+        | (uu____15086,fstar_disc_type) ->
+            let uu____15088 =
+              let uu____15100 =
+                let uu____15101 = FStar_Syntax_Subst.compress fstar_disc_type
                    in
-                uu____15091.FStar_Syntax_Syntax.n  in
-              match uu____15090 with
-              | FStar_Syntax_Syntax.Tm_arrow (binders,uu____15106) ->
+                uu____15101.FStar_Syntax_Syntax.n  in
+              match uu____15100 with
+              | FStar_Syntax_Syntax.Tm_arrow (binders,uu____15116) ->
                   let binders1 =
                     FStar_All.pipe_right binders
                       (FStar_List.filter
-                         (fun uu___2_15161  ->
-                            match uu___2_15161 with
-                            | (uu____15169,FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____15170)) ->
+                         (fun uu___2_15171  ->
+                            match uu___2_15171 with
+                            | (uu____15179,FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____15180)) ->
                                 true
-                            | uu____15175 -> false))
+                            | uu____15185 -> false))
                      in
                   FStar_List.fold_right
-                    (fun uu____15207  ->
-                       fun uu____15208  ->
-                         match uu____15208 with
+                    (fun uu____15217  ->
+                       fun uu____15218  ->
+                         match uu____15218 with
                          | (g,vs) ->
-                             let uu____15253 =
+                             let uu____15263 =
                                FStar_Extraction_ML_UEnv.new_mlident g  in
-                             (match uu____15253 with
+                             (match uu____15263 with
                               | (g1,v) ->
                                   (g1,
                                     ((v, FStar_Extraction_ML_Syntax.MLTY_Top)
                                     :: vs)))) binders1 (env, [])
-              | uu____15299 -> failwith "Discriminator must be a function"
+              | uu____15309 -> failwith "Discriminator must be a function"
                in
-            (match uu____15078 with
+            (match uu____15088 with
              | (g,wildcards) ->
-                 let uu____15328 = FStar_Extraction_ML_UEnv.new_mlident g  in
-                 (match uu____15328 with
+                 let uu____15338 = FStar_Extraction_ML_UEnv.new_mlident g  in
+                 (match uu____15338 with
                   | (g1,mlid) ->
                       let targ = FStar_Extraction_ML_Syntax.MLTY_Top  in
                       let disc_ty = FStar_Extraction_ML_Syntax.MLTY_Top  in
                       let discrBody =
-                        let uu____15341 =
-                          let uu____15342 =
-                            let uu____15354 =
-                              let uu____15355 =
-                                let uu____15356 =
-                                  let uu____15371 =
+                        let uu____15351 =
+                          let uu____15352 =
+                            let uu____15364 =
+                              let uu____15365 =
+                                let uu____15366 =
+                                  let uu____15381 =
                                     FStar_All.pipe_left
                                       (FStar_Extraction_ML_Syntax.with_ty
                                          targ)
                                       (FStar_Extraction_ML_Syntax.MLE_Name
                                          ([], mlid))
                                      in
-                                  let uu____15377 =
-                                    let uu____15388 =
-                                      let uu____15397 =
-                                        let uu____15398 =
-                                          let uu____15405 =
+                                  let uu____15387 =
+                                    let uu____15398 =
+                                      let uu____15407 =
+                                        let uu____15408 =
+                                          let uu____15415 =
                                             FStar_Extraction_ML_UEnv.mlpath_of_lident
                                               g1 constrName
                                              in
-                                          (uu____15405,
+                                          (uu____15415,
                                             [FStar_Extraction_ML_Syntax.MLP_Wild])
                                            in
                                         FStar_Extraction_ML_Syntax.MLP_CTor
-                                          uu____15398
+                                          uu____15408
                                          in
-                                      let uu____15408 =
+                                      let uu____15418 =
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              FStar_Extraction_ML_Syntax.ml_bool_ty)
@@ -4272,13 +4275,13 @@ let (ind_discriminator_body :
                                              (FStar_Extraction_ML_Syntax.MLC_Bool
                                                 true))
                                          in
-                                      (uu____15397,
+                                      (uu____15407,
                                         FStar_Pervasives_Native.None,
-                                        uu____15408)
+                                        uu____15418)
                                        in
-                                    let uu____15412 =
-                                      let uu____15423 =
-                                        let uu____15432 =
+                                    let uu____15422 =
+                                      let uu____15433 =
+                                        let uu____15442 =
                                           FStar_All.pipe_left
                                             (FStar_Extraction_ML_Syntax.with_ty
                                                FStar_Extraction_ML_Syntax.ml_bool_ty)
@@ -4288,33 +4291,33 @@ let (ind_discriminator_body :
                                            in
                                         (FStar_Extraction_ML_Syntax.MLP_Wild,
                                           FStar_Pervasives_Native.None,
-                                          uu____15432)
+                                          uu____15442)
                                          in
-                                      [uu____15423]  in
-                                    uu____15388 :: uu____15412  in
-                                  (uu____15371, uu____15377)  in
+                                      [uu____15433]  in
+                                    uu____15398 :: uu____15422  in
+                                  (uu____15381, uu____15387)  in
                                 FStar_Extraction_ML_Syntax.MLE_Match
-                                  uu____15356
+                                  uu____15366
                                  in
                               FStar_All.pipe_left
                                 (FStar_Extraction_ML_Syntax.with_ty
                                    FStar_Extraction_ML_Syntax.ml_bool_ty)
-                                uu____15355
+                                uu____15365
                                in
                             ((FStar_List.append wildcards [(mlid, targ)]),
-                              uu____15354)
+                              uu____15364)
                              in
-                          FStar_Extraction_ML_Syntax.MLE_Fun uu____15342  in
+                          FStar_Extraction_ML_Syntax.MLE_Fun uu____15352  in
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty disc_ty)
-                          uu____15341
+                          uu____15351
                          in
-                      let uu____15493 =
+                      let uu____15503 =
                         FStar_Extraction_ML_UEnv.mlpath_of_lident env
                           discName
                          in
-                      (match uu____15493 with
-                       | (uu____15494,name) ->
+                      (match uu____15503 with
+                       | (uu____15504,name) ->
                            FStar_Extraction_ML_Syntax.MLM_Let
                              (FStar_Extraction_ML_Syntax.NonRec,
                                [{

--- a/src/ocaml-output/FStar_Extraction_ML_UEnv.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_UEnv.ml
@@ -281,12 +281,12 @@ let (lookup_bv : uenv -> FStar_Syntax_Syntax.bv -> ty_or_exp_b) =
       | FStar_Pervasives_Native.None  ->
           let uu____919 =
             let uu____921 =
-              FStar_Range.string_of_range
-                (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange
-               in
-            let uu____923 = FStar_Syntax_Print.bv_to_string bv  in
+              let uu____923 =
+                FStar_Ident.range_of_id bv.FStar_Syntax_Syntax.ppname  in
+              FStar_Range.string_of_range uu____923  in
+            let uu____924 = FStar_Syntax_Print.bv_to_string bv  in
             FStar_Util.format2 "(%s) bound Variable %s not found\n" uu____921
-              uu____923
+              uu____924
              in
           failwith uu____919
       | FStar_Pervasives_Native.Some y -> y
@@ -301,21 +301,21 @@ let (lookup_term :
     fun t  ->
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_name x ->
-          let uu____951 = lookup_bv g x  in
-          (uu____951, FStar_Pervasives_Native.None)
+          let uu____952 = lookup_bv g x  in
+          (uu____952, FStar_Pervasives_Native.None)
       | FStar_Syntax_Syntax.Tm_fvar x ->
-          let uu____955 =
-            let uu____956 = lookup_fv g x  in FStar_Util.Inr uu____956  in
-          (uu____955, (x.FStar_Syntax_Syntax.fv_qual))
-      | uu____959 -> failwith "Impossible: lookup_term for a non-name"
+          let uu____956 =
+            let uu____957 = lookup_fv g x  in FStar_Util.Inr uu____957  in
+          (uu____956, (x.FStar_Syntax_Syntax.fv_qual))
+      | uu____960 -> failwith "Impossible: lookup_term for a non-name"
   
 let (lookup_ty : uenv -> FStar_Syntax_Syntax.bv -> ty_binding) =
   fun g  ->
     fun x  ->
-      let uu____978 = lookup_bv g x  in
-      match uu____978 with
+      let uu____979 = lookup_bv g x  in
+      match uu____979 with
       | FStar_Util.Inl ty -> ty
-      | uu____980 -> failwith "Expected a type name"
+      | uu____981 -> failwith "Expected a type name"
   
 let (lookup_tydef :
   uenv ->
@@ -323,8 +323,8 @@ let (lookup_tydef :
       FStar_Extraction_ML_Syntax.mltyscheme FStar_Pervasives_Native.option)
   =
   fun env  ->
-    fun uu____994  ->
-      match uu____994 with
+    fun uu____995  ->
+      match uu____995 with
       | (module_name,ty_name) ->
           FStar_Util.find_map env.tydefs
             (fun tydef1  ->
@@ -338,17 +338,21 @@ let (mlpath_of_lident :
   uenv -> FStar_Ident.lident -> FStar_Extraction_ML_Syntax.mlpath) =
   fun g  ->
     fun x  ->
-      let uu____1031 =
-        FStar_Util.psmap_try_find g.mlpath_of_lid x.FStar_Ident.str  in
-      match uu____1031 with
+      let uu____1032 =
+        let uu____1035 = FStar_Ident.string_of_lid x  in
+        FStar_Util.psmap_try_find g.mlpath_of_lid uu____1035  in
+      match uu____1032 with
       | FStar_Pervasives_Native.None  ->
           (debug g
-             (fun uu____1038  ->
-                FStar_Util.print1 "Identifier not found: %s"
-                  x.FStar_Ident.str;
-                (let uu____1041 = print_mlpath_map g  in
-                 FStar_Util.print1 "Env is \n%s\n" uu____1041));
-           failwith (Prims.op_Hat "Identifier not found: " x.FStar_Ident.str))
+             (fun uu____1041  ->
+                (let uu____1043 = FStar_Ident.string_of_lid x  in
+                 FStar_Util.print1 "Identifier not found: %s" uu____1043);
+                (let uu____1046 = print_mlpath_map g  in
+                 FStar_Util.print1 "Env is \n%s\n" uu____1046));
+           (let uu____1049 =
+              let uu____1051 = FStar_Ident.string_of_lid x  in
+              Prims.op_Hat "Identifier not found: " uu____1051  in
+            failwith uu____1049))
       | FStar_Pervasives_Native.Some mlp -> mlp
   
 let (is_type_name : uenv -> FStar_Syntax_Syntax.fv -> Prims.bool) =
@@ -356,9 +360,9 @@ let (is_type_name : uenv -> FStar_Syntax_Syntax.fv -> Prims.bool) =
     fun fv  ->
       FStar_All.pipe_right g.type_names
         (FStar_Util.for_some
-           (fun uu____1072  ->
-              match uu____1072 with
-              | (x,uu____1079) -> FStar_Syntax_Syntax.fv_eq fv x))
+           (fun uu____1081  ->
+              match uu____1081 with
+              | (x,uu____1088) -> FStar_Syntax_Syntax.fv_eq fv x))
   
 let (is_fv_type : uenv -> FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun g  ->
@@ -374,34 +378,36 @@ let (lookup_record_field_name :
       FStar_Extraction_ML_Syntax.mlpath)
   =
   fun g  ->
-    fun uu____1111  ->
-      match uu____1111 with
+    fun uu____1120  ->
+      match uu____1120 with
       | (type_name,fn) ->
           let key =
-            FStar_Ident.lid_of_ids
-              (FStar_List.append type_name.FStar_Ident.ns [fn])
-             in
-          let uu____1119 =
-            FStar_Util.psmap_try_find g.mlpath_of_fieldname
-              key.FStar_Ident.str
-             in
-          (match uu____1119 with
+            let uu____1128 =
+              let uu____1129 = FStar_Ident.ns_of_lid type_name  in
+              FStar_List.append uu____1129 [fn]  in
+            FStar_Ident.lid_of_ids uu____1128  in
+          let uu____1132 =
+            let uu____1135 = FStar_Ident.string_of_lid key  in
+            FStar_Util.psmap_try_find g.mlpath_of_fieldname uu____1135  in
+          (match uu____1132 with
            | FStar_Pervasives_Native.None  ->
-               failwith
-                 (Prims.op_Hat "Field name not found: " key.FStar_Ident.str)
+               let uu____1137 =
+                 let uu____1139 = FStar_Ident.string_of_lid key  in
+                 Prims.op_Hat "Field name not found: " uu____1139  in
+               failwith uu____1137
            | FStar_Pervasives_Native.Some mlp -> mlp)
   
 let (initial_mlident_map : unit -> Prims.string FStar_Util.psmap) =
   let map = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-  fun uu____1148  ->
-    let uu____1149 = FStar_ST.op_Bang map  in
-    match uu____1149 with
+  fun uu____1167  ->
+    let uu____1168 = FStar_ST.op_Bang map  in
+    match uu____1168 with
     | FStar_Pervasives_Native.Some m -> m
     | FStar_Pervasives_Native.None  ->
         let m =
-          let uu____1201 =
-            let uu____1205 = FStar_Options.codegen ()  in
-            match uu____1205 with
+          let uu____1220 =
+            let uu____1224 = FStar_Options.codegen ()  in
+            match uu____1224 with
             | FStar_Pervasives_Native.Some (FStar_Options.FSharp ) ->
                 FStar_Extraction_ML_Syntax.fsharpkeywords
             | FStar_Pervasives_Native.Some (FStar_Options.OCaml ) ->
@@ -411,10 +417,10 @@ let (initial_mlident_map : unit -> Prims.string FStar_Util.psmap) =
             | FStar_Pervasives_Native.Some (FStar_Options.Kremlin ) ->
                 FStar_Extraction_ML_Syntax.kremlin_keywords ()
             | FStar_Pervasives_Native.None  -> []  in
-          let uu____1213 = FStar_Util.psmap_empty ()  in
+          let uu____1232 = FStar_Util.psmap_empty ()  in
           FStar_List.fold_right
-            (fun x  -> fun m  -> FStar_Util.psmap_add m x "") uu____1201
-            uu____1213
+            (fun x  -> fun m  -> FStar_Util.psmap_add m x "") uu____1220
+            uu____1232
            in
         (FStar_ST.op_Colon_Equals map (FStar_Pervasives_Native.Some m); m)
   
@@ -422,61 +428,62 @@ let (rename_conventional : Prims.string -> Prims.bool -> Prims.string) =
   fun s  ->
     fun is_local_type_variable  ->
       let cs = FStar_String.list_of_string s  in
-      let sanitize_typ uu____1294 =
+      let sanitize_typ uu____1313 =
         let valid_rest c = FStar_Util.is_letter_or_digit c  in
         let aux cs1 =
           FStar_List.map
             (fun x  ->
-               let uu____1325 = valid_rest x  in
-               if uu____1325 then x else 117) cs1
+               let uu____1344 = valid_rest x  in
+               if uu____1344 then x else 117) cs1
            in
-        let uu____1332 =
-          let uu____1334 = FStar_List.hd cs  in uu____1334 = 39  in
-        if uu____1332
+        let uu____1351 =
+          let uu____1353 = FStar_List.hd cs  in uu____1353 = 39  in
+        if uu____1351
         then
-          let uu____1343 = FStar_List.hd cs  in
-          let uu____1346 =
-            let uu____1350 = FStar_List.tail cs  in aux uu____1350  in
-          uu____1343 :: uu____1346
-        else (let uu____1358 = aux cs  in 39 :: uu____1358)  in
-      let sanitize_term uu____1372 =
+          let uu____1362 = FStar_List.hd cs  in
+          let uu____1365 =
+            let uu____1369 = FStar_List.tail cs  in aux uu____1369  in
+          uu____1362 :: uu____1365
+        else (let uu____1377 = aux cs  in 39 :: uu____1377)  in
+      let sanitize_term uu____1391 =
         let valid c =
           ((FStar_Util.is_letter_or_digit c) || (c = 95)) || (c = 39)  in
         let cs' =
           FStar_List.fold_right
             (fun c  ->
                fun cs1  ->
-                 let uu____1403 =
-                   let uu____1407 = valid c  in
-                   if uu____1407 then [c] else [95; 95]  in
-                 FStar_List.append uu____1403 cs1) cs []
+                 let uu____1422 =
+                   let uu____1426 = valid c  in
+                   if uu____1426 then [c] else [95; 95]  in
+                 FStar_List.append uu____1422 cs1) cs []
            in
         match cs' with
         | c::cs1 when (FStar_Util.is_digit c) || (c = 39) -> 95 :: c :: cs1
-        | uu____1439 -> cs  in
-      let uu____1443 =
+        | uu____1458 -> cs  in
+      let uu____1462 =
         if is_local_type_variable then sanitize_typ () else sanitize_term ()
          in
-      FStar_String.string_of_list uu____1443
+      FStar_String.string_of_list uu____1462
   
 let (root_name_of_bv :
   FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlident) =
   fun x  ->
-    let uu____1461 =
-      (FStar_Util.starts_with
-         (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-         FStar_Ident.reserved_prefix)
-        || (FStar_Syntax_Syntax.is_null_bv x)
+    let uu____1480 =
+      (let uu____1484 = FStar_Ident.text_of_id x.FStar_Syntax_Syntax.ppname
+          in
+       FStar_Util.starts_with uu____1484 FStar_Ident.reserved_prefix) ||
+        (FStar_Syntax_Syntax.is_null_bv x)
        in
-    if uu____1461
+    if uu____1480
     then
-      let uu____1465 =
-        let uu____1467 = FStar_Util.string_of_int x.FStar_Syntax_Syntax.index
+      let uu____1488 = FStar_Ident.text_of_id x.FStar_Syntax_Syntax.ppname
+         in
+      let uu____1490 =
+        let uu____1492 = FStar_Util.string_of_int x.FStar_Syntax_Syntax.index
            in
-        Prims.op_Hat "_" uu____1467  in
-      Prims.op_Hat (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-        uu____1465
-    else (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+        Prims.op_Hat "_" uu____1492  in
+      Prims.op_Hat uu____1488 uu____1490
+    else FStar_Ident.text_of_id x.FStar_Syntax_Syntax.ppname
   
 let (find_uniq :
   Prims.string FStar_Util.psmap ->
@@ -491,12 +498,12 @@ let (find_uniq :
             if i = Prims.int_zero
             then root_name1
             else
-              (let uu____1537 = FStar_Util.string_of_int i  in
-               Prims.op_Hat root_name1 uu____1537)
+              (let uu____1562 = FStar_Util.string_of_int i  in
+               Prims.op_Hat root_name1 uu____1562)
              in
-          let uu____1539 =
+          let uu____1564 =
             FStar_Util.psmap_try_find ml_ident_map target_mlident  in
-          match uu____1539 with
+          match uu____1564 with
           | FStar_Pervasives_Native.Some x ->
               aux (i + Prims.int_one) root_name1
           | FStar_Pervasives_Native.None  ->
@@ -508,66 +515,75 @@ let (find_uniq :
            in
         if is_local_type_variable
         then
-          let uu____1578 =
-            let uu____1587 = FStar_Util.substring_from mlident Prims.int_one
+          let uu____1603 =
+            let uu____1612 = FStar_Util.substring_from mlident Prims.int_one
                in
-            aux Prims.int_zero uu____1587  in
-          match uu____1578 with | (nm,map) -> ((Prims.op_Hat "'" nm), map)
+            aux Prims.int_zero uu____1612  in
+          match uu____1603 with | (nm,map) -> ((Prims.op_Hat "'" nm), map)
         else aux Prims.int_zero mlident
   
 let (mlns_of_lid : FStar_Ident.lident -> Prims.string Prims.list) =
   fun x  ->
-    FStar_List.map (fun x1  -> x1.FStar_Ident.idText) x.FStar_Ident.ns
+    let uu____1651 = FStar_Ident.ns_of_lid x  in
+    FStar_List.map FStar_Ident.text_of_id uu____1651
   
 let (new_mlpath_of_lident :
   uenv -> FStar_Ident.lident -> (FStar_Extraction_ML_Syntax.mlpath * uenv)) =
   fun g  ->
     fun x  ->
-      let uu____1648 =
-        let uu____1653 =
+      let uu____1674 =
+        let uu____1679 =
           FStar_Ident.lid_equals x FStar_Parser_Const.failwith_lid  in
-        if uu____1653
-        then (([], ((x.FStar_Ident.ident).FStar_Ident.idText)), g)
+        if uu____1679
+        then
+          let uu____1686 =
+            let uu____1687 =
+              let uu____1689 = FStar_Ident.ident_of_lid x  in
+              FStar_Ident.text_of_id uu____1689  in
+            ([], uu____1687)  in
+          (uu____1686, g)
         else
-          (let uu____1667 =
-             find_uniq g.env_mlident_map
-               (x.FStar_Ident.ident).FStar_Ident.idText false
-              in
-           match uu____1667 with
+          (let uu____1697 =
+             let uu____1706 =
+               let uu____1708 = FStar_Ident.ident_of_lid x  in
+               FStar_Ident.text_of_id uu____1708  in
+             find_uniq g.env_mlident_map uu____1706 false  in
+           match uu____1697 with
            | (name,map) ->
                let g1 =
-                 let uu___240_1692 = g  in
+                 let uu___239_1725 = g  in
                  {
-                   env_tcenv = (uu___240_1692.env_tcenv);
-                   env_bindings = (uu___240_1692.env_bindings);
+                   env_tcenv = (uu___239_1725.env_tcenv);
+                   env_bindings = (uu___239_1725.env_bindings);
                    env_mlident_map = map;
-                   mlpath_of_lid = (uu___240_1692.mlpath_of_lid);
-                   env_fieldname_map = (uu___240_1692.env_fieldname_map);
-                   mlpath_of_fieldname = (uu___240_1692.mlpath_of_fieldname);
-                   tydefs = (uu___240_1692.tydefs);
-                   type_names = (uu___240_1692.type_names);
-                   currentModule = (uu___240_1692.currentModule)
+                   mlpath_of_lid = (uu___239_1725.mlpath_of_lid);
+                   env_fieldname_map = (uu___239_1725.env_fieldname_map);
+                   mlpath_of_fieldname = (uu___239_1725.mlpath_of_fieldname);
+                   tydefs = (uu___239_1725.tydefs);
+                   type_names = (uu___239_1725.type_names);
+                   currentModule = (uu___239_1725.currentModule)
                  }  in
-               let uu____1693 =
-                 let uu____1694 = mlns_of_lid x  in (uu____1694, name)  in
-               (uu____1693, g1))
+               let uu____1726 =
+                 let uu____1727 = mlns_of_lid x  in (uu____1727, name)  in
+               (uu____1726, g1))
          in
-      match uu____1648 with
+      match uu____1674 with
       | (mlp,g1) ->
           let g2 =
-            let uu___246_1709 = g1  in
-            let uu____1710 =
-              FStar_Util.psmap_add g1.mlpath_of_lid x.FStar_Ident.str mlp  in
+            let uu___245_1742 = g1  in
+            let uu____1743 =
+              let uu____1746 = FStar_Ident.string_of_lid x  in
+              FStar_Util.psmap_add g1.mlpath_of_lid uu____1746 mlp  in
             {
-              env_tcenv = (uu___246_1709.env_tcenv);
-              env_bindings = (uu___246_1709.env_bindings);
-              env_mlident_map = (uu___246_1709.env_mlident_map);
-              mlpath_of_lid = uu____1710;
-              env_fieldname_map = (uu___246_1709.env_fieldname_map);
-              mlpath_of_fieldname = (uu___246_1709.mlpath_of_fieldname);
-              tydefs = (uu___246_1709.tydefs);
-              type_names = (uu___246_1709.type_names);
-              currentModule = (uu___246_1709.currentModule)
+              env_tcenv = (uu___245_1742.env_tcenv);
+              env_bindings = (uu___245_1742.env_bindings);
+              env_mlident_map = (uu___245_1742.env_mlident_map);
+              mlpath_of_lid = uu____1743;
+              env_fieldname_map = (uu___245_1742.env_fieldname_map);
+              mlpath_of_fieldname = (uu___245_1742.mlpath_of_fieldname);
+              tydefs = (uu___245_1742.tydefs);
+              type_names = (uu___245_1742.type_names);
+              currentModule = (uu___245_1742.currentModule)
             }  in
           (mlp, g2)
   
@@ -576,10 +592,10 @@ let (extend_ty : uenv -> FStar_Syntax_Syntax.bv -> Prims.bool -> uenv) =
     fun a  ->
       fun map_to_top  ->
         let is_local_type_variable = Prims.op_Negation map_to_top  in
-        let uu____1733 =
-          let uu____1742 = root_name_of_bv a  in
-          find_uniq g.env_mlident_map uu____1742 is_local_type_variable  in
-        match uu____1733 with
+        let uu____1768 =
+          let uu____1777 = root_name_of_bv a  in
+          find_uniq g.env_mlident_map uu____1777 is_local_type_variable  in
+        match uu____1768 with
         | (ml_a,mlident_map) ->
             let mapped_to =
               if map_to_top
@@ -591,17 +607,17 @@ let (extend_ty : uenv -> FStar_Syntax_Syntax.bv -> Prims.bool -> uenv) =
                    (FStar_Util.Inl { ty_b_name = ml_a; ty_b_ty = mapped_to })))
               :: (g.env_bindings)  in
             let tcenv = FStar_TypeChecker_Env.push_bv g.env_tcenv a  in
-            let uu___263_1762 = g  in
+            let uu___262_1797 = g  in
             {
               env_tcenv = tcenv;
               env_bindings = gamma;
               env_mlident_map = mlident_map;
-              mlpath_of_lid = (uu___263_1762.mlpath_of_lid);
-              env_fieldname_map = (uu___263_1762.env_fieldname_map);
-              mlpath_of_fieldname = (uu___263_1762.mlpath_of_fieldname);
-              tydefs = (uu___263_1762.tydefs);
-              type_names = (uu___263_1762.type_names);
-              currentModule = (uu___263_1762.currentModule)
+              mlpath_of_lid = (uu___262_1797.mlpath_of_lid);
+              env_fieldname_map = (uu___262_1797.env_fieldname_map);
+              mlpath_of_fieldname = (uu___262_1797.mlpath_of_fieldname);
+              tydefs = (uu___262_1797.tydefs);
+              type_names = (uu___262_1797.type_names);
+              currentModule = (uu___262_1797.currentModule)
             }
   
 let (extend_bv :
@@ -620,11 +636,11 @@ let (extend_bv :
             let ml_ty =
               match t_x with
               | ([],t) -> t
-              | uu____1810 -> FStar_Extraction_ML_Syntax.MLTY_Top  in
-            let uu____1811 =
-              let uu____1820 = root_name_of_bv x  in
-              find_uniq g.env_mlident_map uu____1820 false  in
-            match uu____1811 with
+              | uu____1845 -> FStar_Extraction_ML_Syntax.MLTY_Top  in
+            let uu____1846 =
+              let uu____1855 = root_name_of_bv x  in
+              find_uniq g.env_mlident_map uu____1855 false  in
+            match uu____1846 with
             | (mlident,mlident_map) ->
                 let mlx = FStar_Extraction_ML_Syntax.MLE_Var mlident  in
                 let mlx1 =
@@ -655,21 +671,21 @@ let (extend_bv :
                 let gamma = (Bv (x, (FStar_Util.Inr exp_binding1))) ::
                   (g.env_bindings)  in
                 let tcenv =
-                  let uu____1859 = FStar_Syntax_Syntax.binders_of_list [x]
+                  let uu____1894 = FStar_Syntax_Syntax.binders_of_list [x]
                      in
-                  FStar_TypeChecker_Env.push_binders g.env_tcenv uu____1859
+                  FStar_TypeChecker_Env.push_binders g.env_tcenv uu____1894
                    in
-                ((let uu___289_1862 = g  in
+                ((let uu___288_1897 = g  in
                   {
                     env_tcenv = tcenv;
                     env_bindings = gamma;
                     env_mlident_map = mlident_map;
-                    mlpath_of_lid = (uu___289_1862.mlpath_of_lid);
-                    env_fieldname_map = (uu___289_1862.env_fieldname_map);
-                    mlpath_of_fieldname = (uu___289_1862.mlpath_of_fieldname);
-                    tydefs = (uu___289_1862.tydefs);
-                    type_names = (uu___289_1862.type_names);
-                    currentModule = (uu___289_1862.currentModule)
+                    mlpath_of_lid = (uu___288_1897.mlpath_of_lid);
+                    env_fieldname_map = (uu___288_1897.env_fieldname_map);
+                    mlpath_of_fieldname = (uu___288_1897.mlpath_of_fieldname);
+                    tydefs = (uu___288_1897.tydefs);
+                    type_names = (uu___288_1897.type_names);
+                    currentModule = (uu___288_1897.currentModule)
                   }), mlident, exp_binding1)
   
 let (new_mlident : uenv -> (uenv * FStar_Extraction_ML_Syntax.mlident)) =
@@ -679,9 +695,9 @@ let (new_mlident : uenv -> (uenv * FStar_Extraction_ML_Syntax.mlident)) =
       FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
         FStar_Syntax_Syntax.tun
        in
-    let uu____1881 =
+    let uu____1916 =
       extend_bv g x ([], FStar_Extraction_ML_Syntax.MLTY_Top) false false  in
-    match uu____1881 with | (g1,id,uu____1899) -> (g1, id)
+    match uu____1916 with | (g1,id,uu____1934) -> (g1, id)
   
 let (extend_fv :
   uenv ->
@@ -698,9 +714,9 @@ let (extend_fv :
             match t with
             | FStar_Extraction_ML_Syntax.MLTY_Var x1 -> [x1]
             | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,f,t2) ->
-                let uu____1959 = mltyFvars t1  in
-                let uu____1963 = mltyFvars t2  in
-                FStar_List.append uu____1959 uu____1963
+                let uu____1994 = mltyFvars t1  in
+                let uu____1998 = mltyFvars t2  in
+                FStar_List.append uu____1994 uu____1998
             | FStar_Extraction_ML_Syntax.MLTY_Named (args,path) ->
                 FStar_List.collect mltyFvars args
             | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
@@ -712,20 +728,20 @@ let (extend_fv :
             | h::tla -> (FStar_List.contains h lb) && (subsetMlidents tla lb)
             | [] -> true  in
           let tySchemeIsClosed tys =
-            let uu____2024 = mltyFvars (FStar_Pervasives_Native.snd tys)  in
-            subsetMlidents uu____2024 (FStar_Pervasives_Native.fst tys)  in
-          let uu____2028 = tySchemeIsClosed t_x  in
-          if uu____2028
+            let uu____2059 = mltyFvars (FStar_Pervasives_Native.snd tys)  in
+            subsetMlidents uu____2059 (FStar_Pervasives_Native.fst tys)  in
+          let uu____2063 = tySchemeIsClosed t_x  in
+          if uu____2063
           then
             let ml_ty =
               match t_x with
               | ([],t) -> t
-              | uu____2041 -> FStar_Extraction_ML_Syntax.MLTY_Top  in
-            let uu____2042 =
+              | uu____2076 -> FStar_Extraction_ML_Syntax.MLTY_Top  in
+            let uu____2077 =
               new_mlpath_of_lident g
                 (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                in
-            match uu____2042 with
+            match uu____2077 with
             | (mlpath,g1) ->
                 let mlsymbol = FStar_Pervasives_Native.snd mlpath  in
                 let mly = FStar_Extraction_ML_Syntax.MLE_Name mlpath  in
@@ -753,17 +769,17 @@ let (extend_fv :
                 let gamma = (Fv (x, exp_binding1)) :: (g1.env_bindings)  in
                 let mlident_map =
                   FStar_Util.psmap_add g1.env_mlident_map mlsymbol ""  in
-                ((let uu___348_2085 = g1  in
+                ((let uu___347_2120 = g1  in
                   {
-                    env_tcenv = (uu___348_2085.env_tcenv);
+                    env_tcenv = (uu___347_2120.env_tcenv);
                     env_bindings = gamma;
                     env_mlident_map = mlident_map;
-                    mlpath_of_lid = (uu___348_2085.mlpath_of_lid);
-                    env_fieldname_map = (uu___348_2085.env_fieldname_map);
-                    mlpath_of_fieldname = (uu___348_2085.mlpath_of_fieldname);
-                    tydefs = (uu___348_2085.tydefs);
-                    type_names = (uu___348_2085.type_names);
-                    currentModule = (uu___348_2085.currentModule)
+                    mlpath_of_lid = (uu___347_2120.mlpath_of_lid);
+                    env_fieldname_map = (uu___347_2120.env_fieldname_map);
+                    mlpath_of_fieldname = (uu___347_2120.mlpath_of_fieldname);
+                    tydefs = (uu___347_2120.tydefs);
+                    type_names = (uu___347_2120.type_names);
+                    currentModule = (uu___347_2120.currentModule)
                   }), mlsymbol, exp_binding1)
           else failwith "freevars found"
   
@@ -793,11 +809,11 @@ let (extend_tydef :
   fun g  ->
     fun fv  ->
       fun ts  ->
-        let uu____2169 =
+        let uu____2204 =
           new_mlpath_of_lident g
             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
            in
-        match uu____2169 with
+        match uu____2204 with
         | (name,g1) ->
             let tydef1 =
               {
@@ -807,17 +823,17 @@ let (extend_tydef :
                 tydef_def = ts
               }  in
             (tydef1, name,
-              (let uu___370_2192 = g1  in
+              (let uu___369_2227 = g1  in
                {
-                 env_tcenv = (uu___370_2192.env_tcenv);
-                 env_bindings = (uu___370_2192.env_bindings);
-                 env_mlident_map = (uu___370_2192.env_mlident_map);
-                 mlpath_of_lid = (uu___370_2192.mlpath_of_lid);
-                 env_fieldname_map = (uu___370_2192.env_fieldname_map);
-                 mlpath_of_fieldname = (uu___370_2192.mlpath_of_fieldname);
+                 env_tcenv = (uu___369_2227.env_tcenv);
+                 env_bindings = (uu___369_2227.env_bindings);
+                 env_mlident_map = (uu___369_2227.env_mlident_map);
+                 mlpath_of_lid = (uu___369_2227.mlpath_of_lid);
+                 env_fieldname_map = (uu___369_2227.env_fieldname_map);
+                 mlpath_of_fieldname = (uu___369_2227.mlpath_of_fieldname);
                  tydefs = (tydef1 :: (g1.tydefs));
                  type_names = ((fv, name) :: (g1.type_names));
-                 currentModule = (uu___370_2192.currentModule)
+                 currentModule = (uu___369_2227.currentModule)
                }))
   
 let (extend_type_name :
@@ -826,24 +842,24 @@ let (extend_type_name :
   =
   fun g  ->
     fun fv  ->
-      let uu____2216 =
+      let uu____2251 =
         new_mlpath_of_lident g
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
          in
-      match uu____2216 with
+      match uu____2251 with
       | (name,g1) ->
           (name,
-            (let uu___377_2228 = g1  in
+            (let uu___376_2263 = g1  in
              {
-               env_tcenv = (uu___377_2228.env_tcenv);
-               env_bindings = (uu___377_2228.env_bindings);
-               env_mlident_map = (uu___377_2228.env_mlident_map);
-               mlpath_of_lid = (uu___377_2228.mlpath_of_lid);
-               env_fieldname_map = (uu___377_2228.env_fieldname_map);
-               mlpath_of_fieldname = (uu___377_2228.mlpath_of_fieldname);
-               tydefs = (uu___377_2228.tydefs);
+               env_tcenv = (uu___376_2263.env_tcenv);
+               env_bindings = (uu___376_2263.env_bindings);
+               env_mlident_map = (uu___376_2263.env_mlident_map);
+               mlpath_of_lid = (uu___376_2263.mlpath_of_lid);
+               env_fieldname_map = (uu___376_2263.env_fieldname_map);
+               mlpath_of_fieldname = (uu___376_2263.mlpath_of_fieldname);
+               tydefs = (uu___376_2263.tydefs);
                type_names = ((fv, name) :: (g1.type_names));
-               currentModule = (uu___377_2228.currentModule)
+               currentModule = (uu___376_2263.currentModule)
              }))
   
 let (extend_with_monad_op_name :
@@ -859,21 +875,21 @@ let (extend_with_monad_op_name :
       fun nm  ->
         fun ts  ->
           let lid =
-            let uu____2265 = FStar_Ident.id_of_text nm  in
+            let uu____2300 = FStar_Ident.id_of_text nm  in
             FStar_Syntax_Util.mk_field_projector_name_from_ident
-              ed.FStar_Syntax_Syntax.mname uu____2265
+              ed.FStar_Syntax_Syntax.mname uu____2300
              in
-          let uu____2266 =
-            let uu____2274 =
+          let uu____2301 =
+            let uu____2309 =
               FStar_Syntax_Syntax.lid_as_fv lid
                 FStar_Syntax_Syntax.delta_constant
                 FStar_Pervasives_Native.None
                in
-            extend_fv g uu____2274 ts false  in
-          match uu____2266 with
+            extend_fv g uu____2309 ts false  in
+          match uu____2301 with
           | (g1,mlid,exp_b) ->
               let mlp =
-                let uu____2298 = mlns_of_lid lid  in (uu____2298, mlid)  in
+                let uu____2333 = mlns_of_lid lid  in (uu____2333, mlid)  in
               (mlp, lid, exp_b, g1)
   
 let (extend_with_action_name :
@@ -889,27 +905,29 @@ let (extend_with_action_name :
       fun a  ->
         fun ts  ->
           let nm =
-            ((a.FStar_Syntax_Syntax.action_name).FStar_Ident.ident).FStar_Ident.idText
-             in
-          let module_name = (ed.FStar_Syntax_Syntax.mname).FStar_Ident.ns  in
+            let uu____2372 =
+              FStar_Ident.ident_of_lid a.FStar_Syntax_Syntax.action_name  in
+            FStar_Ident.text_of_id uu____2372  in
+          let module_name =
+            FStar_Ident.ns_of_lid ed.FStar_Syntax_Syntax.mname  in
           let lid =
-            let uu____2341 =
-              let uu____2344 =
-                let uu____2347 = FStar_Ident.id_of_text nm  in [uu____2347]
+            let uu____2375 =
+              let uu____2376 =
+                let uu____2379 = FStar_Ident.id_of_text nm  in [uu____2379]
                  in
-              FStar_List.append module_name uu____2344  in
-            FStar_Ident.lid_of_ids uu____2341  in
-          let uu____2348 =
-            let uu____2356 =
+              FStar_List.append module_name uu____2376  in
+            FStar_Ident.lid_of_ids uu____2375  in
+          let uu____2380 =
+            let uu____2388 =
               FStar_Syntax_Syntax.lid_as_fv lid
                 FStar_Syntax_Syntax.delta_constant
                 FStar_Pervasives_Native.None
                in
-            extend_fv g uu____2356 ts false  in
-          match uu____2348 with
+            extend_fv g uu____2388 ts false  in
+          match uu____2380 with
           | (g1,mlid,exp_b) ->
               let mlp =
-                let uu____2380 = mlns_of_lid lid  in (uu____2380, mlid)  in
+                let uu____2412 = mlns_of_lid lid  in (uu____2412, mlid)  in
               (mlp, lid, exp_b, g1)
   
 let (extend_record_field_name :
@@ -918,35 +936,37 @@ let (extend_record_field_name :
       (FStar_Extraction_ML_Syntax.mlpath * uenv))
   =
   fun g  ->
-    fun uu____2406  ->
-      match uu____2406 with
+    fun uu____2438  ->
+      match uu____2438 with
       | (type_name,fn) ->
           let key =
-            FStar_Ident.lid_of_ids
-              (FStar_List.append type_name.FStar_Ident.ns [fn])
-             in
-          let uu____2418 =
-            find_uniq g.env_fieldname_map fn.FStar_Ident.idText false  in
-          (match uu____2418 with
+            let uu____2450 =
+              let uu____2451 = FStar_Ident.ns_of_lid type_name  in
+              FStar_List.append uu____2451 [fn]  in
+            FStar_Ident.lid_of_ids uu____2450  in
+          let uu____2454 =
+            let uu____2463 = FStar_Ident.text_of_id fn  in
+            find_uniq g.env_fieldname_map uu____2463 false  in
+          (match uu____2454 with
            | (name,fieldname_map) ->
                let ns = mlns_of_lid key  in
                let mlp = (ns, name)  in
                let g1 =
-                 let uu___411_2460 = g  in
-                 let uu____2461 =
-                   FStar_Util.psmap_add g.mlpath_of_fieldname
-                     key.FStar_Ident.str mlp
+                 let uu___410_2498 = g  in
+                 let uu____2499 =
+                   let uu____2502 = FStar_Ident.string_of_lid key  in
+                   FStar_Util.psmap_add g.mlpath_of_fieldname uu____2502 mlp
                     in
                  {
-                   env_tcenv = (uu___411_2460.env_tcenv);
-                   env_bindings = (uu___411_2460.env_bindings);
-                   env_mlident_map = (uu___411_2460.env_mlident_map);
-                   mlpath_of_lid = (uu___411_2460.mlpath_of_lid);
+                   env_tcenv = (uu___410_2498.env_tcenv);
+                   env_bindings = (uu___410_2498.env_bindings);
+                   env_mlident_map = (uu___410_2498.env_mlident_map);
+                   mlpath_of_lid = (uu___410_2498.mlpath_of_lid);
                    env_fieldname_map = fieldname_map;
-                   mlpath_of_fieldname = uu____2461;
-                   tydefs = (uu___411_2460.tydefs);
-                   type_names = (uu___411_2460.type_names);
-                   currentModule = (uu___411_2460.currentModule)
+                   mlpath_of_fieldname = uu____2499;
+                   tydefs = (uu___410_2498.tydefs);
+                   type_names = (uu___410_2498.type_names);
+                   currentModule = (uu___410_2498.currentModule)
                  }  in
                (mlp, g1))
   
@@ -955,39 +975,42 @@ let (extend_with_module_name :
   fun g  ->
     fun m  ->
       let ns = mlns_of_lid m  in
-      let p = (m.FStar_Ident.ident).FStar_Ident.idText  in ((ns, p), g)
+      let p =
+        let uu____2525 = FStar_Ident.ident_of_lid m  in
+        FStar_Ident.text_of_id uu____2525  in
+      ((ns, p), g)
   
 let (exit_module : uenv -> uenv) =
   fun g  ->
-    let uu___419_2495 = g  in
-    let uu____2496 = initial_mlident_map ()  in
-    let uu____2500 = initial_mlident_map ()  in
+    let uu___418_2536 = g  in
+    let uu____2537 = initial_mlident_map ()  in
+    let uu____2541 = initial_mlident_map ()  in
     {
-      env_tcenv = (uu___419_2495.env_tcenv);
-      env_bindings = (uu___419_2495.env_bindings);
-      env_mlident_map = uu____2496;
-      mlpath_of_lid = (uu___419_2495.mlpath_of_lid);
-      env_fieldname_map = uu____2500;
-      mlpath_of_fieldname = (uu___419_2495.mlpath_of_fieldname);
-      tydefs = (uu___419_2495.tydefs);
-      type_names = (uu___419_2495.type_names);
-      currentModule = (uu___419_2495.currentModule)
+      env_tcenv = (uu___418_2536.env_tcenv);
+      env_bindings = (uu___418_2536.env_bindings);
+      env_mlident_map = uu____2537;
+      mlpath_of_lid = (uu___418_2536.mlpath_of_lid);
+      env_fieldname_map = uu____2541;
+      mlpath_of_fieldname = (uu___418_2536.mlpath_of_fieldname);
+      tydefs = (uu___418_2536.tydefs);
+      type_names = (uu___418_2536.type_names);
+      currentModule = (uu___418_2536.currentModule)
     }
   
 let (new_uenv : FStar_TypeChecker_Env.env -> uenv) =
   fun e  ->
     let env =
-      let uu____2511 = initial_mlident_map ()  in
-      let uu____2515 = FStar_Util.psmap_empty ()  in
-      let uu____2518 = initial_mlident_map ()  in
-      let uu____2522 = FStar_Util.psmap_empty ()  in
+      let uu____2552 = initial_mlident_map ()  in
+      let uu____2556 = FStar_Util.psmap_empty ()  in
+      let uu____2559 = initial_mlident_map ()  in
+      let uu____2563 = FStar_Util.psmap_empty ()  in
       {
         env_tcenv = e;
         env_bindings = [];
-        env_mlident_map = uu____2511;
-        mlpath_of_lid = uu____2515;
-        env_fieldname_map = uu____2518;
-        mlpath_of_fieldname = uu____2522;
+        env_mlident_map = uu____2552;
+        mlpath_of_lid = uu____2556;
+        env_fieldname_map = uu____2559;
+        mlpath_of_fieldname = uu____2563;
         tydefs = [];
         type_names = [];
         currentModule = ([], "")
@@ -1001,13 +1024,13 @@ let (new_uenv : FStar_TypeChecker_Env.env -> uenv) =
              FStar_Extraction_ML_Syntax.E_IMPURE,
              (FStar_Extraction_ML_Syntax.MLTY_Var a))))
        in
-    let uu____2555 =
-      let uu____2563 =
-        let uu____2564 =
+    let uu____2596 =
+      let uu____2604 =
+        let uu____2605 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.failwith_lid
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        FStar_Util.Inr uu____2564  in
-      extend_lb env uu____2563 FStar_Syntax_Syntax.tun failwith_ty false  in
-    match uu____2555 with | (g,uu____2567,uu____2568) -> g
+        FStar_Util.Inr uu____2605  in
+      extend_lb env uu____2604 FStar_Syntax_Syntax.tun failwith_ty false  in
+    match uu____2596 with | (g,uu____2608,uu____2609) -> g
   

--- a/src/ocaml-output/FStar_Extraction_ML_Util.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Util.ml
@@ -561,12 +561,14 @@ let (record_field_path :
   fun uu___3_1344  ->
     match uu___3_1344 with
     | f::uu____1351 ->
-        let uu____1354 = FStar_Util.prefix f.FStar_Ident.ns  in
+        let uu____1354 =
+          let uu____1361 = FStar_Ident.ns_of_lid f  in
+          FStar_Util.prefix uu____1361  in
         (match uu____1354 with
-         | (ns,uu____1365) ->
+         | (ns,uu____1368) ->
              FStar_All.pipe_right ns
-               (FStar_List.map (fun id  -> id.FStar_Ident.idText)))
-    | uu____1378 -> failwith "impos"
+               (FStar_List.map (fun id  -> FStar_Ident.text_of_id id)))
+    | uu____1381 -> failwith "impos"
   
 let record_fields :
   'a .
@@ -576,26 +578,30 @@ let record_fields :
   fun fs  ->
     fun vs  ->
       FStar_List.map2
-        (fun f  -> fun e  -> (((f.FStar_Ident.ident).FStar_Ident.idText), e))
-        fs vs
+        (fun f  ->
+           fun e  ->
+             let uu____1431 =
+               let uu____1433 = FStar_Ident.ident_of_lid f  in
+               FStar_Ident.text_of_id uu____1433  in
+             (uu____1431, e)) fs vs
   
 let (is_xtuple_ty :
   (Prims.string Prims.list * Prims.string) ->
     Prims.int FStar_Pervasives_Native.option)
   =
-  fun uu____1444  ->
-    match uu____1444 with
+  fun uu____1451  ->
+    match uu____1451 with
     | (ns,n) ->
-        let uu____1466 =
-          let uu____1468 = FStar_Util.concat_l "." (FStar_List.append ns [n])
+        let uu____1473 =
+          let uu____1475 = FStar_Util.concat_l "." (FStar_List.append ns [n])
              in
-          FStar_Parser_Const.is_tuple_constructor_string uu____1468  in
-        if uu____1466
+          FStar_Parser_Const.is_tuple_constructor_string uu____1475  in
+        if uu____1473
         then
-          let uu____1478 =
-            let uu____1480 = FStar_Util.char_at n (Prims.of_int (5))  in
-            FStar_Util.int_of_char uu____1480  in
-          FStar_Pervasives_Native.Some uu____1478
+          let uu____1485 =
+            let uu____1487 = FStar_Util.char_at n (Prims.of_int (5))  in
+            FStar_Util.int_of_char uu____1487  in
+          FStar_Pervasives_Native.Some uu____1485
         else FStar_Pervasives_Native.None
   
 let (resugar_mlty :
@@ -603,38 +609,42 @@ let (resugar_mlty :
   fun t  ->
     match t with
     | FStar_Extraction_ML_Syntax.MLTY_Named (args,mlp) ->
-        let uu____1499 = is_xtuple_ty mlp  in
-        (match uu____1499 with
+        let uu____1506 = is_xtuple_ty mlp  in
+        (match uu____1506 with
          | FStar_Pervasives_Native.Some n ->
              FStar_Extraction_ML_Syntax.MLTY_Tuple args
-         | uu____1506 -> t)
-    | uu____1510 -> t
+         | uu____1513 -> t)
+    | uu____1517 -> t
   
 let (flatten_ns : Prims.string Prims.list -> Prims.string) =
   fun ns  ->
-    let uu____1524 = codegen_fsharp ()  in
-    if uu____1524
+    let uu____1531 = codegen_fsharp ()  in
+    if uu____1531
     then FStar_String.concat "." ns
     else FStar_String.concat "_" ns
   
 let (flatten_mlpath :
   (Prims.string Prims.list * Prims.string) -> Prims.string) =
-  fun uu____1546  ->
-    match uu____1546 with
+  fun uu____1553  ->
+    match uu____1553 with
     | (ns,n) ->
-        let uu____1566 = codegen_fsharp ()  in
-        if uu____1566
+        let uu____1573 = codegen_fsharp ()  in
+        if uu____1573
         then FStar_String.concat "." (FStar_List.append ns [n])
         else FStar_String.concat "_" (FStar_List.append ns [n])
   
 let (ml_module_name_of_lid : FStar_Ident.lident -> Prims.string) =
   fun l  ->
     let mlp =
-      let uu____1596 =
-        FStar_All.pipe_right l.FStar_Ident.ns
-          (FStar_List.map (fun i  -> i.FStar_Ident.idText))
+      let uu____1603 =
+        let uu____1607 = FStar_All.pipe_right l FStar_Ident.ns_of_lid  in
+        FStar_All.pipe_right uu____1607
+          (FStar_List.map FStar_Ident.text_of_id)
          in
-      (uu____1596, ((l.FStar_Ident.ident).FStar_Ident.idText))  in
+      let uu____1618 =
+        let uu____1620 = FStar_Ident.ident_of_lid l  in
+        FStar_Ident.text_of_id uu____1620  in
+      (uu____1603, uu____1618)  in
     flatten_mlpath mlp
   
 let rec (erasableType :
@@ -647,20 +657,20 @@ let rec (erasableType :
         else
           (match t1 with
            | FStar_Extraction_ML_Syntax.MLTY_Named
-               (uu____1640,("FStar"::"Ghost"::[],"erased")) -> true
+               (uu____1653,("FStar"::"Ghost"::[],"erased")) -> true
            | FStar_Extraction_ML_Syntax.MLTY_Named
-               (uu____1656,("FStar"::"Tactics"::"Effect"::[],"tactic")) ->
-               let uu____1673 = FStar_Options.codegen ()  in
-               uu____1673 <>
+               (uu____1669,("FStar"::"Tactics"::"Effect"::[],"tactic")) ->
+               let uu____1686 = FStar_Options.codegen ()  in
+               uu____1686 <>
                  (FStar_Pervasives_Native.Some FStar_Options.Plugin)
-           | uu____1678 -> false)
+           | uu____1691 -> false)
          in
-      let uu____1680 = erasableTypeNoDelta t  in
-      if uu____1680
+      let uu____1693 = erasableTypeNoDelta t  in
+      if uu____1693
       then true
       else
-        (let uu____1687 = unfold_ty t  in
-         match uu____1687 with
+        (let uu____1700 = unfold_ty t  in
+         match uu____1700 with
          | FStar_Pervasives_Native.Some t1 -> erasableType unfold_ty t1
          | FStar_Pervasives_Native.None  -> false)
   
@@ -674,26 +684,26 @@ let rec (eraseTypeDeep :
       | FStar_Extraction_ML_Syntax.MLTY_Fun (tyd,etag,tycd) ->
           if etag = FStar_Extraction_ML_Syntax.E_PURE
           then
-            let uu____1710 =
-              let uu____1717 = eraseTypeDeep unfold_ty tyd  in
-              let uu____1718 = eraseTypeDeep unfold_ty tycd  in
-              (uu____1717, etag, uu____1718)  in
-            FStar_Extraction_ML_Syntax.MLTY_Fun uu____1710
+            let uu____1723 =
+              let uu____1730 = eraseTypeDeep unfold_ty tyd  in
+              let uu____1731 = eraseTypeDeep unfold_ty tycd  in
+              (uu____1730, etag, uu____1731)  in
+            FStar_Extraction_ML_Syntax.MLTY_Fun uu____1723
           else t
       | FStar_Extraction_ML_Syntax.MLTY_Named (lty,mlp) ->
-          let uu____1727 = erasableType unfold_ty t  in
-          if uu____1727
+          let uu____1740 = erasableType unfold_ty t  in
+          if uu____1740
           then FStar_Extraction_ML_Syntax.MLTY_Erased
           else
-            (let uu____1732 =
-               let uu____1739 = FStar_List.map (eraseTypeDeep unfold_ty) lty
+            (let uu____1745 =
+               let uu____1752 = FStar_List.map (eraseTypeDeep unfold_ty) lty
                   in
-               (uu____1739, mlp)  in
-             FStar_Extraction_ML_Syntax.MLTY_Named uu____1732)
+               (uu____1752, mlp)  in
+             FStar_Extraction_ML_Syntax.MLTY_Named uu____1745)
       | FStar_Extraction_ML_Syntax.MLTY_Tuple lty ->
-          let uu____1747 = FStar_List.map (eraseTypeDeep unfold_ty) lty  in
-          FStar_Extraction_ML_Syntax.MLTY_Tuple uu____1747
-      | uu____1750 -> t
+          let uu____1760 = FStar_List.map (eraseTypeDeep unfold_ty) lty  in
+          FStar_Extraction_ML_Syntax.MLTY_Tuple uu____1760
+      | uu____1763 -> t
   
 let (prims_op_equality : FStar_Extraction_ML_Syntax.mlexpr) =
   FStar_All.pipe_left
@@ -701,15 +711,15 @@ let (prims_op_equality : FStar_Extraction_ML_Syntax.mlexpr) =
     (FStar_Extraction_ML_Syntax.MLE_Name (["Prims"], "op_Equality"))
   
 let (prims_op_amp_amp : FStar_Extraction_ML_Syntax.mlexpr) =
-  let uu____1761 =
-    let uu____1766 =
+  let uu____1774 =
+    let uu____1779 =
       mk_ty_fun
         [("x", FStar_Extraction_ML_Syntax.ml_bool_ty);
         ("y", FStar_Extraction_ML_Syntax.ml_bool_ty)]
         FStar_Extraction_ML_Syntax.ml_bool_ty
        in
-    FStar_Extraction_ML_Syntax.with_ty uu____1766  in
-  FStar_All.pipe_left uu____1761
+    FStar_Extraction_ML_Syntax.with_ty uu____1779  in
+  FStar_All.pipe_left uu____1774
     (FStar_Extraction_ML_Syntax.MLE_Name (["Prims"], "op_AmpAmp"))
   
 let (conjoin :
@@ -738,14 +748,14 @@ let (conjoin_opt :
       | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.Some x) ->
           FStar_Pervasives_Native.Some x
       | (FStar_Pervasives_Native.Some x,FStar_Pervasives_Native.Some y) ->
-          let uu____1854 = conjoin x y  in
-          FStar_Pervasives_Native.Some uu____1854
+          let uu____1867 = conjoin x y  in
+          FStar_Pervasives_Native.Some uu____1867
   
 let (mlloc_of_range : FStar_Range.range -> (Prims.int * Prims.string)) =
   fun r  ->
     let pos = FStar_Range.start_of_range r  in
     let line = FStar_Range.line_of_pos pos  in
-    let uu____1870 = FStar_Range.file_of_range r  in (line, uu____1870)
+    let uu____1883 = FStar_Range.file_of_range r  in (line, uu____1883)
   
 let rec (doms_and_cod :
   FStar_Extraction_ML_Syntax.mlty ->
@@ -754,18 +764,18 @@ let rec (doms_and_cod :
   =
   fun t  ->
     match t with
-    | FStar_Extraction_ML_Syntax.MLTY_Fun (a,uu____1893,b) ->
-        let uu____1895 = doms_and_cod b  in
-        (match uu____1895 with | (ds,c) -> ((a :: ds), c))
-    | uu____1916 -> ([], t)
+    | FStar_Extraction_ML_Syntax.MLTY_Fun (a,uu____1906,b) ->
+        let uu____1908 = doms_and_cod b  in
+        (match uu____1908 with | (ds,c) -> ((a :: ds), c))
+    | uu____1929 -> ([], t)
   
 let (argTypes :
   FStar_Extraction_ML_Syntax.mlty ->
     FStar_Extraction_ML_Syntax.mlty Prims.list)
   =
   fun t  ->
-    let uu____1929 = doms_and_cod t  in
-    FStar_Pervasives_Native.fst uu____1929
+    let uu____1942 = doms_and_cod t  in
+    FStar_Pervasives_Native.fst uu____1942
   
 let rec (uncurry_mlty_fun :
   FStar_Extraction_ML_Syntax.mlty ->
@@ -774,34 +784,34 @@ let rec (uncurry_mlty_fun :
   =
   fun t  ->
     match t with
-    | FStar_Extraction_ML_Syntax.MLTY_Fun (a,uu____1957,b) ->
-        let uu____1959 = uncurry_mlty_fun b  in
-        (match uu____1959 with | (args,res) -> ((a :: args), res))
-    | uu____1980 -> ([], t)
+    | FStar_Extraction_ML_Syntax.MLTY_Fun (a,uu____1970,b) ->
+        let uu____1972 = uncurry_mlty_fun b  in
+        (match uu____1972 with | (args,res) -> ((a :: args), res))
+    | uu____1993 -> ([], t)
   
 exception NoTacticEmbedding of Prims.string 
 let (uu___is_NoTacticEmbedding : Prims.exn -> Prims.bool) =
   fun projectee  ->
     match projectee with
-    | NoTacticEmbedding uu____1996 -> true
-    | uu____1999 -> false
+    | NoTacticEmbedding uu____2009 -> true
+    | uu____2012 -> false
   
 let (__proj__NoTacticEmbedding__item__uu___ : Prims.exn -> Prims.string) =
   fun projectee  ->
-    match projectee with | NoTacticEmbedding uu____2009 -> uu____2009
+    match projectee with | NoTacticEmbedding uu____2022 -> uu____2022
   
 let (not_implemented_warning :
   FStar_Range.range -> Prims.string -> Prims.string -> unit) =
   fun r  ->
     fun t  ->
       fun msg  ->
-        let uu____2031 =
-          let uu____2037 =
+        let uu____2044 =
+          let uu____2050 =
             FStar_Util.format2
               "Plugin %s will not run natively because %s.\n" t msg
              in
-          (FStar_Errors.Warning_CallNotImplementedAsWarning, uu____2037)  in
-        FStar_Errors.log_issue r uu____2031
+          (FStar_Errors.Warning_CallNotImplementedAsWarning, uu____2050)  in
+        FStar_Errors.log_issue r uu____2044
   
 type emb_loc =
   | Syntax_term 
@@ -810,19 +820,19 @@ type emb_loc =
   | NBERefl_emb 
 let (uu___is_Syntax_term : emb_loc -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Syntax_term  -> true | uu____2050 -> false
+    match projectee with | Syntax_term  -> true | uu____2063 -> false
   
 let (uu___is_Refl_emb : emb_loc -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Refl_emb  -> true | uu____2061 -> false
+    match projectee with | Refl_emb  -> true | uu____2074 -> false
   
 let (uu___is_NBE_t : emb_loc -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NBE_t  -> true | uu____2072 -> false
+    match projectee with | NBE_t  -> true | uu____2085 -> false
   
 let (uu___is_NBERefl_emb : emb_loc -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NBERefl_emb  -> true | uu____2083 -> false
+    match projectee with | NBERefl_emb  -> true | uu____2096 -> false
   
 type wrapped_term =
   (FStar_Extraction_ML_Syntax.mlexpr * FStar_Extraction_ML_Syntax.mlexpr *
@@ -863,13 +873,13 @@ let (interpret_plugin_as_term_fun :
                 (FStar_Extraction_ML_Syntax.MLE_Name mlp)
                in
             let lid_to_name l =
-              let uu____2161 =
-                let uu____2162 =
+              let uu____2174 =
+                let uu____2175 =
                   FStar_Extraction_ML_UEnv.mlpath_of_lident env l  in
-                FStar_Extraction_ML_Syntax.MLE_Name uu____2162  in
+                FStar_Extraction_ML_Syntax.MLE_Name uu____2175  in
               FStar_All.pipe_left
                 (FStar_Extraction_ML_Syntax.with_ty
-                   FStar_Extraction_ML_Syntax.MLTY_Top) uu____2161
+                   FStar_Extraction_ML_Syntax.MLTY_Top) uu____2174
                in
             let str_to_name s = as_name ([], s)  in
             let fstar_tc_nbe_prefix s =
@@ -881,32 +891,32 @@ let (interpret_plugin_as_term_fun :
             let fstar_refl_nbeemb_prefix s =
               as_name (["FStar_Reflection_NBEEmbeddings"], s)  in
             let fv_lid_embedded =
-              let uu____2237 =
-                let uu____2238 =
-                  let uu____2245 = as_name (["FStar_Ident"], "lid_of_str")
+              let uu____2250 =
+                let uu____2251 =
+                  let uu____2258 = as_name (["FStar_Ident"], "lid_of_str")
                      in
-                  let uu____2254 =
-                    let uu____2257 =
-                      let uu____2258 =
-                        let uu____2259 =
-                          let uu____2260 = FStar_Ident.string_of_lid fv_lid
+                  let uu____2267 =
+                    let uu____2270 =
+                      let uu____2271 =
+                        let uu____2272 =
+                          let uu____2273 = FStar_Ident.string_of_lid fv_lid
                              in
-                          FStar_Extraction_ML_Syntax.MLC_String uu____2260
+                          FStar_Extraction_ML_Syntax.MLC_String uu____2273
                            in
-                        FStar_Extraction_ML_Syntax.MLE_Const uu____2259  in
+                        FStar_Extraction_ML_Syntax.MLE_Const uu____2272  in
                       FStar_All.pipe_left
                         (FStar_Extraction_ML_Syntax.with_ty
-                           FStar_Extraction_ML_Syntax.MLTY_Top) uu____2258
+                           FStar_Extraction_ML_Syntax.MLTY_Top) uu____2271
                        in
-                    [uu____2257]  in
-                  (uu____2245, uu____2254)  in
-                FStar_Extraction_ML_Syntax.MLE_App uu____2238  in
+                    [uu____2270]  in
+                  (uu____2258, uu____2267)  in
+                FStar_Extraction_ML_Syntax.MLE_App uu____2251  in
               FStar_All.pipe_left
                 (FStar_Extraction_ML_Syntax.with_ty
-                   FStar_Extraction_ML_Syntax.MLTY_Top) uu____2237
+                   FStar_Extraction_ML_Syntax.MLTY_Top) uu____2250
                in
-            let emb_prefix uu___4_2275 =
-              match uu___4_2275 with
+            let emb_prefix uu___4_2288 =
+              match uu___4_2288 with
               | Syntax_term  -> fstar_syn_emb_prefix
               | Refl_emb  -> fstar_refl_emb_prefix
               | NBE_t  -> fstar_tc_nbe_prefix
@@ -915,223 +925,223 @@ let (interpret_plugin_as_term_fun :
               let idroot =
                 match l with
                 | Syntax_term  -> "mk_tactic_interpretation_"
-                | uu____2297 -> "mk_nbe_tactic_interpretation_"  in
-              let uu____2299 =
-                let uu____2300 =
-                  let uu____2302 = FStar_Util.string_of_int arity  in
-                  Prims.op_Hat idroot uu____2302  in
-                (["FStar_Tactics_InterpFuns"], uu____2300)  in
-              as_name uu____2299  in
+                | uu____2310 -> "mk_nbe_tactic_interpretation_"  in
+              let uu____2312 =
+                let uu____2313 =
+                  let uu____2315 = FStar_Util.string_of_int arity  in
+                  Prims.op_Hat idroot uu____2315  in
+                (["FStar_Tactics_InterpFuns"], uu____2313)  in
+              as_name uu____2312  in
             let mk_from_tactic l arity =
               let idroot =
                 match l with
                 | Syntax_term  -> "from_tactic_"
-                | uu____2328 -> "from_nbe_tactic_"  in
-              let uu____2330 =
-                let uu____2331 =
-                  let uu____2333 = FStar_Util.string_of_int arity  in
-                  Prims.op_Hat idroot uu____2333  in
-                (["FStar_Tactics_Native"], uu____2331)  in
-              as_name uu____2330  in
+                | uu____2341 -> "from_nbe_tactic_"  in
+              let uu____2343 =
+                let uu____2344 =
+                  let uu____2346 = FStar_Util.string_of_int arity  in
+                  Prims.op_Hat idroot uu____2346  in
+                (["FStar_Tactics_Native"], uu____2344)  in
+              as_name uu____2343  in
             let mk_basic_embedding l s = emb_prefix l (Prims.op_Hat "e_" s)
                in
             let mk_arrow_as_prim_step l arity =
-              let uu____2369 =
-                let uu____2371 = FStar_Util.string_of_int arity  in
-                Prims.op_Hat "arrow_as_prim_step_" uu____2371  in
-              emb_prefix l uu____2369  in
+              let uu____2382 =
+                let uu____2384 = FStar_Util.string_of_int arity  in
+                Prims.op_Hat "arrow_as_prim_step_" uu____2384  in
+              emb_prefix l uu____2382  in
             let mk_any_embedding l s =
-              let uu____2387 =
-                let uu____2388 =
-                  let uu____2395 = emb_prefix l "mk_any_emb"  in
-                  let uu____2397 =
-                    let uu____2400 = str_to_name s  in [uu____2400]  in
-                  (uu____2395, uu____2397)  in
-                FStar_Extraction_ML_Syntax.MLE_App uu____2388  in
-              FStar_All.pipe_left w uu____2387  in
+              let uu____2400 =
+                let uu____2401 =
+                  let uu____2408 = emb_prefix l "mk_any_emb"  in
+                  let uu____2410 =
+                    let uu____2413 = str_to_name s  in [uu____2413]  in
+                  (uu____2408, uu____2410)  in
+                FStar_Extraction_ML_Syntax.MLE_App uu____2401  in
+              FStar_All.pipe_left w uu____2400  in
             let mk_lam nm e =
               FStar_All.pipe_left w
                 (FStar_Extraction_ML_Syntax.MLE_Fun
                    ([(nm, FStar_Extraction_ML_Syntax.MLTY_Top)], e))
                in
             let emb_arrow l e1 e2 =
-              let uu____2450 =
-                let uu____2451 =
-                  let uu____2458 = emb_prefix l "e_arrow"  in
-                  (uu____2458, [e1; e2])  in
-                FStar_Extraction_ML_Syntax.MLE_App uu____2451  in
-              FStar_All.pipe_left w uu____2450  in
+              let uu____2463 =
+                let uu____2464 =
+                  let uu____2471 = emb_prefix l "e_arrow"  in
+                  (uu____2471, [e1; e2])  in
+                FStar_Extraction_ML_Syntax.MLE_App uu____2464  in
+              FStar_All.pipe_left w uu____2463  in
             let known_type_constructors =
               let term_cs =
-                let uu____2496 =
-                  let uu____2511 =
-                    let uu____2526 =
-                      let uu____2541 =
-                        let uu____2556 =
-                          let uu____2571 =
-                            let uu____2586 =
-                              let uu____2601 =
-                                let uu____2614 =
-                                  let uu____2623 =
+                let uu____2509 =
+                  let uu____2524 =
+                    let uu____2539 =
+                      let uu____2554 =
+                        let uu____2569 =
+                          let uu____2584 =
+                            let uu____2599 =
+                              let uu____2614 =
+                                let uu____2627 =
+                                  let uu____2636 =
                                     FStar_Parser_Const.mk_tuple_lid
                                       (Prims.of_int (2))
                                       FStar_Range.dummyRange
                                      in
-                                  (uu____2623, (Prims.of_int (2)), "tuple2")
+                                  (uu____2636, (Prims.of_int (2)), "tuple2")
                                    in
-                                (uu____2614, Syntax_term)  in
-                              let uu____2637 =
-                                let uu____2652 =
-                                  let uu____2665 =
-                                    let uu____2674 =
+                                (uu____2627, Syntax_term)  in
+                              let uu____2650 =
+                                let uu____2665 =
+                                  let uu____2678 =
+                                    let uu____2687 =
                                       FStar_Reflection_Data.fstar_refl_types_lid
                                         "term"
                                        in
-                                    (uu____2674, Prims.int_zero, "term")  in
-                                  (uu____2665, Refl_emb)  in
-                                let uu____2688 =
-                                  let uu____2703 =
-                                    let uu____2716 =
-                                      let uu____2725 =
+                                    (uu____2687, Prims.int_zero, "term")  in
+                                  (uu____2678, Refl_emb)  in
+                                let uu____2701 =
+                                  let uu____2716 =
+                                    let uu____2729 =
+                                      let uu____2738 =
                                         FStar_Reflection_Data.fstar_refl_types_lid
                                           "sigelt"
                                          in
-                                      (uu____2725, Prims.int_zero, "sigelt")
+                                      (uu____2738, Prims.int_zero, "sigelt")
                                        in
-                                    (uu____2716, Refl_emb)  in
-                                  let uu____2739 =
-                                    let uu____2754 =
-                                      let uu____2767 =
-                                        let uu____2776 =
+                                    (uu____2729, Refl_emb)  in
+                                  let uu____2752 =
+                                    let uu____2767 =
+                                      let uu____2780 =
+                                        let uu____2789 =
                                           FStar_Reflection_Data.fstar_refl_types_lid
                                             "fv"
                                            in
-                                        (uu____2776, Prims.int_zero, "fv")
+                                        (uu____2789, Prims.int_zero, "fv")
                                          in
-                                      (uu____2767, Refl_emb)  in
-                                    let uu____2790 =
-                                      let uu____2805 =
-                                        let uu____2818 =
-                                          let uu____2827 =
+                                      (uu____2780, Refl_emb)  in
+                                    let uu____2803 =
+                                      let uu____2818 =
+                                        let uu____2831 =
+                                          let uu____2840 =
                                             FStar_Reflection_Data.fstar_refl_types_lid
                                               "binder"
                                              in
-                                          (uu____2827, Prims.int_zero,
+                                          (uu____2840, Prims.int_zero,
                                             "binder")
                                            in
-                                        (uu____2818, Refl_emb)  in
-                                      let uu____2841 =
-                                        let uu____2856 =
-                                          let uu____2869 =
-                                            let uu____2878 =
+                                        (uu____2831, Refl_emb)  in
+                                      let uu____2854 =
+                                        let uu____2869 =
+                                          let uu____2882 =
+                                            let uu____2891 =
                                               FStar_Reflection_Data.fstar_refl_syntax_lid
                                                 "binders"
                                                in
-                                            (uu____2878, Prims.int_zero,
+                                            (uu____2891, Prims.int_zero,
                                               "binders")
                                              in
-                                          (uu____2869, Refl_emb)  in
-                                        let uu____2892 =
-                                          let uu____2907 =
-                                            let uu____2920 =
-                                              let uu____2929 =
+                                          (uu____2882, Refl_emb)  in
+                                        let uu____2905 =
+                                          let uu____2920 =
+                                            let uu____2933 =
+                                              let uu____2942 =
                                                 FStar_Reflection_Data.fstar_refl_data_lid
                                                   "exp"
                                                  in
-                                              (uu____2929, Prims.int_zero,
+                                              (uu____2942, Prims.int_zero,
                                                 "exp")
                                                in
-                                            (uu____2920, Refl_emb)  in
-                                          [uu____2907]  in
-                                        uu____2856 :: uu____2892  in
-                                      uu____2805 :: uu____2841  in
-                                    uu____2754 :: uu____2790  in
-                                  uu____2703 :: uu____2739  in
-                                uu____2652 :: uu____2688  in
-                              uu____2601 :: uu____2637  in
+                                            (uu____2933, Refl_emb)  in
+                                          [uu____2920]  in
+                                        uu____2869 :: uu____2905  in
+                                      uu____2818 :: uu____2854  in
+                                    uu____2767 :: uu____2803  in
+                                  uu____2716 :: uu____2752  in
+                                uu____2665 :: uu____2701  in
+                              uu____2614 :: uu____2650  in
                             ((FStar_Parser_Const.option_lid, Prims.int_one,
                                "option"), Syntax_term)
-                              :: uu____2586
+                              :: uu____2599
                              in
                           ((FStar_Parser_Const.list_lid, Prims.int_one,
                              "list"), Syntax_term)
-                            :: uu____2571
+                            :: uu____2584
                            in
                         ((FStar_Parser_Const.norm_step_lid, Prims.int_zero,
                            "norm_step"), Syntax_term)
-                          :: uu____2556
+                          :: uu____2569
                          in
                       ((FStar_Parser_Const.string_lid, Prims.int_zero,
                          "string"), Syntax_term)
-                        :: uu____2541
+                        :: uu____2554
                        in
                     ((FStar_Parser_Const.unit_lid, Prims.int_zero, "unit"),
-                      Syntax_term) :: uu____2526
+                      Syntax_term) :: uu____2539
                      in
                   ((FStar_Parser_Const.bool_lid, Prims.int_zero, "bool"),
-                    Syntax_term) :: uu____2511
+                    Syntax_term) :: uu____2524
                    in
                 ((FStar_Parser_Const.int_lid, Prims.int_zero, "int"),
-                  Syntax_term) :: uu____2496
+                  Syntax_term) :: uu____2509
                  in
               let nbe_cs =
                 FStar_List.map
-                  (fun uu___5_3248  ->
-                     match uu___5_3248 with
+                  (fun uu___5_3261  ->
+                     match uu___5_3261 with
                      | (x,Syntax_term ) -> (x, NBE_t)
                      | (x,Refl_emb ) -> (x, NBERefl_emb)
-                     | uu____3323 -> failwith "Impossible") term_cs
+                     | uu____3336 -> failwith "Impossible") term_cs
                  in
-              fun uu___6_3349  ->
-                match uu___6_3349 with
+              fun uu___6_3362  ->
+                match uu___6_3362 with
                 | Syntax_term  -> term_cs
                 | Refl_emb  -> term_cs
-                | uu____3364 -> nbe_cs
+                | uu____3377 -> nbe_cs
                in
             let is_known_type_constructor l fv1 n =
               FStar_Util.for_some
-                (fun uu____3401  ->
-                   match uu____3401 with
-                   | ((x,args,uu____3417),uu____3418) ->
+                (fun uu____3414  ->
+                   match uu____3414 with
+                   | ((x,args,uu____3430),uu____3431) ->
                        (FStar_Syntax_Syntax.fv_eq_lid fv1 x) && (n = args))
                 (known_type_constructors l)
                in
-            let find_env_entry bv uu____3448 =
-              match uu____3448 with
-              | (bv',uu____3456) -> FStar_Syntax_Syntax.bv_eq bv bv'  in
+            let find_env_entry bv uu____3461 =
+              match uu____3461 with
+              | (bv',uu____3469) -> FStar_Syntax_Syntax.bv_eq bv bv'  in
             let rec mk_embedding l env1 t2 =
               let t3 = FStar_TypeChecker_Normalize.unfold_whnf tcenv t2  in
-              let uu____3490 =
-                let uu____3491 = FStar_Syntax_Subst.compress t3  in
-                uu____3491.FStar_Syntax_Syntax.n  in
-              match uu____3490 with
+              let uu____3503 =
+                let uu____3504 = FStar_Syntax_Subst.compress t3  in
+                uu____3504.FStar_Syntax_Syntax.n  in
+              match uu____3503 with
               | FStar_Syntax_Syntax.Tm_name bv when
                   FStar_Util.for_some (find_env_entry bv) env1 ->
-                  let uu____3500 =
-                    let uu____3502 =
-                      let uu____3508 =
+                  let uu____3513 =
+                    let uu____3515 =
+                      let uu____3521 =
                         FStar_Util.find_opt (find_env_entry bv) env1  in
-                      FStar_Util.must uu____3508  in
-                    FStar_Pervasives_Native.snd uu____3502  in
-                  FStar_All.pipe_left (mk_any_embedding l) uu____3500
-              | FStar_Syntax_Syntax.Tm_refine (x,uu____3529) ->
+                      FStar_Util.must uu____3521  in
+                    FStar_Pervasives_Native.snd uu____3515  in
+                  FStar_All.pipe_left (mk_any_embedding l) uu____3513
+              | FStar_Syntax_Syntax.Tm_refine (x,uu____3542) ->
                   mk_embedding l env1 x.FStar_Syntax_Syntax.sort
-              | FStar_Syntax_Syntax.Tm_ascribed (t4,uu____3535,uu____3536) ->
+              | FStar_Syntax_Syntax.Tm_ascribed (t4,uu____3548,uu____3549) ->
                   mk_embedding l env1 t4
               | FStar_Syntax_Syntax.Tm_arrow (b::[],c) when
                   FStar_Syntax_Util.is_pure_comp c ->
-                  let uu____3609 = FStar_Syntax_Subst.open_comp [b] c  in
-                  (match uu____3609 with
+                  let uu____3622 = FStar_Syntax_Subst.open_comp [b] c  in
+                  (match uu____3622 with
                    | (bs,c1) ->
                        let t0 =
-                         let uu____3631 =
-                           let uu____3632 = FStar_List.hd bs  in
-                           FStar_Pervasives_Native.fst uu____3632  in
-                         uu____3631.FStar_Syntax_Syntax.sort  in
+                         let uu____3644 =
+                           let uu____3645 = FStar_List.hd bs  in
+                           FStar_Pervasives_Native.fst uu____3645  in
+                         uu____3644.FStar_Syntax_Syntax.sort  in
                        let t11 = FStar_Syntax_Util.comp_result c1  in
-                       let uu____3650 = mk_embedding l env1 t0  in
-                       let uu____3651 = mk_embedding l env1 t11  in
-                       emb_arrow l uu____3650 uu____3651)
+                       let uu____3663 = mk_embedding l env1 t0  in
+                       let uu____3664 = mk_embedding l env1 t11  in
+                       emb_arrow l uu____3663 uu____3664)
               | FStar_Syntax_Syntax.Tm_arrow (b::more::bs,c) ->
                   let tail =
                     FStar_Syntax_Syntax.mk
@@ -1139,246 +1149,255 @@ let (interpret_plugin_as_term_fun :
                       FStar_Pervasives_Native.None t3.FStar_Syntax_Syntax.pos
                      in
                   let t4 =
-                    let uu____3722 =
-                      let uu____3729 =
-                        let uu____3730 =
-                          let uu____3745 = FStar_Syntax_Syntax.mk_Total tail
+                    let uu____3735 =
+                      let uu____3742 =
+                        let uu____3743 =
+                          let uu____3758 = FStar_Syntax_Syntax.mk_Total tail
                              in
-                          ([b], uu____3745)  in
-                        FStar_Syntax_Syntax.Tm_arrow uu____3730  in
-                      FStar_Syntax_Syntax.mk uu____3729  in
-                    uu____3722 FStar_Pervasives_Native.None
+                          ([b], uu____3758)  in
+                        FStar_Syntax_Syntax.Tm_arrow uu____3743  in
+                      FStar_Syntax_Syntax.mk uu____3742  in
+                    uu____3735 FStar_Pervasives_Native.None
                       t3.FStar_Syntax_Syntax.pos
                      in
                   mk_embedding l env1 t4
-              | FStar_Syntax_Syntax.Tm_fvar uu____3770 ->
-                  let uu____3771 = FStar_Syntax_Util.head_and_args t3  in
-                  (match uu____3771 with
+              | FStar_Syntax_Syntax.Tm_fvar uu____3783 ->
+                  let uu____3784 = FStar_Syntax_Util.head_and_args t3  in
+                  (match uu____3784 with
                    | (head,args) ->
                        let n_args = FStar_List.length args  in
-                       let uu____3823 =
-                         let uu____3824 = FStar_Syntax_Util.un_uinst head  in
-                         uu____3824.FStar_Syntax_Syntax.n  in
-                       (match uu____3823 with
+                       let uu____3836 =
+                         let uu____3837 = FStar_Syntax_Util.un_uinst head  in
+                         uu____3837.FStar_Syntax_Syntax.n  in
+                       (match uu____3836 with
                         | FStar_Syntax_Syntax.Tm_fvar fv1 when
                             is_known_type_constructor l fv1 n_args ->
                             let arg_embeddings =
                               FStar_All.pipe_right args
                                 (FStar_List.map
-                                   (fun uu____3850  ->
-                                      match uu____3850 with
-                                      | (t4,uu____3858) ->
+                                   (fun uu____3863  ->
+                                      match uu____3863 with
+                                      | (t4,uu____3871) ->
                                           mk_embedding l env1 t4))
                                in
                             let nm =
-                              (((fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.ident).FStar_Ident.idText
-                               in
-                            let uu____3865 =
                               let uu____3878 =
+                                FStar_Ident.ident_of_lid
+                                  (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                                 in
+                              FStar_Ident.text_of_id uu____3878  in
+                            let uu____3879 =
+                              let uu____3892 =
                                 FStar_Util.find_opt
-                                  (fun uu____3910  ->
-                                     match uu____3910 with
-                                     | ((x,uu____3925,uu____3926),uu____3927)
+                                  (fun uu____3924  ->
+                                     match uu____3924 with
+                                     | ((x,uu____3939,uu____3940),uu____3941)
                                          ->
                                          FStar_Syntax_Syntax.fv_eq_lid fv1 x)
                                   (known_type_constructors l)
                                  in
-                              FStar_All.pipe_right uu____3878 FStar_Util.must
+                              FStar_All.pipe_right uu____3892 FStar_Util.must
                                in
-                            (match uu____3865 with
-                             | ((uu____3978,t_arity,_trepr_head),loc_embedding)
+                            (match uu____3879 with
+                             | ((uu____3992,t_arity,_trepr_head),loc_embedding)
                                  ->
                                  let head1 =
                                    mk_basic_embedding loc_embedding nm  in
                                  (match t_arity with
-                                  | uu____3995 when
-                                      uu____3995 = Prims.int_zero -> head1
+                                  | uu____4009 when
+                                      uu____4009 = Prims.int_zero -> head1
                                   | n ->
                                       FStar_All.pipe_left w
                                         (FStar_Extraction_ML_Syntax.MLE_App
                                            (head1, arg_embeddings))))
-                        | uu____4000 ->
-                            let uu____4001 =
-                              let uu____4002 =
-                                let uu____4004 =
+                        | uu____4014 ->
+                            let uu____4015 =
+                              let uu____4016 =
+                                let uu____4018 =
                                   FStar_Syntax_Print.term_to_string t3  in
                                 Prims.op_Hat
                                   "Embedding not defined for type "
-                                  uu____4004
+                                  uu____4018
                                  in
-                              NoTacticEmbedding uu____4002  in
-                            FStar_Exn.raise uu____4001))
-              | FStar_Syntax_Syntax.Tm_uinst uu____4007 ->
-                  let uu____4014 = FStar_Syntax_Util.head_and_args t3  in
-                  (match uu____4014 with
+                              NoTacticEmbedding uu____4016  in
+                            FStar_Exn.raise uu____4015))
+              | FStar_Syntax_Syntax.Tm_uinst uu____4021 ->
+                  let uu____4028 = FStar_Syntax_Util.head_and_args t3  in
+                  (match uu____4028 with
                    | (head,args) ->
                        let n_args = FStar_List.length args  in
-                       let uu____4066 =
-                         let uu____4067 = FStar_Syntax_Util.un_uinst head  in
-                         uu____4067.FStar_Syntax_Syntax.n  in
-                       (match uu____4066 with
+                       let uu____4080 =
+                         let uu____4081 = FStar_Syntax_Util.un_uinst head  in
+                         uu____4081.FStar_Syntax_Syntax.n  in
+                       (match uu____4080 with
                         | FStar_Syntax_Syntax.Tm_fvar fv1 when
                             is_known_type_constructor l fv1 n_args ->
                             let arg_embeddings =
                               FStar_All.pipe_right args
                                 (FStar_List.map
-                                   (fun uu____4093  ->
-                                      match uu____4093 with
-                                      | (t4,uu____4101) ->
+                                   (fun uu____4107  ->
+                                      match uu____4107 with
+                                      | (t4,uu____4115) ->
                                           mk_embedding l env1 t4))
                                in
                             let nm =
-                              (((fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.ident).FStar_Ident.idText
-                               in
-                            let uu____4108 =
-                              let uu____4121 =
+                              let uu____4122 =
+                                FStar_Ident.ident_of_lid
+                                  (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                                 in
+                              FStar_Ident.text_of_id uu____4122  in
+                            let uu____4123 =
+                              let uu____4136 =
                                 FStar_Util.find_opt
-                                  (fun uu____4153  ->
-                                     match uu____4153 with
-                                     | ((x,uu____4168,uu____4169),uu____4170)
+                                  (fun uu____4168  ->
+                                     match uu____4168 with
+                                     | ((x,uu____4183,uu____4184),uu____4185)
                                          ->
                                          FStar_Syntax_Syntax.fv_eq_lid fv1 x)
                                   (known_type_constructors l)
                                  in
-                              FStar_All.pipe_right uu____4121 FStar_Util.must
+                              FStar_All.pipe_right uu____4136 FStar_Util.must
                                in
-                            (match uu____4108 with
-                             | ((uu____4221,t_arity,_trepr_head),loc_embedding)
+                            (match uu____4123 with
+                             | ((uu____4236,t_arity,_trepr_head),loc_embedding)
                                  ->
                                  let head1 =
                                    mk_basic_embedding loc_embedding nm  in
                                  (match t_arity with
-                                  | uu____4238 when
-                                      uu____4238 = Prims.int_zero -> head1
+                                  | uu____4253 when
+                                      uu____4253 = Prims.int_zero -> head1
                                   | n ->
                                       FStar_All.pipe_left w
                                         (FStar_Extraction_ML_Syntax.MLE_App
                                            (head1, arg_embeddings))))
-                        | uu____4243 ->
-                            let uu____4244 =
-                              let uu____4245 =
-                                let uu____4247 =
+                        | uu____4258 ->
+                            let uu____4259 =
+                              let uu____4260 =
+                                let uu____4262 =
                                   FStar_Syntax_Print.term_to_string t3  in
                                 Prims.op_Hat
                                   "Embedding not defined for type "
-                                  uu____4247
+                                  uu____4262
                                  in
-                              NoTacticEmbedding uu____4245  in
-                            FStar_Exn.raise uu____4244))
-              | FStar_Syntax_Syntax.Tm_app uu____4250 ->
-                  let uu____4267 = FStar_Syntax_Util.head_and_args t3  in
-                  (match uu____4267 with
+                              NoTacticEmbedding uu____4260  in
+                            FStar_Exn.raise uu____4259))
+              | FStar_Syntax_Syntax.Tm_app uu____4265 ->
+                  let uu____4282 = FStar_Syntax_Util.head_and_args t3  in
+                  (match uu____4282 with
                    | (head,args) ->
                        let n_args = FStar_List.length args  in
-                       let uu____4319 =
-                         let uu____4320 = FStar_Syntax_Util.un_uinst head  in
-                         uu____4320.FStar_Syntax_Syntax.n  in
-                       (match uu____4319 with
+                       let uu____4334 =
+                         let uu____4335 = FStar_Syntax_Util.un_uinst head  in
+                         uu____4335.FStar_Syntax_Syntax.n  in
+                       (match uu____4334 with
                         | FStar_Syntax_Syntax.Tm_fvar fv1 when
                             is_known_type_constructor l fv1 n_args ->
                             let arg_embeddings =
                               FStar_All.pipe_right args
                                 (FStar_List.map
-                                   (fun uu____4346  ->
-                                      match uu____4346 with
-                                      | (t4,uu____4354) ->
+                                   (fun uu____4361  ->
+                                      match uu____4361 with
+                                      | (t4,uu____4369) ->
                                           mk_embedding l env1 t4))
                                in
                             let nm =
-                              (((fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.ident).FStar_Ident.idText
-                               in
-                            let uu____4361 =
-                              let uu____4374 =
+                              let uu____4376 =
+                                FStar_Ident.ident_of_lid
+                                  (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                                 in
+                              FStar_Ident.text_of_id uu____4376  in
+                            let uu____4377 =
+                              let uu____4390 =
                                 FStar_Util.find_opt
-                                  (fun uu____4406  ->
-                                     match uu____4406 with
-                                     | ((x,uu____4421,uu____4422),uu____4423)
+                                  (fun uu____4422  ->
+                                     match uu____4422 with
+                                     | ((x,uu____4437,uu____4438),uu____4439)
                                          ->
                                          FStar_Syntax_Syntax.fv_eq_lid fv1 x)
                                   (known_type_constructors l)
                                  in
-                              FStar_All.pipe_right uu____4374 FStar_Util.must
+                              FStar_All.pipe_right uu____4390 FStar_Util.must
                                in
-                            (match uu____4361 with
-                             | ((uu____4474,t_arity,_trepr_head),loc_embedding)
+                            (match uu____4377 with
+                             | ((uu____4490,t_arity,_trepr_head),loc_embedding)
                                  ->
                                  let head1 =
                                    mk_basic_embedding loc_embedding nm  in
                                  (match t_arity with
-                                  | uu____4491 when
-                                      uu____4491 = Prims.int_zero -> head1
+                                  | uu____4507 when
+                                      uu____4507 = Prims.int_zero -> head1
                                   | n ->
                                       FStar_All.pipe_left w
                                         (FStar_Extraction_ML_Syntax.MLE_App
                                            (head1, arg_embeddings))))
-                        | uu____4496 ->
-                            let uu____4497 =
-                              let uu____4498 =
-                                let uu____4500 =
+                        | uu____4512 ->
+                            let uu____4513 =
+                              let uu____4514 =
+                                let uu____4516 =
                                   FStar_Syntax_Print.term_to_string t3  in
                                 Prims.op_Hat
                                   "Embedding not defined for type "
-                                  uu____4500
+                                  uu____4516
                                  in
-                              NoTacticEmbedding uu____4498  in
-                            FStar_Exn.raise uu____4497))
-              | uu____4503 ->
-                  let uu____4504 =
-                    let uu____4505 =
-                      let uu____4507 = FStar_Syntax_Print.term_to_string t3
+                              NoTacticEmbedding uu____4514  in
+                            FStar_Exn.raise uu____4513))
+              | uu____4519 ->
+                  let uu____4520 =
+                    let uu____4521 =
+                      let uu____4523 = FStar_Syntax_Print.term_to_string t3
                          in
                       Prims.op_Hat "Embedding not defined for type "
-                        uu____4507
+                        uu____4523
                        in
-                    NoTacticEmbedding uu____4505  in
-                  FStar_Exn.raise uu____4504
+                    NoTacticEmbedding uu____4521  in
+                  FStar_Exn.raise uu____4520
                in
             let abstract_tvars tvar_names body =
               match tvar_names with
               | [] ->
                   let body1 =
-                    let uu____4529 =
-                      let uu____4530 =
-                        let uu____4537 =
+                    let uu____4545 =
+                      let uu____4546 =
+                        let uu____4553 =
                           as_name (["FStar_Syntax_Embeddings"], "debug_wrap")
                            in
-                        let uu____4546 =
-                          let uu____4549 =
-                            let uu____4550 =
-                              let uu____4551 =
-                                let uu____4552 =
+                        let uu____4562 =
+                          let uu____4565 =
+                            let uu____4566 =
+                              let uu____4567 =
+                                let uu____4568 =
                                   FStar_Ident.string_of_lid fv_lid  in
                                 FStar_Extraction_ML_Syntax.MLC_String
-                                  uu____4552
+                                  uu____4568
                                  in
-                              FStar_Extraction_ML_Syntax.MLE_Const uu____4551
+                              FStar_Extraction_ML_Syntax.MLE_Const uu____4567
                                in
                             FStar_All.pipe_left
                               (FStar_Extraction_ML_Syntax.with_ty
                                  FStar_Extraction_ML_Syntax.MLTY_Top)
-                              uu____4550
+                              uu____4566
                              in
-                          let uu____4554 =
-                            let uu____4557 =
-                              let uu____4558 =
-                                let uu____4559 =
-                                  let uu____4560 =
-                                    let uu____4567 =
-                                      let uu____4570 = str_to_name "args"  in
-                                      [uu____4570]  in
-                                    (body, uu____4567)  in
+                          let uu____4570 =
+                            let uu____4573 =
+                              let uu____4574 =
+                                let uu____4575 =
+                                  let uu____4576 =
+                                    let uu____4583 =
+                                      let uu____4586 = str_to_name "args"  in
+                                      [uu____4586]  in
+                                    (body, uu____4583)  in
                                   FStar_Extraction_ML_Syntax.MLE_App
-                                    uu____4560
+                                    uu____4576
                                    in
-                                FStar_All.pipe_left w uu____4559  in
-                              mk_lam "_" uu____4558  in
-                            [uu____4557]  in
-                          uu____4549 :: uu____4554  in
-                        (uu____4537, uu____4546)  in
-                      FStar_Extraction_ML_Syntax.MLE_App uu____4530  in
-                    FStar_All.pipe_left w uu____4529  in
+                                FStar_All.pipe_left w uu____4575  in
+                              mk_lam "_" uu____4574  in
+                            [uu____4573]  in
+                          uu____4565 :: uu____4570  in
+                        (uu____4553, uu____4562)  in
+                      FStar_Extraction_ML_Syntax.MLE_App uu____4546  in
+                    FStar_All.pipe_left w uu____4545  in
                   mk_lam "args" body1
-              | uu____4578 ->
+              | uu____4594 ->
                   let args_tail =
                     FStar_Extraction_ML_Syntax.MLP_Var "args_tail"  in
                   let mk_cons hd_pat tail_pat =
@@ -1396,79 +1415,79 @@ let (interpret_plugin_as_term_fun :
                       args_tail
                      in
                   let branch =
-                    let uu____4627 =
-                      let uu____4628 =
-                        let uu____4629 =
-                          let uu____4636 =
-                            let uu____4639 = as_name ([], "args")  in
-                            [uu____4639]  in
-                          (body, uu____4636)  in
-                        FStar_Extraction_ML_Syntax.MLE_App uu____4629  in
-                      FStar_All.pipe_left w uu____4628  in
-                    (pattern, FStar_Pervasives_Native.None, uu____4627)  in
+                    let uu____4643 =
+                      let uu____4644 =
+                        let uu____4645 =
+                          let uu____4652 =
+                            let uu____4655 = as_name ([], "args")  in
+                            [uu____4655]  in
+                          (body, uu____4652)  in
+                        FStar_Extraction_ML_Syntax.MLE_App uu____4645  in
+                      FStar_All.pipe_left w uu____4644  in
+                    (pattern, FStar_Pervasives_Native.None, uu____4643)  in
                   let default_branch =
-                    let uu____4659 =
-                      let uu____4660 =
-                        let uu____4661 =
-                          let uu____4668 = str_to_name "failwith"  in
-                          let uu____4670 =
-                            let uu____4673 =
-                              let uu____4674 =
+                    let uu____4675 =
+                      let uu____4676 =
+                        let uu____4677 =
+                          let uu____4684 = str_to_name "failwith"  in
+                          let uu____4686 =
+                            let uu____4689 =
+                              let uu____4690 =
                                 mlexpr_of_const FStar_Range.dummyRange
                                   (FStar_Const.Const_string
                                      ("arity mismatch",
                                        FStar_Range.dummyRange))
                                  in
-                              FStar_All.pipe_left w uu____4674  in
-                            [uu____4673]  in
-                          (uu____4668, uu____4670)  in
-                        FStar_Extraction_ML_Syntax.MLE_App uu____4661  in
-                      FStar_All.pipe_left w uu____4660  in
+                              FStar_All.pipe_left w uu____4690  in
+                            [uu____4689]  in
+                          (uu____4684, uu____4686)  in
+                        FStar_Extraction_ML_Syntax.MLE_App uu____4677  in
+                      FStar_All.pipe_left w uu____4676  in
                     (FStar_Extraction_ML_Syntax.MLP_Wild,
-                      FStar_Pervasives_Native.None, uu____4659)
+                      FStar_Pervasives_Native.None, uu____4675)
                      in
                   let body1 =
-                    let uu____4682 =
-                      let uu____4683 =
-                        let uu____4698 = as_name ([], "args")  in
-                        (uu____4698, [branch; default_branch])  in
-                      FStar_Extraction_ML_Syntax.MLE_Match uu____4683  in
-                    FStar_All.pipe_left w uu____4682  in
+                    let uu____4698 =
+                      let uu____4699 =
+                        let uu____4714 = as_name ([], "args")  in
+                        (uu____4714, [branch; default_branch])  in
+                      FStar_Extraction_ML_Syntax.MLE_Match uu____4699  in
+                    FStar_All.pipe_left w uu____4698  in
                   let body2 =
-                    let uu____4740 =
-                      let uu____4741 =
-                        let uu____4748 =
+                    let uu____4756 =
+                      let uu____4757 =
+                        let uu____4764 =
                           as_name (["FStar_Syntax_Embeddings"], "debug_wrap")
                            in
-                        let uu____4757 =
-                          let uu____4760 =
-                            let uu____4761 =
-                              let uu____4762 =
-                                let uu____4763 =
+                        let uu____4773 =
+                          let uu____4776 =
+                            let uu____4777 =
+                              let uu____4778 =
+                                let uu____4779 =
                                   FStar_Ident.string_of_lid fv_lid  in
                                 FStar_Extraction_ML_Syntax.MLC_String
-                                  uu____4763
+                                  uu____4779
                                  in
-                              FStar_Extraction_ML_Syntax.MLE_Const uu____4762
+                              FStar_Extraction_ML_Syntax.MLE_Const uu____4778
                                in
                             FStar_All.pipe_left
                               (FStar_Extraction_ML_Syntax.with_ty
                                  FStar_Extraction_ML_Syntax.MLTY_Top)
-                              uu____4761
+                              uu____4777
                              in
-                          let uu____4765 =
-                            let uu____4768 = mk_lam "_" body1  in
-                            [uu____4768]  in
-                          uu____4760 :: uu____4765  in
-                        (uu____4748, uu____4757)  in
-                      FStar_Extraction_ML_Syntax.MLE_App uu____4741  in
-                    FStar_All.pipe_left w uu____4740  in
+                          let uu____4781 =
+                            let uu____4784 = mk_lam "_" body1  in
+                            [uu____4784]  in
+                          uu____4776 :: uu____4781  in
+                        (uu____4764, uu____4773)  in
+                      FStar_Extraction_ML_Syntax.MLE_App uu____4757  in
+                    FStar_All.pipe_left w uu____4756  in
                   mk_lam "args" body2
                in
-            let uu____4773 = FStar_Syntax_Util.arrow_formals_comp t1  in
-            match uu____4773 with
+            let uu____4789 = FStar_Syntax_Util.arrow_formals_comp t1  in
+            match uu____4789 with
             | (bs,c) ->
-                let uu____4782 =
+                let uu____4798 =
                   match arity_opt with
                   | FStar_Pervasives_Native.None  -> (bs, c)
                   | FStar_Pervasives_Native.Some n ->
@@ -1478,56 +1497,56 @@ let (interpret_plugin_as_term_fun :
                       else
                         if n < n_bs
                         then
-                          (let uu____4875 = FStar_Util.first_N n bs  in
-                           match uu____4875 with
+                          (let uu____4891 = FStar_Util.first_N n bs  in
+                           match uu____4891 with
                            | (bs1,rest) ->
                                let c1 =
-                                 let uu____4953 =
+                                 let uu____4969 =
                                    FStar_Syntax_Util.arrow rest c  in
                                  FStar_All.pipe_left
-                                   FStar_Syntax_Syntax.mk_Total uu____4953
+                                   FStar_Syntax_Syntax.mk_Total uu____4969
                                   in
                                (bs1, c1))
                         else
                           (let msg =
-                             let uu____4970 =
+                             let uu____4986 =
                                FStar_Ident.string_of_lid fv_lid  in
-                             let uu____4972 = FStar_Util.string_of_int n  in
-                             let uu____4974 = FStar_Util.string_of_int n_bs
+                             let uu____4988 = FStar_Util.string_of_int n  in
+                             let uu____4990 = FStar_Util.string_of_int n_bs
                                 in
                              FStar_Util.format3
                                "Embedding not defined for %s; expected arity at least %s; got %s"
-                               uu____4970 uu____4972 uu____4974
+                               uu____4986 uu____4988 uu____4990
                               in
                            FStar_Exn.raise (NoTacticEmbedding msg))
                    in
-                (match uu____4782 with
+                (match uu____4798 with
                  | (bs1,c1) ->
                      let result_typ = FStar_Syntax_Util.comp_result c1  in
                      let arity = FStar_List.length bs1  in
-                     let uu____5025 =
-                       let uu____5046 =
+                     let uu____5041 =
+                       let uu____5062 =
                          FStar_Util.prefix_until
-                           (fun uu____5088  ->
-                              match uu____5088 with
-                              | (b,uu____5097) ->
-                                  let uu____5102 =
-                                    let uu____5103 =
+                           (fun uu____5104  ->
+                              match uu____5104 with
+                              | (b,uu____5113) ->
+                                  let uu____5118 =
+                                    let uu____5119 =
                                       FStar_Syntax_Subst.compress
                                         b.FStar_Syntax_Syntax.sort
                                        in
-                                    uu____5103.FStar_Syntax_Syntax.n  in
-                                  (match uu____5102 with
-                                   | FStar_Syntax_Syntax.Tm_type uu____5107
+                                    uu____5119.FStar_Syntax_Syntax.n  in
+                                  (match uu____5118 with
+                                   | FStar_Syntax_Syntax.Tm_type uu____5123
                                        -> false
-                                   | uu____5109 -> true)) bs1
+                                   | uu____5125 -> true)) bs1
                           in
-                       match uu____5046 with
+                       match uu____5062 with
                        | FStar_Pervasives_Native.None  -> (bs1, [])
                        | FStar_Pervasives_Native.Some (tvars,x,rest) ->
                            (tvars, (x :: rest))
                         in
-                     (match uu____5025 with
+                     (match uu____5041 with
                       | (type_vars,bs2) ->
                           let tvar_arity = FStar_List.length type_vars  in
                           let non_tvar_arity = FStar_List.length bs2  in
@@ -1535,9 +1554,9 @@ let (interpret_plugin_as_term_fun :
                             FStar_List.mapi
                               (fun i  ->
                                  fun tv  ->
-                                   let uu____5351 =
+                                   let uu____5367 =
                                      FStar_Util.string_of_int i  in
-                                   Prims.op_Hat "tv_" uu____5351) type_vars
+                                   Prims.op_Hat "tv_" uu____5367) type_vars
                              in
                           let tvar_context =
                             FStar_List.map2
@@ -1557,48 +1576,48 @@ let (interpret_plugin_as_term_fun :
                                 let fv_lid1 =
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                    in
-                                let uu____5451 =
+                                let uu____5467 =
                                   FStar_Syntax_Util.is_pure_comp c1  in
-                                if uu____5451
+                                if uu____5467
                                 then
                                   let cb = str_to_name "cb"  in
                                   let embed_fun_N =
                                     mk_arrow_as_prim_step loc non_tvar_arity
                                      in
                                   let args =
-                                    let uu____5468 =
-                                      let uu____5471 =
-                                        let uu____5474 = lid_to_name fv_lid1
+                                    let uu____5484 =
+                                      let uu____5487 =
+                                        let uu____5490 = lid_to_name fv_lid1
                                            in
-                                        let uu____5475 =
-                                          let uu____5478 =
-                                            let uu____5479 =
-                                              let uu____5480 =
-                                                let uu____5481 =
-                                                  let uu____5493 =
+                                        let uu____5491 =
+                                          let uu____5494 =
+                                            let uu____5495 =
+                                              let uu____5496 =
+                                                let uu____5497 =
+                                                  let uu____5509 =
                                                     FStar_Util.string_of_int
                                                       tvar_arity
                                                      in
-                                                  (uu____5493,
+                                                  (uu____5509,
                                                     FStar_Pervasives_Native.None)
                                                    in
                                                 FStar_Extraction_ML_Syntax.MLC_Int
-                                                  uu____5481
+                                                  uu____5497
                                                  in
                                               FStar_Extraction_ML_Syntax.MLE_Const
-                                                uu____5480
+                                                uu____5496
                                                in
                                             FStar_All.pipe_left
                                               (FStar_Extraction_ML_Syntax.with_ty
                                                  FStar_Extraction_ML_Syntax.MLTY_Top)
-                                              uu____5479
+                                              uu____5495
                                              in
-                                          [uu____5478; fv_lid_embedded; cb]
+                                          [uu____5494; fv_lid_embedded; cb]
                                            in
-                                        uu____5474 :: uu____5475  in
-                                      res_embedding :: uu____5471  in
+                                        uu____5490 :: uu____5491  in
+                                      res_embedding :: uu____5487  in
                                     FStar_List.append arg_unembeddings
-                                      uu____5468
+                                      uu____5484
                                      in
                                   let fun_embedding =
                                     FStar_All.pipe_left w
@@ -1609,44 +1628,44 @@ let (interpret_plugin_as_term_fun :
                                     abstract_tvars tvar_names fun_embedding
                                      in
                                   let cb_tabs = mk_lam "cb" tabs  in
-                                  let uu____5512 =
+                                  let uu____5528 =
                                     if loc = NBE_t
                                     then cb_tabs
                                     else mk_lam "_psc" cb_tabs  in
-                                  (uu____5512, arity, true)
+                                  (uu____5528, arity, true)
                                 else
-                                  (let uu____5522 =
-                                     let uu____5524 =
+                                  (let uu____5538 =
+                                     let uu____5540 =
                                        FStar_TypeChecker_Env.norm_eff_name
                                          tcenv
                                          (FStar_Syntax_Util.comp_effect_name
                                             c1)
                                         in
-                                     FStar_Ident.lid_equals uu____5524
+                                     FStar_Ident.lid_equals uu____5540
                                        FStar_Parser_Const.effect_TAC_lid
                                       in
-                                   if uu____5522
+                                   if uu____5538
                                    then
                                      let h =
                                        mk_tactic_interpretation loc
                                          non_tvar_arity
                                         in
                                      let tac_fun =
-                                       let uu____5536 =
-                                         let uu____5537 =
-                                           let uu____5544 =
+                                       let uu____5552 =
+                                         let uu____5553 =
+                                           let uu____5560 =
                                              mk_from_tactic loc
                                                non_tvar_arity
                                               in
-                                           let uu____5545 =
-                                             let uu____5548 =
+                                           let uu____5561 =
+                                             let uu____5564 =
                                                lid_to_name fv_lid1  in
-                                             [uu____5548]  in
-                                           (uu____5544, uu____5545)  in
+                                             [uu____5564]  in
+                                           (uu____5560, uu____5561)  in
                                          FStar_Extraction_ML_Syntax.MLE_App
-                                           uu____5537
+                                           uu____5553
                                           in
-                                       FStar_All.pipe_left w uu____5536  in
+                                       FStar_All.pipe_left w uu____5552  in
                                      let psc = str_to_name "psc"  in
                                      let ncb = str_to_name "ncb"  in
                                      let all_args = str_to_name "args"  in
@@ -1658,69 +1677,69 @@ let (interpret_plugin_as_term_fun :
                                      let tabs =
                                        match tvar_names with
                                        | [] ->
-                                           let uu____5562 =
+                                           let uu____5578 =
                                              FStar_All.pipe_left w
                                                (FStar_Extraction_ML_Syntax.MLE_App
                                                   (h,
                                                     (FStar_List.append args
                                                        [all_args])))
                                               in
-                                           mk_lam "args" uu____5562
-                                       | uu____5566 ->
-                                           let uu____5570 =
+                                           mk_lam "args" uu____5578
+                                       | uu____5582 ->
+                                           let uu____5586 =
                                              FStar_All.pipe_left w
                                                (FStar_Extraction_ML_Syntax.MLE_App
                                                   (h, args))
                                               in
                                            abstract_tvars tvar_names
-                                             uu____5570
+                                             uu____5586
                                         in
-                                     let uu____5573 =
-                                       let uu____5574 = mk_lam "ncb" tabs  in
-                                       mk_lam "psc" uu____5574  in
-                                     (uu____5573, (arity + Prims.int_one),
+                                     let uu____5589 =
+                                       let uu____5590 = mk_lam "ncb" tabs  in
+                                       mk_lam "psc" uu____5590  in
+                                     (uu____5589, (arity + Prims.int_one),
                                        false)
                                    else
-                                     (let uu____5583 =
-                                        let uu____5584 =
-                                          let uu____5586 =
+                                     (let uu____5599 =
+                                        let uu____5600 =
+                                          let uu____5602 =
                                             FStar_Syntax_Print.term_to_string
                                               t1
                                              in
                                           Prims.op_Hat
                                             "Plugins not defined for type "
-                                            uu____5586
+                                            uu____5602
                                            in
-                                        NoTacticEmbedding uu____5584  in
-                                      FStar_Exn.raise uu____5583))
-                            | (b,uu____5598)::bs4 ->
-                                let uu____5618 =
-                                  let uu____5621 =
+                                        NoTacticEmbedding uu____5600  in
+                                      FStar_Exn.raise uu____5599))
+                            | (b,uu____5614)::bs4 ->
+                                let uu____5634 =
+                                  let uu____5637 =
                                     mk_embedding loc tvar_context
                                       b.FStar_Syntax_Syntax.sort
                                      in
-                                  uu____5621 :: accum_embeddings  in
-                                aux loc uu____5618 bs4
+                                  uu____5637 :: accum_embeddings  in
+                                aux loc uu____5634 bs4
                              in
                           (try
-                             (fun uu___711_5643  ->
+                             (fun uu___710_5659  ->
                                 match () with
                                 | () ->
-                                    let uu____5656 = aux Syntax_term [] bs2
+                                    let uu____5672 = aux Syntax_term [] bs2
                                        in
-                                    (match uu____5656 with
+                                    (match uu____5672 with
                                      | (w1,a,b) ->
-                                         let uu____5684 = aux NBE_t [] bs2
+                                         let uu____5700 = aux NBE_t [] bs2
                                             in
-                                         (match uu____5684 with
-                                          | (w',uu____5706,uu____5707) ->
+                                         (match uu____5700 with
+                                          | (w',uu____5722,uu____5723) ->
                                               FStar_Pervasives_Native.Some
                                                 (w1, w', a, b)))) ()
                            with
                            | NoTacticEmbedding msg ->
-                               ((let uu____5743 =
+                               ((let uu____5759 =
                                    FStar_Syntax_Print.fv_to_string fv  in
                                  not_implemented_warning
-                                   t1.FStar_Syntax_Syntax.pos uu____5743 msg);
+                                   t1.FStar_Syntax_Syntax.pos uu____5759 msg);
                                 FStar_Pervasives_Native.None))))
   

--- a/src/ocaml-output/FStar_Ident.ml
+++ b/src/ocaml-output/FStar_Ident.ml
@@ -6,14 +6,15 @@ let (__proj__Mkident__item__idText : ident -> Prims.string) =
   fun projectee  -> match projectee with | { idText; idRange;_} -> idText 
 let (__proj__Mkident__item__idRange : ident -> FStar_Range.range) =
   fun projectee  -> match projectee with | { idText; idRange;_} -> idRange 
-type path = Prims.string Prims.list
+type path = Prims.string Prims.list[@@deriving yojson,show]
+type ipath = ident Prims.list[@@deriving yojson,show]
 type lident =
   {
-  ns: ident Prims.list ;
+  ns: ipath ;
   ident: ident ;
   nsstr: Prims.string ;
   str: Prims.string }[@@deriving yojson,show]
-let (__proj__Mklident__item__ns : lident -> ident Prims.list) =
+let (__proj__Mklident__item__ns : lident -> ipath) =
   fun projectee  ->
     match projectee with | { ns; ident = ident1; nsstr; str;_} -> ns
   
@@ -31,17 +32,20 @@ let (__proj__Mklident__item__str : lident -> Prims.string) =
   
 type lid = lident[@@deriving yojson,show]
 let (mk_ident : (Prims.string * FStar_Range.range) -> ident) =
-  fun uu____137  ->
-    match uu____137 with | (text,range) -> { idText = text; idRange = range }
+  fun uu____125  ->
+    match uu____125 with | (text,range) -> { idText = text; idRange = range }
+  
+let (set_id_range : FStar_Range.range -> ident -> ident) =
+  fun r  ->
+    fun i  ->
+      let uu___23_146 = i  in { idText = (uu___23_146.idText); idRange = r }
   
 let (reserved_prefix : Prims.string) = "uu___" 
 let (_gen : ((unit -> Prims.int) * (unit -> unit))) =
   let x = FStar_Util.mk_ref Prims.int_zero  in
   let next_id uu____174 =
-    let v = FStar_ST.op_Bang x  in
-    FStar_ST.op_Colon_Equals x (v + Prims.int_one); v  in
-  let reset uu____226 = FStar_ST.op_Colon_Equals x Prims.int_zero  in
-  (next_id, reset) 
+    let v = FStar_ST.read x  in FStar_ST.write x (v + Prims.int_one); v  in
+  let reset uu____226 = FStar_ST.write x Prims.int_zero  in (next_id, reset) 
 let (next_id : unit -> Prims.int) =
   fun uu____262  -> FStar_Pervasives_Native.fst _gen () 
 let (reset_gensym : unit -> unit) =
@@ -53,6 +57,7 @@ let (gen' : Prims.string -> FStar_Range.range -> ident) =
       mk_ident ((Prims.op_Hat s (Prims.string_of_int i)), r)
   
 let (gen : FStar_Range.range -> ident) = fun r  -> gen' reserved_prefix r 
+let (ident_of_lid : lident -> ident) = fun l  -> l.ident 
 let (range_of_id : ident -> FStar_Range.range) = fun id  -> id.idRange 
 let (id_of_text : Prims.string -> ident) =
   fun str  -> mk_ident (str, FStar_Range.dummyRange) 
@@ -61,20 +66,20 @@ let (text_of_path : path -> Prims.string) =
   fun path1  -> FStar_Util.concat_l "." path1 
 let (path_of_text : Prims.string -> path) =
   fun text  -> FStar_String.split [46] text 
-let (path_of_ns : ident Prims.list -> path) =
-  fun ns  -> FStar_List.map text_of_id ns 
+let (path_of_ns : ipath -> path) = fun ns  -> FStar_List.map text_of_id ns 
 let (path_of_lid : lident -> path) =
   fun lid1  ->
     FStar_List.map text_of_id (FStar_List.append lid1.ns [lid1.ident])
   
-let (ids_of_lid : lident -> ident Prims.list) =
+let (ns_of_lid : lident -> ipath) = fun lid1  -> lid1.ns 
+let (ids_of_lid : lident -> ipath) =
   fun lid1  -> FStar_List.append lid1.ns [lid1.ident] 
-let (lid_of_ns_and_id : ident Prims.list -> ident -> lident) =
+let (lid_of_ns_and_id : ipath -> ident -> lident) =
   fun ns  ->
     fun id  ->
       let nsstr =
-        let uu____389 = FStar_List.map text_of_id ns  in
-        FStar_All.pipe_right uu____389 text_of_path  in
+        let uu____391 = FStar_List.map text_of_id ns  in
+        FStar_All.pipe_right uu____391 text_of_path  in
       {
         ns;
         ident = id;
@@ -85,15 +90,15 @@ let (lid_of_ns_and_id : ident Prims.list -> ident -> lident) =
            else Prims.op_Hat nsstr (Prims.op_Hat "." id.idText))
       }
   
-let (lid_of_ids : ident Prims.list -> lident) =
+let (lid_of_ids : ipath -> lident) =
   fun ids  ->
-    let uu____409 = FStar_Util.prefix ids  in
-    match uu____409 with | (ns,id) -> lid_of_ns_and_id ns id
+    let uu____407 = FStar_Util.prefix ids  in
+    match uu____407 with | (ns,id) -> lid_of_ns_and_id ns id
   
 let (lid_of_str : Prims.string -> lident) =
   fun str  ->
-    let uu____430 = FStar_List.map id_of_text (FStar_Util.split str ".")  in
-    lid_of_ids uu____430
+    let uu____428 = FStar_List.map id_of_text (FStar_Util.split str ".")  in
+    lid_of_ids uu____428
   
 let (lid_of_path : path -> FStar_Range.range -> lident) =
   fun path1  ->
@@ -111,32 +116,38 @@ let (range_of_lid : lident -> FStar_Range.range) =
 let (set_lid_range : lident -> FStar_Range.range -> lident) =
   fun l  ->
     fun r  ->
-      let uu___63_504 = l  in
+      let uu___69_500 = l  in
       {
-        ns = (uu___63_504.ns);
+        ns = (uu___69_500.ns);
         ident =
-          (let uu___65_506 = l.ident  in
-           { idText = (uu___65_506.idText); idRange = r });
-        nsstr = (uu___63_504.nsstr);
-        str = (uu___63_504.str)
+          (let uu___71_502 = l.ident  in
+           { idText = (uu___71_502.idText); idRange = r });
+        nsstr = (uu___69_500.nsstr);
+        str = (uu___69_500.str)
       }
   
 let (lid_add_suffix : lident -> Prims.string -> lident) =
   fun l  ->
     fun s  ->
       let path1 = path_of_lid l  in
-      let uu____521 = range_of_lid l  in
-      lid_of_path (FStar_List.append path1 [s]) uu____521
+      let uu____517 = range_of_lid l  in
+      lid_of_path (FStar_List.append path1 [s]) uu____517
   
 let (ml_path_of_lid : lident -> Prims.string) =
   fun lid1  ->
-    let uu____532 =
-      let uu____536 = path_of_ns lid1.ns  in
-      let uu____540 = let uu____544 = text_of_id lid1.ident  in [uu____544]
+    let uu____528 =
+      let uu____532 = path_of_ns lid1.ns  in
+      let uu____536 = let uu____540 = text_of_id lid1.ident  in [uu____540]
          in
-      FStar_List.append uu____536 uu____540  in
-    FStar_All.pipe_left (FStar_String.concat "_") uu____532
+      FStar_List.append uu____532 uu____536  in
+    FStar_All.pipe_left (FStar_String.concat "_") uu____528
   
-let (string_of_ident : ident -> Prims.string) = fun id  -> id.idText 
-let (string_of_lid : lident -> Prims.string) =
-  fun lid1  -> let uu____568 = path_of_lid lid1  in text_of_path uu____568 
+let (string_of_lid : lident -> Prims.string) = fun lid1  -> lid1.str 
+let (qual_id : lident -> ident -> lident) =
+  fun lid1  ->
+    fun id  ->
+      let uu____568 = lid_of_ids (FStar_List.append lid1.ns [lid1.ident; id])
+         in
+      let uu____569 = range_of_id id  in set_lid_range uu____568 uu____569
+  
+let (nsstr : lident -> Prims.string) = fun l  -> l.nsstr 

--- a/src/ocaml-output/FStar_Interactive_Ide.ml
+++ b/src/ocaml-output/FStar_Interactive_Ide.ml
@@ -2501,7 +2501,7 @@ let (json_of_search_result :
                 FStar_Syntax_DsEnv.shorten_lid
                   tcenv.FStar_TypeChecker_Env.dsenv sc.sc_lid
                  in
-              uu____7174.FStar_Ident.str  in
+              FStar_Ident.string_of_lid uu____7174  in
             FStar_Util.JsonStr uu____7172  in
           ("lid", uu____7171)  in
         [uu____7165; ("type", (FStar_Util.JsonStr typ_str))]  in
@@ -2534,10 +2534,11 @@ let run_search :
         let found =
           match term.st_term with
           | NameContainsStr str ->
-              FStar_Util.contains (candidate.sc_lid).FStar_Ident.str str
+              let uu____7275 = FStar_Ident.string_of_lid candidate.sc_lid  in
+              FStar_Util.contains uu____7275 str
           | TypeContainsLid lid ->
-              let uu____7276 = sc_fvars tcenv candidate  in
-              FStar_Util.set_mem lid uu____7276
+              let uu____7278 = sc_fvars tcenv candidate  in
+              FStar_Util.set_mem lid uu____7278
            in
         found <> term.st_negate  in
       let parse search_str1 =
@@ -2559,32 +2560,32 @@ let run_search :
           let parsed =
             if beg_quote <> end_quote
             then
-              let uu____7335 =
-                let uu____7336 =
+              let uu____7337 =
+                let uu____7338 =
                   FStar_Util.format1 "Improperly quoted search term: %s"
                     term1
                    in
-                InvalidSearch uu____7336  in
-              FStar_Exn.raise uu____7335
+                InvalidSearch uu____7338  in
+              FStar_Exn.raise uu____7337
             else
               if beg_quote
               then
-                (let uu____7342 = strip_quotes term1  in
-                 NameContainsStr uu____7342)
+                (let uu____7344 = strip_quotes term1  in
+                 NameContainsStr uu____7344)
               else
                 (let lid = FStar_Ident.lid_of_str term1  in
-                 let uu____7347 =
+                 let uu____7349 =
                    FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                      tcenv.FStar_TypeChecker_Env.dsenv lid
                     in
-                 match uu____7347 with
+                 match uu____7349 with
                  | FStar_Pervasives_Native.None  ->
-                     let uu____7350 =
-                       let uu____7351 =
+                     let uu____7352 =
+                       let uu____7353 =
                          FStar_Util.format1 "Unknown identifier: %s" term1
                           in
-                       InvalidSearch uu____7351  in
-                     FStar_Exn.raise uu____7350
+                       InvalidSearch uu____7353  in
+                     FStar_Exn.raise uu____7352
                  | FStar_Pervasives_Native.Some lid1 -> TypeContainsLid lid1)
              in
           { st_negate = negate; st_term = parsed }  in
@@ -2593,15 +2594,17 @@ let run_search :
         let cmp x y = (st_cost x.st_term) - (st_cost y.st_term)  in
         FStar_Util.sort_with cmp terms  in
       let pprint_one term =
-        let uu____7379 =
+        let uu____7381 =
           match term.st_term with
           | NameContainsStr s -> FStar_Util.format1 "\"%s\"" s
-          | TypeContainsLid l -> FStar_Util.format1 "%s" l.FStar_Ident.str
+          | TypeContainsLid l ->
+              let uu____7388 = FStar_Ident.string_of_lid l  in
+              FStar_Util.format1 "%s" uu____7388
            in
-        Prims.op_Hat (if term.st_negate then "-" else "") uu____7379  in
+        Prims.op_Hat (if term.st_negate then "-" else "") uu____7381  in
       let results =
         try
-          (fun uu___922_7413  ->
+          (fun uu___922_7417  ->
              match () with
              | () ->
                  let terms = parse search_str  in
@@ -2611,9 +2614,9 @@ let run_search :
                  let matches_all candidate =
                    FStar_List.for_all (st_matches candidate) terms  in
                  let cmp r1 r2 =
-                   FStar_Util.compare (r1.sc_lid).FStar_Ident.str
-                     (r2.sc_lid).FStar_Ident.str
-                    in
+                   let uu____7450 = FStar_Ident.string_of_lid r1.sc_lid  in
+                   let uu____7452 = FStar_Ident.string_of_lid r2.sc_lid  in
+                   FStar_Util.compare uu____7450 uu____7452  in
                  let results = FStar_List.filter matches_all all_candidates
                     in
                  let sorted = FStar_Util.sort_with cmp results  in
@@ -2622,16 +2625,16 @@ let run_search :
                  (match results with
                   | [] ->
                       let kwds =
-                        let uu____7461 = FStar_List.map pprint_one terms  in
-                        FStar_Util.concat_l " " uu____7461  in
-                      let uu____7467 =
-                        let uu____7468 =
+                        let uu____7469 = FStar_List.map pprint_one terms  in
+                        FStar_Util.concat_l " " uu____7469  in
+                      let uu____7475 =
+                        let uu____7476 =
                           FStar_Util.format1
                             "No results found for query [%s]" kwds
                            in
-                        InvalidSearch uu____7468  in
-                      FStar_Exn.raise uu____7467
-                  | uu____7475 -> (QueryOK, (FStar_Util.JsonList js)))) ()
+                        InvalidSearch uu____7476  in
+                      FStar_Exn.raise uu____7475
+                  | uu____7483 -> (QueryOK, (FStar_Util.JsonList js)))) ()
         with | InvalidSearch s -> (QueryNOK, (FStar_Util.JsonStr s))  in
       (results, (FStar_Util.Inl st))
   
@@ -2668,8 +2671,8 @@ let (validate_query :
       match q.qq with
       | Push
           { push_kind = FStar_Interactive_PushHelper.SyntaxCheck ;
-            push_code = uu____7606; push_line = uu____7607;
-            push_column = uu____7608; push_peek_only = false ;_}
+            push_code = uu____7614; push_line = uu____7615;
+            push_column = uu____7616; push_peek_only = false ;_}
           ->
           {
             qq =
@@ -2677,12 +2680,12 @@ let (validate_query :
                  "Cannot use 'kind': 'syntax' with 'query': 'push'");
             qid = (q.qid)
           }
-      | uu____7614 ->
+      | uu____7622 ->
           (match st.FStar_Interactive_JsonHelper.repl_curmod with
            | FStar_Pervasives_Native.None  when
                query_needs_current_module q.qq ->
                { qq = (GenericError "Current module unset"); qid = (q.qid) }
-           | uu____7616 -> q)
+           | uu____7624 -> q)
   
 let (validate_and_run_query :
   FStar_Interactive_JsonHelper.repl_state ->
@@ -2706,8 +2709,8 @@ let (js_repl_eval :
   =
   fun st  ->
     fun query1  ->
-      let uu____7689 = validate_and_run_query st query1  in
-      match uu____7689 with
+      let uu____7697 = validate_and_run_query st query1  in
+      match uu____7697 with
       | ((status,response),st_opt) ->
           let js_response = json_of_response query1.qid status response  in
           (js_response, st_opt)
@@ -2720,8 +2723,8 @@ let (js_repl_eval_js :
   =
   fun st  ->
     fun query_js  ->
-      let uu____7755 = deserialize_interactive_query query_js  in
-      js_repl_eval st uu____7755
+      let uu____7763 = deserialize_interactive_query query_js  in
+      js_repl_eval st uu____7763
   
 let (js_repl_eval_str :
   FStar_Interactive_JsonHelper.repl_state ->
@@ -2731,18 +2734,18 @@ let (js_repl_eval_str :
   =
   fun st  ->
     fun query_str  ->
-      let uu____7779 =
-        let uu____7789 = parse_interactive_query query_str  in
-        js_repl_eval st uu____7789  in
-      match uu____7779 with
+      let uu____7787 =
+        let uu____7797 = parse_interactive_query query_str  in
+        js_repl_eval st uu____7797  in
+      match uu____7787 with
       | (js_response,st_opt) ->
-          let uu____7812 = FStar_Util.string_of_json js_response  in
-          (uu____7812, st_opt)
+          let uu____7820 = FStar_Util.string_of_json js_response  in
+          (uu____7820, st_opt)
   
 let (js_repl_init_opts : unit -> unit) =
-  fun uu____7825  ->
-    let uu____7826 = FStar_Options.parse_cmd_line ()  in
-    match uu____7826 with
+  fun uu____7833  ->
+    let uu____7834 = FStar_Options.parse_cmd_line ()  in
+    match uu____7834 with
     | (res,fnames) ->
         (match res with
          | FStar_Getopt.Error msg ->
@@ -2753,17 +2756,17 @@ let (js_repl_init_opts : unit -> unit) =
               | [] ->
                   failwith
                     "repl_init: No file name given in --ide invocation"
-              | h::uu____7849::uu____7850 ->
+              | h::uu____7857::uu____7858 ->
                   failwith
                     "repl_init: Too many file names given in --ide invocation"
-              | uu____7859 -> ()))
+              | uu____7867 -> ()))
   
 let rec (go : FStar_Interactive_JsonHelper.repl_state -> Prims.int) =
   fun st  ->
     let query1 =
       read_interactive_query st.FStar_Interactive_JsonHelper.repl_stdin  in
-    let uu____7872 = validate_and_run_query st query1  in
-    match uu____7872 with
+    let uu____7880 = validate_and_run_query st query1  in
+    match uu____7880 with
     | ((status,response),state_opt) ->
         (write_response query1.qid status response;
          (match state_opt with
@@ -2773,21 +2776,21 @@ let rec (go : FStar_Interactive_JsonHelper.repl_state -> Prims.int) =
 let (interactive_error_handler : FStar_Errors.error_handler) =
   let issues = FStar_Util.mk_ref []  in
   let add_one e =
-    let uu____7925 =
-      let uu____7928 = FStar_ST.op_Bang issues  in e :: uu____7928  in
-    FStar_ST.op_Colon_Equals issues uu____7925  in
-  let count_errors uu____7982 =
-    let uu____7983 =
-      let uu____7986 = FStar_ST.op_Bang issues  in
+    let uu____7933 =
+      let uu____7936 = FStar_ST.op_Bang issues  in e :: uu____7936  in
+    FStar_ST.op_Colon_Equals issues uu____7933  in
+  let count_errors uu____7990 =
+    let uu____7991 =
+      let uu____7994 = FStar_ST.op_Bang issues  in
       FStar_List.filter
         (fun e  -> e.FStar_Errors.issue_level = FStar_Errors.EError)
-        uu____7986
+        uu____7994
        in
-    FStar_List.length uu____7983  in
-  let report uu____8021 =
-    let uu____8022 = FStar_ST.op_Bang issues  in
-    FStar_List.sortWith FStar_Errors.compare_issues uu____8022  in
-  let clear uu____8053 = FStar_ST.op_Colon_Equals issues []  in
+    FStar_List.length uu____7991  in
+  let report uu____8029 =
+    let uu____8030 = FStar_ST.op_Bang issues  in
+    FStar_List.sortWith FStar_Errors.compare_issues uu____8030  in
+  let clear uu____8061 = FStar_ST.op_Colon_Equals issues []  in
   {
     FStar_Errors.eh_add_one = add_one;
     FStar_Errors.eh_count_errors = count_errors;
@@ -2807,8 +2810,8 @@ let (interactive_printer : (FStar_Util.json -> unit) -> FStar_Util.printer) =
         (fun label  ->
            fun get_string  ->
              fun get_json  ->
-               let uu____8114 = get_json ()  in
-               forward_message printer label uu____8114)
+               let uu____8122 = get_json ()  in
+               forward_message printer label uu____8122)
     }
   
 let (install_ide_mode_hooks : (FStar_Util.json -> unit) -> unit) =
@@ -2817,15 +2820,15 @@ let (install_ide_mode_hooks : (FStar_Util.json -> unit) -> unit) =
     FStar_Errors.set_handler interactive_error_handler
   
 let (initial_range : FStar_Range.range) =
-  let uu____8128 = FStar_Range.mk_pos Prims.int_one Prims.int_zero  in
-  let uu____8131 = FStar_Range.mk_pos Prims.int_one Prims.int_zero  in
-  FStar_Range.mk_range "<input>" uu____8128 uu____8131 
+  let uu____8136 = FStar_Range.mk_pos Prims.int_one Prims.int_zero  in
+  let uu____8139 = FStar_Range.mk_pos Prims.int_one Prims.int_zero  in
+  FStar_Range.mk_range "<input>" uu____8136 uu____8139 
 let (build_initial_repl_state :
   Prims.string -> FStar_Interactive_JsonHelper.repl_state) =
   fun filename  ->
     let env = FStar_Universal.init_env FStar_Parser_Dep.empty_deps  in
     let env1 = FStar_TypeChecker_Env.set_range env initial_range  in
-    let uu____8145 = FStar_Util.open_stdin ()  in
+    let uu____8153 = FStar_Util.open_stdin ()  in
     {
       FStar_Interactive_JsonHelper.repl_line = Prims.int_one;
       FStar_Interactive_JsonHelper.repl_column = Prims.int_zero;
@@ -2833,25 +2836,25 @@ let (build_initial_repl_state :
       FStar_Interactive_JsonHelper.repl_deps_stack = [];
       FStar_Interactive_JsonHelper.repl_curmod = FStar_Pervasives_Native.None;
       FStar_Interactive_JsonHelper.repl_env = env1;
-      FStar_Interactive_JsonHelper.repl_stdin = uu____8145;
+      FStar_Interactive_JsonHelper.repl_stdin = uu____8153;
       FStar_Interactive_JsonHelper.repl_names =
         FStar_Interactive_CompletionTable.empty
     }
   
 let interactive_mode' :
-  'uuuuuu8161 . FStar_Interactive_JsonHelper.repl_state -> 'uuuuuu8161 =
+  'uuuuuu8169 . FStar_Interactive_JsonHelper.repl_state -> 'uuuuuu8169 =
   fun init_st  ->
     write_hello ();
     (let exit_code =
-       let uu____8170 =
+       let uu____8178 =
          (FStar_Options.record_hints ()) || (FStar_Options.use_hints ())  in
-       if uu____8170
+       if uu____8178
        then
-         let uu____8174 =
-           let uu____8176 = FStar_Options.file_list ()  in
-           FStar_List.hd uu____8176  in
-         FStar_SMTEncoding_Solver.with_hints_db uu____8174
-           (fun uu____8183  -> go init_st)
+         let uu____8182 =
+           let uu____8184 = FStar_Options.file_list ()  in
+           FStar_List.hd uu____8184  in
+         FStar_SMTEncoding_Solver.with_hints_db uu____8182
+           (fun uu____8191  -> go init_st)
        else go init_st  in
      FStar_All.exit exit_code)
   
@@ -2859,24 +2862,24 @@ let (interactive_mode : Prims.string -> unit) =
   fun filename  ->
     install_ide_mode_hooks FStar_Interactive_JsonHelper.write_json;
     FStar_Util.set_sigint_handler FStar_Util.sigint_ignore;
-    (let uu____8197 =
-       let uu____8199 = FStar_Options.codegen ()  in
-       FStar_Option.isSome uu____8199  in
-     if uu____8197
+    (let uu____8205 =
+       let uu____8207 = FStar_Options.codegen ()  in
+       FStar_Option.isSome uu____8207  in
+     if uu____8205
      then
        FStar_Errors.log_issue FStar_Range.dummyRange
          (FStar_Errors.Warning_IDEIgnoreCodeGen, "--ide: ignoring --codegen")
      else ());
     (let init = build_initial_repl_state filename  in
-     let uu____8208 = FStar_Options.trace_error ()  in
-     if uu____8208
+     let uu____8216 = FStar_Options.trace_error ()  in
+     if uu____8216
      then interactive_mode' init
      else
        (try
-          (fun uu___1070_8214  ->
+          (fun uu___1070_8222  ->
              match () with | () -> interactive_mode' init) ()
         with
-        | uu___1069_8217 ->
+        | uu___1069_8225 ->
             (FStar_Errors.set_handler FStar_Errors.default_handler;
-             FStar_Exn.raise uu___1069_8217)))
+             FStar_Exn.raise uu___1069_8225)))
   

--- a/src/ocaml-output/FStar_Interactive_Legacy.ml
+++ b/src/ocaml-output/FStar_Interactive_Legacy.ml
@@ -689,49 +689,49 @@ let rec (go :
                              if fqn_only
                              then lid
                              else
-                               (let uu____3127 =
+                               (let uu____3125 =
                                   FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                                     env.FStar_TypeChecker_Env.dsenv lid
                                    in
-                                match uu____3127 with
+                                match uu____3125 with
                                 | FStar_Pervasives_Native.None  -> lid
                                 | FStar_Pervasives_Native.Some lid1 -> lid1)
                               in
-                           let uu____3131 =
+                           let uu____3129 =
                              FStar_TypeChecker_Env.try_lookup_lid env lid1
                               in
-                           FStar_All.pipe_right uu____3131
+                           FStar_All.pipe_right uu____3129
                              (FStar_Util.map_option
-                                (fun uu____3188  ->
-                                   match uu____3188 with
-                                   | ((uu____3208,typ),r) ->
+                                (fun uu____3186  ->
+                                   match uu____3186 with
+                                   | ((uu____3206,typ),r) ->
                                        ((FStar_Util.Inr lid1), typ, r))))
                      in
                   ((match info_opt with
                     | FStar_Pervasives_Native.None  ->
                         FStar_Util.print_string "\n#done-nok\n"
                     | FStar_Pervasives_Native.Some (name_or_lid,typ,rng) ->
-                        let uu____3258 =
+                        let uu____3256 =
                           match name_or_lid with
                           | FStar_Util.Inl name ->
                               (name, FStar_Pervasives_Native.None)
                           | FStar_Util.Inr lid ->
-                              let uu____3285 = FStar_Ident.string_of_lid lid
+                              let uu____3283 = FStar_Ident.string_of_lid lid
                                  in
-                              (uu____3285, FStar_Pervasives_Native.None)
+                              (uu____3283, FStar_Pervasives_Native.None)
                            in
-                        (match uu____3258 with
+                        (match uu____3256 with
                          | (name,doc) ->
-                             let uu____3302 =
+                             let uu____3300 =
                                format_info env name typ rng doc  in
-                             FStar_Util.print1 "%s\n#done-ok\n" uu____3302));
+                             FStar_Util.print1 "%s\n#done-ok\n" uu____3300));
                    go line_col filename stack curmod env ts)
               | Completions search_term ->
                   let rec measure_anchored_match search_term1 candidate =
                     match (search_term1, candidate) with
-                    | ([],uu____3351) ->
+                    | ([],uu____3349) ->
                         FStar_Pervasives_Native.Some ([], Prims.int_zero)
-                    | (uu____3371,[]) -> FStar_Pervasives_Native.None
+                    | (uu____3369,[]) -> FStar_Pervasives_Native.None
                     | (hs::ts1,hc::tc) ->
                         let hc_text = FStar_Ident.text_of_id hc  in
                         if FStar_Util.starts_with hc_text hs
@@ -740,13 +740,13 @@ let rec (go :
                            | [] ->
                                FStar_Pervasives_Native.Some
                                  (candidate, (FStar_String.length hs))
-                           | uu____3435 ->
-                               let uu____3439 = measure_anchored_match ts1 tc
+                           | uu____3433 ->
+                               let uu____3437 = measure_anchored_match ts1 tc
                                   in
-                               FStar_All.pipe_right uu____3439
+                               FStar_All.pipe_right uu____3437
                                  (FStar_Util.map_option
-                                    (fun uu____3484  ->
-                                       match uu____3484 with
+                                    (fun uu____3482  ->
+                                       match uu____3482 with
                                        | (matched,len) ->
                                            ((hc :: matched),
                                              (((FStar_String.length hc_text)
@@ -755,53 +755,56 @@ let rec (go :
                         else FStar_Pervasives_Native.None
                      in
                   let rec locate_match needle candidate =
-                    let uu____3554 = measure_anchored_match needle candidate
+                    let uu____3552 = measure_anchored_match needle candidate
                        in
-                    match uu____3554 with
+                    match uu____3552 with
                     | FStar_Pervasives_Native.Some (matched,n) ->
                         FStar_Pervasives_Native.Some ([], matched, n)
                     | FStar_Pervasives_Native.None  ->
                         (match candidate with
                          | [] -> FStar_Pervasives_Native.None
                          | hc::tc ->
-                             let uu____3643 = locate_match needle tc  in
-                             FStar_All.pipe_right uu____3643
+                             let uu____3641 = locate_match needle tc  in
+                             FStar_All.pipe_right uu____3641
                                (FStar_Util.map_option
-                                  (fun uu____3709  ->
-                                     match uu____3709 with
+                                  (fun uu____3707  ->
+                                     match uu____3707 with
                                      | (prefix,matched,len) ->
                                          ((hc :: prefix), matched, len))))
                      in
                   let str_of_ids ids =
-                    let uu____3761 =
+                    let uu____3759 =
                       FStar_List.map FStar_Ident.text_of_id ids  in
-                    FStar_Util.concat_l "." uu____3761  in
+                    FStar_Util.concat_l "." uu____3759  in
                   let match_lident_against needle lident =
-                    locate_match needle
-                      (FStar_List.append lident.FStar_Ident.ns
-                         [lident.FStar_Ident.ident])
-                     in
-                  let shorten_namespace uu____3825 =
-                    match uu____3825 with
+                    let uu____3795 =
+                      let uu____3798 = FStar_Ident.ns_of_lid lident  in
+                      let uu____3801 =
+                        let uu____3804 = FStar_Ident.ident_of_lid lident  in
+                        [uu____3804]  in
+                      FStar_List.append uu____3798 uu____3801  in
+                    locate_match needle uu____3795  in
+                  let shorten_namespace uu____3833 =
+                    match uu____3833 with
                     | (prefix,matched,match_len) ->
                         let naked_match =
                           match matched with
-                          | uu____3865::[] -> true
-                          | uu____3867 -> false  in
-                        let uu____3871 =
+                          | uu____3873::[] -> true
+                          | uu____3875 -> false  in
+                        let uu____3879 =
                           FStar_Syntax_DsEnv.shorten_module_path
                             env.FStar_TypeChecker_Env.dsenv prefix
                             naked_match
                            in
-                        (match uu____3871 with
+                        (match uu____3879 with
                          | (stripped_ns,shortened) ->
-                             let uu____3902 = str_of_ids shortened  in
-                             let uu____3904 = str_of_ids matched  in
-                             let uu____3906 = str_of_ids stripped_ns  in
-                             (uu____3902, uu____3904, uu____3906, match_len))
+                             let uu____3910 = str_of_ids shortened  in
+                             let uu____3912 = str_of_ids matched  in
+                             let uu____3914 = str_of_ids stripped_ns  in
+                             (uu____3910, uu____3912, uu____3914, match_len))
                      in
-                  let prepare_candidate uu____3938 =
-                    match uu____3938 with
+                  let prepare_candidate uu____3946 =
+                    match uu____3946 with
                     | (prefix,matched,stripped_ns,match_len) ->
                         if prefix = ""
                         then (matched, stripped_ns, match_len)
@@ -834,73 +837,77 @@ let rec (go :
                               if FStar_Util.starts_with n id
                               then
                                 let lid =
-                                  let uu____4127 = FStar_Ident.ids_of_lid m
+                                  let uu____4135 = FStar_Ident.ids_of_lid m
                                      in
-                                  let uu____4130 = FStar_Ident.id_of_text n
+                                  let uu____4136 = FStar_Ident.id_of_text n
                                      in
-                                  FStar_Ident.lid_of_ns_and_id uu____4127
-                                    uu____4130
+                                  FStar_Ident.lid_of_ns_and_id uu____4135
+                                    uu____4136
                                    in
-                                let uu____4131 =
+                                let uu____4137 =
                                   FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                                     env.FStar_TypeChecker_Env.dsenv lid
                                    in
                                 FStar_Option.map
                                   (fun fqn  ->
-                                     let uu____4148 =
-                                       let uu____4151 =
+                                     let uu____4154 =
+                                       let uu____4157 =
                                          FStar_List.map
                                            FStar_Ident.id_of_text orig_ns
                                           in
-                                       FStar_List.append uu____4151
-                                         [fqn.FStar_Ident.ident]
+                                       let uu____4161 =
+                                         let uu____4164 =
+                                           FStar_Ident.ident_of_lid fqn  in
+                                         [uu____4164]  in
+                                       FStar_List.append uu____4157
+                                         uu____4161
                                         in
-                                     ([], uu____4148, matched_length))
-                                  uu____4131
+                                     ([], uu____4154, matched_length))
+                                  uu____4137
                               else FStar_Pervasives_Native.None))
                        in
-                    let case_b_find_matches_in_env uu____4191 =
+                    let case_b_find_matches_in_env uu____4201 =
                       let matches =
                         FStar_List.filter_map (match_lident_against needle)
                           all_lidents_in_env
                          in
                       FStar_All.pipe_right matches
                         (FStar_List.filter
-                           (fun uu____4272  ->
-                              match uu____4272 with
-                              | (ns,id,uu____4287) ->
-                                  let uu____4298 =
-                                    let uu____4301 =
+                           (fun uu____4282  ->
+                              match uu____4282 with
+                              | (ns,id,uu____4297) ->
+                                  let uu____4308 =
+                                    let uu____4311 =
                                       FStar_Ident.lid_of_ids id  in
                                     FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                                       env.FStar_TypeChecker_Env.dsenv
-                                      uu____4301
+                                      uu____4311
                                      in
-                                  (match uu____4298 with
+                                  (match uu____4308 with
                                    | FStar_Pervasives_Native.None  -> false
                                    | FStar_Pervasives_Native.Some l ->
-                                       let uu____4305 =
+                                       let uu____4315 =
                                          FStar_Ident.lid_of_ids
                                            (FStar_List.append ns id)
                                           in
-                                       FStar_Ident.lid_equals l uu____4305)))
+                                       FStar_Ident.lid_equals l uu____4315)))
                        in
-                    let uu____4306 = FStar_Util.prefix needle  in
-                    match uu____4306 with
+                    let uu____4316 = FStar_Util.prefix needle  in
+                    match uu____4316 with
                     | (ns,id) ->
                         let matched_ids =
                           match ns with
                           | [] -> case_b_find_matches_in_env ()
-                          | uu____4365 ->
+                          | uu____4375 ->
                               let l =
                                 FStar_Ident.lid_of_path ns
                                   FStar_Range.dummyRange
                                  in
-                              let uu____4370 =
+                              let uu____4380 =
                                 FStar_Syntax_DsEnv.resolve_module_name
                                   env.FStar_TypeChecker_Env.dsenv l true
                                  in
-                              (match uu____4370 with
+                              (match uu____4380 with
                                | FStar_Pervasives_Native.None  ->
                                    case_b_find_matches_in_env ()
                                | FStar_Pervasives_Native.Some m ->
@@ -909,34 +916,34 @@ let rec (go :
                         FStar_All.pipe_right matched_ids
                           (FStar_List.map
                              (fun x  ->
-                                let uu____4446 = shorten_namespace x  in
-                                prepare_candidate uu____4446))
+                                let uu____4456 = shorten_namespace x  in
+                                prepare_candidate uu____4456))
                      in
-                  ((let uu____4460 =
+                  ((let uu____4470 =
                       FStar_Util.sort_with
-                        (fun uu____4489  ->
-                           fun uu____4490  ->
-                             match (uu____4489, uu____4490) with
-                             | ((cd1,ns1,uu____4530),(cd2,ns2,uu____4533)) ->
+                        (fun uu____4499  ->
+                           fun uu____4500  ->
+                             match (uu____4499, uu____4500) with
+                             | ((cd1,ns1,uu____4540),(cd2,ns2,uu____4543)) ->
                                  (match FStar_String.compare cd1 cd2 with
-                                  | uu____4565 when
-                                      uu____4565 = Prims.int_zero ->
+                                  | uu____4575 when
+                                      uu____4575 = Prims.int_zero ->
                                       FStar_String.compare ns1 ns2
                                   | n -> n)) matches
                        in
                     FStar_List.iter
-                      (fun uu____4582  ->
-                         match uu____4582 with
+                      (fun uu____4592  ->
+                         match uu____4592 with
                          | (candidate,ns,match_len) ->
-                             let uu____4601 =
+                             let uu____4611 =
                                FStar_Util.string_of_int match_len  in
-                             FStar_Util.print3 "%s %s %s \n" uu____4601 ns
-                               candidate) uu____4460);
+                             FStar_Util.print3 "%s %s %s \n" uu____4611 ns
+                               candidate) uu____4470);
                    FStar_Util.print_string "#done-ok\n";
                    go line_col filename stack curmod env ts)
               | Pop msg ->
                   (pop env msg;
-                   (let uu____4609 =
+                   (let uu____4619 =
                       match stack with
                       | [] ->
                           (FStar_Errors.log_issue FStar_Range.dummyRange
@@ -944,18 +951,18 @@ let rec (go :
                                "too many pops");
                            FStar_All.exit Prims.int_one)
                       | hd::tl -> (hd, tl)  in
-                    match uu____4609 with
+                    match uu____4619 with
                     | ((env1,curmod1),stack1) ->
                         go line_col filename stack1 curmod1 env1 ts))
               | Push (lax,l,c) ->
-                  let uu____4678 =
+                  let uu____4688 =
                     if (FStar_List.length stack) = (FStar_List.length ts)
                     then
-                      let uu____4720 =
+                      let uu____4730 =
                         update_deps filename curmod stack env ts  in
-                      (true, uu____4720)
+                      (true, uu____4730)
                     else (false, (stack, env, ts))  in
-                  (match uu____4678 with
+                  (match uu____4688 with
                    | (restore_cmd_line_options,(stack1,env1,ts1)) ->
                        let stack2 = (env1, curmod) :: stack1  in
                        let env2 =
@@ -985,33 +992,33 @@ let rec (go :
                          (FStar_Util.print1 "\n%s\n" ok;
                           go line_col filename stack curmod1 env1 ts)
                        else fail1 curmod1 env1
-                   | uu____4844 -> fail1 curmod env)
+                   | uu____4854 -> fail1 curmod env)
   
 let (interactive_mode : Prims.string -> unit) =
   fun filename  ->
-    (let uu____4865 =
-       let uu____4867 = FStar_Options.codegen ()  in
-       FStar_Option.isSome uu____4867  in
-     if uu____4865
+    (let uu____4875 =
+       let uu____4877 = FStar_Options.codegen ()  in
+       FStar_Option.isSome uu____4877  in
+     if uu____4875
      then
        FStar_Errors.log_issue FStar_Range.dummyRange
          (FStar_Errors.Warning_IDEIgnoreCodeGen,
            "code-generation is not supported in interactive mode, ignoring the codegen flag")
      else ());
-    (let uu____4875 = deps_of_our_file filename  in
-     match uu____4875 with
+    (let uu____4885 = deps_of_our_file filename  in
+     match uu____4885 with
      | (filenames,maybe_intf,dep_graph) ->
          let env = FStar_Universal.init_env dep_graph  in
-         let uu____4904 =
+         let uu____4914 =
            tc_deps FStar_Pervasives_Native.None [] env filenames []  in
-         (match uu____4904 with
+         (match uu____4914 with
           | (stack,env1,ts) ->
               let initial_range =
-                let uu____4933 =
+                let uu____4943 =
                   FStar_Range.mk_pos Prims.int_one Prims.int_zero  in
-                let uu____4936 =
+                let uu____4946 =
                   FStar_Range.mk_pos Prims.int_one Prims.int_zero  in
-                FStar_Range.mk_range filename uu____4933 uu____4936  in
+                FStar_Range.mk_range filename uu____4943 uu____4946  in
               let env2 = FStar_TypeChecker_Env.set_range env1 initial_range
                  in
               let env3 =
@@ -1019,17 +1026,17 @@ let (interactive_mode : Prims.string -> unit) =
                 | FStar_Pervasives_Native.Some intf ->
                     FStar_Universal.load_interface_decls env2 intf
                 | FStar_Pervasives_Native.None  -> env2  in
-              let uu____4945 =
+              let uu____4955 =
                 (FStar_Options.record_hints ()) ||
                   (FStar_Options.use_hints ())
                  in
-              if uu____4945
+              if uu____4955
               then
-                let uu____4948 =
-                  let uu____4950 = FStar_Options.file_list ()  in
-                  FStar_List.hd uu____4950  in
-                FStar_SMTEncoding_Solver.with_hints_db uu____4948
-                  (fun uu____4956  ->
+                let uu____4958 =
+                  let uu____4960 = FStar_Options.file_list ()  in
+                  FStar_List.hd uu____4960  in
+                FStar_SMTEncoding_Solver.with_hints_db uu____4958
+                  (fun uu____4966  ->
                      go (Prims.int_one, Prims.int_zero) filename stack
                        FStar_Pervasives_Native.None env3 ts)
               else

--- a/src/ocaml-output/FStar_Interactive_PushHelper.ml
+++ b/src/ocaml-output/FStar_Interactive_PushHelper.ml
@@ -429,8 +429,12 @@ let (query_of_ids :
 let (query_of_lid :
   FStar_Ident.lident -> FStar_Interactive_CompletionTable.query) =
   fun lid  ->
-    query_of_ids
-      (FStar_List.append lid.FStar_Ident.ns [lid.FStar_Ident.ident])
+    let uu____1011 =
+      let uu____1014 = FStar_Ident.ns_of_lid lid  in
+      let uu____1017 =
+        let uu____1020 = FStar_Ident.ident_of_lid lid  in [uu____1020]  in
+      FStar_List.append uu____1014 uu____1017  in
+    query_of_ids uu____1011
   
 let (update_names_from_event :
   Prims.string ->
@@ -440,47 +444,59 @@ let (update_names_from_event :
   fun cur_mod_str  ->
     fun table  ->
       fun evt  ->
-        let is_cur_mod lid = lid.FStar_Ident.str = cur_mod_str  in
+        let is_cur_mod lid =
+          let uu____1046 = FStar_Ident.string_of_lid lid  in
+          uu____1046 = cur_mod_str  in
         match evt with
         | NTAlias (host,id,included) ->
-            if is_cur_mod host
+            let uu____1052 = is_cur_mod host  in
+            if uu____1052
             then
-              let uu____1041 = FStar_Ident.text_of_id id  in
-              let uu____1043 = query_of_lid included  in
+              let uu____1055 = FStar_Ident.text_of_id id  in
+              let uu____1057 = query_of_lid included  in
               FStar_Interactive_CompletionTable.register_alias table
-                uu____1041 [] uu____1043
+                uu____1055 [] uu____1057
             else table
         | NTOpen (host,(included,kind)) ->
-            if is_cur_mod host
+            let uu____1064 = is_cur_mod host  in
+            if uu____1064
             then
-              let uu____1051 = query_of_lid included  in
+              let uu____1067 = query_of_lid included  in
               FStar_Interactive_CompletionTable.register_open table
-                (kind = FStar_Syntax_DsEnv.Open_module) [] uu____1051
+                (kind = FStar_Syntax_DsEnv.Open_module) [] uu____1067
             else table
         | NTInclude (host,included) ->
-            let uu____1057 =
-              if is_cur_mod host then [] else query_of_lid host  in
-            let uu____1062 = query_of_lid included  in
+            let uu____1073 =
+              let uu____1074 = is_cur_mod host  in
+              if uu____1074 then [] else query_of_lid host  in
+            let uu____1080 = query_of_lid included  in
             FStar_Interactive_CompletionTable.register_include table
-              uu____1057 uu____1062
+              uu____1073 uu____1080
         | NTBinding binding ->
             let lids =
               match binding with
               | FStar_Util.Inl (FStar_Syntax_Syntax.Binding_lid
-                  (lid,uu____1074)) -> [lid]
-              | FStar_Util.Inr (lids,uu____1092) -> lids
-              | uu____1097 -> []  in
+                  (lid,uu____1092)) -> [lid]
+              | FStar_Util.Inr (lids,uu____1110) -> lids
+              | uu____1115 -> []  in
             FStar_List.fold_left
               (fun tbl  ->
                  fun lid  ->
                    let ns_query =
-                     if lid.FStar_Ident.nsstr = cur_mod_str
+                     let uu____1127 =
+                       let uu____1129 = FStar_Ident.nsstr lid  in
+                       uu____1129 = cur_mod_str  in
+                     if uu____1127
                      then []
-                     else query_of_ids lid.FStar_Ident.ns  in
-                   let uu____1114 =
-                     FStar_Ident.text_of_id lid.FStar_Ident.ident  in
+                     else
+                       (let uu____1136 = FStar_Ident.ns_of_lid lid  in
+                        query_of_ids uu____1136)
+                      in
+                   let uu____1139 =
+                     let uu____1141 = FStar_Ident.ident_of_lid lid  in
+                     FStar_Ident.text_of_id uu____1141  in
                    FStar_Interactive_CompletionTable.insert tbl ns_query
-                     uu____1114 lid) table lids
+                     uu____1139 lid) table lids
   
 let (commit_name_tracking' :
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
@@ -495,8 +511,8 @@ let (commit_name_tracking' :
           match cur_mod with
           | FStar_Pervasives_Native.None  -> ""
           | FStar_Pervasives_Native.Some md ->
-              let uu____1145 = FStar_Syntax_Syntax.mod_name md  in
-              uu____1145.FStar_Ident.str
+              let uu____1171 = FStar_Syntax_Syntax.mod_name md  in
+              FStar_Ident.string_of_lid uu____1171
            in
         let updater = update_names_from_event cur_mod_str  in
         FStar_List.fold_left updater names name_events
@@ -511,22 +527,22 @@ let (commit_name_tracking :
         commit_name_tracking' st.FStar_Interactive_JsonHelper.repl_curmod
           st.FStar_Interactive_JsonHelper.repl_names name_events
          in
-      let uu___166_1171 = st  in
+      let uu___166_1197 = st  in
       {
         FStar_Interactive_JsonHelper.repl_line =
-          (uu___166_1171.FStar_Interactive_JsonHelper.repl_line);
+          (uu___166_1197.FStar_Interactive_JsonHelper.repl_line);
         FStar_Interactive_JsonHelper.repl_column =
-          (uu___166_1171.FStar_Interactive_JsonHelper.repl_column);
+          (uu___166_1197.FStar_Interactive_JsonHelper.repl_column);
         FStar_Interactive_JsonHelper.repl_fname =
-          (uu___166_1171.FStar_Interactive_JsonHelper.repl_fname);
+          (uu___166_1197.FStar_Interactive_JsonHelper.repl_fname);
         FStar_Interactive_JsonHelper.repl_deps_stack =
-          (uu___166_1171.FStar_Interactive_JsonHelper.repl_deps_stack);
+          (uu___166_1197.FStar_Interactive_JsonHelper.repl_deps_stack);
         FStar_Interactive_JsonHelper.repl_curmod =
-          (uu___166_1171.FStar_Interactive_JsonHelper.repl_curmod);
+          (uu___166_1197.FStar_Interactive_JsonHelper.repl_curmod);
         FStar_Interactive_JsonHelper.repl_env =
-          (uu___166_1171.FStar_Interactive_JsonHelper.repl_env);
+          (uu___166_1197.FStar_Interactive_JsonHelper.repl_env);
         FStar_Interactive_JsonHelper.repl_stdin =
-          (uu___166_1171.FStar_Interactive_JsonHelper.repl_stdin);
+          (uu___166_1197.FStar_Interactive_JsonHelper.repl_stdin);
         FStar_Interactive_JsonHelper.repl_names = names
       }
   
@@ -535,49 +551,49 @@ let (fresh_name_tracking_hooks :
     (name_tracking_event Prims.list FStar_ST.ref *
       FStar_Syntax_DsEnv.dsenv_hooks * FStar_TypeChecker_Env.tcenv_hooks))
   =
-  fun uu____1187  ->
+  fun uu____1213  ->
     let events = FStar_Util.mk_ref []  in
     let push_event evt =
-      let uu____1201 =
-        let uu____1204 = FStar_ST.op_Bang events  in evt :: uu____1204  in
-      FStar_ST.op_Colon_Equals events uu____1201  in
+      let uu____1227 =
+        let uu____1230 = FStar_ST.op_Bang events  in evt :: uu____1230  in
+      FStar_ST.op_Colon_Equals events uu____1227  in
     (events,
       {
         FStar_Syntax_DsEnv.ds_push_open_hook =
           (fun dsenv  ->
              fun op  ->
-               let uu____1265 =
-                 let uu____1266 =
-                   let uu____1271 = FStar_Syntax_DsEnv.current_module dsenv
+               let uu____1291 =
+                 let uu____1292 =
+                   let uu____1297 = FStar_Syntax_DsEnv.current_module dsenv
                       in
-                   (uu____1271, op)  in
-                 NTOpen uu____1266  in
-               push_event uu____1265);
+                   (uu____1297, op)  in
+                 NTOpen uu____1292  in
+               push_event uu____1291);
         FStar_Syntax_DsEnv.ds_push_include_hook =
           (fun dsenv  ->
              fun ns  ->
-               let uu____1277 =
-                 let uu____1278 =
-                   let uu____1283 = FStar_Syntax_DsEnv.current_module dsenv
+               let uu____1303 =
+                 let uu____1304 =
+                   let uu____1309 = FStar_Syntax_DsEnv.current_module dsenv
                       in
-                   (uu____1283, ns)  in
-                 NTInclude uu____1278  in
-               push_event uu____1277);
+                   (uu____1309, ns)  in
+                 NTInclude uu____1304  in
+               push_event uu____1303);
         FStar_Syntax_DsEnv.ds_push_module_abbrev_hook =
           (fun dsenv  ->
              fun x  ->
                fun l  ->
-                 let uu____1291 =
-                   let uu____1292 =
-                     let uu____1299 = FStar_Syntax_DsEnv.current_module dsenv
+                 let uu____1317 =
+                   let uu____1318 =
+                     let uu____1325 = FStar_Syntax_DsEnv.current_module dsenv
                         in
-                     (uu____1299, x, l)  in
-                   NTAlias uu____1292  in
-                 push_event uu____1291)
+                     (uu____1325, x, l)  in
+                   NTAlias uu____1318  in
+                 push_event uu____1317)
       },
       {
         FStar_TypeChecker_Env.tc_push_in_gamma_hook =
-          (fun uu____1304  -> fun s  -> push_event (NTBinding s))
+          (fun uu____1330  -> fun s  -> push_event (NTBinding s))
       })
   
 let (track_name_changes :
@@ -588,34 +604,34 @@ let (track_name_changes :
   =
   fun env  ->
     let set_hooks dshooks tchooks env1 =
-      let uu____1358 =
+      let uu____1384 =
         FStar_Universal.with_dsenv_of_tcenv env1
           (fun dsenv  ->
-             let uu____1366 = FStar_Syntax_DsEnv.set_ds_hooks dsenv dshooks
+             let uu____1392 = FStar_Syntax_DsEnv.set_ds_hooks dsenv dshooks
                 in
-             ((), uu____1366))
+             ((), uu____1392))
          in
-      match uu____1358 with
+      match uu____1384 with
       | ((),tcenv') -> FStar_TypeChecker_Env.set_tc_hooks tcenv' tchooks  in
-    let uu____1368 =
-      let uu____1373 =
+    let uu____1394 =
+      let uu____1399 =
         FStar_Syntax_DsEnv.ds_hooks env.FStar_TypeChecker_Env.dsenv  in
-      let uu____1374 = FStar_TypeChecker_Env.tc_hooks env  in
-      (uu____1373, uu____1374)  in
-    match uu____1368 with
+      let uu____1400 = FStar_TypeChecker_Env.tc_hooks env  in
+      (uu____1399, uu____1400)  in
+    match uu____1394 with
     | (old_dshooks,old_tchooks) ->
-        let uu____1390 = fresh_name_tracking_hooks ()  in
-        (match uu____1390 with
+        let uu____1416 = fresh_name_tracking_hooks ()  in
+        (match uu____1416 with
          | (events,new_dshooks,new_tchooks) ->
-             let uu____1425 = set_hooks new_dshooks new_tchooks env  in
-             (uu____1425,
+             let uu____1451 = set_hooks new_dshooks new_tchooks env  in
+             (uu____1451,
                ((fun env1  ->
-                   let uu____1439 = set_hooks old_dshooks old_tchooks env1
+                   let uu____1465 = set_hooks old_dshooks old_tchooks env1
                       in
-                   let uu____1440 =
-                     let uu____1443 = FStar_ST.op_Bang events  in
-                     FStar_List.rev uu____1443  in
-                   (uu____1439, uu____1440)))))
+                   let uu____1466 =
+                     let uu____1469 = FStar_ST.op_Bang events  in
+                     FStar_List.rev uu____1469  in
+                   (uu____1465, uu____1466)))))
   
 let (repl_tx :
   FStar_Interactive_JsonHelper.repl_state ->
@@ -628,80 +644,80 @@ let (repl_tx :
     fun push_kind1  ->
       fun task  ->
         try
-          (fun uu___202_1512  ->
+          (fun uu___202_1538  ->
              match () with
              | () ->
                  let st1 = push_repl "repl_tx" push_kind1 task st  in
-                 let uu____1521 =
+                 let uu____1547 =
                    track_name_changes
                      st1.FStar_Interactive_JsonHelper.repl_env
                     in
-                 (match uu____1521 with
+                 (match uu____1547 with
                   | (env,finish_name_tracking) ->
-                      let uu____1561 =
+                      let uu____1587 =
                         run_repl_task
                           st1.FStar_Interactive_JsonHelper.repl_curmod env
                           task
                          in
-                      (match uu____1561 with
+                      (match uu____1587 with
                        | (curmod,env1) ->
                            let st2 =
-                             let uu___228_1575 = st1  in
+                             let uu___228_1601 = st1  in
                              {
                                FStar_Interactive_JsonHelper.repl_line =
-                                 (uu___228_1575.FStar_Interactive_JsonHelper.repl_line);
+                                 (uu___228_1601.FStar_Interactive_JsonHelper.repl_line);
                                FStar_Interactive_JsonHelper.repl_column =
-                                 (uu___228_1575.FStar_Interactive_JsonHelper.repl_column);
+                                 (uu___228_1601.FStar_Interactive_JsonHelper.repl_column);
                                FStar_Interactive_JsonHelper.repl_fname =
-                                 (uu___228_1575.FStar_Interactive_JsonHelper.repl_fname);
+                                 (uu___228_1601.FStar_Interactive_JsonHelper.repl_fname);
                                FStar_Interactive_JsonHelper.repl_deps_stack =
-                                 (uu___228_1575.FStar_Interactive_JsonHelper.repl_deps_stack);
+                                 (uu___228_1601.FStar_Interactive_JsonHelper.repl_deps_stack);
                                FStar_Interactive_JsonHelper.repl_curmod =
                                  curmod;
                                FStar_Interactive_JsonHelper.repl_env = env1;
                                FStar_Interactive_JsonHelper.repl_stdin =
-                                 (uu___228_1575.FStar_Interactive_JsonHelper.repl_stdin);
+                                 (uu___228_1601.FStar_Interactive_JsonHelper.repl_stdin);
                                FStar_Interactive_JsonHelper.repl_names =
-                                 (uu___228_1575.FStar_Interactive_JsonHelper.repl_names)
+                                 (uu___228_1601.FStar_Interactive_JsonHelper.repl_names)
                              }  in
-                           let uu____1576 = finish_name_tracking env1  in
-                           (match uu____1576 with
+                           let uu____1602 = finish_name_tracking env1  in
+                           (match uu____1602 with
                             | (env2,name_events) ->
-                                let uu____1595 =
+                                let uu____1621 =
                                   commit_name_tracking st2 name_events  in
-                                (FStar_Pervasives_Native.None, uu____1595)))))
+                                (FStar_Pervasives_Native.None, uu____1621)))))
             ()
         with
         | FStar_All.Failure msg ->
-            let uu____1610 =
-              let uu____1613 =
+            let uu____1636 =
+              let uu____1639 =
                 FStar_Interactive_JsonHelper.js_diag
                   st.FStar_Interactive_JsonHelper.repl_fname msg
                   FStar_Pervasives_Native.None
                  in
-              FStar_Pervasives_Native.Some uu____1613  in
-            (uu____1610, st)
+              FStar_Pervasives_Native.Some uu____1639  in
+            (uu____1636, st)
         | FStar_Util.SigInt  ->
             (FStar_Util.print_error "[E] Interrupt";
              (FStar_Pervasives_Native.None, st))
         | FStar_Errors.Error (e,msg,r) ->
-            let uu____1625 =
-              let uu____1628 =
+            let uu____1651 =
+              let uu____1654 =
                 FStar_Interactive_JsonHelper.js_diag
                   st.FStar_Interactive_JsonHelper.repl_fname msg
                   (FStar_Pervasives_Native.Some r)
                  in
-              FStar_Pervasives_Native.Some uu____1628  in
-            (uu____1625, st)
+              FStar_Pervasives_Native.Some uu____1654  in
+            (uu____1651, st)
         | FStar_Errors.Err (e,msg) ->
-            let uu____1635 =
-              let uu____1638 =
+            let uu____1661 =
+              let uu____1664 =
                 FStar_Interactive_JsonHelper.js_diag
                   st.FStar_Interactive_JsonHelper.repl_fname msg
                   FStar_Pervasives_Native.None
                  in
-              FStar_Pervasives_Native.Some uu____1638  in
-            (uu____1635, st)
+              FStar_Pervasives_Native.Some uu____1664  in
+            (uu____1661, st)
         | FStar_Errors.Stop  ->
             (FStar_Util.print_error "[E] Stop";
              (FStar_Pervasives_Native.None, st))
@@ -709,35 +725,35 @@ let (repl_tx :
 let (tf_of_fname : Prims.string -> FStar_Interactive_JsonHelper.timed_fname)
   =
   fun fname  ->
-    let uu____1653 =
+    let uu____1679 =
       FStar_Parser_ParseIt.get_file_last_modification_time fname  in
     {
       FStar_Interactive_JsonHelper.tf_fname = fname;
-      FStar_Interactive_JsonHelper.tf_modtime = uu____1653
+      FStar_Interactive_JsonHelper.tf_modtime = uu____1679
     }
   
 let (update_task_timestamps :
   FStar_Interactive_JsonHelper.repl_task ->
     FStar_Interactive_JsonHelper.repl_task)
   =
-  fun uu___0_1659  ->
-    match uu___0_1659 with
+  fun uu___0_1685  ->
+    match uu___0_1685 with
     | FStar_Interactive_JsonHelper.LDInterleaved (intf,impl) ->
-        let uu____1662 =
-          let uu____1667 =
+        let uu____1688 =
+          let uu____1693 =
             tf_of_fname intf.FStar_Interactive_JsonHelper.tf_fname  in
-          let uu____1668 =
+          let uu____1694 =
             tf_of_fname impl.FStar_Interactive_JsonHelper.tf_fname  in
-          (uu____1667, uu____1668)  in
-        FStar_Interactive_JsonHelper.LDInterleaved uu____1662
+          (uu____1693, uu____1694)  in
+        FStar_Interactive_JsonHelper.LDInterleaved uu____1688
     | FStar_Interactive_JsonHelper.LDSingle intf_or_impl ->
-        let uu____1670 =
+        let uu____1696 =
           tf_of_fname intf_or_impl.FStar_Interactive_JsonHelper.tf_fname  in
-        FStar_Interactive_JsonHelper.LDSingle uu____1670
+        FStar_Interactive_JsonHelper.LDSingle uu____1696
     | FStar_Interactive_JsonHelper.LDInterfaceOfCurrentFile intf ->
-        let uu____1672 =
+        let uu____1698 =
           tf_of_fname intf.FStar_Interactive_JsonHelper.tf_fname  in
-        FStar_Interactive_JsonHelper.LDInterfaceOfCurrentFile uu____1672
+        FStar_Interactive_JsonHelper.LDInterfaceOfCurrentFile uu____1698
     | other -> other
   
 let (repl_ldtx :
@@ -746,8 +762,8 @@ let (repl_ldtx :
   =
   fun st  ->
     fun tasks  ->
-      let rec revert_many st1 uu___1_1709 =
-        match uu___1_1709 with
+      let rec revert_many st1 uu___1_1735 =
+        match uu___1_1735 with
         | [] -> st1
         | (_id,(task,_st'))::entries ->
             let st' = pop_repl "repl_ldtx" st1  in
@@ -756,27 +772,27 @@ let (repl_ldtx :
                 st1.FStar_Interactive_JsonHelper.repl_env
                in
             let st'1 =
-              let uu___260_1758 = st'  in
-              let uu____1759 =
+              let uu___260_1784 = st'  in
+              let uu____1785 =
                 FStar_TypeChecker_Env.set_dep_graph
                   st'.FStar_Interactive_JsonHelper.repl_env dep_graph
                  in
               {
                 FStar_Interactive_JsonHelper.repl_line =
-                  (uu___260_1758.FStar_Interactive_JsonHelper.repl_line);
+                  (uu___260_1784.FStar_Interactive_JsonHelper.repl_line);
                 FStar_Interactive_JsonHelper.repl_column =
-                  (uu___260_1758.FStar_Interactive_JsonHelper.repl_column);
+                  (uu___260_1784.FStar_Interactive_JsonHelper.repl_column);
                 FStar_Interactive_JsonHelper.repl_fname =
-                  (uu___260_1758.FStar_Interactive_JsonHelper.repl_fname);
+                  (uu___260_1784.FStar_Interactive_JsonHelper.repl_fname);
                 FStar_Interactive_JsonHelper.repl_deps_stack =
-                  (uu___260_1758.FStar_Interactive_JsonHelper.repl_deps_stack);
+                  (uu___260_1784.FStar_Interactive_JsonHelper.repl_deps_stack);
                 FStar_Interactive_JsonHelper.repl_curmod =
-                  (uu___260_1758.FStar_Interactive_JsonHelper.repl_curmod);
-                FStar_Interactive_JsonHelper.repl_env = uu____1759;
+                  (uu___260_1784.FStar_Interactive_JsonHelper.repl_curmod);
+                FStar_Interactive_JsonHelper.repl_env = uu____1785;
                 FStar_Interactive_JsonHelper.repl_stdin =
-                  (uu___260_1758.FStar_Interactive_JsonHelper.repl_stdin);
+                  (uu___260_1784.FStar_Interactive_JsonHelper.repl_stdin);
                 FStar_Interactive_JsonHelper.repl_names =
-                  (uu___260_1758.FStar_Interactive_JsonHelper.repl_names)
+                  (uu___260_1784.FStar_Interactive_JsonHelper.repl_names)
               }  in
             revert_many st'1 entries
          in
@@ -785,42 +801,42 @@ let (repl_ldtx :
         | ([],[]) -> FStar_Util.Inl st1
         | (task::tasks2,[]) ->
             let timestamped_task = update_task_timestamps task  in
-            let uu____1809 = repl_tx st1 LaxCheck timestamped_task  in
-            (match uu____1809 with
+            let uu____1835 = repl_tx st1 LaxCheck timestamped_task  in
+            (match uu____1835 with
              | (diag,st2) ->
                  if Prims.op_Negation (FStar_Util.is_some diag)
                  then
-                   let uu____1831 =
-                     let uu___280_1832 = st2  in
-                     let uu____1833 = FStar_ST.op_Bang repl_stack  in
+                   let uu____1857 =
+                     let uu___280_1858 = st2  in
+                     let uu____1859 = FStar_ST.op_Bang repl_stack  in
                      {
                        FStar_Interactive_JsonHelper.repl_line =
-                         (uu___280_1832.FStar_Interactive_JsonHelper.repl_line);
+                         (uu___280_1858.FStar_Interactive_JsonHelper.repl_line);
                        FStar_Interactive_JsonHelper.repl_column =
-                         (uu___280_1832.FStar_Interactive_JsonHelper.repl_column);
+                         (uu___280_1858.FStar_Interactive_JsonHelper.repl_column);
                        FStar_Interactive_JsonHelper.repl_fname =
-                         (uu___280_1832.FStar_Interactive_JsonHelper.repl_fname);
+                         (uu___280_1858.FStar_Interactive_JsonHelper.repl_fname);
                        FStar_Interactive_JsonHelper.repl_deps_stack =
-                         uu____1833;
+                         uu____1859;
                        FStar_Interactive_JsonHelper.repl_curmod =
-                         (uu___280_1832.FStar_Interactive_JsonHelper.repl_curmod);
+                         (uu___280_1858.FStar_Interactive_JsonHelper.repl_curmod);
                        FStar_Interactive_JsonHelper.repl_env =
-                         (uu___280_1832.FStar_Interactive_JsonHelper.repl_env);
+                         (uu___280_1858.FStar_Interactive_JsonHelper.repl_env);
                        FStar_Interactive_JsonHelper.repl_stdin =
-                         (uu___280_1832.FStar_Interactive_JsonHelper.repl_stdin);
+                         (uu___280_1858.FStar_Interactive_JsonHelper.repl_stdin);
                        FStar_Interactive_JsonHelper.repl_names =
-                         (uu___280_1832.FStar_Interactive_JsonHelper.repl_names)
+                         (uu___280_1858.FStar_Interactive_JsonHelper.repl_names)
                      }  in
-                   aux uu____1831 tasks2 []
+                   aux uu____1857 tasks2 []
                  else FStar_Util.Inr st2)
         | (task::tasks2,prev::previous1) when
-            let uu____1877 = update_task_timestamps task  in
+            let uu____1903 = update_task_timestamps task  in
             (FStar_Pervasives_Native.fst (FStar_Pervasives_Native.snd prev))
-              = uu____1877
+              = uu____1903
             -> aux st1 tasks2 previous1
         | (tasks2,previous1) ->
-            let uu____1892 = revert_many st1 previous1  in
-            aux uu____1892 tasks2 []
+            let uu____1918 = revert_many st1 previous1  in
+            aux uu____1918 tasks2 []
          in
       aux st tasks
         (FStar_List.rev st.FStar_Interactive_JsonHelper.repl_deps_stack)
@@ -832,44 +848,44 @@ let (ld_deps :
   =
   fun st  ->
     try
-      (fun uu___294_1937  ->
+      (fun uu___294_1963  ->
          match () with
          | () ->
-             let uu____1949 =
+             let uu____1975 =
                deps_and_repl_ld_tasks_of_our_file
                  st.FStar_Interactive_JsonHelper.repl_fname
                 in
-             (match uu____1949 with
+             (match uu____1975 with
               | (deps,tasks,dep_graph) ->
                   let st1 =
-                    let uu___304_1986 = st  in
-                    let uu____1987 =
+                    let uu___304_2012 = st  in
+                    let uu____2013 =
                       FStar_TypeChecker_Env.set_dep_graph
                         st.FStar_Interactive_JsonHelper.repl_env dep_graph
                        in
                     {
                       FStar_Interactive_JsonHelper.repl_line =
-                        (uu___304_1986.FStar_Interactive_JsonHelper.repl_line);
+                        (uu___304_2012.FStar_Interactive_JsonHelper.repl_line);
                       FStar_Interactive_JsonHelper.repl_column =
-                        (uu___304_1986.FStar_Interactive_JsonHelper.repl_column);
+                        (uu___304_2012.FStar_Interactive_JsonHelper.repl_column);
                       FStar_Interactive_JsonHelper.repl_fname =
-                        (uu___304_1986.FStar_Interactive_JsonHelper.repl_fname);
+                        (uu___304_2012.FStar_Interactive_JsonHelper.repl_fname);
                       FStar_Interactive_JsonHelper.repl_deps_stack =
-                        (uu___304_1986.FStar_Interactive_JsonHelper.repl_deps_stack);
+                        (uu___304_2012.FStar_Interactive_JsonHelper.repl_deps_stack);
                       FStar_Interactive_JsonHelper.repl_curmod =
-                        (uu___304_1986.FStar_Interactive_JsonHelper.repl_curmod);
-                      FStar_Interactive_JsonHelper.repl_env = uu____1987;
+                        (uu___304_2012.FStar_Interactive_JsonHelper.repl_curmod);
+                      FStar_Interactive_JsonHelper.repl_env = uu____2013;
                       FStar_Interactive_JsonHelper.repl_stdin =
-                        (uu___304_1986.FStar_Interactive_JsonHelper.repl_stdin);
+                        (uu___304_2012.FStar_Interactive_JsonHelper.repl_stdin);
                       FStar_Interactive_JsonHelper.repl_names =
-                        (uu___304_1986.FStar_Interactive_JsonHelper.repl_names)
+                        (uu___304_2012.FStar_Interactive_JsonHelper.repl_names)
                     }  in
-                  let uu____1988 = repl_ldtx st1 tasks  in
-                  (match uu____1988 with
+                  let uu____2014 = repl_ldtx st1 tasks  in
+                  (match uu____2014 with
                    | FStar_Util.Inr st2 -> FStar_Util.Inr st2
                    | FStar_Util.Inl st2 -> FStar_Util.Inl (st2, deps)))) ()
     with
-    | uu___293_2021 ->
+    | uu___293_2047 ->
         (FStar_Util.print_error "[E] Failed to load deps"; FStar_Util.Inr st)
   
 let (add_module_completions :
@@ -887,25 +903,25 @@ let (add_module_completions :
           else
             (let first =
                FStar_String.substring str Prims.int_zero Prims.int_one  in
-             let uu____2085 =
+             let uu____2111 =
                FStar_String.substring str Prims.int_one
                  ((FStar_String.length str) - Prims.int_one)
                 in
-             Prims.op_Hat (FStar_String.uppercase first) uu____2085)
+             Prims.op_Hat (FStar_String.uppercase first) uu____2111)
            in
         let mods = FStar_Parser_Dep.build_inclusion_candidates_list ()  in
         let loaded_mods_set =
-          let uu____2102 = FStar_Util.psmap_empty ()  in
-          let uu____2107 =
-            let uu____2111 = FStar_Options.prims ()  in uu____2111 :: deps
+          let uu____2128 = FStar_Util.psmap_empty ()  in
+          let uu____2133 =
+            let uu____2137 = FStar_Options.prims ()  in uu____2137 :: deps
              in
           FStar_List.fold_left
             (fun acc  ->
                fun dep  ->
-                 let uu____2127 = FStar_Parser_Dep.lowercase_module_name dep
+                 let uu____2153 = FStar_Parser_Dep.lowercase_module_name dep
                     in
-                 FStar_Util.psmap_add acc uu____2127 true) uu____2102
-            uu____2107
+                 FStar_Util.psmap_add acc uu____2153 true) uu____2128
+            uu____2133
            in
         let loaded modname =
           FStar_Util.psmap_find_default loaded_mods_set modname false  in
@@ -913,19 +929,19 @@ let (add_module_completions :
            in
         FStar_List.fold_left
           (fun table1  ->
-             fun uu____2156  ->
-               match uu____2156 with
+             fun uu____2182  ->
+               match uu____2182 with
                | (modname,mod_path) ->
                    let mod_key = FStar_String.lowercase modname  in
                    if this_mod_key = mod_key
                    then table1
                    else
                      (let ns_query =
-                        let uu____2179 = capitalize modname  in
-                        FStar_Util.split uu____2179 "."  in
-                      let uu____2182 = loaded mod_key  in
+                        let uu____2205 = capitalize modname  in
+                        FStar_Util.split uu____2205 "."  in
+                      let uu____2208 = loaded mod_key  in
                       FStar_Interactive_CompletionTable.register_module_path
-                        table1 uu____2182 mod_path ns_query)) table
+                        table1 uu____2208 mod_path ns_query)) table
           (FStar_List.rev mods)
   
 let (full_lax :
@@ -946,8 +962,8 @@ let (full_lax :
            FStar_Parser_ParseIt.frag_line = Prims.int_one;
            FStar_Parser_ParseIt.frag_col = Prims.int_zero
          }  in
-       let uu____2214 = ld_deps st  in
-       match uu____2214 with
+       let uu____2240 = ld_deps st  in
+       match uu____2240 with
        | FStar_Util.Inl (st1,deps) ->
            let names =
              add_module_completions
@@ -955,22 +971,22 @@ let (full_lax :
                st1.FStar_Interactive_JsonHelper.repl_names
               in
            repl_tx
-             (let uu___341_2250 = st1  in
+             (let uu___341_2276 = st1  in
               {
                 FStar_Interactive_JsonHelper.repl_line =
-                  (uu___341_2250.FStar_Interactive_JsonHelper.repl_line);
+                  (uu___341_2276.FStar_Interactive_JsonHelper.repl_line);
                 FStar_Interactive_JsonHelper.repl_column =
-                  (uu___341_2250.FStar_Interactive_JsonHelper.repl_column);
+                  (uu___341_2276.FStar_Interactive_JsonHelper.repl_column);
                 FStar_Interactive_JsonHelper.repl_fname =
-                  (uu___341_2250.FStar_Interactive_JsonHelper.repl_fname);
+                  (uu___341_2276.FStar_Interactive_JsonHelper.repl_fname);
                 FStar_Interactive_JsonHelper.repl_deps_stack =
-                  (uu___341_2250.FStar_Interactive_JsonHelper.repl_deps_stack);
+                  (uu___341_2276.FStar_Interactive_JsonHelper.repl_deps_stack);
                 FStar_Interactive_JsonHelper.repl_curmod =
-                  (uu___341_2250.FStar_Interactive_JsonHelper.repl_curmod);
+                  (uu___341_2276.FStar_Interactive_JsonHelper.repl_curmod);
                 FStar_Interactive_JsonHelper.repl_env =
-                  (uu___341_2250.FStar_Interactive_JsonHelper.repl_env);
+                  (uu___341_2276.FStar_Interactive_JsonHelper.repl_env);
                 FStar_Interactive_JsonHelper.repl_stdin =
-                  (uu___341_2250.FStar_Interactive_JsonHelper.repl_stdin);
+                  (uu___341_2276.FStar_Interactive_JsonHelper.repl_stdin);
                 FStar_Interactive_JsonHelper.repl_names = names
               }) LaxCheck (FStar_Interactive_JsonHelper.PushFragment frag)
        | FStar_Util.Inr st1 -> (FStar_Pervasives_Native.None, st1))

--- a/src/ocaml-output/FStar_Interactive_QueryHelper.ml
+++ b/src/ocaml-output/FStar_Interactive_QueryHelper.ml
@@ -76,40 +76,40 @@ let (symlookup :
                  in
               FStar_Ident.lid_of_ids uu____293  in
             let lid1 =
-              let uu____299 =
+              let uu____297 =
                 FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                   tcenv.FStar_TypeChecker_Env.dsenv lid
                  in
-              FStar_All.pipe_left (FStar_Util.dflt lid) uu____299  in
-            let uu____304 = FStar_TypeChecker_Env.try_lookup_lid tcenv lid1
+              FStar_All.pipe_left (FStar_Util.dflt lid) uu____297  in
+            let uu____302 = FStar_TypeChecker_Env.try_lookup_lid tcenv lid1
                in
-            FStar_All.pipe_right uu____304
+            FStar_All.pipe_right uu____302
               (FStar_Util.map_option
-                 (fun uu____361  ->
-                    match uu____361 with
-                    | ((uu____381,typ),r) -> ((FStar_Util.Inr lid1), typ, r)))
+                 (fun uu____359  ->
+                    match uu____359 with
+                    | ((uu____379,typ),r) -> ((FStar_Util.Inr lid1), typ, r)))
              in
           let docs_of_lid lid = FStar_Pervasives_Native.None  in
           let def_of_lid lid =
-            let uu____413 = FStar_TypeChecker_Env.lookup_qname tcenv lid  in
-            FStar_Util.bind_opt uu____413
-              (fun uu___0_458  ->
-                 match uu___0_458 with
-                 | (FStar_Util.Inr (se,uu____481),uu____482) ->
-                     let uu____511 = sigelt_to_string se  in
-                     FStar_Pervasives_Native.Some uu____511
-                 | uu____514 -> FStar_Pervasives_Native.None)
+            let uu____411 = FStar_TypeChecker_Env.lookup_qname tcenv lid  in
+            FStar_Util.bind_opt uu____411
+              (fun uu___0_456  ->
+                 match uu___0_456 with
+                 | (FStar_Util.Inr (se,uu____479),uu____480) ->
+                     let uu____509 = sigelt_to_string se  in
+                     FStar_Pervasives_Native.Some uu____509
+                 | uu____512 -> FStar_Pervasives_Native.None)
              in
           let info_at_pos_opt =
             FStar_Util.bind_opt pos_opt
-              (fun uu____563  ->
-                 match uu____563 with
+              (fun uu____561  ->
+                 match uu____561 with
                  | (file,row,col) ->
                      FStar_TypeChecker_Err.info_at_pos tcenv file row col)
              in
           let info_opt =
             match info_at_pos_opt with
-            | FStar_Pervasives_Native.Some uu____613 -> info_at_pos_opt
+            | FStar_Pervasives_Native.Some uu____611 -> info_at_pos_opt
             | FStar_Pervasives_Native.None  ->
                 if symbol = ""
                 then FStar_Pervasives_Native.None
@@ -125,21 +125,21 @@ let (symlookup :
               let typ_str =
                 if FStar_List.mem "type" requested_info
                 then
-                  let uu____731 = term_to_string tcenv typ  in
-                  FStar_Pervasives_Native.Some uu____731
+                  let uu____729 = term_to_string tcenv typ  in
+                  FStar_Pervasives_Native.Some uu____729
                 else FStar_Pervasives_Native.None  in
               let doc_str =
                 match name_or_lid with
                 | FStar_Util.Inr lid when
                     FStar_List.mem "documentation" requested_info ->
                     docs_of_lid lid
-                | uu____748 -> FStar_Pervasives_Native.None  in
+                | uu____746 -> FStar_Pervasives_Native.None  in
               let def_str =
                 match name_or_lid with
                 | FStar_Util.Inr lid when
                     FStar_List.mem "definition" requested_info ->
                     def_of_lid lid
-                | uu____766 -> FStar_Pervasives_Native.None  in
+                | uu____764 -> FStar_Pervasives_Native.None  in
               let def_range =
                 if FStar_List.mem "defined-at" requested_info
                 then FStar_Pervasives_Native.Some rng
@@ -154,39 +154,39 @@ let (symlookup :
                 }
   
 let mod_filter :
-  'uuuuuu788 .
-    ('uuuuuu788 * FStar_Interactive_CompletionTable.mod_symbol) ->
-      ('uuuuuu788 * FStar_Interactive_CompletionTable.mod_symbol)
+  'uuuuuu786 .
+    ('uuuuuu786 * FStar_Interactive_CompletionTable.mod_symbol) ->
+      ('uuuuuu786 * FStar_Interactive_CompletionTable.mod_symbol)
         FStar_Pervasives_Native.option
   =
-  fun uu___1_803  ->
-    match uu___1_803 with
-    | (uu____808,FStar_Interactive_CompletionTable.Namespace uu____809) ->
+  fun uu___1_801  ->
+    match uu___1_801 with
+    | (uu____806,FStar_Interactive_CompletionTable.Namespace uu____807) ->
         FStar_Pervasives_Native.None
-    | (uu____814,FStar_Interactive_CompletionTable.Module
-       { FStar_Interactive_CompletionTable.mod_name = uu____815;
-         FStar_Interactive_CompletionTable.mod_path = uu____816;
+    | (uu____812,FStar_Interactive_CompletionTable.Module
+       { FStar_Interactive_CompletionTable.mod_name = uu____813;
+         FStar_Interactive_CompletionTable.mod_path = uu____814;
          FStar_Interactive_CompletionTable.mod_loaded = true ;_})
         -> FStar_Pervasives_Native.None
     | (pth,FStar_Interactive_CompletionTable.Module md) ->
-        let uu____826 =
-          let uu____831 =
-            let uu____832 =
-              let uu___99_833 = md  in
-              let uu____834 =
-                let uu____836 = FStar_Interactive_CompletionTable.mod_name md
+        let uu____824 =
+          let uu____829 =
+            let uu____830 =
+              let uu___99_831 = md  in
+              let uu____832 =
+                let uu____834 = FStar_Interactive_CompletionTable.mod_name md
                    in
-                Prims.op_Hat uu____836 "."  in
+                Prims.op_Hat uu____834 "."  in
               {
-                FStar_Interactive_CompletionTable.mod_name = uu____834;
+                FStar_Interactive_CompletionTable.mod_name = uu____832;
                 FStar_Interactive_CompletionTable.mod_path =
-                  (uu___99_833.FStar_Interactive_CompletionTable.mod_path);
+                  (uu___99_831.FStar_Interactive_CompletionTable.mod_path);
                 FStar_Interactive_CompletionTable.mod_loaded =
-                  (uu___99_833.FStar_Interactive_CompletionTable.mod_loaded)
+                  (uu___99_831.FStar_Interactive_CompletionTable.mod_loaded)
               }  in
-            FStar_Interactive_CompletionTable.Module uu____832  in
-          (pth, uu____831)  in
-        FStar_Pervasives_Native.Some uu____826
+            FStar_Interactive_CompletionTable.Module uu____830  in
+          (pth, uu____829)  in
+        FStar_Pervasives_Native.Some uu____824
   
 let (ck_completion :
   FStar_Interactive_JsonHelper.repl_state ->
@@ -213,20 +213,20 @@ let (deflookup :
   =
   fun env  ->
     fun pos  ->
-      let uu____886 =
-        let uu____889 =
-          let uu____892 = FStar_Interactive_JsonHelper.pos_munge pos  in
-          FStar_Pervasives_Native.Some uu____892  in
-        symlookup env "" uu____889 ["defined-at"]  in
-      match uu____886 with
+      let uu____884 =
+        let uu____887 =
+          let uu____890 = FStar_Interactive_JsonHelper.pos_munge pos  in
+          FStar_Pervasives_Native.Some uu____890  in
+        symlookup env "" uu____887 ["defined-at"]  in
+      match uu____884 with
       | FStar_Pervasives_Native.Some
-          { slr_name = uu____899;
+          { slr_name = uu____897;
             slr_def_range = FStar_Pervasives_Native.Some r;
-            slr_typ = uu____901; slr_doc = uu____902; slr_def = uu____903;_}
+            slr_typ = uu____899; slr_doc = uu____900; slr_def = uu____901;_}
           ->
-          let uu____914 = FStar_Interactive_JsonHelper.js_loclink r  in
-          FStar_Interactive_JsonHelper.resultResponse uu____914
-      | uu____915 -> FStar_Interactive_JsonHelper.nullResponse
+          let uu____912 = FStar_Interactive_JsonHelper.js_loclink r  in
+          FStar_Interactive_JsonHelper.resultResponse uu____912
+      | uu____913 -> FStar_Interactive_JsonHelper.nullResponse
   
 let (hoverlookup :
   FStar_TypeChecker_Env.env ->
@@ -235,15 +235,15 @@ let (hoverlookup :
   =
   fun env  ->
     fun pos  ->
-      let uu____933 =
-        let uu____936 =
-          let uu____939 = FStar_Interactive_JsonHelper.pos_munge pos  in
-          FStar_Pervasives_Native.Some uu____939  in
-        symlookup env "" uu____936 ["type"; "definition"]  in
-      match uu____933 with
+      let uu____931 =
+        let uu____934 =
+          let uu____937 = FStar_Interactive_JsonHelper.pos_munge pos  in
+          FStar_Pervasives_Native.Some uu____937  in
+        symlookup env "" uu____934 ["type"; "definition"]  in
+      match uu____931 with
       | FStar_Pervasives_Native.Some
-          { slr_name = n; slr_def_range = uu____949;
-            slr_typ = FStar_Pervasives_Native.Some t; slr_doc = uu____951;
+          { slr_name = n; slr_def_range = uu____947;
+            slr_typ = FStar_Pervasives_Native.Some t; slr_doc = uu____949;
             slr_def = FStar_Pervasives_Native.Some d;_}
           ->
           let hovertxt =
@@ -256,7 +256,7 @@ let (hoverlookup :
                   (FStar_Util.JsonAssoc
                      [("kind", (FStar_Util.JsonStr "markdown"));
                      ("value", (FStar_Util.JsonStr hovertxt))]))])
-      | uu____998 -> FStar_Interactive_JsonHelper.nullResponse
+      | uu____996 -> FStar_Interactive_JsonHelper.nullResponse
   
 let (complookup :
   FStar_Interactive_JsonHelper.repl_state ->
@@ -265,12 +265,12 @@ let (complookup :
   =
   fun st  ->
     fun pos  ->
-      let uu____1016 = FStar_Interactive_JsonHelper.pos_munge pos  in
-      match uu____1016 with
+      let uu____1014 = FStar_Interactive_JsonHelper.pos_munge pos  in
+      match uu____1014 with
       | (file,row,current_col) ->
-          let uu____1037 = FStar_Parser_ParseIt.read_vfs_entry file  in
-          (match uu____1037 with
-           | FStar_Pervasives_Native.Some (uu____1047,text) ->
+          let uu____1035 = FStar_Parser_ParseIt.read_vfs_entry file  in
+          (match uu____1035 with
+           | FStar_Pervasives_Native.Some (uu____1045,text) ->
                let rec find_col l =
                  match l with
                  | [] -> Prims.int_zero
@@ -288,18 +288,18 @@ let (complookup :
                    if i < Prims.int_zero
                    then l
                    else
-                     (let uu____1132 =
-                        let uu____1136 = FStar_String.get s i  in uu____1136
+                     (let uu____1130 =
+                        let uu____1134 = FStar_String.get s i  in uu____1134
                           :: l
                          in
-                      exp (i - Prims.int_one) uu____1132)
+                      exp (i - Prims.int_one) uu____1130)
                     in
                  exp ((FStar_String.length s) - Prims.int_one) []  in
                let begin_col =
-                 let uu____1144 =
-                   let uu____1148 = explode str  in FStar_List.rev uu____1148
+                 let uu____1142 =
+                   let uu____1146 = explode str  in FStar_List.rev uu____1146
                     in
-                 find_col uu____1144  in
+                 find_col uu____1142  in
                let term =
                  FStar_Util.substring str begin_col (current_col - begin_col)
                   in

--- a/src/ocaml-output/FStar_Main.ml
+++ b/src/ocaml-output/FStar_Main.ml
@@ -26,177 +26,176 @@ let (finished_message :
                        if iface then "i'face (or impl+i'face)" else "module"
                         in
                      let uu____109 =
-                       FStar_Options.should_print_message
-                         name.FStar_Ident.str
-                        in
+                       let uu____111 = FStar_Ident.string_of_lid name  in
+                       FStar_Options.should_print_message uu____111  in
                      if uu____109
                      then
-                       let uu____112 =
-                         let uu____114 = FStar_Ident.text_of_lid name  in
-                         FStar_Util.format2 "Verified %s: %s\n" tag uu____114
+                       let uu____114 =
+                         let uu____116 = FStar_Ident.string_of_lid name  in
+                         FStar_Util.format2 "Verified %s: %s\n" tag uu____116
                           in
-                       print_to uu____112
+                       print_to uu____114
                      else ()));
          if errs > Prims.int_zero
          then
            (if errs = Prims.int_one
             then FStar_Util.print_error "1 error was reported (see above)\n"
             else
-              (let uu____127 = FStar_Util.string_of_int errs  in
+              (let uu____129 = FStar_Util.string_of_int errs  in
                FStar_Util.print1_error
-                 "%s errors were reported (see above)\n" uu____127))
+                 "%s errors were reported (see above)\n" uu____129))
          else
-           (let uu____132 =
+           (let uu____134 =
               FStar_Util.colorize_bold
                 "All verification conditions discharged successfully"
                in
-            FStar_Util.print1 "%s\n" uu____132))
+            FStar_Util.print1 "%s\n" uu____134))
       else ()
   
 let (report_errors : (Prims.bool * FStar_Ident.lident) Prims.list -> unit) =
   fun fmods  ->
-    (let uu____159 = FStar_Errors.report_all ()  in
-     FStar_All.pipe_right uu____159 (fun uu____164  -> ()));
+    (let uu____161 = FStar_Errors.report_all ()  in
+     FStar_All.pipe_right uu____161 (fun uu____166  -> ()));
     (let nerrs = FStar_Errors.get_err_count ()  in
      if nerrs > Prims.int_zero
      then (finished_message fmods nerrs; FStar_All.exit Prims.int_one)
      else ())
   
 let (load_native_tactics : unit -> unit) =
-  fun uu____178  ->
+  fun uu____180  ->
     let modules_to_load =
-      let uu____182 = FStar_Options.load ()  in
-      FStar_All.pipe_right uu____182 (FStar_List.map FStar_Ident.lid_of_str)
+      let uu____184 = FStar_Options.load ()  in
+      FStar_All.pipe_right uu____184 (FStar_List.map FStar_Ident.lid_of_str)
        in
     let ml_module_name m = FStar_Extraction_ML_Util.ml_module_name_of_lid m
        in
     let ml_file m =
-      let uu____206 = ml_module_name m  in Prims.op_Hat uu____206 ".ml"  in
+      let uu____208 = ml_module_name m  in Prims.op_Hat uu____208 ".ml"  in
     let cmxs_file m =
       let cmxs =
-        let uu____218 = ml_module_name m  in Prims.op_Hat uu____218 ".cmxs"
+        let uu____220 = ml_module_name m  in Prims.op_Hat uu____220 ".cmxs"
          in
-      let uu____221 = FStar_Options.find_file cmxs  in
-      match uu____221 with
+      let uu____223 = FStar_Options.find_file cmxs  in
+      match uu____223 with
       | FStar_Pervasives_Native.Some f -> f
       | FStar_Pervasives_Native.None  ->
-          let uu____230 =
-            let uu____234 = ml_file m  in FStar_Options.find_file uu____234
+          let uu____232 =
+            let uu____236 = ml_file m  in FStar_Options.find_file uu____236
              in
-          (match uu____230 with
+          (match uu____232 with
            | FStar_Pervasives_Native.None  ->
-               let uu____238 =
-                 let uu____244 =
-                   let uu____246 = ml_file m  in
+               let uu____240 =
+                 let uu____246 =
+                   let uu____248 = ml_file m  in
                    FStar_Util.format1
                      "Failed to compile native tactic; extracted module %s not found"
-                     uu____246
+                     uu____248
                     in
-                 (FStar_Errors.Fatal_FailToCompileNativeTactic, uu____244)
+                 (FStar_Errors.Fatal_FailToCompileNativeTactic, uu____246)
                   in
-               FStar_Errors.raise_err uu____238
+               FStar_Errors.raise_err uu____240
            | FStar_Pervasives_Native.Some ml ->
                let dir = FStar_Util.dirname ml  in
-               ((let uu____257 =
-                   let uu____261 = ml_module_name m  in [uu____261]  in
-                 FStar_Tactics_Load.compile_modules dir uu____257);
-                (let uu____265 = FStar_Options.find_file cmxs  in
-                 match uu____265 with
+               ((let uu____259 =
+                   let uu____263 = ml_module_name m  in [uu____263]  in
+                 FStar_Tactics_Load.compile_modules dir uu____259);
+                (let uu____267 = FStar_Options.find_file cmxs  in
+                 match uu____267 with
                  | FStar_Pervasives_Native.None  ->
-                     let uu____271 =
-                       let uu____277 =
+                     let uu____273 =
+                       let uu____279 =
                          FStar_Util.format1
                            "Failed to compile native tactic; compiled object %s not found"
                            cmxs
                           in
                        (FStar_Errors.Fatal_FailToCompileNativeTactic,
-                         uu____277)
+                         uu____279)
                         in
-                     FStar_Errors.raise_err uu____271
+                     FStar_Errors.raise_err uu____273
                  | FStar_Pervasives_Native.Some f -> f)))
        in
     let cmxs_files =
       FStar_All.pipe_right modules_to_load (FStar_List.map cmxs_file)  in
     FStar_List.iter (fun x  -> FStar_Util.print1 "cmxs file: %s\n" x)
       cmxs_files;
-    (let uu____302 =
-       (let uu____306 = FStar_Options.no_load_fstartaclib ()  in
-        Prims.op_Negation uu____306) &&
+    (let uu____304 =
+       (let uu____308 = FStar_Options.no_load_fstartaclib ()  in
+        Prims.op_Negation uu____308) &&
          (Prims.op_Negation (FStar_Platform.system = FStar_Platform.Windows))
         in
-     if uu____302 then FStar_Tactics_Load.try_load_lib () else ());
+     if uu____304 then FStar_Tactics_Load.try_load_lib () else ());
     FStar_Tactics_Load.load_tactics cmxs_files;
-    (let uu____313 = FStar_Options.use_native_tactics ()  in
-     FStar_Util.iter_opt uu____313 FStar_Tactics_Load.load_tactics_dir)
+    (let uu____315 = FStar_Options.use_native_tactics ()  in
+     FStar_Util.iter_opt uu____315 FStar_Tactics_Load.load_tactics_dir)
   
 let (fstar_files :
   Prims.string Prims.list FStar_Pervasives_Native.option FStar_ST.ref) =
   FStar_Util.mk_ref FStar_Pervasives_Native.None 
-let go : 'uuuuuu339 . 'uuuuuu339 -> unit =
-  fun uu____344  ->
-    let uu____345 = process_args ()  in
-    match uu____345 with
+let go : 'uuuuuu341 . 'uuuuuu341 -> unit =
+  fun uu____346  ->
+    let uu____347 = process_args ()  in
+    match uu____347 with
     | (res,filenames) ->
         (match res with
          | FStar_Getopt.Help  ->
              (FStar_Options.display_usage (); FStar_All.exit Prims.int_zero)
          | FStar_Getopt.Error msg ->
              (FStar_Util.print_error msg; FStar_All.exit Prims.int_one)
-         | uu____367 when FStar_Options.print_cache_version () ->
-             ((let uu____369 =
+         | uu____369 when FStar_Options.print_cache_version () ->
+             ((let uu____371 =
                  FStar_Util.string_of_int
                    FStar_CheckedFiles.cache_version_number
                   in
-               FStar_Util.print1 "F* cache version number: %s\n" uu____369);
+               FStar_Util.print1 "F* cache version number: %s\n" uu____371);
               FStar_All.exit Prims.int_zero)
          | FStar_Getopt.Success  ->
              (FStar_ST.op_Colon_Equals fstar_files
                 (FStar_Pervasives_Native.Some filenames);
-              (let uu____406 =
-                 let uu____408 = FStar_Options.dep ()  in
-                 uu____408 <> FStar_Pervasives_Native.None  in
-               if uu____406
+              (let uu____408 =
+                 let uu____410 = FStar_Options.dep ()  in
+                 uu____410 <> FStar_Pervasives_Native.None  in
+               if uu____408
                then
-                 let uu____417 =
+                 let uu____419 =
                    FStar_Parser_Dep.collect filenames
                      FStar_CheckedFiles.load_parsing_data_from_cache
                     in
-                 match uu____417 with
-                 | (uu____425,deps) -> FStar_Parser_Dep.print deps
+                 match uu____419 with
+                 | (uu____427,deps) -> FStar_Parser_Dep.print deps
                else
-                 (let uu____435 =
+                 (let uu____437 =
                     ((FStar_Options.use_extracted_interfaces ()) &&
-                       (let uu____438 = FStar_Options.expose_interfaces ()
+                       (let uu____440 = FStar_Options.expose_interfaces ()
                            in
-                        Prims.op_Negation uu____438))
+                        Prims.op_Negation uu____440))
                       && ((FStar_List.length filenames) > Prims.int_one)
                      in
-                  if uu____435
+                  if uu____437
                   then
-                    let uu____443 =
-                      let uu____449 =
-                        let uu____451 =
+                    let uu____445 =
+                      let uu____451 =
+                        let uu____453 =
                           FStar_Util.string_of_int
                             (FStar_List.length filenames)
                            in
                         Prims.op_Hat
                           "Only one command line file is allowed if --use_extracted_interfaces is set, found "
-                          uu____451
+                          uu____453
                          in
-                      (FStar_Errors.Error_TooManyFiles, uu____449)  in
-                    FStar_Errors.raise_error uu____443 FStar_Range.dummyRange
+                      (FStar_Errors.Error_TooManyFiles, uu____451)  in
+                    FStar_Errors.raise_error uu____445 FStar_Range.dummyRange
                   else
-                    (let uu____458 =
+                    (let uu____460 =
                        (FStar_Options.print ()) ||
                          (FStar_Options.print_in_place ())
                         in
-                     if uu____458
+                     if uu____460
                      then
                        (if FStar_Platform.is_fstar_compiler_using_ocaml
                         then
                           let printing_mode =
-                            let uu____463 = FStar_Options.print ()  in
-                            if uu____463
+                            let uu____465 = FStar_Options.print ()  in
+                            if uu____465
                             then FStar_Prettyprint.FromTempToStdout
                             else FStar_Prettyprint.FromTempToFile  in
                           FStar_Prettyprint.generate printing_mode filenames
@@ -204,13 +203,13 @@ let go : 'uuuuuu339 . 'uuuuuu339 -> unit =
                           failwith
                             "You seem to be using the F#-generated version ofthe compiler ; \\o\n                         reindenting is not known to work yet with this version")
                      else
-                       (let uu____473 = FStar_Options.lsp_server ()  in
-                        if uu____473
+                       (let uu____475 = FStar_Options.lsp_server ()  in
+                        if uu____475
                         then FStar_Interactive_Lsp.start_server ()
                         else
                           (load_native_tactics ();
-                           (let uu____479 = FStar_Options.interactive ()  in
-                            if uu____479
+                           (let uu____481 = FStar_Options.interactive ()  in
+                            if uu____481
                             then
                               match filenames with
                               | [] ->
@@ -219,16 +218,16 @@ let go : 'uuuuuu339 . 'uuuuuu339 -> unit =
                                      (FStar_Errors.Error_MissingFileName,
                                        "--ide: Name of current file missing in command line invocation\n");
                                    FStar_All.exit Prims.int_one)
-                              | uu____487::uu____488::uu____489 ->
+                              | uu____489::uu____490::uu____491 ->
                                   (FStar_Errors.log_issue
                                      FStar_Range.dummyRange
                                      (FStar_Errors.Error_TooManyFiles,
                                        "--ide: Too many files in command line invocation\n");
                                    FStar_All.exit Prims.int_one)
                               | filename::[] ->
-                                  let uu____505 =
+                                  let uu____507 =
                                     FStar_Options.legacy_interactive ()  in
-                                  (if uu____505
+                                  (if uu____507
                                    then
                                      FStar_Interactive_Legacy.interactive_mode
                                        filename
@@ -240,20 +239,20 @@ let go : 'uuuuuu339 . 'uuuuuu339 -> unit =
                                 (FStar_List.length filenames) >=
                                   Prims.int_one
                               then
-                                (let uu____515 =
+                                (let uu____517 =
                                    FStar_Dependencies.find_deps_if_needed
                                      filenames
                                      FStar_CheckedFiles.load_parsing_data_from_cache
                                     in
-                                 match uu____515 with
+                                 match uu____517 with
                                  | (filenames1,dep_graph) ->
-                                     let uu____531 =
+                                     let uu____533 =
                                        FStar_Universal.batch_mode_tc
                                          filenames1 dep_graph
                                         in
-                                     (match uu____531 with
+                                     (match uu____533 with
                                       | (tcrs,env,cleanup1) ->
-                                          ((let uu____557 = cleanup1 env  in
+                                          ((let uu____559 = cleanup1 env  in
                                             ());
                                            (let module_names =
                                               FStar_All.pipe_right tcrs
@@ -301,11 +300,11 @@ let (lazy_chooser :
           FStar_Tactics_Embedding.unfold_lazy_goal i
       | FStar_Syntax_Syntax.Lazy_uvar  ->
           FStar_Syntax_Util.exp_string "((uvar))"
-      | FStar_Syntax_Syntax.Lazy_embedding (uu____607,t) ->
+      | FStar_Syntax_Syntax.Lazy_embedding (uu____609,t) ->
           FStar_Thunk.force t
   
 let (setup_hooks : unit -> unit) =
-  fun uu____624  ->
+  fun uu____626  ->
     FStar_Options.initialize_parse_warn_error
       FStar_Parser_ParseIt.parse_warn_error;
     FStar_ST.op_Colon_Equals FStar_Syntax_Syntax.lazy_chooser
@@ -320,47 +319,47 @@ let (setup_hooks : unit -> unit) =
 let (handle_error : Prims.exn -> unit) =
   fun e  ->
     if FStar_Errors.handleable e then FStar_Errors.err_exn e else ();
-    (let uu____775 = FStar_Options.trace_error ()  in
-     if uu____775
+    (let uu____777 = FStar_Options.trace_error ()  in
+     if uu____777
      then
-       let uu____778 = FStar_Util.message_of_exn e  in
-       let uu____780 = FStar_Util.trace_of_exn e  in
-       FStar_Util.print2_error "Unexpected error\n%s\n%s\n" uu____778
-         uu____780
+       let uu____780 = FStar_Util.message_of_exn e  in
+       let uu____782 = FStar_Util.trace_of_exn e  in
+       FStar_Util.print2_error "Unexpected error\n%s\n%s\n" uu____780
+         uu____782
      else
        if Prims.op_Negation (FStar_Errors.handleable e)
        then
-         (let uu____786 = FStar_Util.message_of_exn e  in
+         (let uu____788 = FStar_Util.message_of_exn e  in
           FStar_Util.print1_error
             "Unexpected error; please file a bug report, ideally with a minimized version of the source program that triggered the error.\n%s\n"
-            uu____786)
+            uu____788)
        else ());
     cleanup ();
     report_errors []
   
-let main : 'uuuuuu802 . unit -> 'uuuuuu802 =
-  fun uu____807  ->
+let main : 'uuuuuu804 . unit -> 'uuuuuu804 =
+  fun uu____809  ->
     try
-      (fun uu___129_815  ->
+      (fun uu___129_817  ->
          match () with
          | () ->
              (setup_hooks ();
-              (let uu____817 = FStar_Util.record_time go  in
-               match uu____817 with
-               | (uu____823,time) ->
-                   ((let uu____828 = FStar_Options.query_stats ()  in
-                     if uu____828
+              (let uu____819 = FStar_Util.record_time go  in
+               match uu____819 with
+               | (uu____825,time) ->
+                   ((let uu____830 = FStar_Options.query_stats ()  in
+                     if uu____830
                      then
-                       let uu____831 = FStar_Util.string_of_int time  in
-                       let uu____833 =
-                         let uu____835 = FStar_Getopt.cmdline ()  in
-                         FStar_String.concat " " uu____835  in
+                       let uu____833 = FStar_Util.string_of_int time  in
+                       let uu____835 =
+                         let uu____837 = FStar_Getopt.cmdline ()  in
+                         FStar_String.concat " " uu____837  in
                        FStar_Util.print2_error "TOTAL TIME %s ms: %s\n"
-                         uu____831 uu____833
+                         uu____833 uu____835
                      else ());
                     cleanup ();
                     FStar_All.exit Prims.int_zero)))) ()
     with
-    | uu___128_847 ->
-        (handle_error uu___128_847; FStar_All.exit Prims.int_one)
+    | uu___128_849 ->
+        (handle_error uu___128_849; FStar_All.exit Prims.int_one)
   

--- a/src/ocaml-output/FStar_Parser_AST.ml
+++ b/src/ocaml-output/FStar_Parser_AST.ml
@@ -990,26 +990,27 @@ let (decl_drange : decl -> FStar_Range.range) = fun decl1  -> decl1.drange
 let (check_id : FStar_Ident.ident -> unit) =
   fun id  ->
     let first_char =
-      FStar_String.substring id.FStar_Ident.idText Prims.int_zero
-        Prims.int_one
-       in
+      let uu____5079 = FStar_Ident.text_of_id id  in
+      FStar_String.substring uu____5079 Prims.int_zero Prims.int_one  in
     if (FStar_String.lowercase first_char) = first_char
     then ()
     else
-      (let uu____5085 =
-         let uu____5091 =
+      (let uu____5087 =
+         let uu____5093 =
+           let uu____5095 = FStar_Ident.text_of_id id  in
            FStar_Util.format1
              "Invalid identifer '%s'; expected a symbol that begins with a lower-case character"
-             id.FStar_Ident.idText
+             uu____5095
             in
-         (FStar_Errors.Fatal_InvalidIdentifier, uu____5091)  in
-       FStar_Errors.raise_error uu____5085 id.FStar_Ident.idRange)
+         (FStar_Errors.Fatal_InvalidIdentifier, uu____5093)  in
+       let uu____5099 = FStar_Ident.range_of_id id  in
+       FStar_Errors.raise_error uu____5087 uu____5099)
   
 let at_most_one :
-  'uuuuuu5104 .
+  'uuuuuu5109 .
     Prims.string ->
       FStar_Range.range ->
-        'uuuuuu5104 Prims.list -> 'uuuuuu5104 FStar_Pervasives_Native.option
+        'uuuuuu5109 Prims.list -> 'uuuuuu5109 FStar_Pervasives_Native.option
   =
   fun s  ->
     fun r  ->
@@ -1017,35 +1018,35 @@ let at_most_one :
         match l with
         | x::[] -> FStar_Pervasives_Native.Some x
         | [] -> FStar_Pervasives_Native.None
-        | uu____5129 ->
-            let uu____5132 =
-              let uu____5138 =
+        | uu____5134 ->
+            let uu____5137 =
+              let uu____5143 =
                 FStar_Util.format1
                   "At most one %s is allowed on declarations" s
                  in
-              (FStar_Errors.Fatal_MoreThanOneDeclaration, uu____5138)  in
-            FStar_Errors.raise_error uu____5132 r
+              (FStar_Errors.Fatal_MoreThanOneDeclaration, uu____5143)  in
+            FStar_Errors.raise_error uu____5137 r
   
 let (mk_decl : decl' -> FStar_Range.range -> decoration Prims.list -> decl) =
   fun d  ->
     fun r  ->
       fun decorations  ->
         let attributes_1 =
-          let uu____5169 =
+          let uu____5174 =
             FStar_List.choose
-              (fun uu___0_5178  ->
-                 match uu___0_5178 with
+              (fun uu___0_5183  ->
+                 match uu___0_5183 with
                  | DeclAttributes a -> FStar_Pervasives_Native.Some a
-                 | uu____5188 -> FStar_Pervasives_Native.None) decorations
+                 | uu____5193 -> FStar_Pervasives_Native.None) decorations
              in
-          at_most_one "attribute set" r uu____5169  in
+          at_most_one "attribute set" r uu____5174  in
         let attributes_2 = FStar_Util.dflt [] attributes_1  in
         let qualifiers1 =
           FStar_List.choose
-            (fun uu___1_5204  ->
-               match uu___1_5204 with
+            (fun uu___1_5209  ->
+               match uu___1_5209 with
                | Qualifier q -> FStar_Pervasives_Native.Some q
-               | uu____5208 -> FStar_Pervasives_Native.None) decorations
+               | uu____5213 -> FStar_Pervasives_Native.None) decorations
            in
         { d; drange = r; quals = qualifiers1; attrs = attributes_2 }
   
@@ -1075,11 +1076,11 @@ let (mk_uminus :
                      ((Prims.op_Hat "-" s),
                        (FStar_Pervasives_Native.Some
                           (FStar_Const.Signed, width))))
-            | uu____5298 ->
-                let uu____5299 =
-                  let uu____5306 = FStar_Ident.mk_ident ("-", rminus)  in
-                  (uu____5306, [t])  in
-                Op uu____5299
+            | uu____5303 ->
+                let uu____5304 =
+                  let uu____5311 = FStar_Ident.mk_ident ("-", rminus)  in
+                  (uu____5311, [t])  in
+                Op uu____5304
              in
           mk_term t1 r l
   
@@ -1090,7 +1091,7 @@ let (un_curry_abs : pattern Prims.list -> term -> term') =
     fun body  ->
       match body.tm with
       | Abs (p',body') -> Abs ((FStar_List.append ps p'), body')
-      | uu____5345 -> Abs (ps, body)
+      | uu____5350 -> Abs (ps, body)
   
 let (mk_function :
   (pattern * term FStar_Pervasives_Native.option * term) Prims.list ->
@@ -1100,41 +1101,41 @@ let (mk_function :
     fun r1  ->
       fun r2  ->
         let x = FStar_Ident.gen r1  in
-        let uu____5385 =
-          let uu____5386 =
-            let uu____5393 =
-              let uu____5394 =
-                let uu____5395 =
-                  let uu____5410 =
-                    let uu____5411 =
-                      let uu____5412 = FStar_Ident.lid_of_ids [x]  in
-                      Var uu____5412  in
-                    mk_term uu____5411 r1 Expr  in
-                  (uu____5410, branches)  in
-                Match uu____5395  in
-              mk_term uu____5394 r2 Expr  in
+        let uu____5390 =
+          let uu____5391 =
+            let uu____5398 =
+              let uu____5399 =
+                let uu____5400 =
+                  let uu____5415 =
+                    let uu____5416 =
+                      let uu____5417 = FStar_Ident.lid_of_ids [x]  in
+                      Var uu____5417  in
+                    mk_term uu____5416 r1 Expr  in
+                  (uu____5415, branches)  in
+                Match uu____5400  in
+              mk_term uu____5399 r2 Expr  in
             ([mk_pattern (PatVar (x, FStar_Pervasives_Native.None)) r1],
-              uu____5393)
+              uu____5398)
              in
-          Abs uu____5386  in
-        mk_term uu____5385 r2 Expr
+          Abs uu____5391  in
+        mk_term uu____5390 r2 Expr
   
 let (un_function :
   pattern -> term -> (pattern * term) FStar_Pervasives_Native.option) =
   fun p  ->
     fun tm  ->
       match ((p.pat), (tm.tm)) with
-      | (PatVar uu____5450,Abs (pats,body)) ->
+      | (PatVar uu____5455,Abs (pats,body)) ->
           FStar_Pervasives_Native.Some
             ((mk_pattern (PatApp (p, pats)) p.prange), body)
-      | uu____5469 -> FStar_Pervasives_Native.None
+      | uu____5474 -> FStar_Pervasives_Native.None
   
 let (lid_with_range :
   FStar_Ident.lident -> FStar_Range.range -> FStar_Ident.lident) =
   fun lid  ->
     fun r  ->
-      let uu____5489 = FStar_Ident.path_of_lid lid  in
-      FStar_Ident.lid_of_path uu____5489 r
+      let uu____5494 = FStar_Ident.path_of_lid lid  in
+      FStar_Ident.lid_of_path uu____5494 r
   
 let (consPat : FStar_Range.range -> pattern -> pattern -> pattern') =
   fun r  ->
@@ -1193,46 +1194,46 @@ let (mkApp : term -> (term * imp) Prims.list -> FStar_Range.range -> term) =
       fun r  ->
         match args with
         | [] -> t
-        | uu____5684 ->
+        | uu____5689 ->
             (match t.tm with
              | Name s -> mk_term (Construct (s, args)) r Un
-             | uu____5698 ->
+             | uu____5703 ->
                  FStar_List.fold_left
                    (fun t1  ->
-                      fun uu____5708  ->
-                        match uu____5708 with
+                      fun uu____5713  ->
+                        match uu____5713 with
                         | (a,imp1) -> mk_term (App (t1, a, imp1)) r Un) t
                    args)
   
 let (mkRefSet : FStar_Range.range -> term Prims.list -> term) =
   fun r  ->
     fun elts  ->
-      let uu____5730 =
+      let uu____5735 =
         (FStar_Parser_Const.set_empty, FStar_Parser_Const.set_singleton,
           FStar_Parser_Const.set_union, FStar_Parser_Const.heap_addr_of_lid)
          in
-      match uu____5730 with
+      match uu____5735 with
       | (empty_lid,singleton_lid,union_lid,addr_of_lid) ->
           let empty =
-            let uu____5744 =
-              let uu____5745 = FStar_Ident.set_lid_range empty_lid r  in
-              Var uu____5745  in
-            mk_term uu____5744 r Expr  in
+            let uu____5749 =
+              let uu____5750 = FStar_Ident.set_lid_range empty_lid r  in
+              Var uu____5750  in
+            mk_term uu____5749 r Expr  in
           let addr_of =
-            let uu____5747 =
-              let uu____5748 = FStar_Ident.set_lid_range addr_of_lid r  in
-              Var uu____5748  in
-            mk_term uu____5747 r Expr  in
+            let uu____5752 =
+              let uu____5753 = FStar_Ident.set_lid_range addr_of_lid r  in
+              Var uu____5753  in
+            mk_term uu____5752 r Expr  in
           let singleton =
-            let uu____5750 =
-              let uu____5751 = FStar_Ident.set_lid_range singleton_lid r  in
-              Var uu____5751  in
-            mk_term uu____5750 r Expr  in
+            let uu____5755 =
+              let uu____5756 = FStar_Ident.set_lid_range singleton_lid r  in
+              Var uu____5756  in
+            mk_term uu____5755 r Expr  in
           let union =
-            let uu____5753 =
-              let uu____5754 = FStar_Ident.set_lid_range union_lid r  in
-              Var uu____5754  in
-            mk_term uu____5753 r Expr  in
+            let uu____5758 =
+              let uu____5759 = FStar_Ident.set_lid_range union_lid r  in
+              Var uu____5759  in
+            mk_term uu____5758 r Expr  in
           FStar_List.fold_right
             (fun e  ->
                fun tl  ->
@@ -1247,17 +1248,17 @@ let (mkExplicitApp : term -> term Prims.list -> FStar_Range.range -> term) =
       fun r  ->
         match args with
         | [] -> t
-        | uu____5811 ->
+        | uu____5816 ->
             (match t.tm with
              | Name s ->
-                 let uu____5815 =
-                   let uu____5816 =
-                     let uu____5827 =
+                 let uu____5820 =
+                   let uu____5821 =
+                     let uu____5832 =
                        FStar_List.map (fun a  -> (a, Nothing)) args  in
-                     (s, uu____5827)  in
-                   Construct uu____5816  in
-                 mk_term uu____5815 r Un
-             | uu____5846 ->
+                     (s, uu____5832)  in
+                   Construct uu____5821  in
+                 mk_term uu____5820 r Un
+             | uu____5851 ->
                  FStar_List.fold_left
                    (fun t1  -> fun a  -> mk_term (App (t1, a, Nothing)) r Un)
                    t args)
@@ -1268,38 +1269,38 @@ let (mkAdmitMagic : FStar_Range.range -> term) =
   fun r  ->
     let admit =
       let admit_name =
-        let uu____5865 =
-          let uu____5866 =
+        let uu____5870 =
+          let uu____5871 =
             FStar_Ident.set_lid_range FStar_Parser_Const.admit_lid r  in
-          Var uu____5866  in
-        mk_term uu____5865 r Expr  in
+          Var uu____5871  in
+        mk_term uu____5870 r Expr  in
       mkExplicitApp admit_name [unit_const r] r  in
     let magic =
       let magic_name =
-        let uu____5869 =
-          let uu____5870 =
+        let uu____5874 =
+          let uu____5875 =
             FStar_Ident.set_lid_range FStar_Parser_Const.magic_lid r  in
-          Var uu____5870  in
-        mk_term uu____5869 r Expr  in
+          Var uu____5875  in
+        mk_term uu____5874 r Expr  in
       mkExplicitApp magic_name [unit_const r] r  in
     let admit_magic = mk_term (Seq (admit, magic)) r Expr  in admit_magic
   
 let mkWildAdmitMagic :
-  'uuuuuu5877 .
+  'uuuuuu5882 .
     FStar_Range.range ->
-      (pattern * 'uuuuuu5877 FStar_Pervasives_Native.option * term)
+      (pattern * 'uuuuuu5882 FStar_Pervasives_Native.option * term)
   =
   fun r  ->
-    let uu____5891 = mkAdmitMagic r  in
+    let uu____5896 = mkAdmitMagic r  in
     ((mk_pattern (PatWild FStar_Pervasives_Native.None) r),
-      FStar_Pervasives_Native.None, uu____5891)
+      FStar_Pervasives_Native.None, uu____5896)
   
 let focusBranches :
-  'uuuuuu5901 .
-    (Prims.bool * (pattern * 'uuuuuu5901 FStar_Pervasives_Native.option *
+  'uuuuuu5906 .
+    (Prims.bool * (pattern * 'uuuuuu5906 FStar_Pervasives_Native.option *
       term)) Prims.list ->
       FStar_Range.range ->
-        (pattern * 'uuuuuu5901 FStar_Pervasives_Native.option * term)
+        (pattern * 'uuuuuu5906 FStar_Pervasives_Native.option * term)
           Prims.list
   =
   fun branches  ->
@@ -1311,22 +1312,22 @@ let focusBranches :
         (FStar_Errors.log_issue r
            (FStar_Errors.Warning_Filtered, "Focusing on only some cases");
          (let focussed =
-            let uu____6001 =
+            let uu____6006 =
               FStar_List.filter FStar_Pervasives_Native.fst branches  in
-            FStar_All.pipe_right uu____6001
+            FStar_All.pipe_right uu____6006
               (FStar_List.map FStar_Pervasives_Native.snd)
              in
-          let uu____6094 =
-            let uu____6105 = mkWildAdmitMagic r  in [uu____6105]  in
-          FStar_List.append focussed uu____6094))
+          let uu____6099 =
+            let uu____6110 = mkWildAdmitMagic r  in [uu____6110]  in
+          FStar_List.append focussed uu____6099))
       else
         FStar_All.pipe_right branches
           (FStar_List.map FStar_Pervasives_Native.snd)
   
 let focusLetBindings :
-  'uuuuuu6202 .
-    (Prims.bool * ('uuuuuu6202 * term)) Prims.list ->
-      FStar_Range.range -> ('uuuuuu6202 * term) Prims.list
+  'uuuuuu6207 .
+    (Prims.bool * ('uuuuuu6207 * term)) Prims.list ->
+      FStar_Range.range -> ('uuuuuu6207 * term) Prims.list
   =
   fun lbs  ->
     fun r  ->
@@ -1338,28 +1339,28 @@ let focusLetBindings :
            (FStar_Errors.Warning_Filtered,
              "Focusing on only some cases in this (mutually) recursive definition");
          FStar_List.map
-           (fun uu____6283  ->
-              match uu____6283 with
+           (fun uu____6288  ->
+              match uu____6288 with
               | (f,lb) ->
                   if f
                   then lb
                   else
-                    (let uu____6316 = mkAdmitMagic r  in
-                     ((FStar_Pervasives_Native.fst lb), uu____6316))) lbs)
+                    (let uu____6321 = mkAdmitMagic r  in
+                     ((FStar_Pervasives_Native.fst lb), uu____6321))) lbs)
       else
         FStar_All.pipe_right lbs (FStar_List.map FStar_Pervasives_Native.snd)
   
 let focusAttrLetBindings :
-  'uuuuuu6363 'uuuuuu6364 .
-    ('uuuuuu6363 * (Prims.bool * ('uuuuuu6364 * term))) Prims.list ->
-      FStar_Range.range -> ('uuuuuu6363 * ('uuuuuu6364 * term)) Prims.list
+  'uuuuuu6368 'uuuuuu6369 .
+    ('uuuuuu6368 * (Prims.bool * ('uuuuuu6369 * term))) Prims.list ->
+      FStar_Range.range -> ('uuuuuu6368 * ('uuuuuu6369 * term)) Prims.list
   =
   fun lbs  ->
     fun r  ->
       let should_filter =
         FStar_Util.for_some
-          (fun uu____6434  ->
-             match uu____6434 with | (attr,(focus,uu____6451)) -> focus) lbs
+          (fun uu____6439  ->
+             match uu____6439 with | (attr,(focus,uu____6456)) -> focus) lbs
          in
       if should_filter
       then
@@ -1367,44 +1368,44 @@ let focusAttrLetBindings :
            (FStar_Errors.Warning_Filtered,
              "Focusing on only some cases in this (mutually) recursive definition");
          FStar_List.map
-           (fun uu____6510  ->
-              match uu____6510 with
+           (fun uu____6515  ->
+              match uu____6515 with
               | (attr,(f,lb)) ->
                   if f
                   then (attr, lb)
                   else
-                    (let uu____6569 =
-                       let uu____6574 = mkAdmitMagic r  in
-                       ((FStar_Pervasives_Native.fst lb), uu____6574)  in
-                     (attr, uu____6569))) lbs)
+                    (let uu____6574 =
+                       let uu____6579 = mkAdmitMagic r  in
+                       ((FStar_Pervasives_Native.fst lb), uu____6579)  in
+                     (attr, uu____6574))) lbs)
       else
         FStar_All.pipe_right lbs
           (FStar_List.map
-             (fun uu____6631  ->
-                match uu____6631 with | (attr,(uu____6654,lb)) -> (attr, lb)))
+             (fun uu____6636  ->
+                match uu____6636 with | (attr,(uu____6659,lb)) -> (attr, lb)))
   
 let (mkFsTypApp : term -> term Prims.list -> FStar_Range.range -> term) =
   fun t  ->
     fun args  ->
       fun r  ->
-        let uu____6699 = FStar_List.map (fun a  -> (a, FsTypApp)) args  in
-        mkApp t uu____6699 r
+        let uu____6704 = FStar_List.map (fun a  -> (a, FsTypApp)) args  in
+        mkApp t uu____6704 r
   
 let (mkTuple : term Prims.list -> FStar_Range.range -> term) =
   fun args  ->
     fun r  ->
       let cons =
         FStar_Parser_Const.mk_tuple_data_lid (FStar_List.length args) r  in
-      let uu____6728 = FStar_List.map (fun x  -> (x, Nothing)) args  in
-      mkApp (mk_term (Name cons) r Expr) uu____6728 r
+      let uu____6733 = FStar_List.map (fun x  -> (x, Nothing)) args  in
+      mkApp (mk_term (Name cons) r Expr) uu____6733 r
   
 let (mkDTuple : term Prims.list -> FStar_Range.range -> term) =
   fun args  ->
     fun r  ->
       let cons =
         FStar_Parser_Const.mk_dtuple_data_lid (FStar_List.length args) r  in
-      let uu____6757 = FStar_List.map (fun x  -> (x, Nothing)) args  in
-      mkApp (mk_term (Name cons) r Expr) uu____6757 r
+      let uu____6762 = FStar_List.map (fun x  -> (x, Nothing)) args  in
+      mkApp (mk_term (Name cons) r Expr) uu____6762 r
   
 let (mkRefinedBinder :
   FStar_Ident.ident ->
@@ -1459,36 +1460,36 @@ let (mkRefinedPattern :
                     if should_bind_pat
                     then
                       (match pat.pat with
-                       | PatVar (x,uu____6859) ->
+                       | PatVar (x,uu____6864) ->
                            mk_term
                              (Refine
                                 ((mk_binder (Annotated (x, t)) t_range
                                     Type_level FStar_Pervasives_Native.None),
                                   phi)) range Type_level
-                       | uu____6864 ->
+                       | uu____6869 ->
                            let x = FStar_Ident.gen t_range  in
                            let phi1 =
                              let x_var =
-                               let uu____6868 =
-                                 let uu____6869 = FStar_Ident.lid_of_ids [x]
+                               let uu____6873 =
+                                 let uu____6874 = FStar_Ident.lid_of_ids [x]
                                     in
-                                 Var uu____6869  in
-                               mk_term uu____6868 phi.range Formula  in
+                                 Var uu____6874  in
+                               mk_term uu____6873 phi.range Formula  in
                              let pat_branch =
                                (pat, FStar_Pervasives_Native.None, phi)  in
                              let otherwise_branch =
-                               let uu____6890 =
-                                 let uu____6891 =
-                                   let uu____6892 =
+                               let uu____6895 =
+                                 let uu____6896 =
+                                   let uu____6897 =
                                      FStar_Ident.lid_of_path ["False"]
                                        phi.range
                                       in
-                                   Name uu____6892  in
-                                 mk_term uu____6891 phi.range Formula  in
+                                   Name uu____6897  in
+                                 mk_term uu____6896 phi.range Formula  in
                                ((mk_pattern
                                    (PatWild FStar_Pervasives_Native.None)
                                    phi.range), FStar_Pervasives_Native.None,
-                                 uu____6890)
+                                 uu____6895)
                                 in
                              mk_term
                                (Match (x_var, [pat_branch; otherwise_branch]))
@@ -1520,20 +1521,20 @@ let rec (extract_named_refinement :
     | NamedTyp (x,t) ->
         FStar_Pervasives_Native.Some (x, t, FStar_Pervasives_Native.None)
     | Refine
-        ({ b = Annotated (x,t); brange = uu____6983; blevel = uu____6984;
-           aqual = uu____6985;_},t')
+        ({ b = Annotated (x,t); brange = uu____6988; blevel = uu____6989;
+           aqual = uu____6990;_},t')
         ->
         FStar_Pervasives_Native.Some
           (x, t, (FStar_Pervasives_Native.Some t'))
     | Paren t -> extract_named_refinement t
-    | uu____7000 -> FStar_Pervasives_Native.None
+    | uu____7005 -> FStar_Pervasives_Native.None
   
 let rec (as_mlist :
   ((FStar_Ident.lid * decl) * decl Prims.list) -> decl Prims.list -> modul) =
   fun cur  ->
     fun ds  ->
-      let uu____7044 = cur  in
-      match uu____7044 with
+      let uu____7049 = cur  in
+      match uu____7049 with
       | ((m_name,m_decl),cur1) ->
           (match ds with
            | [] -> Module (m_name, (m_decl :: (FStar_List.rev cur1)))
@@ -1543,40 +1544,40 @@ let rec (as_mlist :
                     FStar_Errors.raise_error
                       (FStar_Errors.Fatal_UnexpectedModuleDeclaration,
                         "Unexpected module declaration") d.drange
-                | uu____7075 -> as_mlist ((m_name, m_decl), (d :: cur1)) ds1))
+                | uu____7080 -> as_mlist ((m_name, m_decl), (d :: cur1)) ds1))
   
 let (as_frag :
   Prims.bool -> FStar_Range.range -> decl Prims.list -> inputFragment) =
   fun is_light  ->
     fun light_range  ->
       fun ds  ->
-        let uu____7104 =
+        let uu____7109 =
           match ds with
           | d::ds1 -> (d, ds1)
           | [] -> FStar_Exn.raise FStar_Errors.Empty_frag  in
-        match uu____7104 with
+        match uu____7109 with
         | (d,ds1) ->
             (match d.d with
              | TopLevelModule m ->
                  let ds2 =
                    if is_light
                    then
-                     let uu____7142 =
+                     let uu____7147 =
                        mk_decl (Pragma LightOff) light_range []  in
-                     uu____7142 :: ds1
+                     uu____7147 :: ds1
                    else ds1  in
                  let m1 = as_mlist ((m, d), []) ds2  in FStar_Util.Inl m1
-             | uu____7154 ->
+             | uu____7159 ->
                  let ds2 = d :: ds1  in
                  (FStar_List.iter
-                    (fun uu___2_7164  ->
-                       match uu___2_7164 with
-                       | { d = TopLevelModule uu____7165; drange = r;
-                           quals = uu____7167; attrs = uu____7168;_} ->
+                    (fun uu___2_7169  ->
+                       match uu___2_7169 with
+                       | { d = TopLevelModule uu____7170; drange = r;
+                           quals = uu____7172; attrs = uu____7173;_} ->
                            FStar_Errors.raise_error
                              (FStar_Errors.Fatal_UnexpectedModuleDeclaration,
                                "Unexpected module declaration") r
-                       | uu____7171 -> ()) ds2;
+                       | uu____7176 -> ()) ds2;
                   FStar_Util.Inr ds2))
   
 let (compile_op :
@@ -1584,8 +1585,8 @@ let (compile_op :
   fun arity  ->
     fun s  ->
       fun r  ->
-        let name_of_char uu___3_7202 =
-          match uu___3_7202 with
+        let name_of_char uu___3_7207 =
+          match uu___3_7207 with
           | 38 -> "Amp"
           | 64 -> "At"
           | 43 -> "Plus"
@@ -1622,238 +1623,241 @@ let (compile_op :
         | ".()" -> "op_Array_Access"
         | ".[||]" -> "op_Brack_Lens_Access"
         | ".(||)" -> "op_Lens_Access"
-        | uu____7272 ->
-            let uu____7274 =
-              let uu____7276 =
-                let uu____7280 = FStar_String.list_of_string s  in
-                FStar_List.map name_of_char uu____7280  in
-              FStar_String.concat "_" uu____7276  in
-            Prims.op_Hat "op_" uu____7274
+        | uu____7277 ->
+            let uu____7279 =
+              let uu____7281 =
+                let uu____7285 = FStar_String.list_of_string s  in
+                FStar_List.map name_of_char uu____7285  in
+              FStar_String.concat "_" uu____7281  in
+            Prims.op_Hat "op_" uu____7279
   
 let (compile_op' : Prims.string -> FStar_Range.range -> Prims.string) =
   fun s  -> fun r  -> compile_op (~- Prims.int_one) s r 
 let (string_of_fsdoc :
   (Prims.string * (Prims.string * Prims.string) Prims.list) -> Prims.string)
   =
-  fun uu____7322  ->
-    match uu____7322 with
+  fun uu____7327  ->
+    match uu____7327 with
     | (comment,keywords) ->
-        let uu____7357 =
-          let uu____7359 =
+        let uu____7362 =
+          let uu____7364 =
             FStar_List.map
-              (fun uu____7373  ->
-                 match uu____7373 with
+              (fun uu____7378  ->
+                 match uu____7378 with
                  | (k,v) -> Prims.op_Hat k (Prims.op_Hat "->" v)) keywords
              in
-          FStar_String.concat "," uu____7359  in
-        Prims.op_Hat comment uu____7357
+          FStar_String.concat "," uu____7364  in
+        Prims.op_Hat comment uu____7362
   
 let (string_of_let_qualifier : let_qualifier -> Prims.string) =
-  fun uu___4_7395  ->
-    match uu___4_7395 with | NoLetQualifier  -> "" | Rec  -> "rec"
+  fun uu___4_7400  ->
+    match uu___4_7400 with | NoLetQualifier  -> "" | Rec  -> "rec"
   
 let to_string_l :
-  'uuuuuu7408 .
+  'uuuuuu7413 .
     Prims.string ->
-      ('uuuuuu7408 -> Prims.string) -> 'uuuuuu7408 Prims.list -> Prims.string
+      ('uuuuuu7413 -> Prims.string) -> 'uuuuuu7413 Prims.list -> Prims.string
   =
   fun sep  ->
     fun f  ->
       fun l  ->
-        let uu____7438 = FStar_List.map f l  in
-        FStar_String.concat sep uu____7438
+        let uu____7443 = FStar_List.map f l  in
+        FStar_String.concat sep uu____7443
   
 let (imp_to_string : imp -> Prims.string) =
-  fun uu___5_7449  ->
-    match uu___5_7449 with | Hash  -> "#" | uu____7452 -> ""
+  fun uu___5_7454  ->
+    match uu___5_7454 with | Hash  -> "#" | uu____7457 -> ""
   
 let rec (term_to_string : term -> Prims.string) =
   fun x  ->
     match x.tm with
     | Wild  -> "_"
-    | Requires (t,uu____7495) ->
-        let uu____7502 = term_to_string t  in
-        FStar_Util.format1 "(requires %s)" uu____7502
-    | Ensures (t,uu____7506) ->
-        let uu____7513 = term_to_string t  in
-        FStar_Util.format1 "(ensures %s)" uu____7513
-    | Labeled (t,l,uu____7518) ->
-        let uu____7523 = term_to_string t  in
-        FStar_Util.format2 "(labeled %s %s)" l uu____7523
+    | Requires (t,uu____7500) ->
+        let uu____7507 = term_to_string t  in
+        FStar_Util.format1 "(requires %s)" uu____7507
+    | Ensures (t,uu____7511) ->
+        let uu____7518 = term_to_string t  in
+        FStar_Util.format1 "(ensures %s)" uu____7518
+    | Labeled (t,l,uu____7523) ->
+        let uu____7528 = term_to_string t  in
+        FStar_Util.format2 "(labeled %s %s)" l uu____7528
     | Const c -> FStar_Parser_Const.const_to_string c
     | Op (s,xs) ->
-        let uu____7533 = FStar_Ident.text_of_id s  in
-        let uu____7535 =
-          let uu____7537 =
+        let uu____7538 = FStar_Ident.text_of_id s  in
+        let uu____7540 =
+          let uu____7542 =
             FStar_List.map
               (fun x1  -> FStar_All.pipe_right x1 term_to_string) xs
              in
-          FStar_String.concat ", " uu____7537  in
-        FStar_Util.format2 "%s(%s)" uu____7533 uu____7535
-    | Tvar id -> id.FStar_Ident.idText
-    | Uvar id -> id.FStar_Ident.idText
-    | Var l -> l.FStar_Ident.str
-    | Name l -> l.FStar_Ident.str
+          FStar_String.concat ", " uu____7542  in
+        FStar_Util.format2 "%s(%s)" uu____7538 uu____7540
+    | Tvar id -> FStar_Ident.text_of_id id
+    | Uvar id -> FStar_Ident.text_of_id id
+    | Var l -> FStar_Ident.string_of_lid l
+    | Name l -> FStar_Ident.string_of_lid l
     | Projector (rec_lid,field_id) ->
-        let uu____7553 = FStar_Ident.string_of_lid rec_lid  in
-        FStar_Util.format2 "%s?.%s" uu____7553 field_id.FStar_Ident.idText
+        let uu____7558 = FStar_Ident.string_of_lid rec_lid  in
+        let uu____7560 = FStar_Ident.text_of_id field_id  in
+        FStar_Util.format2 "%s?.%s" uu____7558 uu____7560
     | Construct (l,args) ->
-        let uu____7570 =
+        let uu____7577 = FStar_Ident.string_of_lid l  in
+        let uu____7579 =
           to_string_l " "
-            (fun uu____7581  ->
-               match uu____7581 with
+            (fun uu____7590  ->
+               match uu____7590 with
                | (a,imp1) ->
-                   let uu____7589 = term_to_string a  in
-                   FStar_Util.format2 "%s%s" (imp_to_string imp1) uu____7589)
+                   let uu____7598 = term_to_string a  in
+                   FStar_Util.format2 "%s%s" (imp_to_string imp1) uu____7598)
             args
            in
-        FStar_Util.format2 "(%s %s)" l.FStar_Ident.str uu____7570
+        FStar_Util.format2 "(%s %s)" uu____7577 uu____7579
     | Abs (pats,t) ->
-        let uu____7599 = to_string_l " " pat_to_string pats  in
-        let uu____7602 = FStar_All.pipe_right t term_to_string  in
-        FStar_Util.format2 "(fun %s -> %s)" uu____7599 uu____7602
+        let uu____7608 = to_string_l " " pat_to_string pats  in
+        let uu____7611 = FStar_All.pipe_right t term_to_string  in
+        FStar_Util.format2 "(fun %s -> %s)" uu____7608 uu____7611
     | App (t1,t2,imp1) ->
-        let uu____7609 = FStar_All.pipe_right t1 term_to_string  in
-        let uu____7612 = FStar_All.pipe_right t2 term_to_string  in
-        FStar_Util.format3 "%s %s%s" uu____7609 (imp_to_string imp1)
-          uu____7612
+        let uu____7618 = FStar_All.pipe_right t1 term_to_string  in
+        let uu____7621 = FStar_All.pipe_right t2 term_to_string  in
+        FStar_Util.format3 "%s %s%s" uu____7618 (imp_to_string imp1)
+          uu____7621
     | Let (Rec ,(a,(p,b))::lbs,body) ->
-        let uu____7673 = attrs_opt_to_string a  in
-        let uu____7675 =
-          let uu____7677 = FStar_All.pipe_right p pat_to_string  in
-          let uu____7680 = FStar_All.pipe_right b term_to_string  in
-          FStar_Util.format2 "%s=%s" uu____7677 uu____7680  in
+        let uu____7682 = attrs_opt_to_string a  in
         let uu____7684 =
+          let uu____7686 = FStar_All.pipe_right p pat_to_string  in
+          let uu____7689 = FStar_All.pipe_right b term_to_string  in
+          FStar_Util.format2 "%s=%s" uu____7686 uu____7689  in
+        let uu____7693 =
           to_string_l " "
-            (fun uu____7706  ->
-               match uu____7706 with
+            (fun uu____7715  ->
+               match uu____7715 with
                | (a1,(p1,b1)) ->
-                   let uu____7735 = attrs_opt_to_string a1  in
-                   let uu____7737 = FStar_All.pipe_right p1 pat_to_string  in
-                   let uu____7740 = FStar_All.pipe_right b1 term_to_string
+                   let uu____7744 = attrs_opt_to_string a1  in
+                   let uu____7746 = FStar_All.pipe_right p1 pat_to_string  in
+                   let uu____7749 = FStar_All.pipe_right b1 term_to_string
                       in
-                   FStar_Util.format3 "%sand %s=%s" uu____7735 uu____7737
-                     uu____7740) lbs
+                   FStar_Util.format3 "%sand %s=%s" uu____7744 uu____7746
+                     uu____7749) lbs
            in
-        let uu____7744 = FStar_All.pipe_right body term_to_string  in
-        FStar_Util.format4 "%slet rec %s%s in %s" uu____7673 uu____7675
-          uu____7684 uu____7744
+        let uu____7753 = FStar_All.pipe_right body term_to_string  in
+        FStar_Util.format4 "%slet rec %s%s in %s" uu____7682 uu____7684
+          uu____7693 uu____7753
     | Let (q,(attrs,(pat,tm))::[],body) ->
-        let uu____7803 = attrs_opt_to_string attrs  in
-        let uu____7805 = FStar_All.pipe_right pat pat_to_string  in
-        let uu____7808 = FStar_All.pipe_right tm term_to_string  in
-        let uu____7811 = FStar_All.pipe_right body term_to_string  in
-        FStar_Util.format5 "%slet %s %s = %s in %s" uu____7803
-          (string_of_let_qualifier q) uu____7805 uu____7808 uu____7811
-    | Let (uu____7815,uu____7816,uu____7817) ->
+        let uu____7812 = attrs_opt_to_string attrs  in
+        let uu____7814 = FStar_All.pipe_right pat pat_to_string  in
+        let uu____7817 = FStar_All.pipe_right tm term_to_string  in
+        let uu____7820 = FStar_All.pipe_right body term_to_string  in
+        FStar_Util.format5 "%slet %s %s = %s in %s" uu____7812
+          (string_of_let_qualifier q) uu____7814 uu____7817 uu____7820
+    | Let (uu____7824,uu____7825,uu____7826) ->
         FStar_Errors.raise_error
           (FStar_Errors.Fatal_EmptySurfaceLet,
             "Internal error: found an invalid surface Let") x.range
     | LetOpen (lid,t) ->
-        let uu____7851 = FStar_Ident.string_of_lid lid  in
-        let uu____7853 = term_to_string t  in
-        FStar_Util.format2 "let open %s in %s" uu____7851 uu____7853
+        let uu____7860 = FStar_Ident.string_of_lid lid  in
+        let uu____7862 = term_to_string t  in
+        FStar_Util.format2 "let open %s in %s" uu____7860 uu____7862
     | Seq (t1,t2) ->
-        let uu____7858 = FStar_All.pipe_right t1 term_to_string  in
-        let uu____7861 = FStar_All.pipe_right t2 term_to_string  in
-        FStar_Util.format2 "%s; %s" uu____7858 uu____7861
+        let uu____7867 = FStar_All.pipe_right t1 term_to_string  in
+        let uu____7870 = FStar_All.pipe_right t2 term_to_string  in
+        FStar_Util.format2 "%s; %s" uu____7867 uu____7870
     | Bind (id,t1,t2) ->
-        let uu____7868 = term_to_string t1  in
-        let uu____7870 = term_to_string t2  in
-        FStar_Util.format3 "%s <- %s; %s" id.FStar_Ident.idText uu____7868
-          uu____7870
+        let uu____7877 = FStar_Ident.text_of_id id  in
+        let uu____7879 = term_to_string t1  in
+        let uu____7881 = term_to_string t2  in
+        FStar_Util.format3 "%s <- %s; %s" uu____7877 uu____7879 uu____7881
     | If (t1,t2,t3) ->
-        let uu____7876 = FStar_All.pipe_right t1 term_to_string  in
-        let uu____7879 = FStar_All.pipe_right t2 term_to_string  in
-        let uu____7882 = FStar_All.pipe_right t3 term_to_string  in
-        FStar_Util.format3 "if %s then %s else %s" uu____7876 uu____7879
-          uu____7882
+        let uu____7887 = FStar_All.pipe_right t1 term_to_string  in
+        let uu____7890 = FStar_All.pipe_right t2 term_to_string  in
+        let uu____7893 = FStar_All.pipe_right t3 term_to_string  in
+        FStar_Util.format3 "if %s then %s else %s" uu____7887 uu____7890
+          uu____7893
     | Match (t,branches) ->
         let s =
           match x.tm with
-          | Match uu____7911 -> "match"
-          | TryWith uu____7927 -> "try"
-          | uu____7943 -> failwith "impossible"  in
-        let uu____7946 = FStar_All.pipe_right t term_to_string  in
-        let uu____7949 =
+          | Match uu____7922 -> "match"
+          | TryWith uu____7938 -> "try"
+          | uu____7954 -> failwith "impossible"  in
+        let uu____7957 = FStar_All.pipe_right t term_to_string  in
+        let uu____7960 =
           to_string_l " | "
-            (fun uu____7967  ->
-               match uu____7967 with
+            (fun uu____7978  ->
+               match uu____7978 with
                | (p,w,e) ->
-                   let uu____7984 = FStar_All.pipe_right p pat_to_string  in
-                   let uu____7987 =
+                   let uu____7995 = FStar_All.pipe_right p pat_to_string  in
+                   let uu____7998 =
                      match w with
                      | FStar_Pervasives_Native.None  -> ""
                      | FStar_Pervasives_Native.Some e1 ->
-                         let uu____7992 = term_to_string e1  in
-                         FStar_Util.format1 "when %s" uu____7992
+                         let uu____8003 = term_to_string e1  in
+                         FStar_Util.format1 "when %s" uu____8003
                       in
-                   let uu____7995 = FStar_All.pipe_right e term_to_string  in
-                   FStar_Util.format3 "%s %s -> %s" uu____7984 uu____7987
-                     uu____7995) branches
+                   let uu____8006 = FStar_All.pipe_right e term_to_string  in
+                   FStar_Util.format3 "%s %s -> %s" uu____7995 uu____7998
+                     uu____8006) branches
            in
-        FStar_Util.format3 "%s %s with %s" s uu____7946 uu____7949
+        FStar_Util.format3 "%s %s with %s" s uu____7957 uu____7960
     | TryWith (t,branches) ->
         let s =
           match x.tm with
-          | Match uu____8025 -> "match"
-          | TryWith uu____8041 -> "try"
-          | uu____8057 -> failwith "impossible"  in
-        let uu____8060 = FStar_All.pipe_right t term_to_string  in
-        let uu____8063 =
+          | Match uu____8036 -> "match"
+          | TryWith uu____8052 -> "try"
+          | uu____8068 -> failwith "impossible"  in
+        let uu____8071 = FStar_All.pipe_right t term_to_string  in
+        let uu____8074 =
           to_string_l " | "
-            (fun uu____8081  ->
-               match uu____8081 with
+            (fun uu____8092  ->
+               match uu____8092 with
                | (p,w,e) ->
-                   let uu____8098 = FStar_All.pipe_right p pat_to_string  in
-                   let uu____8101 =
+                   let uu____8109 = FStar_All.pipe_right p pat_to_string  in
+                   let uu____8112 =
                      match w with
                      | FStar_Pervasives_Native.None  -> ""
                      | FStar_Pervasives_Native.Some e1 ->
-                         let uu____8106 = term_to_string e1  in
-                         FStar_Util.format1 "when %s" uu____8106
+                         let uu____8117 = term_to_string e1  in
+                         FStar_Util.format1 "when %s" uu____8117
                       in
-                   let uu____8109 = FStar_All.pipe_right e term_to_string  in
-                   FStar_Util.format3 "%s %s -> %s" uu____8098 uu____8101
-                     uu____8109) branches
+                   let uu____8120 = FStar_All.pipe_right e term_to_string  in
+                   FStar_Util.format3 "%s %s -> %s" uu____8109 uu____8112
+                     uu____8120) branches
            in
-        FStar_Util.format3 "%s %s with %s" s uu____8060 uu____8063
+        FStar_Util.format3 "%s %s with %s" s uu____8071 uu____8074
     | Ascribed (t1,t2,FStar_Pervasives_Native.None ) ->
-        let uu____8118 = FStar_All.pipe_right t1 term_to_string  in
-        let uu____8121 = FStar_All.pipe_right t2 term_to_string  in
-        FStar_Util.format2 "(%s : %s)" uu____8118 uu____8121
+        let uu____8129 = FStar_All.pipe_right t1 term_to_string  in
+        let uu____8132 = FStar_All.pipe_right t2 term_to_string  in
+        FStar_Util.format2 "(%s : %s)" uu____8129 uu____8132
     | Ascribed (t1,t2,FStar_Pervasives_Native.Some tac) ->
-        let uu____8130 = FStar_All.pipe_right t1 term_to_string  in
-        let uu____8133 = FStar_All.pipe_right t2 term_to_string  in
-        let uu____8136 = FStar_All.pipe_right tac term_to_string  in
-        FStar_Util.format3 "(%s : %s by %s)" uu____8130 uu____8133 uu____8136
+        let uu____8141 = FStar_All.pipe_right t1 term_to_string  in
+        let uu____8144 = FStar_All.pipe_right t2 term_to_string  in
+        let uu____8147 = FStar_All.pipe_right tac term_to_string  in
+        FStar_Util.format3 "(%s : %s by %s)" uu____8141 uu____8144 uu____8147
     | Record (FStar_Pervasives_Native.Some e,fields) ->
-        let uu____8156 = FStar_All.pipe_right e term_to_string  in
-        let uu____8159 =
+        let uu____8167 = FStar_All.pipe_right e term_to_string  in
+        let uu____8170 =
           to_string_l " "
-            (fun uu____8170  ->
-               match uu____8170 with
+            (fun uu____8182  ->
+               match uu____8182 with
                | (l,e1) ->
-                   let uu____8178 = FStar_All.pipe_right e1 term_to_string
+                   let uu____8190 = FStar_Ident.string_of_lid l  in
+                   let uu____8192 = FStar_All.pipe_right e1 term_to_string
                       in
-                   FStar_Util.format2 "%s=%s" l.FStar_Ident.str uu____8178)
-            fields
+                   FStar_Util.format2 "%s=%s" uu____8190 uu____8192) fields
            in
-        FStar_Util.format2 "{%s with %s}" uu____8156 uu____8159
+        FStar_Util.format2 "{%s with %s}" uu____8167 uu____8170
     | Record (FStar_Pervasives_Native.None ,fields) ->
-        let uu____8198 =
+        let uu____8212 =
           to_string_l " "
-            (fun uu____8209  ->
-               match uu____8209 with
+            (fun uu____8224  ->
+               match uu____8224 with
                | (l,e) ->
-                   let uu____8217 = FStar_All.pipe_right e term_to_string  in
-                   FStar_Util.format2 "%s=%s" l.FStar_Ident.str uu____8217)
-            fields
+                   let uu____8232 = FStar_Ident.string_of_lid l  in
+                   let uu____8234 = FStar_All.pipe_right e term_to_string  in
+                   FStar_Util.format2 "%s=%s" uu____8232 uu____8234) fields
            in
-        FStar_Util.format1 "{%s}" uu____8198
+        FStar_Util.format1 "{%s}" uu____8212
     | Project (e,l) ->
-        let uu____8224 = FStar_All.pipe_right e term_to_string  in
-        FStar_Util.format2 "%s.%s" uu____8224 l.FStar_Ident.str
+        let uu____8241 = FStar_All.pipe_right e term_to_string  in
+        let uu____8244 = FStar_Ident.string_of_lid l  in
+        FStar_Util.format2 "%s.%s" uu____8241 uu____8244
     | Product ([],t) -> term_to_string t
     | Product (b::hd::tl,t) ->
         term_to_string
@@ -1862,287 +1866,313 @@ let rec (term_to_string : term -> Prims.string) =
                 ([b], (mk_term (Product ((hd :: tl), t)) x.range x.level)))
              x.range x.level)
     | Product (b::[],t) when x.level = Type_level ->
-        let uu____8247 = FStar_All.pipe_right b binder_to_string  in
-        let uu____8250 = FStar_All.pipe_right t term_to_string  in
-        FStar_Util.format2 "%s -> %s" uu____8247 uu____8250
+        let uu____8266 = FStar_All.pipe_right b binder_to_string  in
+        let uu____8269 = FStar_All.pipe_right t term_to_string  in
+        FStar_Util.format2 "%s -> %s" uu____8266 uu____8269
     | Product (b::[],t) when x.level = Kind ->
-        let uu____8258 = FStar_All.pipe_right b binder_to_string  in
-        let uu____8261 = FStar_All.pipe_right t term_to_string  in
-        FStar_Util.format2 "%s => %s" uu____8258 uu____8261
+        let uu____8277 = FStar_All.pipe_right b binder_to_string  in
+        let uu____8280 = FStar_All.pipe_right t term_to_string  in
+        FStar_Util.format2 "%s => %s" uu____8277 uu____8280
     | Sum (binders,t) ->
-        let uu____8279 =
+        let uu____8298 =
           FStar_All.pipe_right (FStar_List.append binders [FStar_Util.Inr t])
             (FStar_List.map
-               (fun uu___6_8311  ->
-                  match uu___6_8311 with
+               (fun uu___6_8330  ->
+                  match uu___6_8330 with
                   | FStar_Util.Inl b -> binder_to_string b
                   | FStar_Util.Inr t1 -> term_to_string t1))
            in
-        FStar_All.pipe_right uu____8279 (FStar_String.concat " & ")
-    | QForall (bs,(uu____8325,pats),t) ->
-        let uu____8354 = to_string_l " " binder_to_string bs  in
-        let uu____8357 =
+        FStar_All.pipe_right uu____8298 (FStar_String.concat " & ")
+    | QForall (bs,(uu____8344,pats),t) ->
+        let uu____8373 = to_string_l " " binder_to_string bs  in
+        let uu____8376 =
           to_string_l " \\/ " (to_string_l "; " term_to_string) pats  in
-        let uu____8363 = FStar_All.pipe_right t term_to_string  in
-        FStar_Util.format3 "forall %s.{:pattern %s} %s" uu____8354 uu____8357
-          uu____8363
-    | QExists (bs,(uu____8368,pats),t) ->
-        let uu____8397 = to_string_l " " binder_to_string bs  in
-        let uu____8400 =
+        let uu____8382 = FStar_All.pipe_right t term_to_string  in
+        FStar_Util.format3 "forall %s.{:pattern %s} %s" uu____8373 uu____8376
+          uu____8382
+    | QExists (bs,(uu____8387,pats),t) ->
+        let uu____8416 = to_string_l " " binder_to_string bs  in
+        let uu____8419 =
           to_string_l " \\/ " (to_string_l "; " term_to_string) pats  in
-        let uu____8406 = FStar_All.pipe_right t term_to_string  in
-        FStar_Util.format3 "exists %s.{:pattern %s} %s" uu____8397 uu____8400
-          uu____8406
+        let uu____8425 = FStar_All.pipe_right t term_to_string  in
+        FStar_Util.format3 "exists %s.{:pattern %s} %s" uu____8416 uu____8419
+          uu____8425
     | Refine (b,t) ->
-        let uu____8412 = FStar_All.pipe_right b binder_to_string  in
-        let uu____8415 = FStar_All.pipe_right t term_to_string  in
-        FStar_Util.format2 "%s:{%s}" uu____8412 uu____8415
+        let uu____8431 = FStar_All.pipe_right b binder_to_string  in
+        let uu____8434 = FStar_All.pipe_right t term_to_string  in
+        FStar_Util.format2 "%s:{%s}" uu____8431 uu____8434
     | NamedTyp (x1,t) ->
-        let uu____8421 = FStar_All.pipe_right t term_to_string  in
-        FStar_Util.format2 "%s:%s" x1.FStar_Ident.idText uu____8421
+        let uu____8440 = FStar_Ident.text_of_id x1  in
+        let uu____8442 = FStar_All.pipe_right t term_to_string  in
+        FStar_Util.format2 "%s:%s" uu____8440 uu____8442
     | Paren t ->
-        let uu____8426 = FStar_All.pipe_right t term_to_string  in
-        FStar_Util.format1 "(%s)" uu____8426
+        let uu____8447 = FStar_All.pipe_right t term_to_string  in
+        FStar_Util.format1 "(%s)" uu____8447
     | Product (bs,t) ->
-        let uu____8436 =
-          let uu____8438 =
+        let uu____8457 =
+          let uu____8459 =
             FStar_All.pipe_right bs (FStar_List.map binder_to_string)  in
-          FStar_All.pipe_right uu____8438 (FStar_String.concat ",")  in
-        let uu____8453 = FStar_All.pipe_right t term_to_string  in
-        FStar_Util.format2 "Unidentified product: [%s] %s" uu____8436
-          uu____8453
+          FStar_All.pipe_right uu____8459 (FStar_String.concat ",")  in
+        let uu____8474 = FStar_All.pipe_right t term_to_string  in
+        FStar_Util.format2 "Unidentified product: [%s] %s" uu____8457
+          uu____8474
     | Discrim lid ->
-        let uu____8458 = FStar_Ident.string_of_lid lid  in
-        FStar_Util.format1 "%s?" uu____8458
+        let uu____8479 = FStar_Ident.string_of_lid lid  in
+        FStar_Util.format1 "%s?" uu____8479
     | Attributes ts ->
-        let uu____8464 =
-          let uu____8466 = FStar_List.map term_to_string ts  in
-          FStar_All.pipe_left (FStar_String.concat " ") uu____8466  in
-        FStar_Util.format1 "(attributes %s)" uu____8464
+        let uu____8485 =
+          let uu____8487 = FStar_List.map term_to_string ts  in
+          FStar_All.pipe_left (FStar_String.concat " ") uu____8487  in
+        FStar_Util.format1 "(attributes %s)" uu____8485
     | Antiquote t ->
-        let uu____8478 = term_to_string t  in
-        FStar_Util.format1 "(`#%s)" uu____8478
+        let uu____8499 = term_to_string t  in
+        FStar_Util.format1 "(`#%s)" uu____8499
     | Quote (t,Static ) ->
-        let uu____8482 = term_to_string t  in
-        FStar_Util.format1 "(`(%s))" uu____8482
+        let uu____8503 = term_to_string t  in
+        FStar_Util.format1 "(`(%s))" uu____8503
     | Quote (t,Dynamic ) ->
-        let uu____8486 = term_to_string t  in
-        FStar_Util.format1 "quote (%s)" uu____8486
+        let uu____8507 = term_to_string t  in
+        FStar_Util.format1 "quote (%s)" uu____8507
     | VQuote t ->
-        let uu____8490 = term_to_string t  in
-        FStar_Util.format1 "`%%%s" uu____8490
+        let uu____8511 = term_to_string t  in
+        FStar_Util.format1 "`%%%s" uu____8511
     | CalcProof (rel,init,steps) ->
-        let uu____8500 = term_to_string rel  in
-        let uu____8502 = term_to_string init  in
-        let uu____8504 =
-          let uu____8506 = FStar_List.map calc_step_to_string steps  in
-          FStar_All.pipe_left (FStar_String.concat " ") uu____8506  in
-        FStar_Util.format3 "calc (%s) { %s %s }" uu____8500 uu____8502
-          uu____8504
+        let uu____8521 = term_to_string rel  in
+        let uu____8523 = term_to_string init  in
+        let uu____8525 =
+          let uu____8527 = FStar_List.map calc_step_to_string steps  in
+          FStar_All.pipe_left (FStar_String.concat " ") uu____8527  in
+        FStar_Util.format3 "calc (%s) { %s %s }" uu____8521 uu____8523
+          uu____8525
 
 and (calc_step_to_string : calc_step -> Prims.string) =
-  fun uu____8517  ->
-    match uu____8517 with
+  fun uu____8538  ->
+    match uu____8538 with
     | CalcStep (rel,just,next) ->
-        let uu____8522 = term_to_string rel  in
-        let uu____8524 = term_to_string just  in
-        let uu____8526 = term_to_string next  in
-        FStar_Util.format3 "%s{ %s } %s" uu____8522 uu____8524 uu____8526
+        let uu____8543 = term_to_string rel  in
+        let uu____8545 = term_to_string just  in
+        let uu____8547 = term_to_string next  in
+        FStar_Util.format3 "%s{ %s } %s" uu____8543 uu____8545 uu____8547
 
 and (binder_to_string : binder -> Prims.string) =
   fun x  ->
     let s =
       match x.b with
-      | Variable i -> i.FStar_Ident.idText
-      | TVariable i -> FStar_Util.format1 "%s:_" i.FStar_Ident.idText
+      | Variable i -> FStar_Ident.text_of_id i
+      | TVariable i ->
+          let uu____8556 = FStar_Ident.text_of_id i  in
+          FStar_Util.format1 "%s:_" uu____8556
       | TAnnotated (i,t) ->
-          let uu____8538 = FStar_All.pipe_right t term_to_string  in
-          FStar_Util.format2 "%s:%s" i.FStar_Ident.idText uu____8538
+          let uu____8561 = FStar_Ident.text_of_id i  in
+          let uu____8563 = FStar_All.pipe_right t term_to_string  in
+          FStar_Util.format2 "%s:%s" uu____8561 uu____8563
       | Annotated (i,t) ->
-          let uu____8544 = FStar_All.pipe_right t term_to_string  in
-          FStar_Util.format2 "%s:%s" i.FStar_Ident.idText uu____8544
+          let uu____8569 = FStar_Ident.text_of_id i  in
+          let uu____8571 = FStar_All.pipe_right t term_to_string  in
+          FStar_Util.format2 "%s:%s" uu____8569 uu____8571
       | NoName t -> FStar_All.pipe_right t term_to_string  in
-    let uu____8550 = aqual_to_string x.aqual  in
-    FStar_Util.format2 "%s%s" uu____8550 s
+    let uu____8577 = aqual_to_string x.aqual  in
+    FStar_Util.format2 "%s%s" uu____8577 s
 
 and (aqual_to_string :
   arg_qualifier FStar_Pervasives_Native.option -> Prims.string) =
-  fun uu___7_8553  ->
-    match uu___7_8553 with
+  fun uu___7_8580  ->
+    match uu___7_8580 with
     | FStar_Pervasives_Native.Some (Equality ) -> "$"
     | FStar_Pervasives_Native.Some (Implicit ) -> "#"
-    | uu____8559 -> ""
+    | uu____8586 -> ""
 
 and (pat_to_string : pattern -> Prims.string) =
   fun x  ->
     match x.pat with
     | PatWild (FStar_Pervasives_Native.None ) -> "_"
-    | PatWild uu____8566 -> "#_"
+    | PatWild uu____8593 -> "#_"
     | PatConst c -> FStar_Parser_Const.const_to_string c
     | PatApp (p,ps) ->
-        let uu____8577 = FStar_All.pipe_right p pat_to_string  in
-        let uu____8580 = to_string_l " " pat_to_string ps  in
-        FStar_Util.format2 "(%s %s)" uu____8577 uu____8580
+        let uu____8604 = FStar_All.pipe_right p pat_to_string  in
+        let uu____8607 = to_string_l " " pat_to_string ps  in
+        FStar_Util.format2 "(%s %s)" uu____8604 uu____8607
     | PatTvar (i,aq) ->
-        let uu____8590 = aqual_to_string aq  in
-        FStar_Util.format2 "%s%s" uu____8590 i.FStar_Ident.idText
+        let uu____8617 = aqual_to_string aq  in
+        let uu____8619 = FStar_Ident.text_of_id i  in
+        FStar_Util.format2 "%s%s" uu____8617 uu____8619
     | PatVar (i,aq) ->
-        let uu____8599 = aqual_to_string aq  in
-        FStar_Util.format2 "%s%s" uu____8599 i.FStar_Ident.idText
-    | PatName l -> l.FStar_Ident.str
+        let uu____8628 = aqual_to_string aq  in
+        let uu____8630 = FStar_Ident.text_of_id i  in
+        FStar_Util.format2 "%s%s" uu____8628 uu____8630
+    | PatName l -> FStar_Ident.string_of_lid l
     | PatList l ->
-        let uu____8606 = to_string_l "; " pat_to_string l  in
-        FStar_Util.format1 "[%s]" uu____8606
+        let uu____8637 = to_string_l "; " pat_to_string l  in
+        FStar_Util.format1 "[%s]" uu____8637
     | PatTuple (l,false ) ->
-        let uu____8617 = to_string_l ", " pat_to_string l  in
-        FStar_Util.format1 "(%s)" uu____8617
+        let uu____8648 = to_string_l ", " pat_to_string l  in
+        FStar_Util.format1 "(%s)" uu____8648
     | PatTuple (l,true ) ->
-        let uu____8628 = to_string_l ", " pat_to_string l  in
-        FStar_Util.format1 "(|%s|)" uu____8628
+        let uu____8659 = to_string_l ", " pat_to_string l  in
+        FStar_Util.format1 "(|%s|)" uu____8659
     | PatRecord l ->
-        let uu____8639 =
+        let uu____8670 =
           to_string_l "; "
-            (fun uu____8650  ->
-               match uu____8650 with
+            (fun uu____8682  ->
+               match uu____8682 with
                | (f,e) ->
-                   let uu____8658 = FStar_All.pipe_right e pat_to_string  in
-                   FStar_Util.format2 "%s=%s" f.FStar_Ident.str uu____8658) l
+                   let uu____8690 = FStar_Ident.string_of_lid f  in
+                   let uu____8692 = FStar_All.pipe_right e pat_to_string  in
+                   FStar_Util.format2 "%s=%s" uu____8690 uu____8692) l
            in
-        FStar_Util.format1 "{%s}" uu____8639
+        FStar_Util.format1 "{%s}" uu____8670
     | PatOr l -> to_string_l "|\n " pat_to_string l
     | PatOp op ->
-        let uu____8668 = FStar_Ident.text_of_id op  in
-        FStar_Util.format1 "(%s)" uu____8668
+        let uu____8702 = FStar_Ident.text_of_id op  in
+        FStar_Util.format1 "(%s)" uu____8702
     | PatAscribed (p,(t,FStar_Pervasives_Native.None )) ->
-        let uu____8681 = FStar_All.pipe_right p pat_to_string  in
-        let uu____8684 = FStar_All.pipe_right t term_to_string  in
-        FStar_Util.format2 "(%s:%s)" uu____8681 uu____8684
+        let uu____8715 = FStar_All.pipe_right p pat_to_string  in
+        let uu____8718 = FStar_All.pipe_right t term_to_string  in
+        FStar_Util.format2 "(%s:%s)" uu____8715 uu____8718
     | PatAscribed (p,(t,FStar_Pervasives_Native.Some tac)) ->
-        let uu____8699 = FStar_All.pipe_right p pat_to_string  in
-        let uu____8702 = FStar_All.pipe_right t term_to_string  in
-        let uu____8705 = FStar_All.pipe_right tac term_to_string  in
-        FStar_Util.format3 "(%s:%s by %s)" uu____8699 uu____8702 uu____8705
+        let uu____8733 = FStar_All.pipe_right p pat_to_string  in
+        let uu____8736 = FStar_All.pipe_right t term_to_string  in
+        let uu____8739 = FStar_All.pipe_right tac term_to_string  in
+        FStar_Util.format3 "(%s:%s by %s)" uu____8733 uu____8736 uu____8739
 
 and (attrs_opt_to_string :
   term Prims.list FStar_Pervasives_Native.option -> Prims.string) =
-  fun uu___8_8709  ->
-    match uu___8_8709 with
+  fun uu___8_8743  ->
+    match uu___8_8743 with
     | FStar_Pervasives_Native.None  -> ""
     | FStar_Pervasives_Native.Some attrs ->
-        let uu____8723 =
-          let uu____8725 = FStar_List.map term_to_string attrs  in
-          FStar_All.pipe_right uu____8725 (FStar_String.concat "; ")  in
-        FStar_Util.format1 "[@ %s]" uu____8723
+        let uu____8757 =
+          let uu____8759 = FStar_List.map term_to_string attrs  in
+          FStar_All.pipe_right uu____8759 (FStar_String.concat "; ")  in
+        FStar_Util.format1 "[@ %s]" uu____8757
 
 let rec (head_id_of_pat : pattern -> FStar_Ident.lident Prims.list) =
   fun p  ->
     match p.pat with
     | PatName l -> [l]
-    | PatVar (i,uu____8748) ->
-        let uu____8753 = FStar_Ident.lid_of_ids [i]  in [uu____8753]
-    | PatApp (p1,uu____8755) -> head_id_of_pat p1
-    | PatAscribed (p1,uu____8761) -> head_id_of_pat p1
-    | uu____8774 -> []
+    | PatVar (i,uu____8782) ->
+        let uu____8787 = FStar_Ident.lid_of_ids [i]  in [uu____8787]
+    | PatApp (p1,uu____8789) -> head_id_of_pat p1
+    | PatAscribed (p1,uu____8795) -> head_id_of_pat p1
+    | uu____8808 -> []
   
 let lids_of_let :
-  'uuuuuu8780 .
-    (pattern * 'uuuuuu8780) Prims.list -> FStar_Ident.lident Prims.list
+  'uuuuuu8814 .
+    (pattern * 'uuuuuu8814) Prims.list -> FStar_Ident.lident Prims.list
   =
   fun defs  ->
     FStar_All.pipe_right defs
       (FStar_List.collect
-         (fun uu____8815  ->
-            match uu____8815 with | (p,uu____8823) -> head_id_of_pat p))
+         (fun uu____8849  ->
+            match uu____8849 with | (p,uu____8857) -> head_id_of_pat p))
   
 let (id_of_tycon : tycon -> Prims.string) =
-  fun uu___9_8830  ->
-    match uu___9_8830 with
-    | TyconAbstract (i,uu____8833,uu____8834) -> i.FStar_Ident.idText
-    | TyconAbbrev (i,uu____8844,uu____8845,uu____8846) ->
-        i.FStar_Ident.idText
-    | TyconRecord (i,uu____8856,uu____8857,uu____8858) ->
-        i.FStar_Ident.idText
-    | TyconVariant (i,uu____8880,uu____8881,uu____8882) ->
-        i.FStar_Ident.idText
+  fun uu___9_8864  ->
+    match uu___9_8864 with
+    | TyconAbstract (i,uu____8867,uu____8868) -> FStar_Ident.text_of_id i
+    | TyconAbbrev (i,uu____8878,uu____8879,uu____8880) ->
+        FStar_Ident.text_of_id i
+    | TyconRecord (i,uu____8890,uu____8891,uu____8892) ->
+        FStar_Ident.text_of_id i
+    | TyconVariant (i,uu____8914,uu____8915,uu____8916) ->
+        FStar_Ident.text_of_id i
   
 let (decl_to_string : decl -> Prims.string) =
   fun d  ->
     match d.d with
-    | TopLevelModule l -> Prims.op_Hat "module " l.FStar_Ident.str
-    | Open l -> Prims.op_Hat "open " l.FStar_Ident.str
-    | Friend l -> Prims.op_Hat "friend " l.FStar_Ident.str
-    | Include l -> Prims.op_Hat "include " l.FStar_Ident.str
+    | TopLevelModule l ->
+        let uu____8956 = FStar_Ident.string_of_lid l  in
+        Prims.op_Hat "module " uu____8956
+    | Open l ->
+        let uu____8960 = FStar_Ident.string_of_lid l  in
+        Prims.op_Hat "open " uu____8960
+    | Friend l ->
+        let uu____8964 = FStar_Ident.string_of_lid l  in
+        Prims.op_Hat "friend " uu____8964
+    | Include l ->
+        let uu____8968 = FStar_Ident.string_of_lid l  in
+        Prims.op_Hat "include " uu____8968
     | ModuleAbbrev (i,l) ->
-        FStar_Util.format2 "module %s = %s" i.FStar_Ident.idText
-          l.FStar_Ident.str
-    | TopLevelLet (uu____8932,pats) ->
-        let uu____8946 =
-          let uu____8948 =
-            let uu____8952 = lids_of_let pats  in
-            FStar_All.pipe_right uu____8952
-              (FStar_List.map (fun l  -> l.FStar_Ident.str))
+        let uu____8973 = FStar_Ident.text_of_id i  in
+        let uu____8975 = FStar_Ident.string_of_lid l  in
+        FStar_Util.format2 "module %s = %s" uu____8973 uu____8975
+    | TopLevelLet (uu____8978,pats) ->
+        let uu____8992 =
+          let uu____8994 =
+            let uu____8998 = lids_of_let pats  in
+            FStar_All.pipe_right uu____8998
+              (FStar_List.map (fun l  -> FStar_Ident.string_of_lid l))
              in
-          FStar_All.pipe_right uu____8948 (FStar_String.concat ", ")  in
-        Prims.op_Hat "let " uu____8946
-    | Main uu____8969 -> "main ..."
-    | Assume (i,uu____8972) -> Prims.op_Hat "assume " i.FStar_Ident.idText
-    | Tycon (uu____8974,uu____8975,tys) ->
-        let uu____8985 =
-          let uu____8987 =
+          FStar_All.pipe_right uu____8994 (FStar_String.concat ", ")  in
+        Prims.op_Hat "let " uu____8992
+    | Main uu____9015 -> "main ..."
+    | Assume (i,uu____9018) ->
+        let uu____9019 = FStar_Ident.text_of_id i  in
+        Prims.op_Hat "assume " uu____9019
+    | Tycon (uu____9022,uu____9023,tys) ->
+        let uu____9033 =
+          let uu____9035 =
             FStar_All.pipe_right tys (FStar_List.map id_of_tycon)  in
-          FStar_All.pipe_right uu____8987 (FStar_String.concat ", ")  in
-        Prims.op_Hat "type " uu____8985
-    | Val (i,uu____9004) -> Prims.op_Hat "val " i.FStar_Ident.idText
-    | Exception (i,uu____9007) ->
-        Prims.op_Hat "exception " i.FStar_Ident.idText
-    | NewEffect (DefineEffect (i,uu____9014,uu____9015,uu____9016)) ->
-        Prims.op_Hat "new_effect " i.FStar_Ident.idText
-    | NewEffect (RedefineEffect (i,uu____9027,uu____9028)) ->
-        Prims.op_Hat "new_effect " i.FStar_Ident.idText
-    | LayeredEffect (DefineEffect (i,uu____9035,uu____9036,uu____9037)) ->
-        Prims.op_Hat "layered_effect " i.FStar_Ident.idText
-    | LayeredEffect (RedefineEffect (i,uu____9048,uu____9049)) ->
-        Prims.op_Hat "layered_effect " i.FStar_Ident.idText
-    | Polymonadic_bind (l1,l2,l3,uu____9058) ->
-        let uu____9059 = FStar_Ident.string_of_lid l1  in
-        let uu____9061 = FStar_Ident.string_of_lid l2  in
-        let uu____9063 = FStar_Ident.string_of_lid l3  in
-        FStar_Util.format3 "polymonadic_bind (%s, %s) |> %s" uu____9059
-          uu____9061 uu____9063
+          FStar_All.pipe_right uu____9035 (FStar_String.concat ", ")  in
+        Prims.op_Hat "type " uu____9033
+    | Val (i,uu____9052) ->
+        let uu____9053 = FStar_Ident.text_of_id i  in
+        Prims.op_Hat "val " uu____9053
+    | Exception (i,uu____9057) ->
+        let uu____9062 = FStar_Ident.text_of_id i  in
+        Prims.op_Hat "exception " uu____9062
+    | NewEffect (DefineEffect (i,uu____9066,uu____9067,uu____9068)) ->
+        let uu____9077 = FStar_Ident.text_of_id i  in
+        Prims.op_Hat "new_effect " uu____9077
+    | NewEffect (RedefineEffect (i,uu____9081,uu____9082)) ->
+        let uu____9087 = FStar_Ident.text_of_id i  in
+        Prims.op_Hat "new_effect " uu____9087
+    | LayeredEffect (DefineEffect (i,uu____9091,uu____9092,uu____9093)) ->
+        let uu____9102 = FStar_Ident.text_of_id i  in
+        Prims.op_Hat "layered_effect " uu____9102
+    | LayeredEffect (RedefineEffect (i,uu____9106,uu____9107)) ->
+        let uu____9112 = FStar_Ident.text_of_id i  in
+        Prims.op_Hat "layered_effect " uu____9112
+    | Polymonadic_bind (l1,l2,l3,uu____9118) ->
+        let uu____9119 = FStar_Ident.string_of_lid l1  in
+        let uu____9121 = FStar_Ident.string_of_lid l2  in
+        let uu____9123 = FStar_Ident.string_of_lid l3  in
+        FStar_Util.format3 "polymonadic_bind (%s, %s) |> %s" uu____9119
+          uu____9121 uu____9123
     | Splice (ids,t) ->
-        let uu____9072 =
-          let uu____9074 =
-            let uu____9076 =
-              FStar_List.map (fun i  -> i.FStar_Ident.idText) ids  in
-            FStar_All.pipe_left (FStar_String.concat ";") uu____9076  in
-          let uu____9088 =
-            let uu____9090 =
-              let uu____9092 = term_to_string t  in
-              Prims.op_Hat uu____9092 ")"  in
-            Prims.op_Hat "] (" uu____9090  in
-          Prims.op_Hat uu____9074 uu____9088  in
-        Prims.op_Hat "splice[" uu____9072
-    | SubEffect uu____9097 -> "sub_effect"
-    | Pragma uu____9099 -> "pragma"
+        let uu____9132 =
+          let uu____9134 =
+            let uu____9136 =
+              FStar_List.map (fun i  -> FStar_Ident.text_of_id i) ids  in
+            FStar_All.pipe_left (FStar_String.concat ";") uu____9136  in
+          let uu____9148 =
+            let uu____9150 =
+              let uu____9152 = term_to_string t  in
+              Prims.op_Hat uu____9152 ")"  in
+            Prims.op_Hat "] (" uu____9150  in
+          Prims.op_Hat uu____9134 uu____9148  in
+        Prims.op_Hat "splice[" uu____9132
+    | SubEffect uu____9157 -> "sub_effect"
+    | Pragma uu____9159 -> "pragma"
   
 let (modul_to_string : modul -> Prims.string) =
   fun m  ->
     match m with
-    | Module (uu____9109,decls) ->
-        let uu____9115 =
+    | Module (uu____9169,decls) ->
+        let uu____9175 =
           FStar_All.pipe_right decls (FStar_List.map decl_to_string)  in
-        FStar_All.pipe_right uu____9115 (FStar_String.concat "\n")
-    | Interface (uu____9130,decls,uu____9132) ->
-        let uu____9139 =
+        FStar_All.pipe_right uu____9175 (FStar_String.concat "\n")
+    | Interface (uu____9190,decls,uu____9192) ->
+        let uu____9199 =
           FStar_All.pipe_right decls (FStar_List.map decl_to_string)  in
-        FStar_All.pipe_right uu____9139 (FStar_String.concat "\n")
+        FStar_All.pipe_right uu____9199 (FStar_String.concat "\n")
   
 let (decl_is_val : FStar_Ident.ident -> decl -> Prims.bool) =
   fun id  ->
     fun decl1  ->
       match decl1.d with
-      | Val (id',uu____9168) -> FStar_Ident.ident_equals id id'
-      | uu____9169 -> false
+      | Val (id',uu____9228) -> FStar_Ident.ident_equals id id'
+      | uu____9229 -> false
   
 let (thunk : term -> term) =
   fun ens  ->
@@ -2160,9 +2190,9 @@ let (idents_of_binders :
               match b.b with
               | Variable i -> i
               | TVariable i -> i
-              | Annotated (i,uu____9207) -> i
-              | TAnnotated (i,uu____9209) -> i
-              | NoName uu____9210 ->
+              | Annotated (i,uu____9267) -> i
+              | TAnnotated (i,uu____9269) -> i
+              | NoName uu____9270 ->
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_MissingQuantifierBinder,
                       "Wildcard binders in quantifiers are not allowed") r))

--- a/src/ocaml-output/FStar_Parser_Const.ml
+++ b/src/ocaml-output/FStar_Parser_Const.ml
@@ -288,8 +288,10 @@ let (sli : FStar_Ident.lident -> Prims.string) =
   fun l  ->
     let uu____1039 = FStar_Options.print_real_names ()  in
     if uu____1039
-    then l.FStar_Ident.str
-    else (l.FStar_Ident.ident).FStar_Ident.idText
+    then FStar_Ident.string_of_lid l
+    else
+      (let uu____1045 = FStar_Ident.ident_of_lid l  in
+       FStar_Ident.text_of_id uu____1045)
   
 let (const_to_string : FStar_Const.sconst -> Prims.string) =
   fun x  ->
@@ -299,29 +301,29 @@ let (const_to_string : FStar_Const.sconst -> Prims.string) =
     | FStar_Const.Const_bool b -> if b then "true" else "false"
     | FStar_Const.Const_real r -> FStar_String.op_Hat r "R"
     | FStar_Const.Const_float x1 -> FStar_Util.string_of_float x1
-    | FStar_Const.Const_string (s,uu____1068) ->
+    | FStar_Const.Const_string (s,uu____1069) ->
         FStar_Util.format1 "\"%s\"" s
-    | FStar_Const.Const_bytearray uu____1072 -> "<bytearray>"
-    | FStar_Const.Const_int (x1,uu____1082) -> x1
+    | FStar_Const.Const_bytearray uu____1073 -> "<bytearray>"
+    | FStar_Const.Const_int (x1,uu____1083) -> x1
     | FStar_Const.Const_char c ->
-        let uu____1099 =
+        let uu____1100 =
           FStar_String.op_Hat (FStar_Util.string_of_char c) "'"  in
-        FStar_String.op_Hat "'" uu____1099
+        FStar_String.op_Hat "'" uu____1100
     | FStar_Const.Const_range r -> FStar_Range.string_of_range r
     | FStar_Const.Const_range_of  -> "range_of"
     | FStar_Const.Const_set_range_of  -> "set_range_of"
     | FStar_Const.Const_reify  -> "reify"
     | FStar_Const.Const_reflect l ->
-        let uu____1108 = sli l  in
-        FStar_Util.format1 "[[%s.reflect]]" uu____1108
+        let uu____1109 = sli l  in
+        FStar_Util.format1 "[[%s.reflect]]" uu____1109
   
 let (mk_tuple_lid : Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n  ->
     fun r  ->
       let t =
-        let uu____1126 = FStar_Util.string_of_int n  in
-        FStar_Util.format1 "tuple%s" uu____1126  in
-      let uu____1129 = psnconst t  in FStar_Ident.set_lid_range uu____1129 r
+        let uu____1127 = FStar_Util.string_of_int n  in
+        FStar_Util.format1 "tuple%s" uu____1127  in
+      let uu____1130 = psnconst t  in FStar_Ident.set_lid_range uu____1130 r
   
 let (lid_tuple2 : FStar_Ident.lident) =
   mk_tuple_lid (Prims.of_int (2)) FStar_Range.dummyRange 
@@ -329,22 +331,22 @@ let (is_tuple_constructor_string : Prims.string -> Prims.bool) =
   fun s  -> FStar_Util.starts_with s "FStar.Pervasives.Native.tuple" 
 let (is_tuple_constructor_id : FStar_Ident.ident -> Prims.bool) =
   fun id  ->
-    let uu____1150 = FStar_Ident.text_of_id id  in
-    is_tuple_constructor_string uu____1150
+    let uu____1151 = FStar_Ident.text_of_id id  in
+    is_tuple_constructor_string uu____1151
   
 let (is_tuple_constructor_lid : FStar_Ident.lident -> Prims.bool) =
   fun lid  ->
-    let uu____1159 = FStar_Ident.text_of_lid lid  in
-    is_tuple_constructor_string uu____1159
+    let uu____1160 = FStar_Ident.string_of_lid lid  in
+    is_tuple_constructor_string uu____1160
   
 let (mk_tuple_data_lid :
   Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n  ->
     fun r  ->
       let t =
-        let uu____1176 = FStar_Util.string_of_int n  in
-        FStar_Util.format1 "Mktuple%s" uu____1176  in
-      let uu____1179 = psnconst t  in FStar_Ident.set_lid_range uu____1179 r
+        let uu____1177 = FStar_Util.string_of_int n  in
+        FStar_Util.format1 "Mktuple%s" uu____1177  in
+      let uu____1180 = psnconst t  in FStar_Ident.set_lid_range uu____1180 r
   
 let (lid_Mktuple2 : FStar_Ident.lident) =
   mk_tuple_data_lid (Prims.of_int (2)) FStar_Range.dummyRange 
@@ -352,33 +354,36 @@ let (is_tuple_datacon_string : Prims.string -> Prims.bool) =
   fun s  -> FStar_Util.starts_with s "FStar.Pervasives.Native.Mktuple" 
 let (is_tuple_datacon_id : FStar_Ident.ident -> Prims.bool) =
   fun id  ->
-    let uu____1200 = FStar_Ident.text_of_id id  in
-    is_tuple_datacon_string uu____1200
+    let uu____1201 = FStar_Ident.text_of_id id  in
+    is_tuple_datacon_string uu____1201
   
 let (is_tuple_datacon_lid : FStar_Ident.lident -> Prims.bool) =
   fun lid  ->
-    let uu____1209 = FStar_Ident.text_of_lid lid  in
-    is_tuple_datacon_string uu____1209
+    let uu____1210 = FStar_Ident.string_of_lid lid  in
+    is_tuple_datacon_string uu____1210
   
 let (is_tuple_data_lid : FStar_Ident.lident -> Prims.int -> Prims.bool) =
   fun f  ->
     fun n  ->
-      let uu____1225 = mk_tuple_data_lid n FStar_Range.dummyRange  in
-      FStar_Ident.lid_equals f uu____1225
+      let uu____1226 = mk_tuple_data_lid n FStar_Range.dummyRange  in
+      FStar_Ident.lid_equals f uu____1226
   
 let (is_tuple_data_lid' : FStar_Ident.lident -> Prims.bool) =
-  fun f  -> is_tuple_datacon_string f.FStar_Ident.str 
+  fun f  ->
+    let uu____1234 = FStar_Ident.string_of_lid f  in
+    is_tuple_datacon_string uu____1234
+  
 let (mod_prefix_dtuple : Prims.int -> Prims.string -> FStar_Ident.lident) =
   fun n  -> if n = (Prims.of_int (2)) then pconst else psconst 
 let (mk_dtuple_lid : Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n  ->
     fun r  ->
       let t =
-        let uu____1273 = FStar_Util.string_of_int n  in
-        FStar_Util.format1 "dtuple%s" uu____1273  in
-      let uu____1276 = let uu____1277 = mod_prefix_dtuple n  in uu____1277 t
+        let uu____1276 = FStar_Util.string_of_int n  in
+        FStar_Util.format1 "dtuple%s" uu____1276  in
+      let uu____1279 = let uu____1280 = mod_prefix_dtuple n  in uu____1280 t
          in
-      FStar_Ident.set_lid_range uu____1276 r
+      FStar_Ident.set_lid_range uu____1279 r
   
 let (is_dtuple_constructor_string : Prims.string -> Prims.bool) =
   fun s  ->
@@ -386,17 +391,20 @@ let (is_dtuple_constructor_string : Prims.string -> Prims.bool) =
       (FStar_Util.starts_with s "FStar.Pervasives.dtuple")
   
 let (is_dtuple_constructor_lid : FStar_Ident.lident -> Prims.bool) =
-  fun lid  -> is_dtuple_constructor_string lid.FStar_Ident.str 
+  fun lid  ->
+    let uu____1306 = FStar_Ident.string_of_lid lid  in
+    is_dtuple_constructor_string uu____1306
+  
 let (mk_dtuple_data_lid :
   Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n  ->
     fun r  ->
       let t =
-        let uu____1318 = FStar_Util.string_of_int n  in
-        FStar_Util.format1 "Mkdtuple%s" uu____1318  in
-      let uu____1321 = let uu____1322 = mod_prefix_dtuple n  in uu____1322 t
+        let uu____1323 = FStar_Util.string_of_int n  in
+        FStar_Util.format1 "Mkdtuple%s" uu____1323  in
+      let uu____1326 = let uu____1327 = mod_prefix_dtuple n  in uu____1327 t
          in
-      FStar_Ident.set_lid_range uu____1321 r
+      FStar_Ident.set_lid_range uu____1326 r
   
 let (is_dtuple_datacon_string : Prims.string -> Prims.bool) =
   fun s  ->
@@ -406,20 +414,21 @@ let (is_dtuple_datacon_string : Prims.string -> Prims.bool) =
 let (is_dtuple_data_lid : FStar_Ident.lident -> Prims.int -> Prims.bool) =
   fun f  ->
     fun n  ->
-      let uu____1355 = mk_dtuple_data_lid n FStar_Range.dummyRange  in
-      FStar_Ident.lid_equals f uu____1355
+      let uu____1360 = mk_dtuple_data_lid n FStar_Range.dummyRange  in
+      FStar_Ident.lid_equals f uu____1360
   
 let (is_dtuple_data_lid' : FStar_Ident.lident -> Prims.bool) =
   fun f  ->
-    let uu____1363 = FStar_Ident.text_of_lid f  in
-    is_dtuple_datacon_string uu____1363
+    let uu____1368 = FStar_Ident.string_of_lid f  in
+    is_dtuple_datacon_string uu____1368
   
 let (is_name : FStar_Ident.lident -> Prims.bool) =
   fun lid  ->
     let c =
-      FStar_Util.char_at (lid.FStar_Ident.ident).FStar_Ident.idText
-        Prims.int_zero
-       in
+      let uu____1379 =
+        let uu____1381 = FStar_Ident.ident_of_lid lid  in
+        FStar_Ident.text_of_id uu____1381  in
+      FStar_Util.char_at uu____1379 Prims.int_zero  in
     FStar_Util.is_upper c
   
 let (fstar_tactics_lid' : Prims.string Prims.list -> FStar_Ident.lid) =

--- a/src/ocaml-output/FStar_Parser_Dep.ml
+++ b/src/ocaml-output/FStar_Parser_Dep.ml
@@ -124,11 +124,12 @@ let (namespace_of_module :
     let lid =
       let uu____367 = FStar_Ident.path_of_text f  in
       FStar_Ident.lid_of_path uu____367 FStar_Range.dummyRange  in
-    match lid.FStar_Ident.ns with
+    let uu____368 = FStar_Ident.ns_of_lid lid  in
+    match uu____368 with
     | [] -> FStar_Pervasives_Native.None
-    | uu____370 ->
-        let uu____373 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
-        FStar_Pervasives_Native.Some uu____373
+    | ns ->
+        let uu____372 = FStar_Ident.lid_of_ids ns  in
+        FStar_Pervasives_Native.Some uu____372
   
 type file_name = Prims.string
 type module_name = Prims.string
@@ -139,19 +140,19 @@ type dependence =
   | FriendImplementation of module_name 
 let (uu___is_UseInterface : dependence -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UseInterface _0 -> true | uu____413 -> false
+    match projectee with | UseInterface _0 -> true | uu____412 -> false
   
 let (__proj__UseInterface__item___0 : dependence -> module_name) =
   fun projectee  -> match projectee with | UseInterface _0 -> _0 
 let (uu___is_PreferInterface : dependence -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PreferInterface _0 -> true | uu____436 -> false
+    match projectee with | PreferInterface _0 -> true | uu____435 -> false
   
 let (__proj__PreferInterface__item___0 : dependence -> module_name) =
   fun projectee  -> match projectee with | PreferInterface _0 -> _0 
 let (uu___is_UseImplementation : dependence -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UseImplementation _0 -> true | uu____459 -> false
+    match projectee with | UseImplementation _0 -> true | uu____458 -> false
   
 let (__proj__UseImplementation__item___0 : dependence -> module_name) =
   fun projectee  -> match projectee with | UseImplementation _0 -> _0 
@@ -159,21 +160,21 @@ let (uu___is_FriendImplementation : dependence -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | FriendImplementation _0 -> true
-    | uu____482 -> false
+    | uu____481 -> false
   
 let (__proj__FriendImplementation__item___0 : dependence -> module_name) =
   fun projectee  -> match projectee with | FriendImplementation _0 -> _0 
 let (dep_to_string : dependence -> Prims.string) =
-  fun uu___1_500  ->
-    match uu___1_500 with
+  fun uu___1_499  ->
+    match uu___1_499 with
     | UseInterface f -> FStar_String.op_Hat "UseInterface " f
     | PreferInterface f -> FStar_String.op_Hat "PreferInterface " f
     | UseImplementation f -> FStar_String.op_Hat "UseImplementation " f
     | FriendImplementation f -> FStar_String.op_Hat "FriendImplementation " f
   
 type dependences = dependence Prims.list
-let empty_dependences : 'uuuuuu519 . unit -> 'uuuuuu519 Prims.list =
-  fun uu____523  -> [] 
+let empty_dependences : 'uuuuuu518 . unit -> 'uuuuuu518 Prims.list =
+  fun uu____522  -> [] 
 type dep_node = {
   edges: dependences ;
   color: color }
@@ -200,14 +201,14 @@ type parsing_data_elt =
   | P_inline_for_extraction 
 let (uu___is_P_begin_module : parsing_data_elt -> Prims.bool) =
   fun projectee  ->
-    match projectee with | P_begin_module _0 -> true | uu____636 -> false
+    match projectee with | P_begin_module _0 -> true | uu____635 -> false
   
 let (__proj__P_begin_module__item___0 :
   parsing_data_elt -> FStar_Ident.lident) =
   fun projectee  -> match projectee with | P_begin_module _0 -> _0 
 let (uu___is_P_open : parsing_data_elt -> Prims.bool) =
   fun projectee  ->
-    match projectee with | P_open _0 -> true | uu____660 -> false
+    match projectee with | P_open _0 -> true | uu____659 -> false
   
 let (__proj__P_open__item___0 :
   parsing_data_elt -> (Prims.bool * FStar_Ident.lident)) =
@@ -216,7 +217,7 @@ let (uu___is_P_open_module_or_namespace : parsing_data_elt -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | P_open_module_or_namespace _0 -> true
-    | uu____698 -> false
+    | uu____697 -> false
   
 let (__proj__P_open_module_or_namespace__item___0 :
   parsing_data_elt -> (open_kind * FStar_Ident.lid)) =
@@ -225,21 +226,21 @@ let (__proj__P_open_module_or_namespace__item___0 :
   
 let (uu___is_P_dep : parsing_data_elt -> Prims.bool) =
   fun projectee  ->
-    match projectee with | P_dep _0 -> true | uu____734 -> false
+    match projectee with | P_dep _0 -> true | uu____733 -> false
   
 let (__proj__P_dep__item___0 :
   parsing_data_elt -> (Prims.bool * FStar_Ident.lident)) =
   fun projectee  -> match projectee with | P_dep _0 -> _0 
 let (uu___is_P_alias : parsing_data_elt -> Prims.bool) =
   fun projectee  ->
-    match projectee with | P_alias _0 -> true | uu____772 -> false
+    match projectee with | P_alias _0 -> true | uu____771 -> false
   
 let (__proj__P_alias__item___0 :
   parsing_data_elt -> (FStar_Ident.ident * FStar_Ident.lident)) =
   fun projectee  -> match projectee with | P_alias _0 -> _0 
 let (uu___is_P_lid : parsing_data_elt -> Prims.bool) =
   fun projectee  ->
-    match projectee with | P_lid _0 -> true | uu____803 -> false
+    match projectee with | P_lid _0 -> true | uu____802 -> false
   
 let (__proj__P_lid__item___0 : parsing_data_elt -> FStar_Ident.lident) =
   fun projectee  -> match projectee with | P_lid _0 -> _0 
@@ -247,7 +248,7 @@ let (uu___is_P_inline_for_extraction : parsing_data_elt -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | P_inline_for_extraction  -> true
-    | uu____821 -> false
+    | uu____820 -> false
   
 type parsing_data =
   | Mk_pd of parsing_data_elt Prims.list 
@@ -256,75 +257,75 @@ let (__proj__Mk_pd__item___0 : parsing_data -> parsing_data_elt Prims.list) =
   fun projectee  -> match projectee with | Mk_pd _0 -> _0 
 let (str_of_parsing_data_elt : parsing_data_elt -> Prims.string) =
   fun elt  ->
-    let str_of_open_kind uu___2_864 =
-      match uu___2_864 with
+    let str_of_open_kind uu___2_863 =
+      match uu___2_863 with
       | Open_module  -> "P_open_module"
       | Open_namespace  -> "P_open_namespace"  in
     match elt with
     | P_begin_module lid ->
-        let uu____870 =
-          let uu____872 = FStar_Ident.text_of_lid lid  in
-          FStar_String.op_Hat uu____872 ")"  in
-        FStar_String.op_Hat "P_begin_module (" uu____870
+        let uu____869 =
+          let uu____871 = FStar_Ident.string_of_lid lid  in
+          FStar_String.op_Hat uu____871 ")"  in
+        FStar_String.op_Hat "P_begin_module (" uu____869
     | P_open (b,lid) ->
-        let uu____880 =
-          let uu____882 = FStar_Util.string_of_bool b  in
-          let uu____884 =
-            let uu____886 =
-              let uu____888 = FStar_Ident.text_of_lid lid  in
-              FStar_String.op_Hat uu____888 ")"  in
-            FStar_String.op_Hat ", " uu____886  in
-          FStar_String.op_Hat uu____882 uu____884  in
-        FStar_String.op_Hat "P_open (" uu____880
+        let uu____879 =
+          let uu____881 = FStar_Util.string_of_bool b  in
+          let uu____883 =
+            let uu____885 =
+              let uu____887 = FStar_Ident.string_of_lid lid  in
+              FStar_String.op_Hat uu____887 ")"  in
+            FStar_String.op_Hat ", " uu____885  in
+          FStar_String.op_Hat uu____881 uu____883  in
+        FStar_String.op_Hat "P_open (" uu____879
     | P_open_module_or_namespace (k,lid) ->
-        let uu____895 =
-          let uu____897 =
-            let uu____899 =
-              let uu____901 = FStar_Ident.text_of_lid lid  in
-              FStar_String.op_Hat uu____901 ")"  in
-            FStar_String.op_Hat ", " uu____899  in
-          FStar_String.op_Hat (str_of_open_kind k) uu____897  in
-        FStar_String.op_Hat "P_open_module_or_namespace (" uu____895
+        let uu____894 =
+          let uu____896 =
+            let uu____898 =
+              let uu____900 = FStar_Ident.string_of_lid lid  in
+              FStar_String.op_Hat uu____900 ")"  in
+            FStar_String.op_Hat ", " uu____898  in
+          FStar_String.op_Hat (str_of_open_kind k) uu____896  in
+        FStar_String.op_Hat "P_open_module_or_namespace (" uu____894
     | P_dep (b,lid) ->
-        let uu____910 =
-          let uu____912 = FStar_Ident.text_of_lid lid  in
-          let uu____914 =
-            let uu____916 =
-              let uu____918 = FStar_Util.string_of_bool b  in
-              FStar_String.op_Hat uu____918 ")"  in
-            FStar_String.op_Hat ", " uu____916  in
-          FStar_String.op_Hat uu____912 uu____914  in
-        FStar_String.op_Hat "P_dep (" uu____910
+        let uu____909 =
+          let uu____911 = FStar_Ident.string_of_lid lid  in
+          let uu____913 =
+            let uu____915 =
+              let uu____917 = FStar_Util.string_of_bool b  in
+              FStar_String.op_Hat uu____917 ")"  in
+            FStar_String.op_Hat ", " uu____915  in
+          FStar_String.op_Hat uu____911 uu____913  in
+        FStar_String.op_Hat "P_dep (" uu____909
     | P_alias (id,lid) ->
-        let uu____925 =
-          let uu____927 = FStar_Ident.text_of_id id  in
-          let uu____929 =
-            let uu____931 =
-              let uu____933 = FStar_Ident.text_of_lid lid  in
-              FStar_String.op_Hat uu____933 ")"  in
-            FStar_String.op_Hat ", " uu____931  in
-          FStar_String.op_Hat uu____927 uu____929  in
-        FStar_String.op_Hat "P_alias (" uu____925
+        let uu____924 =
+          let uu____926 = FStar_Ident.text_of_id id  in
+          let uu____928 =
+            let uu____930 =
+              let uu____932 = FStar_Ident.string_of_lid lid  in
+              FStar_String.op_Hat uu____932 ")"  in
+            FStar_String.op_Hat ", " uu____930  in
+          FStar_String.op_Hat uu____926 uu____928  in
+        FStar_String.op_Hat "P_alias (" uu____924
     | P_lid lid ->
-        let uu____939 =
-          let uu____941 = FStar_Ident.text_of_lid lid  in
-          FStar_String.op_Hat uu____941 ")"  in
-        FStar_String.op_Hat "P_lid (" uu____939
+        let uu____938 =
+          let uu____940 = FStar_Ident.string_of_lid lid  in
+          FStar_String.op_Hat uu____940 ")"  in
+        FStar_String.op_Hat "P_lid (" uu____938
     | P_inline_for_extraction  -> "P_inline_for_extraction"
   
 let (str_of_parsing_data : parsing_data -> Prims.string) =
-  fun uu___3_952  ->
-    match uu___3_952 with
+  fun uu___3_951  ->
+    match uu___3_951 with
     | Mk_pd l ->
         FStar_All.pipe_right l
           (FStar_List.fold_left
              (fun s  ->
                 fun elt  ->
-                  let uu____967 =
-                    let uu____969 =
+                  let uu____966 =
+                    let uu____968 =
                       FStar_All.pipe_right elt str_of_parsing_data_elt  in
-                    FStar_String.op_Hat "; " uu____969  in
-                  FStar_String.op_Hat s uu____967) "")
+                    FStar_String.op_Hat "; " uu____968  in
+                  FStar_String.op_Hat s uu____966) "")
   
 let (parsing_data_elt_eq :
   parsing_data_elt -> parsing_data_elt -> Prims.bool) =
@@ -339,12 +340,12 @@ let (parsing_data_elt_eq :
       | (P_dep (b1,l1),P_dep (b2,l2)) ->
           (b1 = b2) && (FStar_Ident.lid_equals l1 l2)
       | (P_alias (i1,l1),P_alias (i2,l2)) ->
-          (let uu____1019 = FStar_Ident.text_of_id i1  in
-           let uu____1021 = FStar_Ident.text_of_id i2  in
-           uu____1019 = uu____1021) && (FStar_Ident.lid_equals l1 l2)
+          (let uu____1018 = FStar_Ident.text_of_id i1  in
+           let uu____1020 = FStar_Ident.text_of_id i2  in
+           uu____1018 = uu____1020) && (FStar_Ident.lid_equals l1 l2)
       | (P_lid l1,P_lid l2) -> FStar_Ident.lid_equals l1 l2
       | (P_inline_for_extraction ,P_inline_for_extraction ) -> true
-      | (uu____1027,uu____1028) -> false
+      | (uu____1026,uu____1027) -> false
   
 let (empty_parsing_data : parsing_data) = Mk_pd [] 
 type deps =
@@ -397,20 +398,20 @@ let (__proj__Mkdeps__item__parse_results :
 let (deps_try_find :
   dependence_graph -> Prims.string -> dep_node FStar_Pervasives_Native.option)
   =
-  fun uu____1244  ->
-    fun k  -> match uu____1244 with | Deps m -> FStar_Util.smap_try_find m k
+  fun uu____1243  ->
+    fun k  -> match uu____1243 with | Deps m -> FStar_Util.smap_try_find m k
   
 let (deps_add_dep : dependence_graph -> Prims.string -> dep_node -> unit) =
-  fun uu____1266  ->
+  fun uu____1265  ->
     fun k  ->
-      fun v  -> match uu____1266 with | Deps m -> FStar_Util.smap_add m k v
+      fun v  -> match uu____1265 with | Deps m -> FStar_Util.smap_add m k v
   
 let (deps_keys : dependence_graph -> Prims.string Prims.list) =
-  fun uu____1281  -> match uu____1281 with | Deps m -> FStar_Util.smap_keys m 
+  fun uu____1280  -> match uu____1280 with | Deps m -> FStar_Util.smap_keys m 
 let (deps_empty : unit -> dependence_graph) =
-  fun uu____1293  ->
-    let uu____1294 = FStar_Util.smap_create (Prims.of_int (41))  in
-    Deps uu____1294
+  fun uu____1292  ->
+    let uu____1293 = FStar_Util.smap_create (Prims.of_int (41))  in
+    Deps uu____1293
   
 let (mk_deps :
   dependence_graph ->
@@ -435,13 +436,13 @@ let (mk_deps :
               }
   
 let (empty_deps : deps) =
-  let uu____1352 = deps_empty ()  in
-  let uu____1353 = FStar_Util.smap_create Prims.int_zero  in
-  let uu____1365 = FStar_Util.smap_create Prims.int_zero  in
-  mk_deps uu____1352 uu____1353 [] [] [] uu____1365 
+  let uu____1351 = deps_empty ()  in
+  let uu____1352 = FStar_Util.smap_create Prims.int_zero  in
+  let uu____1364 = FStar_Util.smap_create Prims.int_zero  in
+  mk_deps uu____1351 uu____1352 [] [] [] uu____1364 
 let (module_name_of_dep : dependence -> module_name) =
-  fun uu___4_1378  ->
-    match uu___4_1378 with
+  fun uu___4_1377  ->
+    match uu___4_1377 with
     | UseInterface m -> m
     | PreferInterface m -> m
     | UseImplementation m -> m
@@ -453,17 +454,17 @@ let (resolve_module_name :
   =
   fun file_system_map  ->
     fun key  ->
-      let uu____1407 = FStar_Util.smap_try_find file_system_map key  in
-      match uu____1407 with
+      let uu____1406 = FStar_Util.smap_try_find file_system_map key  in
+      match uu____1406 with
       | FStar_Pervasives_Native.Some
-          (FStar_Pervasives_Native.Some fn,uu____1434) ->
-          let uu____1456 = lowercase_module_name fn  in
-          FStar_Pervasives_Native.Some uu____1456
+          (FStar_Pervasives_Native.Some fn,uu____1433) ->
+          let uu____1455 = lowercase_module_name fn  in
+          FStar_Pervasives_Native.Some uu____1455
       | FStar_Pervasives_Native.Some
-          (uu____1459,FStar_Pervasives_Native.Some fn) ->
-          let uu____1482 = lowercase_module_name fn  in
-          FStar_Pervasives_Native.Some uu____1482
-      | uu____1485 -> FStar_Pervasives_Native.None
+          (uu____1458,FStar_Pervasives_Native.Some fn) ->
+          let uu____1481 = lowercase_module_name fn  in
+          FStar_Pervasives_Native.Some uu____1481
+      | uu____1484 -> FStar_Pervasives_Native.None
   
 let (interface_of_internal :
   files_for_module_name ->
@@ -471,12 +472,12 @@ let (interface_of_internal :
   =
   fun file_system_map  ->
     fun key  ->
-      let uu____1518 = FStar_Util.smap_try_find file_system_map key  in
-      match uu____1518 with
+      let uu____1517 = FStar_Util.smap_try_find file_system_map key  in
+      match uu____1517 with
       | FStar_Pervasives_Native.Some
-          (FStar_Pervasives_Native.Some iface,uu____1545) ->
+          (FStar_Pervasives_Native.Some iface,uu____1544) ->
           FStar_Pervasives_Native.Some iface
-      | uu____1568 -> FStar_Pervasives_Native.None
+      | uu____1567 -> FStar_Pervasives_Native.None
   
 let (implementation_of_internal :
   files_for_module_name ->
@@ -484,12 +485,12 @@ let (implementation_of_internal :
   =
   fun file_system_map  ->
     fun key  ->
-      let uu____1601 = FStar_Util.smap_try_find file_system_map key  in
-      match uu____1601 with
+      let uu____1600 = FStar_Util.smap_try_find file_system_map key  in
+      match uu____1600 with
       | FStar_Pervasives_Native.Some
-          (uu____1627,FStar_Pervasives_Native.Some impl) ->
+          (uu____1626,FStar_Pervasives_Native.Some impl) ->
           FStar_Pervasives_Native.Some impl
-      | uu____1651 -> FStar_Pervasives_Native.None
+      | uu____1650 -> FStar_Pervasives_Native.None
   
 let (interface_of :
   deps -> Prims.string -> Prims.string FStar_Pervasives_Native.option) =
@@ -502,15 +503,15 @@ let (implementation_of :
 let (has_interface : files_for_module_name -> module_name -> Prims.bool) =
   fun file_system_map  ->
     fun key  ->
-      let uu____1712 = interface_of_internal file_system_map key  in
-      FStar_Option.isSome uu____1712
+      let uu____1711 = interface_of_internal file_system_map key  in
+      FStar_Option.isSome uu____1711
   
 let (has_implementation : files_for_module_name -> module_name -> Prims.bool)
   =
   fun file_system_map  ->
     fun key  ->
-      let uu____1732 = implementation_of_internal file_system_map key  in
-      FStar_Option.isSome uu____1732
+      let uu____1731 = implementation_of_internal file_system_map key  in
+      FStar_Option.isSome uu____1731
   
 let (cache_file_name : Prims.string -> Prims.string) =
   let checked_file_and_exists_flag fn =
@@ -520,62 +521,62 @@ let (cache_file_name : Prims.string -> Prims.string) =
       then FStar_String.op_Hat fn ".checked.lax"
       else FStar_String.op_Hat fn ".checked"  in
     let mname = FStar_All.pipe_right fn module_name_of_file  in
-    let uu____1767 =
-      let uu____1771 = FStar_All.pipe_right cache_fn FStar_Util.basename  in
-      FStar_Options.find_file uu____1771  in
-    match uu____1767 with
+    let uu____1766 =
+      let uu____1770 = FStar_All.pipe_right cache_fn FStar_Util.basename  in
+      FStar_Options.find_file uu____1770  in
+    match uu____1766 with
     | FStar_Pervasives_Native.Some path ->
         let expected_cache_file = FStar_Options.prepend_cache_dir cache_fn
            in
-        ((let uu____1782 =
-            ((let uu____1786 = FStar_Options.dep ()  in
-              FStar_Option.isSome uu____1786) &&
-               (let uu____1792 = FStar_Options.should_be_already_cached mname
+        ((let uu____1781 =
+            ((let uu____1785 = FStar_Options.dep ()  in
+              FStar_Option.isSome uu____1785) &&
+               (let uu____1791 = FStar_Options.should_be_already_cached mname
                    in
-                Prims.op_Negation uu____1792))
+                Prims.op_Negation uu____1791))
               &&
               ((Prims.op_Negation
                   (FStar_Util.file_exists expected_cache_file))
                  ||
-                 (let uu____1795 =
+                 (let uu____1794 =
                     FStar_Util.paths_to_same_file path expected_cache_file
                      in
-                  Prims.op_Negation uu____1795))
+                  Prims.op_Negation uu____1794))
              in
-          if uu____1782
+          if uu____1781
           then
-            let uu____1798 =
-              let uu____1804 =
-                let uu____1806 = FStar_Options.prepend_cache_dir cache_fn  in
+            let uu____1797 =
+              let uu____1803 =
+                let uu____1805 = FStar_Options.prepend_cache_dir cache_fn  in
                 FStar_Util.format3
                   "Did not expect %s to be already checked, but found it in an unexpected location %s instead of %s"
-                  mname path uu____1806
+                  mname path uu____1805
                  in
-              (FStar_Errors.Warning_UnexpectedCheckedFile, uu____1804)  in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____1798
+              (FStar_Errors.Warning_UnexpectedCheckedFile, uu____1803)  in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu____1797
           else ());
          path)
     | FStar_Pervasives_Native.None  ->
-        let uu____1813 =
+        let uu____1812 =
           FStar_All.pipe_right mname FStar_Options.should_be_already_cached
            in
-        if uu____1813
+        if uu____1812
         then
-          let uu____1819 =
-            let uu____1825 =
+          let uu____1818 =
+            let uu____1824 =
               FStar_Util.format1
                 "Expected %s to be already checked but could not find it"
                 mname
                in
-            (FStar_Errors.Error_AlreadyCachedAssertionFailure, uu____1825)
+            (FStar_Errors.Error_AlreadyCachedAssertionFailure, uu____1824)
              in
-          FStar_Errors.raise_err uu____1819
+          FStar_Errors.raise_err uu____1818
         else FStar_Options.prepend_cache_dir cache_fn
      in
   let memo = FStar_Util.smap_create (Prims.of_int (100))  in
   let memo1 f x =
-    let uu____1861 = FStar_Util.smap_try_find memo x  in
-    match uu____1861 with
+    let uu____1860 = FStar_Util.smap_try_find memo x  in
+    match uu____1860 with
     | FStar_Pervasives_Native.Some res -> res
     | FStar_Pervasives_Native.None  ->
         let res = f x  in (FStar_Util.smap_add memo x res; res)
@@ -584,8 +585,8 @@ let (cache_file_name : Prims.string -> Prims.string) =
 let (parsing_data_of : deps -> Prims.string -> parsing_data) =
   fun deps1  ->
     fun fn  ->
-      let uu____1888 = FStar_Util.smap_try_find deps1.parse_results fn  in
-      FStar_All.pipe_right uu____1888 FStar_Util.must
+      let uu____1887 = FStar_Util.smap_try_find deps1.parse_results fn  in
+      FStar_All.pipe_right uu____1887 FStar_Util.must
   
 let (file_of_dep_aux :
   Prims.bool ->
@@ -600,111 +601,111 @@ let (file_of_dep_aux :
               (FStar_Util.for_some
                  (fun fn  ->
                     (is_implementation fn) &&
-                      (let uu____1942 = lowercase_module_name fn  in
-                       key = uu____1942)))
+                      (let uu____1941 = lowercase_module_name fn  in
+                       key = uu____1941)))
              in
           let maybe_use_cache_of f =
             if use_checked_file then cache_file_name f else f  in
           match d with
           | UseInterface key ->
-              let uu____1961 = interface_of_internal file_system_map key  in
-              (match uu____1961 with
+              let uu____1960 = interface_of_internal file_system_map key  in
+              (match uu____1960 with
                | FStar_Pervasives_Native.None  ->
-                   let uu____1968 =
-                     let uu____1974 =
+                   let uu____1967 =
+                     let uu____1973 =
                        FStar_Util.format1
                          "Expected an interface for module %s, but couldn't find one"
                          key
                         in
-                     (FStar_Errors.Fatal_MissingInterface, uu____1974)  in
-                   FStar_Errors.raise_err uu____1968
+                     (FStar_Errors.Fatal_MissingInterface, uu____1973)  in
+                   FStar_Errors.raise_err uu____1967
                | FStar_Pervasives_Native.Some f -> f)
           | PreferInterface key when has_interface file_system_map key ->
-              let uu____1984 =
+              let uu____1983 =
                 (cmd_line_has_impl key) &&
-                  (let uu____1987 = FStar_Options.dep ()  in
-                   FStar_Option.isNone uu____1987)
+                  (let uu____1986 = FStar_Options.dep ()  in
+                   FStar_Option.isNone uu____1986)
                  in
-              if uu____1984
+              if uu____1983
               then
-                let uu____1994 = FStar_Options.expose_interfaces ()  in
-                (if uu____1994
+                let uu____1993 = FStar_Options.expose_interfaces ()  in
+                (if uu____1993
                  then
-                   let uu____1998 =
-                     let uu____2000 =
+                   let uu____1997 =
+                     let uu____1999 =
                        implementation_of_internal file_system_map key  in
-                     FStar_Option.get uu____2000  in
-                   maybe_use_cache_of uu____1998
+                     FStar_Option.get uu____1999  in
+                   maybe_use_cache_of uu____1997
                  else
-                   (let uu____2007 =
-                      let uu____2013 =
-                        let uu____2015 =
-                          let uu____2017 =
+                   (let uu____2006 =
+                      let uu____2012 =
+                        let uu____2014 =
+                          let uu____2016 =
                             implementation_of_internal file_system_map key
                              in
-                          FStar_Option.get uu____2017  in
-                        let uu____2022 =
-                          let uu____2024 =
+                          FStar_Option.get uu____2016  in
+                        let uu____2021 =
+                          let uu____2023 =
                             interface_of_internal file_system_map key  in
-                          FStar_Option.get uu____2024  in
+                          FStar_Option.get uu____2023  in
                         FStar_Util.format3
                           "You may have a cyclic dependence on module %s: use --dep full to confirm. Alternatively, invoking fstar with %s on the command line breaks the abstraction imposed by its interface %s; if you really want this behavior add the option '--expose_interfaces'"
-                          key uu____2015 uu____2022
+                          key uu____2014 uu____2021
                          in
                       (FStar_Errors.Fatal_MissingExposeInterfacesOption,
-                        uu____2013)
+                        uu____2012)
                        in
-                    FStar_Errors.raise_err uu____2007))
+                    FStar_Errors.raise_err uu____2006))
               else
-                (let uu____2034 =
-                   let uu____2036 = interface_of_internal file_system_map key
+                (let uu____2033 =
+                   let uu____2035 = interface_of_internal file_system_map key
                       in
-                   FStar_Option.get uu____2036  in
-                 maybe_use_cache_of uu____2034)
+                   FStar_Option.get uu____2035  in
+                 maybe_use_cache_of uu____2033)
           | PreferInterface key ->
-              let uu____2043 = implementation_of_internal file_system_map key
+              let uu____2042 = implementation_of_internal file_system_map key
                  in
-              (match uu____2043 with
+              (match uu____2042 with
                | FStar_Pervasives_Native.None  ->
-                   let uu____2049 =
-                     let uu____2055 =
+                   let uu____2048 =
+                     let uu____2054 =
                        FStar_Util.format1
                          "Expected an implementation of module %s, but couldn't find one"
                          key
                         in
-                     (FStar_Errors.Fatal_MissingImplementation, uu____2055)
+                     (FStar_Errors.Fatal_MissingImplementation, uu____2054)
                       in
-                   FStar_Errors.raise_err uu____2049
+                   FStar_Errors.raise_err uu____2048
                | FStar_Pervasives_Native.Some f -> maybe_use_cache_of f)
           | UseImplementation key ->
-              let uu____2065 = implementation_of_internal file_system_map key
+              let uu____2064 = implementation_of_internal file_system_map key
                  in
-              (match uu____2065 with
+              (match uu____2064 with
                | FStar_Pervasives_Native.None  ->
-                   let uu____2071 =
-                     let uu____2077 =
+                   let uu____2070 =
+                     let uu____2076 =
                        FStar_Util.format1
                          "Expected an implementation of module %s, but couldn't find one"
                          key
                         in
-                     (FStar_Errors.Fatal_MissingImplementation, uu____2077)
+                     (FStar_Errors.Fatal_MissingImplementation, uu____2076)
                       in
-                   FStar_Errors.raise_err uu____2071
+                   FStar_Errors.raise_err uu____2070
                | FStar_Pervasives_Native.Some f -> maybe_use_cache_of f)
           | FriendImplementation key ->
-              let uu____2087 = implementation_of_internal file_system_map key
+              let uu____2086 = implementation_of_internal file_system_map key
                  in
-              (match uu____2087 with
+              (match uu____2086 with
                | FStar_Pervasives_Native.None  ->
-                   let uu____2093 =
-                     let uu____2099 =
+                   let uu____2092 =
+                     let uu____2098 =
                        FStar_Util.format1
                          "Expected an implementation of module %s, but couldn't find one"
                          key
                         in
-                     (FStar_Errors.Fatal_MissingImplementation, uu____2099)
+                     (FStar_Errors.Fatal_MissingImplementation, uu____2098)
                       in
-                   FStar_Errors.raise_err uu____2093
+                   FStar_Errors.raise_err uu____2092
                | FStar_Pervasives_Native.Some f -> maybe_use_cache_of f)
   
 let (file_of_dep :
@@ -719,16 +720,16 @@ let (dependences_of :
     fun deps1  ->
       fun all_cmd_line_files  ->
         fun fn  ->
-          let uu____2160 = deps_try_find deps1 fn  in
-          match uu____2160 with
+          let uu____2159 = deps_try_find deps1 fn  in
+          match uu____2159 with
           | FStar_Pervasives_Native.None  -> empty_dependences ()
           | FStar_Pervasives_Native.Some
-              { edges = deps2; color = uu____2168;_} ->
-              let uu____2169 =
+              { edges = deps2; color = uu____2167;_} ->
+              let uu____2168 =
                 FStar_List.map
                   (file_of_dep file_system_map all_cmd_line_files) deps2
                  in
-              FStar_All.pipe_right uu____2169
+              FStar_All.pipe_right uu____2168
                 (FStar_List.filter (fun k  -> k <> fn))
   
 let (print_graph : dependence_graph -> unit) =
@@ -739,45 +740,45 @@ let (print_graph : dependence_graph -> unit) =
       "With GraphViz installed, try: fdp -Tpng -odep.png dep.graph";
     FStar_Util.print_endline
       "Hint: cat dep.graph | grep -v _ | grep -v prims";
-    (let uu____2197 =
-       let uu____2199 =
-         let uu____2201 =
-           let uu____2203 =
-             let uu____2207 =
-               let uu____2211 = deps_keys graph  in
-               FStar_List.unique uu____2211  in
+    (let uu____2196 =
+       let uu____2198 =
+         let uu____2200 =
+           let uu____2202 =
+             let uu____2206 =
+               let uu____2210 = deps_keys graph  in
+               FStar_List.unique uu____2210  in
              FStar_List.collect
                (fun k  ->
                   let deps1 =
-                    let uu____2225 =
-                      let uu____2226 = deps_try_find graph k  in
-                      FStar_Util.must uu____2226  in
-                    uu____2225.edges  in
+                    let uu____2224 =
+                      let uu____2225 = deps_try_find graph k  in
+                      FStar_Util.must uu____2225  in
+                    uu____2224.edges  in
                   let r s = FStar_Util.replace_char s 46 95  in
                   let print dep =
-                    let uu____2247 =
-                      let uu____2249 = lowercase_module_name k  in
-                      r uu____2249  in
-                    FStar_Util.format2 "  \"%s\" -> \"%s\"" uu____2247
+                    let uu____2246 =
+                      let uu____2248 = lowercase_module_name k  in
+                      r uu____2248  in
+                    FStar_Util.format2 "  \"%s\" -> \"%s\"" uu____2246
                       (r (module_name_of_dep dep))
                      in
-                  FStar_List.map print deps1) uu____2207
+                  FStar_List.map print deps1) uu____2206
               in
-           FStar_String.concat "\n" uu____2203  in
-         FStar_String.op_Hat uu____2201 "\n}\n"  in
-       FStar_String.op_Hat "digraph {\n" uu____2199  in
-     FStar_Util.write_file "dep.graph" uu____2197)
+           FStar_String.concat "\n" uu____2202  in
+         FStar_String.op_Hat uu____2200 "\n}\n"  in
+       FStar_String.op_Hat "digraph {\n" uu____2198  in
+     FStar_Util.write_file "dep.graph" uu____2196)
   
 let (build_inclusion_candidates_list :
   unit -> (Prims.string * Prims.string) Prims.list) =
-  fun uu____2270  ->
+  fun uu____2269  ->
     let include_directories = FStar_Options.include_path ()  in
     let include_directories1 =
       FStar_List.map FStar_Util.normalize_file_path include_directories  in
     let include_directories2 = FStar_List.unique include_directories1  in
     let cwd =
-      let uu____2296 = FStar_Util.getcwd ()  in
-      FStar_Util.normalize_file_path uu____2296  in
+      let uu____2295 = FStar_Util.getcwd ()  in
+      FStar_Util.normalize_file_path uu____2295  in
     FStar_List.concatMap
       (fun d  ->
          if FStar_Util.is_directory d
@@ -786,8 +787,8 @@ let (build_inclusion_candidates_list :
            FStar_List.filter_map
              (fun f  ->
                 let f1 = FStar_Util.basename f  in
-                let uu____2336 = check_and_strip_suffix f1  in
-                FStar_All.pipe_right uu____2336
+                let uu____2335 = check_and_strip_suffix f1  in
+                FStar_All.pipe_right uu____2335
                   (FStar_Util.map_option
                      (fun longname  ->
                         let full_path =
@@ -795,22 +796,22 @@ let (build_inclusion_candidates_list :
                            in
                         (longname, full_path)))) files
          else
-           (let uu____2373 =
-              let uu____2379 =
+           (let uu____2372 =
+              let uu____2378 =
                 FStar_Util.format1 "not a valid include directory: %s\n" d
                  in
-              (FStar_Errors.Fatal_NotValidIncludeDirectory, uu____2379)  in
-            FStar_Errors.raise_err uu____2373)) include_directories2
+              (FStar_Errors.Fatal_NotValidIncludeDirectory, uu____2378)  in
+            FStar_Errors.raise_err uu____2372)) include_directories2
   
 let (build_map : Prims.string Prims.list -> files_for_module_name) =
   fun filenames  ->
     let map = FStar_Util.smap_create (Prims.of_int (41))  in
     let add_entry key full_path =
-      let uu____2442 = FStar_Util.smap_try_find map key  in
-      match uu____2442 with
+      let uu____2441 = FStar_Util.smap_try_find map key  in
+      match uu____2441 with
       | FStar_Pervasives_Native.Some (intf,impl) ->
-          let uu____2489 = is_interface full_path  in
-          if uu____2489
+          let uu____2488 = is_interface full_path  in
+          if uu____2488
           then
             FStar_Util.smap_add map key
               ((FStar_Pervasives_Native.Some full_path), impl)
@@ -818,8 +819,8 @@ let (build_map : Prims.string Prims.list -> files_for_module_name) =
             FStar_Util.smap_add map key
               (intf, (FStar_Pervasives_Native.Some full_path))
       | FStar_Pervasives_Native.None  ->
-          let uu____2538 = is_interface full_path  in
-          if uu____2538
+          let uu____2537 = is_interface full_path  in
+          if uu____2537
           then
             FStar_Util.smap_add map key
               ((FStar_Pervasives_Native.Some full_path),
@@ -829,16 +830,16 @@ let (build_map : Prims.string Prims.list -> files_for_module_name) =
               (FStar_Pervasives_Native.None,
                 (FStar_Pervasives_Native.Some full_path))
        in
-    (let uu____2580 = build_inclusion_candidates_list ()  in
+    (let uu____2579 = build_inclusion_candidates_list ()  in
      FStar_List.iter
-       (fun uu____2598  ->
-          match uu____2598 with
+       (fun uu____2597  ->
+          match uu____2597 with
           | (longname,full_path) ->
               add_entry (FStar_String.lowercase longname) full_path)
-       uu____2580);
+       uu____2579);
     FStar_List.iter
       (fun f  ->
-         let uu____2617 = lowercase_module_name f  in add_entry uu____2617 f)
+         let uu____2616 = lowercase_module_name f  in add_entry uu____2616 f)
       filenames;
     map
   
@@ -853,7 +854,7 @@ let (enter_namespace :
         let prefix1 = FStar_String.op_Hat prefix "."  in
         FStar_Util.smap_iter original_map
           (fun k  ->
-             fun uu____2665  ->
+             fun uu____2664  ->
                if FStar_Util.starts_with k prefix1
                then
                  let suffix =
@@ -861,9 +862,9 @@ let (enter_namespace :
                      ((FStar_String.length k) - (FStar_String.length prefix1))
                     in
                  let filename =
-                   let uu____2691 = FStar_Util.smap_try_find original_map k
+                   let uu____2690 = FStar_Util.smap_try_find original_map k
                       in
-                   FStar_Util.must uu____2691  in
+                   FStar_Util.must uu____2690  in
                  (FStar_Util.smap_add working_map suffix filename;
                   FStar_ST.op_Colon_Equals found true)
                else ());
@@ -873,89 +874,96 @@ let (string_of_lid : FStar_Ident.lident -> Prims.bool -> Prims.string) =
   fun l  ->
     fun last  ->
       let suffix =
-        if last then [(l.FStar_Ident.ident).FStar_Ident.idText] else []  in
+        if last
+        then
+          let uu____2801 =
+            let uu____2803 = FStar_Ident.ident_of_lid l  in
+            FStar_Ident.text_of_id uu____2803  in
+          [uu____2801]
+        else []  in
       let names =
-        let uu____2811 =
-          FStar_List.map (fun x  -> x.FStar_Ident.idText) l.FStar_Ident.ns
-           in
-        FStar_List.append uu____2811 suffix  in
+        let uu____2813 =
+          let uu____2817 = FStar_Ident.ns_of_lid l  in
+          FStar_List.map (fun x  -> FStar_Ident.text_of_id x) uu____2817  in
+        FStar_List.append uu____2813 suffix  in
       FStar_String.concat "." names
   
 let (lowercase_join_longident :
   FStar_Ident.lident -> Prims.bool -> Prims.string) =
   fun l  ->
     fun last  ->
-      let uu____2834 = string_of_lid l last  in
-      FStar_String.lowercase uu____2834
+      let uu____2839 = string_of_lid l last  in
+      FStar_String.lowercase uu____2839
   
 let (namespace_of_lid : FStar_Ident.lident -> Prims.string) =
   fun l  ->
-    let uu____2843 = FStar_List.map FStar_Ident.text_of_id l.FStar_Ident.ns
-       in
-    FStar_String.concat "_" uu____2843
+    let uu____2848 =
+      let uu____2852 = FStar_Ident.ns_of_lid l  in
+      FStar_List.map FStar_Ident.text_of_id uu____2852  in
+    FStar_String.concat "_" uu____2848
   
 let (check_module_declaration_against_filename :
   FStar_Ident.lident -> Prims.string -> unit) =
   fun lid  ->
     fun filename  ->
       let k' = lowercase_join_longident lid true  in
-      let uu____2865 =
-        let uu____2867 =
-          let uu____2869 =
-            let uu____2871 =
-              let uu____2875 = FStar_Util.basename filename  in
-              check_and_strip_suffix uu____2875  in
-            FStar_Util.must uu____2871  in
-          FStar_String.lowercase uu____2869  in
-        uu____2867 <> k'  in
-      if uu____2865
+      let uu____2873 =
+        let uu____2875 =
+          let uu____2877 =
+            let uu____2879 =
+              let uu____2883 = FStar_Util.basename filename  in
+              check_and_strip_suffix uu____2883  in
+            FStar_Util.must uu____2879  in
+          FStar_String.lowercase uu____2877  in
+        uu____2875 <> k'  in
+      if uu____2873
       then
-        let uu____2880 = FStar_Ident.range_of_lid lid  in
-        let uu____2881 =
-          let uu____2887 =
-            let uu____2889 = string_of_lid lid true  in
+        let uu____2888 = FStar_Ident.range_of_lid lid  in
+        let uu____2889 =
+          let uu____2895 =
+            let uu____2897 = string_of_lid lid true  in
             FStar_Util.format2
               "The module declaration \"module %s\" found in file %s does not match its filename. Dependencies will be incorrect and the module will not be verified.\n"
-              uu____2889 filename
+              uu____2897 filename
              in
-          (FStar_Errors.Error_ModuleFileNameMismatch, uu____2887)  in
-        FStar_Errors.log_issue uu____2880 uu____2881
+          (FStar_Errors.Error_ModuleFileNameMismatch, uu____2895)  in
+        FStar_Errors.log_issue uu____2888 uu____2889
       else ()
   
 exception Exit 
 let (uu___is_Exit : Prims.exn -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Exit  -> true | uu____2905 -> false
+    match projectee with | Exit  -> true | uu____2913 -> false
   
 let (core_modules : Prims.string Prims.list) =
-  let uu____2911 =
-    let uu____2915 = FStar_Options.prims_basename ()  in
-    let uu____2917 =
-      let uu____2921 = FStar_Options.pervasives_basename ()  in
-      let uu____2923 =
-        let uu____2927 = FStar_Options.pervasives_native_basename ()  in
-        [uu____2927]  in
-      uu____2921 :: uu____2923  in
-    uu____2915 :: uu____2917  in
-  FStar_All.pipe_right uu____2911 (FStar_List.map module_name_of_file) 
+  let uu____2919 =
+    let uu____2923 = FStar_Options.prims_basename ()  in
+    let uu____2925 =
+      let uu____2929 = FStar_Options.pervasives_basename ()  in
+      let uu____2931 =
+        let uu____2935 = FStar_Options.pervasives_native_basename ()  in
+        [uu____2935]  in
+      uu____2929 :: uu____2931  in
+    uu____2923 :: uu____2925  in
+  FStar_All.pipe_right uu____2919 (FStar_List.map module_name_of_file) 
 let (hard_coded_dependencies :
   Prims.string -> (FStar_Ident.lident * open_kind) Prims.list) =
   fun full_filename  ->
     let filename = FStar_Util.basename full_filename  in
-    let uu____2957 =
-      let uu____2959 = module_name_of_file filename  in
-      FStar_List.mem uu____2959 core_modules  in
-    if uu____2957
+    let uu____2965 =
+      let uu____2967 = module_name_of_file filename  in
+      FStar_List.mem uu____2967 core_modules  in
+    if uu____2965
     then []
     else
       (let implicit_deps =
          [(FStar_Parser_Const.fstar_ns_lid, Open_namespace);
          (FStar_Parser_Const.prims_lid, Open_module);
          (FStar_Parser_Const.pervasives_lid, Open_module)]  in
-       let uu____2998 =
-         let uu____3001 = lowercase_module_name full_filename  in
-         namespace_of_module uu____3001  in
-       match uu____2998 with
+       let uu____3006 =
+         let uu____3009 = lowercase_module_name full_filename  in
+         namespace_of_module uu____3009  in
+       match uu____3006 with
        | FStar_Pervasives_Native.None  -> implicit_deps
        | FStar_Pervasives_Native.Some ns ->
            FStar_List.append implicit_deps [(ns, Open_namespace)])
@@ -965,7 +973,7 @@ let (dep_subsumed_by : dependence -> dependence -> Prims.bool) =
     fun d'  ->
       match (d, d') with
       | (PreferInterface l',FriendImplementation l) -> l = l'
-      | uu____3040 -> d = d'
+      | uu____3048 -> d = d'
   
 let (collect_one :
   files_for_module_name ->
@@ -982,37 +990,37 @@ let (collect_one :
           let has_inline_for_extraction = FStar_Util.mk_ref false  in
           let mo_roots =
             let mname = lowercase_module_name filename1  in
-            let uu____3158 =
+            let uu____3166 =
               (is_interface filename1) &&
                 (has_implementation original_map1 mname)
                in
-            if uu____3158 then [UseImplementation mname] else []  in
+            if uu____3166 then [UseImplementation mname] else []  in
           let auto_open =
-            let uu____3168 = hard_coded_dependencies filename1  in
-            FStar_All.pipe_right uu____3168
+            let uu____3176 = hard_coded_dependencies filename1  in
+            FStar_All.pipe_right uu____3176
               (FStar_List.map
-                 (fun uu____3190  ->
-                    match uu____3190 with
+                 (fun uu____3198  ->
+                    match uu____3198 with
                     | (lid,k) -> P_open_module_or_namespace (k, lid)))
              in
           let working_map = FStar_Util.smap_copy original_map1  in
-          let set_interface_inlining uu____3225 =
-            let uu____3226 = is_interface filename1  in
-            if uu____3226
+          let set_interface_inlining uu____3233 =
+            let uu____3234 = is_interface filename1  in
+            if uu____3234
             then FStar_ST.op_Colon_Equals has_inline_for_extraction true
             else ()  in
           let add_dep deps2 d =
-            let uu____3348 =
-              let uu____3350 =
-                let uu____3352 = FStar_ST.op_Bang deps2  in
-                FStar_List.existsML (dep_subsumed_by d) uu____3352  in
-              Prims.op_Negation uu____3350  in
-            if uu____3348
+            let uu____3356 =
+              let uu____3358 =
+                let uu____3360 = FStar_ST.op_Bang deps2  in
+                FStar_List.existsML (dep_subsumed_by d) uu____3360  in
+              Prims.op_Negation uu____3358  in
+            if uu____3356
             then
-              let uu____3379 =
-                let uu____3382 = FStar_ST.op_Bang deps2  in d :: uu____3382
+              let uu____3387 =
+                let uu____3390 = FStar_ST.op_Bang deps2  in d :: uu____3390
                  in
-              FStar_ST.op_Colon_Equals deps2 uu____3379
+              FStar_ST.op_Colon_Equals deps2 uu____3387
             else ()  in
           let dep_edge module_name1 is_friend =
             if is_friend
@@ -1020,33 +1028,33 @@ let (collect_one :
             else PreferInterface module_name1  in
           let add_dependence_edge original_or_working_map lid is_friend =
             let key = lowercase_join_longident lid true  in
-            let uu____3473 = resolve_module_name original_or_working_map key
+            let uu____3481 = resolve_module_name original_or_working_map key
                in
-            match uu____3473 with
+            match uu____3481 with
             | FStar_Pervasives_Native.Some module_name1 ->
                 (add_dep deps1 (dep_edge module_name1 is_friend); true)
-            | uu____3483 -> false  in
+            | uu____3491 -> false  in
           let record_open_module let_open lid =
-            let uu____3502 =
+            let uu____3510 =
               (let_open && (add_dependence_edge working_map lid false)) ||
                 ((Prims.op_Negation let_open) &&
                    (add_dependence_edge original_map1 lid false))
                in
-            if uu____3502
+            if uu____3510
             then true
             else
               (if let_open
                then
-                 (let uu____3513 = FStar_Ident.range_of_lid lid  in
-                  let uu____3514 =
-                    let uu____3520 =
-                      let uu____3522 = string_of_lid lid true  in
-                      FStar_Util.format1 "Module not found: %s" uu____3522
+                 (let uu____3521 = FStar_Ident.range_of_lid lid  in
+                  let uu____3522 =
+                    let uu____3528 =
+                      let uu____3530 = string_of_lid lid true  in
+                      FStar_Util.format1 "Module not found: %s" uu____3530
                        in
                     (FStar_Errors.Warning_ModuleOrFileNotFoundWarning,
-                      uu____3520)
+                      uu____3528)
                      in
-                  FStar_Errors.log_issue uu____3513 uu____3514)
+                  FStar_Errors.log_issue uu____3521 uu____3522)
                else ();
                false)
              in
@@ -1055,102 +1063,107 @@ let (collect_one :
             let r = enter_namespace original_map1 working_map key  in
             if Prims.op_Negation r
             then
-              let uu____3542 = FStar_Ident.range_of_lid lid  in
-              let uu____3543 =
-                let uu____3549 =
-                  let uu____3551 = string_of_lid lid true  in
+              let uu____3550 = FStar_Ident.range_of_lid lid  in
+              let uu____3551 =
+                let uu____3557 =
+                  let uu____3559 = string_of_lid lid true  in
                   FStar_Util.format1
                     "No modules in namespace %s and no file with that name either"
-                    uu____3551
+                    uu____3559
                    in
                 (FStar_Errors.Warning_ModuleOrFileNotFoundWarning,
-                  uu____3549)
+                  uu____3557)
                  in
-              FStar_Errors.log_issue uu____3542 uu____3543
+              FStar_Errors.log_issue uu____3550 uu____3551
             else ()  in
           let record_open let_open lid =
-            let uu____3571 = record_open_module let_open lid  in
-            if uu____3571
+            let uu____3579 = record_open_module let_open lid  in
+            if uu____3579
             then ()
             else
               if Prims.op_Negation let_open
               then record_open_namespace lid
               else ()
              in
-          let record_open_module_or_namespace uu____3588 =
-            match uu____3588 with
+          let record_open_module_or_namespace uu____3596 =
+            match uu____3596 with
             | (lid,kind) ->
                 (match kind with
                  | Open_namespace  -> record_open_namespace lid
                  | Open_module  ->
-                     let uu____3595 = record_open_module false lid  in ())
+                     let uu____3603 = record_open_module false lid  in ())
              in
           let record_module_alias ident lid =
             let key =
-              let uu____3612 = FStar_Ident.text_of_id ident  in
-              FStar_String.lowercase uu____3612  in
+              let uu____3620 = FStar_Ident.text_of_id ident  in
+              FStar_String.lowercase uu____3620  in
             let alias = lowercase_join_longident lid true  in
-            let uu____3617 = FStar_Util.smap_try_find original_map1 alias  in
-            match uu____3617 with
+            let uu____3625 = FStar_Util.smap_try_find original_map1 alias  in
+            match uu____3625 with
             | FStar_Pervasives_Native.Some deps_of_aliased_module ->
                 (FStar_Util.smap_add working_map key deps_of_aliased_module;
-                 (let uu____3674 =
-                    let uu____3675 = lowercase_join_longident lid true  in
-                    dep_edge uu____3675 false  in
-                  add_dep deps1 uu____3674);
+                 (let uu____3682 =
+                    let uu____3683 = lowercase_join_longident lid true  in
+                    dep_edge uu____3683 false  in
+                  add_dep deps1 uu____3682);
                  true)
             | FStar_Pervasives_Native.None  ->
-                ((let uu____3691 = FStar_Ident.range_of_lid lid  in
-                  let uu____3692 =
-                    let uu____3698 =
+                ((let uu____3699 = FStar_Ident.range_of_lid lid  in
+                  let uu____3700 =
+                    let uu____3706 =
                       FStar_Util.format1
                         "module not found in search path: %s\n" alias
                        in
                     (FStar_Errors.Warning_ModuleOrFileNotFoundWarning,
-                      uu____3698)
+                      uu____3706)
                      in
-                  FStar_Errors.log_issue uu____3691 uu____3692);
+                  FStar_Errors.log_issue uu____3699 uu____3700);
                  false)
              in
           let add_dep_on_module module_name1 is_friend =
-            let uu____3716 =
+            let uu____3724 =
               add_dependence_edge working_map module_name1 is_friend  in
-            if uu____3716
+            if uu____3724
             then ()
             else
-              (let uu____3721 =
+              (let uu____3729 =
                  FStar_Options.debug_at_level_no_module
                    (FStar_Options.Other "Dep")
                   in
-               if uu____3721
+               if uu____3729
                then
-                 let uu____3725 = FStar_Ident.range_of_lid module_name1  in
-                 let uu____3726 =
-                   let uu____3732 =
-                     let uu____3734 = FStar_Ident.string_of_lid module_name1
+                 let uu____3733 = FStar_Ident.range_of_lid module_name1  in
+                 let uu____3734 =
+                   let uu____3740 =
+                     let uu____3742 = FStar_Ident.string_of_lid module_name1
                         in
                      FStar_Util.format1 "Unbound module reference %s"
-                       uu____3734
+                       uu____3742
                       in
-                   (FStar_Errors.Warning_UnboundModuleReference, uu____3732)
+                   (FStar_Errors.Warning_UnboundModuleReference, uu____3740)
                     in
-                 FStar_Errors.log_issue uu____3725 uu____3726
+                 FStar_Errors.log_issue uu____3733 uu____3734
                else ())
              in
           let record_lid lid =
-            match lid.FStar_Ident.ns with
+            let uu____3754 = FStar_Ident.ns_of_lid lid  in
+            match uu____3754 with
             | [] -> ()
-            | uu____3746 ->
-                let module_name1 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns
-                   in
+            | ns ->
+                let module_name1 = FStar_Ident.lid_of_ids ns  in
                 add_dep_on_module module_name1 false
              in
           let begin_module lid =
-            if (FStar_List.length lid.FStar_Ident.ns) > Prims.int_zero
+            let uu____3764 =
+              let uu____3766 =
+                let uu____3768 = FStar_Ident.ns_of_lid lid  in
+                FStar_List.length uu____3768  in
+              uu____3766 > Prims.int_zero  in
+            if uu____3764
             then
-              let uu____3759 =
-                let uu____3761 = namespace_of_lid lid  in
-                enter_namespace original_map1 working_map uu____3761  in
+              let uu____3773 =
+                let uu____3775 = namespace_of_lid lid  in
+                enter_namespace original_map1 working_map uu____3775  in
               ()
             else ()  in
           (match pd with
@@ -1165,64 +1178,64 @@ let (collect_one :
                            record_open_module_or_namespace (lid, k)
                        | P_dep (b,lid) -> add_dep_on_module lid b
                        | P_alias (id,lid) ->
-                           let uu____3787 = record_module_alias id lid  in ()
+                           let uu____3801 = record_module_alias id lid  in ()
                        | P_lid lid -> record_lid lid
                        | P_inline_for_extraction  ->
                            set_interface_inlining ())));
-          (let uu____3790 = FStar_ST.op_Bang deps1  in
-           let uu____3816 = FStar_ST.op_Bang has_inline_for_extraction  in
-           (uu____3790, uu____3816, mo_roots))
+          (let uu____3804 = FStar_ST.op_Bang deps1  in
+           let uu____3830 = FStar_ST.op_Bang has_inline_for_extraction  in
+           (uu____3804, uu____3830, mo_roots))
            in
         let data_from_cache =
           FStar_All.pipe_right filename get_parsing_data_from_cache  in
-        let uu____3850 =
+        let uu____3864 =
           FStar_All.pipe_right data_from_cache FStar_Util.is_some  in
-        if uu____3850
+        if uu____3864
         then
-          ((let uu____3870 =
+          ((let uu____3884 =
               FStar_Options.debug_at_level_no_module
                 (FStar_Options.Other "Dep")
                in
-            if uu____3870
+            if uu____3884
             then
               FStar_Util.print1
                 "Reading the parsing data for %s from its checked file\n"
                 filename
             else ());
-           (let uu____3877 =
-              let uu____3889 =
+           (let uu____3891 =
+              let uu____3903 =
                 FStar_All.pipe_right data_from_cache FStar_Util.must  in
-              from_parsing_data uu____3889 original_map filename  in
-            match uu____3877 with
+              from_parsing_data uu____3903 original_map filename  in
+            match uu____3891 with
             | (deps1,has_inline_for_extraction,mo_roots) ->
-                let uu____3918 =
+                let uu____3932 =
                   FStar_All.pipe_right data_from_cache FStar_Util.must  in
-                (uu____3918, deps1, has_inline_for_extraction, mo_roots)))
+                (uu____3932, deps1, has_inline_for_extraction, mo_roots)))
         else
           (let num_of_toplevelmods = FStar_Util.mk_ref Prims.int_zero  in
            let pd = FStar_Util.mk_ref []  in
            let add_to_parsing_data elt =
-             let uu____3947 =
-               let uu____3949 =
-                 let uu____3951 = FStar_ST.op_Bang pd  in
+             let uu____3961 =
+               let uu____3963 =
+                 let uu____3965 = FStar_ST.op_Bang pd  in
                  FStar_List.existsML (fun e  -> parsing_data_elt_eq e elt)
-                   uu____3951
+                   uu____3965
                   in
-               Prims.op_Negation uu____3949  in
-             if uu____3947
+               Prims.op_Negation uu____3963  in
+             if uu____3961
              then
-               let uu____3980 =
-                 let uu____3983 = FStar_ST.op_Bang pd  in elt :: uu____3983
+               let uu____3994 =
+                 let uu____3997 = FStar_ST.op_Bang pd  in elt :: uu____3997
                   in
-               FStar_ST.op_Colon_Equals pd uu____3980
+               FStar_ST.op_Colon_Equals pd uu____3994
              else ()  in
-           let rec collect_module uu___5_4140 =
-             match uu___5_4140 with
+           let rec collect_module uu___5_4154 =
+             match uu___5_4154 with
              | FStar_Parser_AST.Module (lid,decls) ->
                  (check_module_declaration_against_filename lid filename;
                   add_to_parsing_data (P_begin_module lid);
                   collect_decls decls)
-             | FStar_Parser_AST.Interface (lid,decls,uu____4151) ->
+             | FStar_Parser_AST.Interface (lid,decls,uu____4165) ->
                  (check_module_declaration_against_filename lid filename;
                   add_to_parsing_data (P_begin_module lid);
                   collect_decls decls)
@@ -1233,12 +1246,12 @@ let (collect_one :
                   collect_decl x.FStar_Parser_AST.d;
                   FStar_List.iter collect_term x.FStar_Parser_AST.attrs;
                   (match x.FStar_Parser_AST.d with
-                   | FStar_Parser_AST.Val uu____4170 when
+                   | FStar_Parser_AST.Val uu____4184 when
                        FStar_List.contains
                          FStar_Parser_AST.Inline_for_extraction
                          x.FStar_Parser_AST.quals
                        -> add_to_parsing_data P_inline_for_extraction
-                   | uu____4175 -> ())) decls
+                   | uu____4189 -> ())) decls
            
            and collect_decl d =
              match d with
@@ -1247,111 +1260,111 @@ let (collect_one :
              | FStar_Parser_AST.Open lid ->
                  add_to_parsing_data (P_open (false, lid))
              | FStar_Parser_AST.Friend lid ->
-                 let uu____4184 =
-                   let uu____4185 =
-                     let uu____4191 =
-                       let uu____4192 = lowercase_join_longident lid true  in
-                       FStar_All.pipe_right uu____4192 FStar_Ident.lid_of_str
+                 let uu____4198 =
+                   let uu____4199 =
+                     let uu____4205 =
+                       let uu____4206 = lowercase_join_longident lid true  in
+                       FStar_All.pipe_right uu____4206 FStar_Ident.lid_of_str
                         in
-                     (true, uu____4191)  in
-                   P_dep uu____4185  in
-                 add_to_parsing_data uu____4184
+                     (true, uu____4205)  in
+                   P_dep uu____4199  in
+                 add_to_parsing_data uu____4198
              | FStar_Parser_AST.ModuleAbbrev (ident,lid) ->
                  add_to_parsing_data (P_alias (ident, lid))
-             | FStar_Parser_AST.TopLevelLet (uu____4200,patterms) ->
+             | FStar_Parser_AST.TopLevelLet (uu____4214,patterms) ->
                  FStar_List.iter
-                   (fun uu____4222  ->
-                      match uu____4222 with
+                   (fun uu____4236  ->
+                      match uu____4236 with
                       | (pat,t) -> (collect_pattern pat; collect_term t))
                    patterms
              | FStar_Parser_AST.Main t -> collect_term t
-             | FStar_Parser_AST.Splice (uu____4231,t) -> collect_term t
-             | FStar_Parser_AST.Assume (uu____4237,t) -> collect_term t
+             | FStar_Parser_AST.Splice (uu____4245,t) -> collect_term t
+             | FStar_Parser_AST.Assume (uu____4251,t) -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu____4239;
-                   FStar_Parser_AST.mdest = uu____4240;
+                 { FStar_Parser_AST.msource = uu____4253;
+                   FStar_Parser_AST.mdest = uu____4254;
                    FStar_Parser_AST.lift_op =
                      FStar_Parser_AST.NonReifiableLift t;_}
                  -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu____4242;
-                   FStar_Parser_AST.mdest = uu____4243;
+                 { FStar_Parser_AST.msource = uu____4256;
+                   FStar_Parser_AST.mdest = uu____4257;
                    FStar_Parser_AST.lift_op = FStar_Parser_AST.LiftForFree t;_}
                  -> collect_term t
-             | FStar_Parser_AST.Val (uu____4245,t) -> collect_term t
+             | FStar_Parser_AST.Val (uu____4259,t) -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu____4247;
-                   FStar_Parser_AST.mdest = uu____4248;
+                 { FStar_Parser_AST.msource = uu____4261;
+                   FStar_Parser_AST.mdest = uu____4262;
                    FStar_Parser_AST.lift_op = FStar_Parser_AST.ReifiableLift
                      (t0,t1);_}
                  -> (collect_term t0; collect_term t1)
-             | FStar_Parser_AST.Tycon (uu____4252,tc,ts) ->
+             | FStar_Parser_AST.Tycon (uu____4266,tc,ts) ->
                  (if tc
                   then
                     add_to_parsing_data
                       (P_lid FStar_Parser_Const.mk_class_lid)
                   else ();
                   FStar_List.iter collect_tycon ts)
-             | FStar_Parser_AST.Exception (uu____4267,t) ->
+             | FStar_Parser_AST.Exception (uu____4281,t) ->
                  FStar_Util.iter_opt t collect_term
              | FStar_Parser_AST.NewEffect ed -> collect_effect_decl ed
              | FStar_Parser_AST.LayeredEffect ed -> collect_effect_decl ed
              | FStar_Parser_AST.Polymonadic_bind
-                 (uu____4275,uu____4276,uu____4277,bind) -> collect_term bind
-             | FStar_Parser_AST.Pragma uu____4279 -> ()
+                 (uu____4289,uu____4290,uu____4291,bind) -> collect_term bind
+             | FStar_Parser_AST.Pragma uu____4293 -> ()
              | FStar_Parser_AST.TopLevelModule lid ->
                  (FStar_Util.incr num_of_toplevelmods;
-                  (let uu____4282 =
-                     let uu____4284 = FStar_ST.op_Bang num_of_toplevelmods
+                  (let uu____4296 =
+                     let uu____4298 = FStar_ST.op_Bang num_of_toplevelmods
                         in
-                     uu____4284 > Prims.int_one  in
-                   if uu____4282
+                     uu____4298 > Prims.int_one  in
+                   if uu____4296
                    then
-                     let uu____4309 =
-                       let uu____4315 =
-                         let uu____4317 = string_of_lid lid true  in
+                     let uu____4323 =
+                       let uu____4329 =
+                         let uu____4331 = string_of_lid lid true  in
                          FStar_Util.format1
                            "Automatic dependency analysis demands one module per file (module %s not supported)"
-                           uu____4317
+                           uu____4331
                           in
-                       (FStar_Errors.Fatal_OneModulePerFile, uu____4315)  in
-                     let uu____4322 = FStar_Ident.range_of_lid lid  in
-                     FStar_Errors.raise_error uu____4309 uu____4322
+                       (FStar_Errors.Fatal_OneModulePerFile, uu____4329)  in
+                     let uu____4336 = FStar_Ident.range_of_lid lid  in
+                     FStar_Errors.raise_error uu____4323 uu____4336
                    else ()))
            
-           and collect_tycon uu___6_4325 =
-             match uu___6_4325 with
-             | FStar_Parser_AST.TyconAbstract (uu____4326,binders,k) ->
+           and collect_tycon uu___6_4339 =
+             match uu___6_4339 with
+             | FStar_Parser_AST.TyconAbstract (uu____4340,binders,k) ->
                  (collect_binders binders; FStar_Util.iter_opt k collect_term)
-             | FStar_Parser_AST.TyconAbbrev (uu____4338,binders,k,t) ->
+             | FStar_Parser_AST.TyconAbbrev (uu____4352,binders,k,t) ->
                  (collect_binders binders;
                   FStar_Util.iter_opt k collect_term;
                   collect_term t)
-             | FStar_Parser_AST.TyconRecord (uu____4352,binders,k,identterms)
+             | FStar_Parser_AST.TyconRecord (uu____4366,binders,k,identterms)
                  ->
                  (collect_binders binders;
                   FStar_Util.iter_opt k collect_term;
                   FStar_List.iter
-                    (fun uu____4385  ->
-                       match uu____4385 with
-                       | (uu____4390,t) -> collect_term t) identterms)
+                    (fun uu____4399  ->
+                       match uu____4399 with
+                       | (uu____4404,t) -> collect_term t) identterms)
              | FStar_Parser_AST.TyconVariant
-                 (uu____4392,binders,k,identterms) ->
+                 (uu____4406,binders,k,identterms) ->
                  (collect_binders binders;
                   FStar_Util.iter_opt k collect_term;
                   FStar_List.iter
-                    (fun uu____4441  ->
-                       match uu____4441 with
-                       | (uu____4451,t,uu____4453) ->
+                    (fun uu____4455  ->
+                       match uu____4455 with
+                       | (uu____4465,t,uu____4467) ->
                            FStar_Util.iter_opt t collect_term) identterms)
            
-           and collect_effect_decl uu___7_4460 =
-             match uu___7_4460 with
-             | FStar_Parser_AST.DefineEffect (uu____4461,binders,t,decls) ->
+           and collect_effect_decl uu___7_4474 =
+             match uu___7_4474 with
+             | FStar_Parser_AST.DefineEffect (uu____4475,binders,t,decls) ->
                  (collect_binders binders;
                   collect_term t;
                   collect_decls decls)
-             | FStar_Parser_AST.RedefineEffect (uu____4475,binders,t) ->
+             | FStar_Parser_AST.RedefineEffect (uu____4489,binders,t) ->
                  (collect_binders binders; collect_term t)
            
            and collect_binders binders =
@@ -1362,34 +1375,34 @@ let (collect_one :
              (match b with
               | {
                   FStar_Parser_AST.b = FStar_Parser_AST.Annotated
-                    (uu____4488,t);
-                  FStar_Parser_AST.brange = uu____4490;
-                  FStar_Parser_AST.blevel = uu____4491;
-                  FStar_Parser_AST.aqual = uu____4492;_} -> collect_term t
+                    (uu____4502,t);
+                  FStar_Parser_AST.brange = uu____4504;
+                  FStar_Parser_AST.blevel = uu____4505;
+                  FStar_Parser_AST.aqual = uu____4506;_} -> collect_term t
               | {
                   FStar_Parser_AST.b = FStar_Parser_AST.TAnnotated
-                    (uu____4495,t);
-                  FStar_Parser_AST.brange = uu____4497;
-                  FStar_Parser_AST.blevel = uu____4498;
-                  FStar_Parser_AST.aqual = uu____4499;_} -> collect_term t
+                    (uu____4509,t);
+                  FStar_Parser_AST.brange = uu____4511;
+                  FStar_Parser_AST.blevel = uu____4512;
+                  FStar_Parser_AST.aqual = uu____4513;_} -> collect_term t
               | { FStar_Parser_AST.b = FStar_Parser_AST.NoName t;
-                  FStar_Parser_AST.brange = uu____4503;
-                  FStar_Parser_AST.blevel = uu____4504;
-                  FStar_Parser_AST.aqual = uu____4505;_} -> collect_term t
-              | uu____4508 -> ())
+                  FStar_Parser_AST.brange = uu____4517;
+                  FStar_Parser_AST.blevel = uu____4518;
+                  FStar_Parser_AST.aqual = uu____4519;_} -> collect_term t
+              | uu____4522 -> ())
            
-           and collect_aqual uu___8_4509 =
-             match uu___8_4509 with
+           and collect_aqual uu___8_4523 =
+             match uu___8_4523 with
              | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta t) ->
                  collect_term t
-             | uu____4513 -> ()
+             | uu____4527 -> ()
            
            and collect_term t = collect_term' t.FStar_Parser_AST.tm
            
-           and collect_constant uu___9_4517 =
-             match uu___9_4517 with
+           and collect_constant uu___9_4531 =
+             match uu___9_4531 with
              | FStar_Const.Const_int
-                 (uu____4518,FStar_Pervasives_Native.Some (signedness,width))
+                 (uu____4532,FStar_Pervasives_Native.Some (signedness,width))
                  ->
                  let u =
                    match signedness with
@@ -1401,65 +1414,65 @@ let (collect_one :
                    | FStar_Const.Int16  -> "16"
                    | FStar_Const.Int32  -> "32"
                    | FStar_Const.Int64  -> "64"  in
-                 let uu____4545 =
-                   let uu____4546 =
-                     let uu____4552 =
-                       let uu____4553 =
+                 let uu____4559 =
+                   let uu____4560 =
+                     let uu____4566 =
+                       let uu____4567 =
                          FStar_Util.format2 "fstar.%sint%s" u w  in
-                       FStar_All.pipe_right uu____4553 FStar_Ident.lid_of_str
+                       FStar_All.pipe_right uu____4567 FStar_Ident.lid_of_str
                         in
-                     (false, uu____4552)  in
-                   P_dep uu____4546  in
-                 add_to_parsing_data uu____4545
-             | FStar_Const.Const_char uu____4559 ->
-                 let uu____4561 =
-                   let uu____4562 =
-                     let uu____4568 =
+                     (false, uu____4566)  in
+                   P_dep uu____4560  in
+                 add_to_parsing_data uu____4559
+             | FStar_Const.Const_char uu____4573 ->
+                 let uu____4575 =
+                   let uu____4576 =
+                     let uu____4582 =
                        FStar_All.pipe_right "fstar.char"
                          FStar_Ident.lid_of_str
                         in
-                     (false, uu____4568)  in
-                   P_dep uu____4562  in
-                 add_to_parsing_data uu____4561
-             | FStar_Const.Const_float uu____4573 ->
-                 let uu____4574 =
-                   let uu____4575 =
-                     let uu____4581 =
+                     (false, uu____4582)  in
+                   P_dep uu____4576  in
+                 add_to_parsing_data uu____4575
+             | FStar_Const.Const_float uu____4587 ->
+                 let uu____4588 =
+                   let uu____4589 =
+                     let uu____4595 =
                        FStar_All.pipe_right "fstar.float"
                          FStar_Ident.lid_of_str
                         in
-                     (false, uu____4581)  in
-                   P_dep uu____4575  in
-                 add_to_parsing_data uu____4574
-             | uu____4586 -> ()
+                     (false, uu____4595)  in
+                   P_dep uu____4589  in
+                 add_to_parsing_data uu____4588
+             | uu____4600 -> ()
            
-           and collect_term' uu___12_4587 =
-             match uu___12_4587 with
+           and collect_term' uu___12_4601 =
+             match uu___12_4601 with
              | FStar_Parser_AST.Wild  -> ()
              | FStar_Parser_AST.Const c -> collect_constant c
              | FStar_Parser_AST.Op (s,ts) ->
-                 ((let uu____4596 =
-                     let uu____4598 = FStar_Ident.text_of_id s  in
-                     uu____4598 = "@"  in
-                   if uu____4596
+                 ((let uu____4610 =
+                     let uu____4612 = FStar_Ident.text_of_id s  in
+                     uu____4612 = "@"  in
+                   if uu____4610
                    then
-                     let uu____4603 =
-                       let uu____4604 =
-                         let uu____4605 =
+                     let uu____4617 =
+                       let uu____4618 =
+                         let uu____4619 =
                            FStar_Ident.path_of_text
                              "FStar.List.Tot.Base.append"
                             in
-                         FStar_Ident.lid_of_path uu____4605
+                         FStar_Ident.lid_of_path uu____4619
                            FStar_Range.dummyRange
                           in
-                       FStar_Parser_AST.Name uu____4604  in
-                     collect_term' uu____4603
+                       FStar_Parser_AST.Name uu____4618  in
+                     collect_term' uu____4617
                    else ());
                   FStar_List.iter collect_term ts)
-             | FStar_Parser_AST.Tvar uu____4609 -> ()
-             | FStar_Parser_AST.Uvar uu____4610 -> ()
+             | FStar_Parser_AST.Tvar uu____4623 -> ()
+             | FStar_Parser_AST.Uvar uu____4624 -> ()
              | FStar_Parser_AST.Var lid -> add_to_parsing_data (P_lid lid)
-             | FStar_Parser_AST.Projector (lid,uu____4613) ->
+             | FStar_Parser_AST.Projector (lid,uu____4627) ->
                  add_to_parsing_data (P_lid lid)
              | FStar_Parser_AST.Discrim lid ->
                  add_to_parsing_data (P_lid lid)
@@ -1467,19 +1480,19 @@ let (collect_one :
              | FStar_Parser_AST.Construct (lid,termimps) ->
                  (add_to_parsing_data (P_lid lid);
                   FStar_List.iter
-                    (fun uu____4638  ->
-                       match uu____4638 with
-                       | (t,uu____4644) -> collect_term t) termimps)
+                    (fun uu____4652  ->
+                       match uu____4652 with
+                       | (t,uu____4658) -> collect_term t) termimps)
              | FStar_Parser_AST.Abs (pats,t) ->
                  (collect_patterns pats; collect_term t)
-             | FStar_Parser_AST.App (t1,t2,uu____4654) ->
+             | FStar_Parser_AST.App (t1,t2,uu____4668) ->
                  (collect_term t1; collect_term t2)
-             | FStar_Parser_AST.Let (uu____4656,patterms,t) ->
+             | FStar_Parser_AST.Let (uu____4670,patterms,t) ->
                  (FStar_List.iter
-                    (fun uu____4706  ->
-                       match uu____4706 with
+                    (fun uu____4720  ->
+                       match uu____4720 with
                        | (attrs_opt,(pat,t1)) ->
-                           ((let uu____4735 =
+                           ((let uu____4749 =
                                FStar_Util.map_opt attrs_opt
                                  (FStar_List.iter collect_term)
                                 in
@@ -1489,7 +1502,7 @@ let (collect_one :
                   collect_term t)
              | FStar_Parser_AST.LetOpen (lid,t) ->
                  (add_to_parsing_data (P_open (true, lid)); collect_term t)
-             | FStar_Parser_AST.Bind (uu____4746,t1,t2) ->
+             | FStar_Parser_AST.Bind (uu____4760,t1,t2) ->
                  (collect_term t1; collect_term t2)
              | FStar_Parser_AST.Seq (t1,t2) ->
                  (collect_term t1; collect_term t2)
@@ -1508,53 +1521,53 @@ let (collect_one :
              | FStar_Parser_AST.Record (t,idterms) ->
                  (FStar_Util.iter_opt t collect_term;
                   FStar_List.iter
-                    (fun uu____4842  ->
-                       match uu____4842 with
-                       | (uu____4847,t1) -> collect_term t1) idterms)
-             | FStar_Parser_AST.Project (t,uu____4850) -> collect_term t
+                    (fun uu____4856  ->
+                       match uu____4856 with
+                       | (uu____4861,t1) -> collect_term t1) idterms)
+             | FStar_Parser_AST.Project (t,uu____4864) -> collect_term t
              | FStar_Parser_AST.Product (binders,t) ->
                  (collect_binders binders; collect_term t)
              | FStar_Parser_AST.Sum (binders,t) ->
                  (FStar_List.iter
-                    (fun uu___10_4879  ->
-                       match uu___10_4879 with
+                    (fun uu___10_4893  ->
+                       match uu___10_4893 with
                        | FStar_Util.Inl b -> collect_binder b
                        | FStar_Util.Inr t1 -> collect_term t1) binders;
                   collect_term t)
-             | FStar_Parser_AST.QForall (binders,(uu____4887,ts),t) ->
+             | FStar_Parser_AST.QForall (binders,(uu____4901,ts),t) ->
                  (collect_binders binders;
                   FStar_List.iter (FStar_List.iter collect_term) ts;
                   collect_term t)
-             | FStar_Parser_AST.QExists (binders,(uu____4921,ts),t) ->
+             | FStar_Parser_AST.QExists (binders,(uu____4935,ts),t) ->
                  (collect_binders binders;
                   FStar_List.iter (FStar_List.iter collect_term) ts;
                   collect_term t)
              | FStar_Parser_AST.Refine (binder,t) ->
                  (collect_binder binder; collect_term t)
-             | FStar_Parser_AST.NamedTyp (uu____4957,t) -> collect_term t
+             | FStar_Parser_AST.NamedTyp (uu____4971,t) -> collect_term t
              | FStar_Parser_AST.Paren t -> collect_term t
-             | FStar_Parser_AST.Requires (t,uu____4961) -> collect_term t
-             | FStar_Parser_AST.Ensures (t,uu____4969) -> collect_term t
-             | FStar_Parser_AST.Labeled (t,uu____4977,uu____4978) ->
+             | FStar_Parser_AST.Requires (t,uu____4975) -> collect_term t
+             | FStar_Parser_AST.Ensures (t,uu____4983) -> collect_term t
+             | FStar_Parser_AST.Labeled (t,uu____4991,uu____4992) ->
                  collect_term t
-             | FStar_Parser_AST.Quote (t,uu____4984) -> collect_term t
+             | FStar_Parser_AST.Quote (t,uu____4998) -> collect_term t
              | FStar_Parser_AST.Antiquote t -> collect_term t
              | FStar_Parser_AST.VQuote t -> collect_term t
              | FStar_Parser_AST.Attributes cattributes ->
                  FStar_List.iter collect_term cattributes
              | FStar_Parser_AST.CalcProof (rel,init,steps) ->
-                 ((let uu____4998 =
-                     let uu____4999 =
-                       let uu____5005 = FStar_Ident.lid_of_str "FStar.Calc"
+                 ((let uu____5012 =
+                     let uu____5013 =
+                       let uu____5019 = FStar_Ident.lid_of_str "FStar.Calc"
                           in
-                       (false, uu____5005)  in
-                     P_dep uu____4999  in
-                   add_to_parsing_data uu____4998);
+                       (false, uu____5019)  in
+                     P_dep uu____5013  in
+                   add_to_parsing_data uu____5012);
                   collect_term rel;
                   collect_term init;
                   FStar_List.iter
-                    (fun uu___11_5017  ->
-                       match uu___11_5017 with
+                    (fun uu___11_5031  ->
+                       match uu___11_5031 with
                        | FStar_Parser_AST.CalcStep (rel1,just,next) ->
                            (collect_term rel1;
                             collect_term just;
@@ -1564,27 +1577,27 @@ let (collect_one :
            
            and collect_pattern p = collect_pattern' p.FStar_Parser_AST.pat
            
-           and collect_pattern' uu___13_5027 =
-             match uu___13_5027 with
-             | FStar_Parser_AST.PatVar (uu____5028,aqual) ->
+           and collect_pattern' uu___13_5041 =
+             match uu___13_5041 with
+             | FStar_Parser_AST.PatVar (uu____5042,aqual) ->
                  collect_aqual aqual
-             | FStar_Parser_AST.PatTvar (uu____5034,aqual) ->
+             | FStar_Parser_AST.PatTvar (uu____5048,aqual) ->
                  collect_aqual aqual
              | FStar_Parser_AST.PatWild aqual -> collect_aqual aqual
-             | FStar_Parser_AST.PatOp uu____5043 -> ()
-             | FStar_Parser_AST.PatConst uu____5044 -> ()
+             | FStar_Parser_AST.PatOp uu____5057 -> ()
+             | FStar_Parser_AST.PatConst uu____5058 -> ()
              | FStar_Parser_AST.PatApp (p,ps) ->
                  (collect_pattern p; collect_patterns ps)
-             | FStar_Parser_AST.PatName uu____5052 -> ()
+             | FStar_Parser_AST.PatName uu____5066 -> ()
              | FStar_Parser_AST.PatList ps -> collect_patterns ps
              | FStar_Parser_AST.PatOr ps -> collect_patterns ps
-             | FStar_Parser_AST.PatTuple (ps,uu____5060) ->
+             | FStar_Parser_AST.PatTuple (ps,uu____5074) ->
                  collect_patterns ps
              | FStar_Parser_AST.PatRecord lidpats ->
                  FStar_List.iter
-                   (fun uu____5081  ->
-                      match uu____5081 with
-                      | (uu____5086,p) -> collect_pattern p) lidpats
+                   (fun uu____5095  ->
+                      match uu____5095 with
+                      | (uu____5100,p) -> collect_pattern p) lidpats
              | FStar_Parser_AST.PatAscribed
                  (p,(t,FStar_Pervasives_Native.None )) ->
                  (collect_pattern p; collect_term t)
@@ -1594,25 +1607,25 @@ let (collect_one :
            
            and collect_branches bs = FStar_List.iter collect_branch bs
            
-           and collect_branch uu____5131 =
-             match uu____5131 with
+           and collect_branch uu____5145 =
+             match uu____5145 with
              | (pat,t1,t2) ->
                  (collect_pattern pat;
                   FStar_Util.iter_opt t1 collect_term;
                   collect_term t2)
             in
-           let uu____5149 = FStar_Parser_Driver.parse_file filename  in
-           match uu____5149 with
-           | (ast,uu____5175) ->
+           let uu____5163 = FStar_Parser_Driver.parse_file filename  in
+           match uu____5163 with
+           | (ast,uu____5189) ->
                (collect_module ast;
                 (let pd1 =
-                   let uu____5192 =
-                     let uu____5195 = FStar_ST.op_Bang pd  in
-                     FStar_List.rev uu____5195  in
-                   Mk_pd uu____5192  in
-                 let uu____5221 = from_parsing_data pd1 original_map filename
+                   let uu____5206 =
+                     let uu____5209 = FStar_ST.op_Bang pd  in
+                     FStar_List.rev uu____5209  in
+                   Mk_pd uu____5206  in
+                 let uu____5235 = from_parsing_data pd1 original_map filename
                     in
-                 match uu____5221 with
+                 match uu____5235 with
                  | (deps1,has_inline_for_extraction,mo_roots) ->
                      (pd1, deps1, has_inline_for_extraction, mo_roots))))
   
@@ -1620,17 +1633,17 @@ let (collect_one_cache :
   (dependence Prims.list * dependence Prims.list * Prims.bool)
     FStar_Util.smap FStar_ST.ref)
   =
-  let uu____5280 = FStar_Util.smap_create Prims.int_zero  in
-  FStar_Util.mk_ref uu____5280 
+  let uu____5294 = FStar_Util.smap_create Prims.int_zero  in
+  FStar_Util.mk_ref uu____5294 
 let (set_collect_one_cache :
   (dependence Prims.list * dependence Prims.list * Prims.bool)
     FStar_Util.smap -> unit)
   = fun cache  -> FStar_ST.op_Colon_Equals collect_one_cache cache 
 let (dep_graph_copy : dependence_graph -> dependence_graph) =
   fun dep_graph  ->
-    let uu____5402 = dep_graph  in
-    match uu____5402 with
-    | Deps g -> let uu____5406 = FStar_Util.smap_copy g  in Deps uu____5406
+    let uu____5416 = dep_graph  in
+    match uu____5416 with
+    | Deps g -> let uu____5420 = FStar_Util.smap_copy g  in Deps uu____5420
   
 let (widen_deps :
   module_name Prims.list ->
@@ -1642,11 +1655,11 @@ let (widen_deps :
       fun file_system_map  ->
         fun widened  ->
           let widened1 = FStar_Util.mk_ref widened  in
-          let uu____5448 = dep_graph  in
-          match uu____5448 with
+          let uu____5462 = dep_graph  in
+          match uu____5462 with
           | Deps dg ->
-              let uu____5457 = deps_empty ()  in
-              (match uu____5457 with
+              let uu____5471 = deps_empty ()  in
+              (match uu____5471 with
                | Deps dg' ->
                    let widen_one deps1 =
                      FStar_All.pipe_right deps1
@@ -1659,19 +1672,19 @@ let (widen_deps :
                                  ->
                                  (FStar_ST.op_Colon_Equals widened1 true;
                                   FriendImplementation m)
-                             | uu____5512 -> d))
+                             | uu____5526 -> d))
                       in
                    (FStar_Util.smap_fold dg
                       (fun filename  ->
                          fun dep_node1  ->
-                           fun uu____5520  ->
-                             let uu____5522 =
-                               let uu___984_5523 = dep_node1  in
-                               let uu____5524 = widen_one dep_node1.edges  in
-                               { edges = uu____5524; color = White }  in
-                             FStar_Util.smap_add dg' filename uu____5522) ();
-                    (let uu____5525 = FStar_ST.op_Bang widened1  in
-                     (uu____5525, (Deps dg')))))
+                           fun uu____5534  ->
+                             let uu____5536 =
+                               let uu___984_5537 = dep_node1  in
+                               let uu____5538 = widen_one dep_node1.edges  in
+                               { edges = uu____5538; color = White }  in
+                             FStar_Util.smap_add dg' filename uu____5536) ();
+                    (let uu____5539 = FStar_ST.op_Bang widened1  in
+                     (uu____5539, (Deps dg')))))
   
 let (topological_dependences_of' :
   files_for_module_name ->
@@ -1685,70 +1698,70 @@ let (topological_dependences_of' :
       fun interfaces_needing_inlining  ->
         fun root_files  ->
           fun widened  ->
-            let rec all_friend_deps_1 dep_graph1 cycle uu____5691 filename =
-              match uu____5691 with
+            let rec all_friend_deps_1 dep_graph1 cycle uu____5705 filename =
+              match uu____5705 with
               | (all_friends,all_files) ->
                   let dep_node1 =
-                    let uu____5732 = deps_try_find dep_graph1 filename  in
-                    FStar_Util.must uu____5732  in
+                    let uu____5746 = deps_try_find dep_graph1 filename  in
+                    FStar_Util.must uu____5746  in
                   (match dep_node1.color with
                    | Gray  ->
                        failwith
                          "Impossible: cycle detected after cycle detection has passed"
                    | Black  -> (all_friends, all_files)
                    | White  ->
-                       ((let uu____5763 =
+                       ((let uu____5777 =
                            FStar_Options.debug_at_level_no_module
                              (FStar_Options.Other "Dep")
                             in
-                         if uu____5763
+                         if uu____5777
                          then
-                           let uu____5767 =
-                             let uu____5769 =
+                           let uu____5781 =
+                             let uu____5783 =
                                FStar_List.map dep_to_string dep_node1.edges
                                 in
-                             FStar_String.concat ", " uu____5769  in
+                             FStar_String.concat ", " uu____5783  in
                            FStar_Util.print2
                              "Visiting %s: direct deps are %s\n" filename
-                             uu____5767
+                             uu____5781
                          else ());
                         deps_add_dep dep_graph1 filename
-                          (let uu___1006_5780 = dep_node1  in
-                           { edges = (uu___1006_5780.edges); color = Gray });
-                        (let uu____5781 =
-                           let uu____5792 =
+                          (let uu___1006_5794 = dep_node1  in
+                           { edges = (uu___1006_5794.edges); color = Gray });
+                        (let uu____5795 =
+                           let uu____5806 =
                              dependences_of file_system_map dep_graph1
                                root_files filename
                               in
                            all_friend_deps dep_graph1 cycle
-                             (all_friends, all_files) uu____5792
+                             (all_friends, all_files) uu____5806
                             in
-                         match uu____5781 with
+                         match uu____5795 with
                          | (all_friends1,all_files1) ->
                              (deps_add_dep dep_graph1 filename
-                                (let uu___1012_5828 = dep_node1  in
+                                (let uu___1012_5842 = dep_node1  in
                                  {
-                                   edges = (uu___1012_5828.edges);
+                                   edges = (uu___1012_5842.edges);
                                    color = Black
                                  });
-                              (let uu____5830 =
+                              (let uu____5844 =
                                  FStar_Options.debug_at_level_no_module
                                    (FStar_Options.Other "Dep")
                                   in
-                               if uu____5830
+                               if uu____5844
                                then FStar_Util.print1 "Adding %s\n" filename
                                else ());
-                              (let uu____5837 =
-                                 let uu____5841 =
+                              (let uu____5851 =
+                                 let uu____5855 =
                                    FStar_List.collect
-                                     (fun uu___14_5848  ->
-                                        match uu___14_5848 with
+                                     (fun uu___14_5862  ->
+                                        match uu___14_5862 with
                                         | FriendImplementation m -> [m]
                                         | d -> []) dep_node1.edges
                                     in
-                                 FStar_List.append uu____5841 all_friends1
+                                 FStar_List.append uu____5855 all_friends1
                                   in
-                               (uu____5837, (filename :: all_files1)))))))
+                               (uu____5851, (filename :: all_files1)))))))
             
             and all_friend_deps dep_graph1 cycle all_friends filenames =
               FStar_List.fold_left
@@ -1757,49 +1770,49 @@ let (topological_dependences_of' :
                      all_friend_deps_1 dep_graph1 (k :: cycle) all_friends1 k)
                 all_friends filenames
              in
-            let uu____5913 = all_friend_deps dep_graph [] ([], []) root_files
+            let uu____5927 = all_friend_deps dep_graph [] ([], []) root_files
                in
-            match uu____5913 with
+            match uu____5927 with
             | (friends,all_files_0) ->
-                ((let uu____5956 =
+                ((let uu____5970 =
                     FStar_Options.debug_at_level_no_module
                       (FStar_Options.Other "Dep")
                      in
-                  if uu____5956
+                  if uu____5970
                   then
-                    let uu____5960 =
-                      let uu____5962 =
+                    let uu____5974 =
+                      let uu____5976 =
                         FStar_Util.remove_dups (fun x  -> fun y  -> x = y)
                           friends
                          in
-                      FStar_String.concat ", " uu____5962  in
+                      FStar_String.concat ", " uu____5976  in
                     FStar_Util.print3
                       "Phase1 complete:\n\tall_files = %s\n\tall_friends=%s\n\tinterfaces_with_inlining=%s\n"
-                      (FStar_String.concat ", " all_files_0) uu____5960
+                      (FStar_String.concat ", " all_files_0) uu____5974
                       (FStar_String.concat ", " interfaces_needing_inlining)
                   else ());
-                 (let uu____5980 =
+                 (let uu____5994 =
                     widen_deps friends dep_graph file_system_map widened  in
-                  match uu____5980 with
+                  match uu____5994 with
                   | (widened1,dep_graph1) ->
-                      let uu____5998 =
-                        (let uu____6010 =
+                      let uu____6012 =
+                        (let uu____6024 =
                            FStar_Options.debug_at_level_no_module
                              (FStar_Options.Other "Dep")
                             in
-                         if uu____6010
+                         if uu____6024
                          then
                            FStar_Util.print_string
                              "==============Phase2==================\n"
                          else ());
                         all_friend_deps dep_graph1 [] ([], []) root_files  in
-                      (match uu____5998 with
-                       | (uu____6034,all_files) ->
-                           ((let uu____6049 =
+                      (match uu____6012 with
+                       | (uu____6048,all_files) ->
+                           ((let uu____6063 =
                                FStar_Options.debug_at_level_no_module
                                  (FStar_Options.Other "Dep")
                                 in
-                             if uu____6049
+                             if uu____6063
                              then
                                FStar_Util.print1
                                  "Phase2 complete: all_files = %s\n"
@@ -1816,18 +1829,18 @@ let (phase1 :
     fun dep_graph  ->
       fun interfaces_needing_inlining  ->
         fun for_extraction  ->
-          (let uu____6096 =
+          (let uu____6110 =
              FStar_Options.debug_at_level_no_module
                (FStar_Options.Other "Dep")
               in
-           if uu____6096
+           if uu____6110
            then
              FStar_Util.print_string
                "==============Phase1==================\n"
            else ());
           (let widened = false  in
-           let uu____6106 = (FStar_Options.cmi ()) && for_extraction  in
-           if uu____6106
+           let uu____6120 = (FStar_Options.cmi ()) && for_extraction  in
+           if uu____6120
            then
              widen_deps interfaces_needing_inlining dep_graph file_system_map
                widened
@@ -1845,11 +1858,11 @@ let (topological_dependences_of :
       fun interfaces_needing_inlining  ->
         fun root_files  ->
           fun for_extraction  ->
-            let uu____6173 =
+            let uu____6187 =
               phase1 file_system_map dep_graph interfaces_needing_inlining
                 for_extraction
                in
-            match uu____6173 with
+            match uu____6187 with
             | (widened,dep_graph1) ->
                 topological_dependences_of' file_system_map dep_graph1
                   interfaces_needing_inlining root_files widened
@@ -1865,16 +1878,16 @@ let (collect :
         FStar_All.pipe_right all_cmd_line_files
           (FStar_List.map
              (fun fn  ->
-                let uu____6250 = FStar_Options.find_file fn  in
-                match uu____6250 with
+                let uu____6264 = FStar_Options.find_file fn  in
+                match uu____6264 with
                 | FStar_Pervasives_Native.None  ->
-                    let uu____6256 =
-                      let uu____6262 =
+                    let uu____6270 =
+                      let uu____6276 =
                         FStar_Util.format1 "File %s could not be found\n" fn
                          in
-                      (FStar_Errors.Fatal_ModuleOrFileNotFound, uu____6262)
+                      (FStar_Errors.Fatal_ModuleOrFileNotFound, uu____6276)
                        in
-                    FStar_Errors.raise_err uu____6256
+                    FStar_Errors.raise_err uu____6270
                 | FStar_Pervasives_Native.Some fn1 -> fn1))
          in
       let dep_graph = deps_empty ()  in
@@ -1882,35 +1895,35 @@ let (collect :
       let interfaces_needing_inlining = FStar_Util.mk_ref []  in
       let add_interface_for_inlining l =
         let l1 = lowercase_module_name l  in
-        let uu____6292 =
-          let uu____6296 = FStar_ST.op_Bang interfaces_needing_inlining  in
-          l1 :: uu____6296  in
-        FStar_ST.op_Colon_Equals interfaces_needing_inlining uu____6292  in
+        let uu____6306 =
+          let uu____6310 = FStar_ST.op_Bang interfaces_needing_inlining  in
+          l1 :: uu____6310  in
+        FStar_ST.op_Colon_Equals interfaces_needing_inlining uu____6306  in
       let parse_results = FStar_Util.smap_create (Prims.of_int (40))  in
       let rec discover_one file_name1 =
-        let uu____6363 =
-          let uu____6365 = deps_try_find dep_graph file_name1  in
-          uu____6365 = FStar_Pervasives_Native.None  in
-        if uu____6363
+        let uu____6377 =
+          let uu____6379 = deps_try_find dep_graph file_name1  in
+          uu____6379 = FStar_Pervasives_Native.None  in
+        if uu____6377
         then
-          let uu____6371 =
-            let uu____6387 =
-              let uu____6401 = FStar_ST.op_Bang collect_one_cache  in
-              FStar_Util.smap_try_find uu____6401 file_name1  in
-            match uu____6387 with
+          let uu____6385 =
+            let uu____6401 =
+              let uu____6415 = FStar_ST.op_Bang collect_one_cache  in
+              FStar_Util.smap_try_find uu____6415 file_name1  in
+            match uu____6401 with
             | FStar_Pervasives_Native.Some cached -> ((Mk_pd []), cached)
             | FStar_Pervasives_Native.None  ->
-                let uu____6531 =
+                let uu____6545 =
                   collect_one file_system_map file_name1
                     get_parsing_data_from_cache
                    in
-                (match uu____6531 with
+                (match uu____6545 with
                  | (parsing_data1,deps1,needs_interface_inlining,additional_roots)
                      ->
                      (parsing_data1,
                        (deps1, additional_roots, needs_interface_inlining)))
              in
-          match uu____6371 with
+          match uu____6385 with
           | (parsing_data1,(deps1,mo_roots,needs_interface_inlining)) ->
               (if needs_interface_inlining
                then add_interface_for_inlining file_name1
@@ -1918,26 +1931,26 @@ let (collect :
                FStar_Util.smap_add parse_results file_name1 parsing_data1;
                (let deps2 =
                   let module_name1 = lowercase_module_name file_name1  in
-                  let uu____6625 =
+                  let uu____6639 =
                     (is_implementation file_name1) &&
                       (has_interface file_system_map module_name1)
                      in
-                  if uu____6625
+                  if uu____6639
                   then FStar_List.append deps1 [UseInterface module_name1]
                   else deps1  in
                 let dep_node1 =
-                  let uu____6633 = FStar_List.unique deps2  in
-                  { edges = uu____6633; color = White }  in
+                  let uu____6647 = FStar_List.unique deps2  in
+                  { edges = uu____6647; color = White }  in
                 deps_add_dep dep_graph file_name1 dep_node1;
-                (let uu____6635 =
+                (let uu____6649 =
                    FStar_List.map
                      (file_of_dep file_system_map all_cmd_line_files1)
                      (FStar_List.append deps2 mo_roots)
                     in
-                 FStar_List.iter discover_one uu____6635)))
+                 FStar_List.iter discover_one uu____6649)))
         else ()  in
       profile
-        (fun uu____6645  -> FStar_List.iter discover_one all_cmd_line_files1)
+        (fun uu____6659  -> FStar_List.iter discover_one all_cmd_line_files1)
         "FStar.Parser.Dep.discover";
       (let cycle_detected dep_graph1 cycle filename =
          FStar_Util.print1
@@ -1945,28 +1958,28 @@ let (collect :
            (FStar_String.concat "\n`used by` " cycle);
          print_graph dep_graph1;
          FStar_Util.print_string "\n";
-         (let uu____6678 =
-            let uu____6684 =
+         (let uu____6692 =
+            let uu____6698 =
               FStar_Util.format1 "Recursive dependency on module %s\n"
                 filename
                in
-            (FStar_Errors.Fatal_CyclicDependence, uu____6684)  in
-          FStar_Errors.raise_err uu____6678)
+            (FStar_Errors.Fatal_CyclicDependence, uu____6698)  in
+          FStar_Errors.raise_err uu____6692)
           in
        let full_cycle_detection all_command_line_files file_system_map1 =
          let dep_graph1 = dep_graph_copy dep_graph  in
          let mo_files = FStar_Util.mk_ref []  in
          let rec aux cycle filename =
            let node =
-             let uu____6736 = deps_try_find dep_graph1 filename  in
-             match uu____6736 with
+             let uu____6750 = deps_try_find dep_graph1 filename  in
+             match uu____6750 with
              | FStar_Pervasives_Native.Some node -> node
              | FStar_Pervasives_Native.None  ->
-                 let uu____6740 =
+                 let uu____6754 =
                    FStar_Util.format1
                      "Impossible: Failed to find dependencies of %s" filename
                     in
-                 failwith uu____6740
+                 failwith uu____6754
               in
            let direct_deps =
              FStar_All.pipe_right node.edges
@@ -1974,61 +1987,61 @@ let (collect :
                   (fun x  ->
                      match x with
                      | UseInterface f ->
-                         let uu____6754 =
+                         let uu____6768 =
                            implementation_of_internal file_system_map1 f  in
-                         (match uu____6754 with
+                         (match uu____6768 with
                           | FStar_Pervasives_Native.None  -> [x]
                           | FStar_Pervasives_Native.Some fn when
                               fn = filename -> [x]
-                          | uu____6765 -> [x; UseImplementation f])
+                          | uu____6779 -> [x; UseImplementation f])
                      | PreferInterface f ->
-                         let uu____6771 =
+                         let uu____6785 =
                            implementation_of_internal file_system_map1 f  in
-                         (match uu____6771 with
+                         (match uu____6785 with
                           | FStar_Pervasives_Native.None  -> [x]
                           | FStar_Pervasives_Native.Some fn when
                               fn = filename -> [x]
-                          | uu____6782 -> [x; UseImplementation f])
-                     | uu____6786 -> [x]))
+                          | uu____6796 -> [x; UseImplementation f])
+                     | uu____6800 -> [x]))
               in
            match node.color with
            | Gray  -> cycle_detected dep_graph1 cycle filename
            | Black  -> ()
            | White  ->
                (deps_add_dep dep_graph1 filename
-                  (let uu___1133_6789 = node  in
+                  (let uu___1133_6803 = node  in
                    { edges = direct_deps; color = Gray });
-                (let uu____6791 =
+                (let uu____6805 =
                    dependences_of file_system_map1 dep_graph1
                      all_command_line_files filename
                     in
-                 FStar_List.iter (fun k  -> aux (k :: cycle) k) uu____6791);
+                 FStar_List.iter (fun k  -> aux (k :: cycle) k) uu____6805);
                 deps_add_dep dep_graph1 filename
-                  (let uu___1138_6802 = node  in
+                  (let uu___1138_6816 = node  in
                    { edges = direct_deps; color = Black });
-                (let uu____6803 = is_interface filename  in
-                 if uu____6803
+                (let uu____6817 = is_interface filename  in
+                 if uu____6817
                  then
-                   let uu____6806 =
-                     let uu____6810 = lowercase_module_name filename  in
-                     implementation_of_internal file_system_map1 uu____6810
+                   let uu____6820 =
+                     let uu____6824 = lowercase_module_name filename  in
+                     implementation_of_internal file_system_map1 uu____6824
                       in
-                   FStar_Util.iter_opt uu____6806
+                   FStar_Util.iter_opt uu____6820
                      (fun impl  ->
                         if
                           Prims.op_Negation
                             (FStar_List.contains impl all_command_line_files)
                         then
-                          let uu____6819 =
-                            let uu____6823 = FStar_ST.op_Bang mo_files  in
-                            impl :: uu____6823  in
-                          FStar_ST.op_Colon_Equals mo_files uu____6819
+                          let uu____6833 =
+                            let uu____6837 = FStar_ST.op_Bang mo_files  in
+                            impl :: uu____6837  in
+                          FStar_ST.op_Colon_Equals mo_files uu____6833
                         else ())
                  else ()))
             in
          FStar_List.iter (aux []) all_command_line_files;
-         (let uu____6885 = FStar_ST.op_Bang mo_files  in
-          FStar_List.iter (aux []) uu____6885)
+         (let uu____6899 = FStar_ST.op_Bang mo_files  in
+          FStar_List.iter (aux []) uu____6899)
           in
        full_cycle_detection all_cmd_line_files1 file_system_map;
        FStar_All.pipe_right all_cmd_line_files1
@@ -2038,23 +2051,23 @@ let (collect :
                FStar_Options.add_verify_module m));
        (let inlining_ifaces = FStar_ST.op_Bang interfaces_needing_inlining
            in
-        let uu____6957 =
+        let uu____6971 =
           profile
-            (fun uu____6976  ->
-               let uu____6977 =
-                 let uu____6979 = FStar_Options.codegen ()  in
-                 uu____6979 <> FStar_Pervasives_Native.None  in
+            (fun uu____6990  ->
+               let uu____6991 =
+                 let uu____6993 = FStar_Options.codegen ()  in
+                 uu____6993 <> FStar_Pervasives_Native.None  in
                topological_dependences_of file_system_map dep_graph
-                 inlining_ifaces all_cmd_line_files1 uu____6977)
+                 inlining_ifaces all_cmd_line_files1 uu____6991)
             "FStar.Parser.Dep.topological_dependences_of"
            in
-        match uu____6957 with
-        | (all_files,uu____6993) ->
-            ((let uu____7003 =
+        match uu____6971 with
+        | (all_files,uu____7007) ->
+            ((let uu____7017 =
                 FStar_Options.debug_at_level_no_module
                   (FStar_Options.Other "Dep")
                  in
-              if uu____7003
+              if uu____7017
               then
                 FStar_Util.print1 "Interfaces needing inlining: %s\n"
                   (FStar_String.concat ", " inlining_ifaces)
@@ -2072,16 +2085,16 @@ let (deps_of : deps -> Prims.string -> Prims.string Prims.list) =
 let (print_digest : (Prims.string * Prims.string) Prims.list -> Prims.string)
   =
   fun dig  ->
-    let uu____7057 =
+    let uu____7071 =
       FStar_All.pipe_right dig
         (FStar_List.map
-           (fun uu____7083  ->
-              match uu____7083 with
+           (fun uu____7097  ->
+              match uu____7097 with
               | (m,d) ->
-                  let uu____7097 = FStar_Util.base64_encode d  in
-                  FStar_Util.format2 "%s:%s" m uu____7097))
+                  let uu____7111 = FStar_Util.base64_encode d  in
+                  FStar_Util.format2 "%s:%s" m uu____7111))
        in
-    FStar_All.pipe_right uu____7057 (FStar_String.concat "\n")
+    FStar_All.pipe_right uu____7071 (FStar_String.concat "\n")
   
 let (print_make : deps -> unit) =
   fun deps1  ->
@@ -2093,8 +2106,8 @@ let (print_make : deps -> unit) =
       (FStar_List.iter
          (fun f  ->
             let dep_node1 =
-              let uu____7132 = deps_try_find deps2 f  in
-              FStar_All.pipe_right uu____7132 FStar_Option.get  in
+              let uu____7146 = deps_try_find deps2 f  in
+              FStar_All.pipe_right uu____7146 FStar_Option.get  in
             let files =
               FStar_List.map (file_of_dep file_system_map all_cmd_line_files)
                 dep_node1.edges
@@ -2107,28 +2120,28 @@ let (print_make : deps -> unit) =
   
 let (print_raw : deps -> unit) =
   fun deps1  ->
-    let uu____7161 = deps1.dep_graph  in
-    match uu____7161 with
+    let uu____7175 = deps1.dep_graph  in
+    match uu____7175 with
     | Deps deps2 ->
-        let uu____7165 =
-          let uu____7167 =
+        let uu____7179 =
+          let uu____7181 =
             FStar_Util.smap_fold deps2
               (fun k  ->
                  fun dep_node1  ->
                    fun out  ->
-                     let uu____7185 =
-                       let uu____7187 =
-                         let uu____7189 =
+                     let uu____7199 =
+                       let uu____7201 =
+                         let uu____7203 =
                            FStar_List.map dep_to_string dep_node1.edges  in
-                         FStar_All.pipe_right uu____7189
+                         FStar_All.pipe_right uu____7203
                            (FStar_String.concat ";\n\t")
                           in
-                       FStar_Util.format2 "%s -> [\n\t%s\n] " k uu____7187
+                       FStar_Util.format2 "%s -> [\n\t%s\n] " k uu____7201
                         in
-                     uu____7185 :: out) []
+                     uu____7199 :: out) []
              in
-          FStar_All.pipe_right uu____7167 (FStar_String.concat ";;\n")  in
-        FStar_All.pipe_right uu____7165 FStar_Util.print_endline
+          FStar_All.pipe_right uu____7181 (FStar_String.concat ";;\n")  in
+        FStar_All.pipe_right uu____7179 FStar_Util.print_endline
   
 let (print_full : deps -> unit) =
   fun deps1  ->
@@ -2139,13 +2152,13 @@ let (print_full : deps -> unit) =
       let visited_other_modules = FStar_Util.smap_create (Prims.of_int (41))
          in
       let should_visit lc_module_name =
-        (let uu____7261 =
+        (let uu____7275 =
            FStar_Util.smap_try_find remaining_output_files lc_module_name  in
-         FStar_Option.isSome uu____7261) ||
-          (let uu____7268 =
+         FStar_Option.isSome uu____7275) ||
+          (let uu____7282 =
              FStar_Util.smap_try_find visited_other_modules lc_module_name
               in
-           FStar_Option.isNone uu____7268)
+           FStar_Option.isNone uu____7282)
          in
       let mark_visiting lc_module_name =
         let ml_file_opt =
@@ -2157,32 +2170,32 @@ let (print_full : deps -> unit) =
         match ml_file_opt with
         | FStar_Pervasives_Native.None  -> ()
         | FStar_Pervasives_Native.Some ml_file ->
-            let uu____7311 =
-              let uu____7315 = FStar_ST.op_Bang order  in ml_file ::
-                uu____7315
+            let uu____7325 =
+              let uu____7329 = FStar_ST.op_Bang order  in ml_file ::
+                uu____7329
                in
-            FStar_ST.op_Colon_Equals order uu____7311
+            FStar_ST.op_Colon_Equals order uu____7325
          in
-      let rec aux uu___15_7378 =
-        match uu___15_7378 with
+      let rec aux uu___15_7392 =
+        match uu___15_7392 with
         | [] -> ()
         | lc_module_name::modules_to_extract ->
             let visit_file file_opt =
               match file_opt with
               | FStar_Pervasives_Native.None  -> ()
               | FStar_Pervasives_Native.Some file_name1 ->
-                  let uu____7406 = deps_try_find deps1.dep_graph file_name1
+                  let uu____7420 = deps_try_find deps1.dep_graph file_name1
                      in
-                  (match uu____7406 with
+                  (match uu____7420 with
                    | FStar_Pervasives_Native.None  ->
-                       let uu____7409 =
+                       let uu____7423 =
                          FStar_Util.format2
                            "Impossible: module %s: %s not found"
                            lc_module_name file_name1
                           in
-                       failwith uu____7409
+                       failwith uu____7423
                    | FStar_Pervasives_Native.Some
-                       { edges = immediate_deps; color = uu____7413;_} ->
+                       { edges = immediate_deps; color = uu____7427;_} ->
                        let immediate_deps1 =
                          FStar_List.map
                            (fun x  ->
@@ -2191,14 +2204,14 @@ let (print_full : deps -> unit) =
                           in
                        aux immediate_deps1)
                in
-            ((let uu____7422 = should_visit lc_module_name  in
-              if uu____7422
+            ((let uu____7436 = should_visit lc_module_name  in
+              if uu____7436
               then
                 let ml_file_opt = mark_visiting lc_module_name  in
-                ((let uu____7430 = implementation_of deps1 lc_module_name  in
-                  visit_file uu____7430);
-                 (let uu____7435 = interface_of deps1 lc_module_name  in
-                  visit_file uu____7435);
+                ((let uu____7444 = implementation_of deps1 lc_module_name  in
+                  visit_file uu____7444);
+                 (let uu____7449 = interface_of deps1 lc_module_name  in
+                  visit_file uu____7449);
                  emit_output_file_opt ml_file_opt)
               else ());
              aux modules_to_extract)
@@ -2206,93 +2219,93 @@ let (print_full : deps -> unit) =
       let all_extracted_modules = FStar_Util.smap_keys orig_output_file_map
          in
       aux all_extracted_modules;
-      (let uu____7447 = FStar_ST.op_Bang order  in FStar_List.rev uu____7447)
+      (let uu____7461 = FStar_ST.op_Bang order  in FStar_List.rev uu____7461)
        in
     let sb =
-      let uu____7478 = FStar_BigInt.of_int_fs (Prims.of_int (10000))  in
-      FStar_StringBuffer.create uu____7478  in
+      let uu____7492 = FStar_BigInt.of_int_fs (Prims.of_int (10000))  in
+      FStar_StringBuffer.create uu____7492  in
     let pr str =
-      let uu____7488 = FStar_StringBuffer.add str sb  in
-      FStar_All.pipe_left (fun uu____7489  -> ()) uu____7488  in
+      let uu____7502 = FStar_StringBuffer.add str sb  in
+      FStar_All.pipe_left (fun uu____7503  -> ()) uu____7502  in
     let print_entry target first_dep all_deps =
       pr target; pr ": "; pr first_dep; pr "\\\n\t"; pr all_deps; pr "\n\n"
        in
     let keys = deps_keys deps1.dep_graph  in
     let output_file ext fst_file =
       let ml_base_name =
-        let uu____7542 =
-          let uu____7544 =
-            let uu____7548 = FStar_Util.basename fst_file  in
-            check_and_strip_suffix uu____7548  in
-          FStar_Option.get uu____7544  in
-        FStar_Util.replace_chars uu____7542 46 "_"  in
-      let uu____7553 = FStar_String.op_Hat ml_base_name ext  in
-      FStar_Options.prepend_output_dir uu____7553  in
+        let uu____7556 =
+          let uu____7558 =
+            let uu____7562 = FStar_Util.basename fst_file  in
+            check_and_strip_suffix uu____7562  in
+          FStar_Option.get uu____7558  in
+        FStar_Util.replace_chars uu____7556 46 "_"  in
+      let uu____7567 = FStar_String.op_Hat ml_base_name ext  in
+      FStar_Options.prepend_output_dir uu____7567  in
     let norm_path s = FStar_Util.replace_chars s 92 "/"  in
     let output_ml_file f =
-      let uu____7575 = output_file ".ml" f  in norm_path uu____7575  in
+      let uu____7589 = output_file ".ml" f  in norm_path uu____7589  in
     let output_krml_file f =
-      let uu____7587 = output_file ".krml" f  in norm_path uu____7587  in
+      let uu____7601 = output_file ".krml" f  in norm_path uu____7601  in
     let output_cmx_file f =
-      let uu____7599 = output_file ".cmx" f  in norm_path uu____7599  in
+      let uu____7613 = output_file ".cmx" f  in norm_path uu____7613  in
     let cache_file f =
-      let uu____7611 = cache_file_name f  in norm_path uu____7611  in
-    let uu____7613 =
+      let uu____7625 = cache_file_name f  in norm_path uu____7625  in
+    let uu____7627 =
       phase1 deps1.file_system_map deps1.dep_graph
         deps1.interfaces_with_inlining true
        in
-    match uu____7613 with
+    match uu____7627 with
     | (widened,dep_graph) ->
         let all_checked_files =
           FStar_All.pipe_right keys
             (FStar_List.fold_left
                (fun all_checked_files  ->
                   fun file_name1  ->
-                    let process_one_key uu____7655 =
+                    let process_one_key uu____7669 =
                       let dep_node1 =
-                        let uu____7657 =
+                        let uu____7671 =
                           deps_try_find deps1.dep_graph file_name1  in
-                        FStar_All.pipe_right uu____7657 FStar_Option.get  in
-                      let uu____7662 =
-                        let uu____7674 = is_interface file_name1  in
-                        if uu____7674
+                        FStar_All.pipe_right uu____7671 FStar_Option.get  in
+                      let uu____7676 =
+                        let uu____7688 = is_interface file_name1  in
+                        if uu____7688
                         then
                           (FStar_Pervasives_Native.None,
                             FStar_Pervasives_Native.None)
                         else
-                          (let uu____7700 =
-                             let uu____7704 =
+                          (let uu____7714 =
+                             let uu____7718 =
                                lowercase_module_name file_name1  in
-                             interface_of deps1 uu____7704  in
-                           match uu____7700 with
+                             interface_of deps1 uu____7718  in
+                           match uu____7714 with
                            | FStar_Pervasives_Native.None  ->
                                (FStar_Pervasives_Native.None,
                                  FStar_Pervasives_Native.None)
                            | FStar_Pervasives_Native.Some iface ->
-                               let uu____7731 =
-                                 let uu____7736 =
-                                   let uu____7739 =
-                                     let uu____7740 =
+                               let uu____7745 =
+                                 let uu____7750 =
+                                   let uu____7753 =
+                                     let uu____7754 =
                                        deps_try_find deps1.dep_graph iface
                                         in
-                                     FStar_Option.get uu____7740  in
-                                   uu____7739.edges  in
-                                 FStar_Pervasives_Native.Some uu____7736  in
+                                     FStar_Option.get uu____7754  in
+                                   uu____7753.edges  in
+                                 FStar_Pervasives_Native.Some uu____7750  in
                                ((FStar_Pervasives_Native.Some iface),
-                                 uu____7731))
+                                 uu____7745))
                          in
-                      match uu____7662 with
+                      match uu____7676 with
                       | (iface_fn,iface_deps) ->
                           let iface_deps1 =
                             FStar_Util.map_opt iface_deps
                               (FStar_List.filter
                                  (fun iface_dep  ->
-                                    let uu____7784 =
+                                    let uu____7798 =
                                       FStar_Util.for_some
                                         (dep_subsumed_by iface_dep)
                                         dep_node1.edges
                                        in
-                                    Prims.op_Negation uu____7784))
+                                    Prims.op_Negation uu____7798))
                              in
                           let norm_f = norm_path file_name1  in
                           let files =
@@ -2315,25 +2328,25 @@ let (print_full : deps -> unit) =
                                   (FStar_List.append files iface_files)
                              in
                           let files2 =
-                            let uu____7827 =
+                            let uu____7841 =
                               FStar_All.pipe_right iface_fn
                                 FStar_Util.is_some
                                in
-                            if uu____7827
+                            if uu____7841
                             then
                               let iface_fn1 =
                                 FStar_All.pipe_right iface_fn FStar_Util.must
                                  in
-                              let uu____7845 =
+                              let uu____7859 =
                                 FStar_All.pipe_right files1
                                   (FStar_List.filter
                                      (fun f  -> f <> iface_fn1))
                                  in
-                              FStar_All.pipe_right uu____7845
+                              FStar_All.pipe_right uu____7859
                                 (fun files2  ->
-                                   let uu____7872 = cache_file_name iface_fn1
+                                   let uu____7886 = cache_file_name iface_fn1
                                       in
-                                   uu____7872 :: files2)
+                                   uu____7886 :: files2)
                             else files1  in
                           let files3 = FStar_List.map norm_path files2  in
                           let files4 =
@@ -2345,31 +2358,31 @@ let (print_full : deps -> unit) =
                              in
                           let cache_file_name1 = cache_file file_name1  in
                           let all_checked_files1 =
-                            let uu____7903 =
-                              let uu____7905 =
-                                let uu____7907 =
+                            let uu____7917 =
+                              let uu____7919 =
+                                let uu____7921 =
                                   module_name_of_file file_name1  in
                                 FStar_Options.should_be_already_cached
-                                  uu____7907
+                                  uu____7921
                                  in
-                              Prims.op_Negation uu____7905  in
-                            if uu____7903
+                              Prims.op_Negation uu____7919  in
+                            if uu____7917
                             then
                               (print_entry cache_file_name1 norm_f files5;
                                cache_file_name1
                                ::
                                all_checked_files)
                             else all_checked_files  in
-                          let uu____7917 =
-                            let uu____7926 = FStar_Options.cmi ()  in
-                            if uu____7926
+                          let uu____7931 =
+                            let uu____7940 = FStar_Options.cmi ()  in
+                            if uu____7940
                             then
                               profile
-                                (fun uu____7947  ->
-                                   let uu____7948 = dep_graph_copy dep_graph
+                                (fun uu____7961  ->
+                                   let uu____7962 = dep_graph_copy dep_graph
                                       in
                                    topological_dependences_of'
-                                     deps1.file_system_map uu____7948
+                                     deps1.file_system_map uu____7962
                                      deps1.interfaces_with_inlining
                                      [file_name1] widened)
                                 "FStar.Parser.Dep.topological_dependences_of_2"
@@ -2389,15 +2402,15 @@ let (print_full : deps -> unit) =
                                  | FStar_Pervasives_Native.Some iface_deps2
                                      -> maybe_widen_deps iface_deps2
                                   in
-                               let uu____7986 =
+                               let uu____8000 =
                                  FStar_Util.remove_dups
                                    (fun x  -> fun y  -> x = y)
                                    (FStar_List.append fst_files
                                       fst_files_from_iface)
                                   in
-                               (uu____7986, false))
+                               (uu____8000, false))
                              in
-                          (match uu____7917 with
+                          (match uu____7931 with
                            | (all_fst_files_dep,widened1) ->
                                let all_checked_fst_dep_files =
                                  FStar_All.pipe_right all_fst_files_dep
@@ -2407,32 +2420,32 @@ let (print_full : deps -> unit) =
                                  FStar_String.concat " \\\n\t"
                                    all_checked_fst_dep_files
                                   in
-                               ((let uu____8033 =
+                               ((let uu____8047 =
                                    is_implementation file_name1  in
-                                 if uu____8033
+                                 if uu____8047
                                  then
-                                   ((let uu____8037 =
+                                   ((let uu____8051 =
                                        (FStar_Options.cmi ()) && widened1  in
-                                     if uu____8037
+                                     if uu____8051
                                      then
-                                       ((let uu____8041 =
+                                       ((let uu____8055 =
                                            output_ml_file file_name1  in
-                                         print_entry uu____8041
+                                         print_entry uu____8055
                                            cache_file_name1
                                            all_checked_fst_dep_files_string);
-                                        (let uu____8043 =
+                                        (let uu____8057 =
                                            output_krml_file file_name1  in
-                                         print_entry uu____8043
+                                         print_entry uu____8057
                                            cache_file_name1
                                            all_checked_fst_dep_files_string))
                                      else
-                                       ((let uu____8048 =
+                                       ((let uu____8062 =
                                            output_ml_file file_name1  in
-                                         print_entry uu____8048
+                                         print_entry uu____8062
                                            cache_file_name1 "");
-                                        (let uu____8051 =
+                                        (let uu____8065 =
                                            output_krml_file file_name1  in
-                                         print_entry uu____8051
+                                         print_entry uu____8065
                                            cache_file_name1 "")));
                                     (let cmx_files =
                                        let extracted_fst_files =
@@ -2440,74 +2453,74 @@ let (print_full : deps -> unit) =
                                            all_fst_files_dep
                                            (FStar_List.filter
                                               (fun df  ->
-                                                 (let uu____8076 =
+                                                 (let uu____8090 =
                                                     lowercase_module_name df
                                                      in
-                                                  let uu____8078 =
+                                                  let uu____8092 =
                                                     lowercase_module_name
                                                       file_name1
                                                      in
-                                                  uu____8076 <> uu____8078)
+                                                  uu____8090 <> uu____8092)
                                                    &&
-                                                   (let uu____8082 =
+                                                   (let uu____8096 =
                                                       lowercase_module_name
                                                         df
                                                        in
                                                     FStar_Options.should_extract
-                                                      uu____8082)))
+                                                      uu____8096)))
                                           in
                                        FStar_All.pipe_right
                                          extracted_fst_files
                                          (FStar_List.map output_cmx_file)
                                         in
-                                     let uu____8092 =
-                                       let uu____8094 =
+                                     let uu____8106 =
+                                       let uu____8108 =
                                          lowercase_module_name file_name1  in
                                        FStar_Options.should_extract
-                                         uu____8094
+                                         uu____8108
                                         in
-                                     if uu____8092
+                                     if uu____8106
                                      then
                                        let cmx_files1 =
                                          FStar_String.concat "\\\n\t"
                                            cmx_files
                                           in
-                                       let uu____8100 =
+                                       let uu____8114 =
                                          output_cmx_file file_name1  in
-                                       let uu____8102 =
+                                       let uu____8116 =
                                          output_ml_file file_name1  in
-                                       print_entry uu____8100 uu____8102
+                                       print_entry uu____8114 uu____8116
                                          cmx_files1
                                      else ()))
                                  else
-                                   (let uu____8108 =
-                                      (let uu____8112 =
-                                         let uu____8114 =
+                                   (let uu____8122 =
+                                      (let uu____8126 =
+                                         let uu____8128 =
                                            lowercase_module_name file_name1
                                             in
                                          has_implementation
-                                           deps1.file_system_map uu____8114
+                                           deps1.file_system_map uu____8128
                                           in
-                                       Prims.op_Negation uu____8112) &&
+                                       Prims.op_Negation uu____8126) &&
                                         (is_interface file_name1)
                                        in
-                                    if uu____8108
+                                    if uu____8122
                                     then
-                                      let uu____8117 =
+                                      let uu____8131 =
                                         (FStar_Options.cmi ()) &&
                                           (widened1 || true)
                                          in
-                                      (if uu____8117
+                                      (if uu____8131
                                        then
-                                         let uu____8121 =
+                                         let uu____8135 =
                                            output_krml_file file_name1  in
-                                         print_entry uu____8121
+                                         print_entry uu____8135
                                            cache_file_name1
                                            all_checked_fst_dep_files_string
                                        else
-                                         (let uu____8125 =
+                                         (let uu____8139 =
                                             output_krml_file file_name1  in
-                                          print_entry uu____8125
+                                          print_entry uu____8139
                                             cache_file_name1 ""))
                                     else ()));
                                 all_checked_files1))
@@ -2516,16 +2529,16 @@ let (print_full : deps -> unit) =
                       "FStar.Parser.Dep.process_one_key") [])
            in
         let all_fst_files =
-          let uu____8139 =
+          let uu____8153 =
             FStar_All.pipe_right keys (FStar_List.filter is_implementation)
              in
-          FStar_All.pipe_right uu____8139
+          FStar_All.pipe_right uu____8153
             (FStar_Util.sort_with FStar_String.compare)
            in
         let all_fsti_files =
-          let uu____8161 =
+          let uu____8175 =
             FStar_All.pipe_right keys (FStar_List.filter is_interface)  in
-          FStar_All.pipe_right uu____8161
+          FStar_All.pipe_right uu____8175
             (FStar_Util.sort_with FStar_String.compare)
            in
         let all_ml_files =
@@ -2534,11 +2547,11 @@ let (print_full : deps -> unit) =
             (FStar_List.iter
                (fun fst_file  ->
                   let mname = lowercase_module_name fst_file  in
-                  let uu____8202 = FStar_Options.should_extract mname  in
-                  if uu____8202
+                  let uu____8216 = FStar_Options.should_extract mname  in
+                  if uu____8216
                   then
-                    let uu____8205 = output_ml_file fst_file  in
-                    FStar_Util.smap_add ml_file_map mname uu____8205
+                    let uu____8219 = output_ml_file fst_file  in
+                    FStar_Util.smap_add ml_file_map mname uu____8219
                   else ()));
           sort_output_files ml_file_map  in
         let all_krml_files =
@@ -2547,8 +2560,8 @@ let (print_full : deps -> unit) =
             (FStar_List.iter
                (fun fst_file  ->
                   let mname = lowercase_module_name fst_file  in
-                  let uu____8232 = output_krml_file fst_file  in
-                  FStar_Util.smap_add krml_file_map mname uu____8232));
+                  let uu____8246 = output_krml_file fst_file  in
+                  FStar_Util.smap_add krml_file_map mname uu____8246));
           sort_output_files krml_file_map  in
         let print_all tag files =
           pr tag;
@@ -2564,15 +2577,15 @@ let (print_full : deps -> unit) =
   
 let (print : deps -> unit) =
   fun deps1  ->
-    let uu____8282 = FStar_Options.dep ()  in
-    match uu____8282 with
+    let uu____8296 = FStar_Options.dep ()  in
+    match uu____8296 with
     | FStar_Pervasives_Native.Some "make" -> print_make deps1
     | FStar_Pervasives_Native.Some "full" ->
-        profile (fun uu____8291  -> print_full deps1)
+        profile (fun uu____8305  -> print_full deps1)
           "FStar.Parser.Deps.print_full_deps"
     | FStar_Pervasives_Native.Some "graph" -> print_graph deps1.dep_graph
     | FStar_Pervasives_Native.Some "raw" -> print_raw deps1
-    | FStar_Pervasives_Native.Some uu____8297 ->
+    | FStar_Pervasives_Native.Some uu____8311 ->
         FStar_Errors.raise_err
           (FStar_Errors.Fatal_UnknownToolForDep, "unknown tool for --dep\n")
     | FStar_Pervasives_Native.None  -> ()
@@ -2584,38 +2597,38 @@ let (print_fsmap :
   fun fsmap  ->
     FStar_Util.smap_fold fsmap
       (fun k  ->
-         fun uu____8352  ->
+         fun uu____8366  ->
            fun s  ->
-             match uu____8352 with
+             match uu____8366 with
              | (v0,v1) ->
-                 let uu____8381 =
-                   let uu____8383 =
+                 let uu____8395 =
+                   let uu____8397 =
                      FStar_Util.format3 "%s -> (%s, %s)" k
                        (FStar_Util.dflt "_" v0) (FStar_Util.dflt "_" v1)
                       in
-                   FStar_String.op_Hat "; " uu____8383  in
-                 FStar_String.op_Hat s uu____8381) ""
+                   FStar_String.op_Hat "; " uu____8397  in
+                 FStar_String.op_Hat s uu____8395) ""
   
 let (module_has_interface : deps -> FStar_Ident.lident -> Prims.bool) =
   fun deps1  ->
     fun module_name1  ->
-      let uu____8404 =
-        let uu____8406 = FStar_Ident.string_of_lid module_name1  in
-        FStar_String.lowercase uu____8406  in
-      has_interface deps1.file_system_map uu____8404
+      let uu____8418 =
+        let uu____8420 = FStar_Ident.string_of_lid module_name1  in
+        FStar_String.lowercase uu____8420  in
+      has_interface deps1.file_system_map uu____8418
   
 let (deps_has_implementation : deps -> FStar_Ident.lident -> Prims.bool) =
   fun deps1  ->
     fun module_name1  ->
       let m =
-        let uu____8422 = FStar_Ident.string_of_lid module_name1  in
-        FStar_String.lowercase uu____8422  in
+        let uu____8436 = FStar_Ident.string_of_lid module_name1  in
+        FStar_String.lowercase uu____8436  in
       FStar_All.pipe_right deps1.all_files
         (FStar_Util.for_some
            (fun f  ->
               (is_implementation f) &&
-                (let uu____8433 =
-                   let uu____8435 = module_name_of_file f  in
-                   FStar_String.lowercase uu____8435  in
-                 uu____8433 = m)))
+                (let uu____8447 =
+                   let uu____8449 = module_name_of_file f  in
+                   FStar_String.lowercase uu____8449  in
+                 uu____8447 = m)))
   

--- a/src/ocaml-output/FStar_Parser_ToDocument.ml
+++ b/src/ocaml-output/FStar_Parser_ToDocument.ml
@@ -386,9 +386,10 @@ let (matches_var : FStar_Parser_AST.term -> FStar_Ident.ident -> Prims.bool)
     fun x  ->
       match t.FStar_Parser_AST.tm with
       | FStar_Parser_AST.Var y ->
-          let uu____1182 = FStar_Ident.text_of_lid y  in
-          x.FStar_Ident.idText = uu____1182
-      | uu____1185 -> false
+          let uu____1182 = FStar_Ident.text_of_id x  in
+          let uu____1184 = FStar_Ident.string_of_lid y  in
+          uu____1182 = uu____1184
+      | uu____1187 -> false
   
 let (is_tuple_constructor : FStar_Ident.lident -> Prims.bool) =
   FStar_Parser_Const.is_tuple_data_lid' 
@@ -404,9 +405,9 @@ let (is_list_structure :
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Construct (lid,[]) ->
             FStar_Ident.lid_equals lid nil_lid
-        | FStar_Parser_AST.Construct (lid,uu____1236::(e2,uu____1238)::[]) ->
+        | FStar_Parser_AST.Construct (lid,uu____1238::(e2,uu____1240)::[]) ->
             (FStar_Ident.lid_equals lid cons_lid) && (aux e2)
-        | uu____1261 -> false  in
+        | uu____1263 -> false  in
       aux
   
 let (is_list : FStar_Parser_AST.term -> Prims.bool) =
@@ -419,29 +420,29 @@ let rec (extract_from_list :
   FStar_Parser_AST.term -> FStar_Parser_AST.term Prims.list) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Construct (uu____1285,[]) -> []
+    | FStar_Parser_AST.Construct (uu____1287,[]) -> []
     | FStar_Parser_AST.Construct
-        (uu____1296,(e1,FStar_Parser_AST.Nothing )::(e2,FStar_Parser_AST.Nothing
+        (uu____1298,(e1,FStar_Parser_AST.Nothing )::(e2,FStar_Parser_AST.Nothing
                                                      )::[])
-        -> let uu____1317 = extract_from_list e2  in e1 :: uu____1317
-    | uu____1320 ->
-        let uu____1321 =
-          let uu____1323 = FStar_Parser_AST.term_to_string e  in
-          FStar_Util.format1 "Not a list %s" uu____1323  in
-        failwith uu____1321
+        -> let uu____1319 = extract_from_list e2  in e1 :: uu____1319
+    | uu____1322 ->
+        let uu____1323 =
+          let uu____1325 = FStar_Parser_AST.term_to_string e  in
+          FStar_Util.format1 "Not a list %s" uu____1325  in
+        failwith uu____1323
   
 let (is_array : FStar_Parser_AST.term -> Prims.bool) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.App
         ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var lid;
-           FStar_Parser_AST.range = uu____1337;
-           FStar_Parser_AST.level = uu____1338;_},l,FStar_Parser_AST.Nothing
+           FStar_Parser_AST.range = uu____1339;
+           FStar_Parser_AST.level = uu____1340;_},l,FStar_Parser_AST.Nothing
          )
         ->
         (FStar_Ident.lid_equals lid FStar_Parser_Const.array_of_list_lid) &&
           (is_list l)
-    | uu____1340 -> false
+    | uu____1342 -> false
   
 let rec (is_ref_set : FStar_Parser_AST.term -> Prims.bool) =
   fun e  ->
@@ -450,8 +451,8 @@ let rec (is_ref_set : FStar_Parser_AST.term -> Prims.bool) =
         FStar_Ident.lid_equals maybe_empty_lid FStar_Parser_Const.set_empty
     | FStar_Parser_AST.App
         ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var maybe_singleton_lid;
-           FStar_Parser_AST.range = uu____1352;
-           FStar_Parser_AST.level = uu____1353;_},{
+           FStar_Parser_AST.range = uu____1354;
+           FStar_Parser_AST.level = uu____1355;_},{
                                                     FStar_Parser_AST.tm =
                                                       FStar_Parser_AST.App
                                                       ({
@@ -460,14 +461,14 @@ let rec (is_ref_set : FStar_Parser_AST.term -> Prims.bool) =
                                                            FStar_Parser_AST.Var
                                                            maybe_addr_of_lid;
                                                          FStar_Parser_AST.range
-                                                           = uu____1355;
+                                                           = uu____1357;
                                                          FStar_Parser_AST.level
-                                                           = uu____1356;_},e1,FStar_Parser_AST.Nothing
+                                                           = uu____1358;_},e1,FStar_Parser_AST.Nothing
                                                        );
                                                     FStar_Parser_AST.range =
-                                                      uu____1358;
+                                                      uu____1360;
                                                     FStar_Parser_AST.level =
-                                                      uu____1359;_},FStar_Parser_AST.Nothing
+                                                      uu____1361;_},FStar_Parser_AST.Nothing
          )
         ->
         (FStar_Ident.lid_equals maybe_singleton_lid
@@ -479,83 +480,83 @@ let rec (is_ref_set : FStar_Parser_AST.term -> Prims.bool) =
         ({
            FStar_Parser_AST.tm = FStar_Parser_AST.App
              ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var maybe_union_lid;
-                FStar_Parser_AST.range = uu____1361;
-                FStar_Parser_AST.level = uu____1362;_},e1,FStar_Parser_AST.Nothing
+                FStar_Parser_AST.range = uu____1363;
+                FStar_Parser_AST.level = uu____1364;_},e1,FStar_Parser_AST.Nothing
               );
-           FStar_Parser_AST.range = uu____1364;
-           FStar_Parser_AST.level = uu____1365;_},e2,FStar_Parser_AST.Nothing
+           FStar_Parser_AST.range = uu____1366;
+           FStar_Parser_AST.level = uu____1367;_},e2,FStar_Parser_AST.Nothing
          )
         ->
         ((FStar_Ident.lid_equals maybe_union_lid FStar_Parser_Const.set_union)
            && (is_ref_set e1))
           && (is_ref_set e2)
-    | uu____1367 -> false
+    | uu____1369 -> false
   
 let rec (extract_from_ref_set :
   FStar_Parser_AST.term -> FStar_Parser_AST.term Prims.list) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Var uu____1379 -> []
+    | FStar_Parser_AST.Var uu____1381 -> []
     | FStar_Parser_AST.App
-        ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu____1380;
-           FStar_Parser_AST.range = uu____1381;
-           FStar_Parser_AST.level = uu____1382;_},{
+        ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu____1382;
+           FStar_Parser_AST.range = uu____1383;
+           FStar_Parser_AST.level = uu____1384;_},{
                                                     FStar_Parser_AST.tm =
                                                       FStar_Parser_AST.App
                                                       ({
                                                          FStar_Parser_AST.tm
                                                            =
                                                            FStar_Parser_AST.Var
-                                                           uu____1383;
+                                                           uu____1385;
                                                          FStar_Parser_AST.range
-                                                           = uu____1384;
+                                                           = uu____1386;
                                                          FStar_Parser_AST.level
-                                                           = uu____1385;_},e1,FStar_Parser_AST.Nothing
+                                                           = uu____1387;_},e1,FStar_Parser_AST.Nothing
                                                        );
                                                     FStar_Parser_AST.range =
-                                                      uu____1387;
+                                                      uu____1389;
                                                     FStar_Parser_AST.level =
-                                                      uu____1388;_},FStar_Parser_AST.Nothing
+                                                      uu____1390;_},FStar_Parser_AST.Nothing
          )
         -> [e1]
     | FStar_Parser_AST.App
         ({
            FStar_Parser_AST.tm = FStar_Parser_AST.App
-             ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu____1389;
-                FStar_Parser_AST.range = uu____1390;
-                FStar_Parser_AST.level = uu____1391;_},e1,FStar_Parser_AST.Nothing
+             ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu____1391;
+                FStar_Parser_AST.range = uu____1392;
+                FStar_Parser_AST.level = uu____1393;_},e1,FStar_Parser_AST.Nothing
               );
-           FStar_Parser_AST.range = uu____1393;
-           FStar_Parser_AST.level = uu____1394;_},e2,FStar_Parser_AST.Nothing
+           FStar_Parser_AST.range = uu____1395;
+           FStar_Parser_AST.level = uu____1396;_},e2,FStar_Parser_AST.Nothing
          )
         ->
-        let uu____1396 = extract_from_ref_set e1  in
-        let uu____1399 = extract_from_ref_set e2  in
-        FStar_List.append uu____1396 uu____1399
-    | uu____1402 ->
-        let uu____1403 =
-          let uu____1405 = FStar_Parser_AST.term_to_string e  in
-          FStar_Util.format1 "Not a ref set %s" uu____1405  in
-        failwith uu____1403
+        let uu____1398 = extract_from_ref_set e1  in
+        let uu____1401 = extract_from_ref_set e2  in
+        FStar_List.append uu____1398 uu____1401
+    | uu____1404 ->
+        let uu____1405 =
+          let uu____1407 = FStar_Parser_AST.term_to_string e  in
+          FStar_Util.format1 "Not a ref set %s" uu____1407  in
+        failwith uu____1405
   
 let (is_general_application : FStar_Parser_AST.term -> Prims.bool) =
   fun e  ->
-    let uu____1417 = (is_array e) || (is_ref_set e)  in
-    Prims.op_Negation uu____1417
+    let uu____1419 = (is_array e) || (is_ref_set e)  in
+    Prims.op_Negation uu____1419
   
 let (is_general_construction : FStar_Parser_AST.term -> Prims.bool) =
   fun e  ->
-    let uu____1426 = (is_list e) || (is_lex_list e)  in
-    Prims.op_Negation uu____1426
+    let uu____1428 = (is_list e) || (is_lex_list e)  in
+    Prims.op_Negation uu____1428
   
 let (is_general_prefix_op : FStar_Ident.ident -> Prims.bool) =
   fun op  ->
     let op_starting_char =
-      let uu____1437 = FStar_Ident.text_of_id op  in
-      FStar_Util.char_at uu____1437 Prims.int_zero  in
+      let uu____1439 = FStar_Ident.text_of_id op  in
+      FStar_Util.char_at uu____1439 Prims.int_zero  in
     ((op_starting_char = 33) || (op_starting_char = 63)) ||
       ((op_starting_char = 126) &&
-         (let uu____1447 = FStar_Ident.text_of_id op  in uu____1447 <> "~"))
+         (let uu____1449 = FStar_Ident.text_of_id op  in uu____1449 <> "~"))
   
 let (head_and_args :
   FStar_Parser_AST.term ->
@@ -566,7 +567,7 @@ let (head_and_args :
     let rec aux e1 acc =
       match e1.FStar_Parser_AST.tm with
       | FStar_Parser_AST.App (head,arg,imp) -> aux head ((arg, imp) :: acc)
-      | uu____1517 -> (e1, acc)  in
+      | uu____1519 -> (e1, acc)  in
     aux e []
   
 type associativity =
@@ -575,22 +576,22 @@ type associativity =
   | NonAssoc 
 let (uu___is_Left : associativity -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Left  -> true | uu____1537 -> false
+    match projectee with | Left  -> true | uu____1539 -> false
   
 let (uu___is_Right : associativity -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Right  -> true | uu____1548 -> false
+    match projectee with | Right  -> true | uu____1550 -> false
   
 let (uu___is_NonAssoc : associativity -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NonAssoc  -> true | uu____1559 -> false
+    match projectee with | NonAssoc  -> true | uu____1561 -> false
   
 type token = (FStar_Char.char,Prims.string) FStar_Util.either
 type associativity_level = (associativity * token Prims.list)
 let (token_to_string :
   (FStar_BaseTypes.char,Prims.string) FStar_Util.either -> Prims.string) =
-  fun uu___1_1585  ->
-    match uu___1_1585 with
+  fun uu___1_1587  ->
+    match uu___1_1587 with
     | FStar_Util.Inl c -> Prims.op_Hat (FStar_Util.string_of_char c) ".*"
     | FStar_Util.Inr s -> s
   
@@ -599,25 +600,25 @@ let (matches_token :
     (FStar_Char.char,Prims.string) FStar_Util.either -> Prims.bool)
   =
   fun s  ->
-    fun uu___2_1620  ->
-      match uu___2_1620 with
+    fun uu___2_1622  ->
+      match uu___2_1622 with
       | FStar_Util.Inl c ->
-          let uu____1633 = FStar_String.get s Prims.int_zero  in
-          uu____1633 = c
+          let uu____1635 = FStar_String.get s Prims.int_zero  in
+          uu____1635 = c
       | FStar_Util.Inr s' -> s = s'
   
 let matches_level :
-  'uuuuuu1649 .
+  'uuuuuu1651 .
     Prims.string ->
-      ('uuuuuu1649 * (FStar_Char.char,Prims.string) FStar_Util.either
+      ('uuuuuu1651 * (FStar_Char.char,Prims.string) FStar_Util.either
         Prims.list) -> Prims.bool
   =
   fun s  ->
-    fun uu____1673  ->
-      match uu____1673 with
+    fun uu____1675  ->
+      match uu____1675 with
       | (assoc_levels,tokens) ->
-          let uu____1705 = FStar_List.tryFind (matches_token s) tokens  in
-          uu____1705 <> FStar_Pervasives_Native.None
+          let uu____1707 = FStar_List.tryFind (matches_token s) tokens  in
+          uu____1707 <> FStar_Pervasives_Native.None
   
 let (opinfix4 : associativity_level) = (Right, [FStar_Util.Inr "**"]) 
 let (opinfix3 : associativity_level) =
@@ -652,15 +653,15 @@ let (level_associativity_spec : associativity_level Prims.list) =
   colon_colon] 
 let (level_table :
   ((Prims.int * Prims.int * Prims.int) * token Prims.list) Prims.list) =
-  let levels_from_associativity l uu___3_1877 =
-    match uu___3_1877 with
+  let levels_from_associativity l uu___3_1879 =
+    match uu___3_1879 with
     | Left  -> (l, l, (l - Prims.int_one))
     | Right  -> ((l - Prims.int_one), l, l)
     | NonAssoc  -> ((l - Prims.int_one), l, (l - Prims.int_one))  in
   FStar_List.mapi
     (fun i  ->
-       fun uu____1927  ->
-         match uu____1927 with
+       fun uu____1929  ->
+         match uu____1929 with
          | (assoc,tokens) -> ((levels_from_associativity i assoc), tokens))
     level_associativity_spec
   
@@ -670,44 +671,44 @@ let (assign_levels :
   =
   fun token_associativity_spec  ->
     fun s  ->
-      let uu____2002 = FStar_List.tryFind (matches_level s) level_table  in
-      match uu____2002 with
-      | FStar_Pervasives_Native.Some (assoc_levels,uu____2054) ->
+      let uu____2004 = FStar_List.tryFind (matches_level s) level_table  in
+      match uu____2004 with
+      | FStar_Pervasives_Native.Some (assoc_levels,uu____2056) ->
           assoc_levels
-      | uu____2092 -> failwith (Prims.op_Hat "Unrecognized operator " s)
+      | uu____2094 -> failwith (Prims.op_Hat "Unrecognized operator " s)
   
 let max_level :
-  'uuuuuu2125 . ('uuuuuu2125 * token Prims.list) Prims.list -> Prims.int =
+  'uuuuuu2127 . ('uuuuuu2127 * token Prims.list) Prims.list -> Prims.int =
   fun l  ->
     let find_level_and_max n level =
-      let uu____2174 =
+      let uu____2176 =
         FStar_List.tryFind
-          (fun uu____2210  ->
-             match uu____2210 with
-             | (uu____2227,tokens) ->
+          (fun uu____2212  ->
+             match uu____2212 with
+             | (uu____2229,tokens) ->
                  tokens = (FStar_Pervasives_Native.snd level)) level_table
          in
-      match uu____2174 with
-      | FStar_Pervasives_Native.Some ((uu____2256,l1,uu____2258),uu____2259)
+      match uu____2176 with
+      | FStar_Pervasives_Native.Some ((uu____2258,l1,uu____2260),uu____2261)
           -> max n l1
       | FStar_Pervasives_Native.None  ->
-          let uu____2309 =
-            let uu____2311 =
-              let uu____2313 =
+          let uu____2311 =
+            let uu____2313 =
+              let uu____2315 =
                 FStar_List.map token_to_string
                   (FStar_Pervasives_Native.snd level)
                  in
-              FStar_String.concat "," uu____2313  in
-            FStar_Util.format1 "Undefined associativity level %s" uu____2311
+              FStar_String.concat "," uu____2315  in
+            FStar_Util.format1 "Undefined associativity level %s" uu____2313
              in
-          failwith uu____2309
+          failwith uu____2311
        in
     FStar_List.fold_left find_level_and_max Prims.int_zero l
   
 let (levels : Prims.string -> (Prims.int * Prims.int * Prims.int)) =
   fun op  ->
-    let uu____2348 = assign_levels level_associativity_spec op  in
-    match uu____2348 with
+    let uu____2350 = assign_levels level_associativity_spec op  in
+    match uu____2350 with
     | (left,mine,right) ->
         if op = "*"
         then ((left - Prims.int_one), mine, right)
@@ -717,37 +718,37 @@ let (operatorInfix0ad12 : associativity_level Prims.list) =
   [opinfix0a; opinfix0b; opinfix0c; opinfix0d; opinfix1; opinfix2] 
 let (is_operatorInfix0ad12 : FStar_Ident.ident -> Prims.bool) =
   fun op  ->
-    let uu____2407 =
-      let uu____2410 =
-        let uu____2416 = FStar_Ident.text_of_id op  in
-        FStar_All.pipe_left matches_level uu____2416  in
-      FStar_List.tryFind uu____2410 operatorInfix0ad12  in
-    uu____2407 <> FStar_Pervasives_Native.None
+    let uu____2409 =
+      let uu____2412 =
+        let uu____2418 = FStar_Ident.text_of_id op  in
+        FStar_All.pipe_left matches_level uu____2418  in
+      FStar_List.tryFind uu____2412 operatorInfix0ad12  in
+    uu____2409 <> FStar_Pervasives_Native.None
   
 let (is_operatorInfix34 : FStar_Ident.ident -> Prims.bool) =
   let opinfix34 = [opinfix3; opinfix4]  in
   fun op  ->
-    let uu____2483 =
-      let uu____2498 =
-        let uu____2516 = FStar_Ident.text_of_id op  in
-        FStar_All.pipe_left matches_level uu____2516  in
-      FStar_List.tryFind uu____2498 opinfix34  in
-    uu____2483 <> FStar_Pervasives_Native.None
+    let uu____2485 =
+      let uu____2500 =
+        let uu____2518 = FStar_Ident.text_of_id op  in
+        FStar_All.pipe_left matches_level uu____2518  in
+      FStar_List.tryFind uu____2500 opinfix34  in
+    uu____2485 <> FStar_Pervasives_Native.None
   
 let (handleable_args_length : FStar_Ident.ident -> Prims.int) =
   fun op  ->
     let op_s = FStar_Ident.text_of_id op  in
-    let uu____2582 =
+    let uu____2584 =
       (is_general_prefix_op op) || (FStar_List.mem op_s ["-"; "~"])  in
-    if uu____2582
+    if uu____2584
     then Prims.int_one
     else
-      (let uu____2595 =
+      (let uu____2597 =
          ((is_operatorInfix0ad12 op) || (is_operatorInfix34 op)) ||
            (FStar_List.mem op_s
               ["<==>"; "==>"; "\\/"; "/\\"; "="; "|>"; ":="; ".()"; ".[]"])
           in
-       if uu____2595
+       if uu____2597
        then (Prims.of_int (2))
        else
          if FStar_List.mem op_s [".()<-"; ".[]<-"]
@@ -755,38 +756,38 @@ let (handleable_args_length : FStar_Ident.ident -> Prims.int) =
          else Prims.int_zero)
   
 let handleable_op :
-  'uuuuuu2641 . FStar_Ident.ident -> 'uuuuuu2641 Prims.list -> Prims.bool =
+  'uuuuuu2643 . FStar_Ident.ident -> 'uuuuuu2643 Prims.list -> Prims.bool =
   fun op  ->
     fun args  ->
       match FStar_List.length args with
-      | uu____2657 when uu____2657 = Prims.int_zero -> true
-      | uu____2659 when uu____2659 = Prims.int_one ->
+      | uu____2659 when uu____2659 = Prims.int_zero -> true
+      | uu____2661 when uu____2661 = Prims.int_one ->
           (is_general_prefix_op op) ||
-            (let uu____2661 = FStar_Ident.text_of_id op  in
-             FStar_List.mem uu____2661 ["-"; "~"])
-      | uu____2669 when uu____2669 = (Prims.of_int (2)) ->
+            (let uu____2663 = FStar_Ident.text_of_id op  in
+             FStar_List.mem uu____2663 ["-"; "~"])
+      | uu____2671 when uu____2671 = (Prims.of_int (2)) ->
           ((is_operatorInfix0ad12 op) || (is_operatorInfix34 op)) ||
-            (let uu____2671 = FStar_Ident.text_of_id op  in
-             FStar_List.mem uu____2671
+            (let uu____2673 = FStar_Ident.text_of_id op  in
+             FStar_List.mem uu____2673
                ["<==>"; "==>"; "\\/"; "/\\"; "="; "|>"; ":="; ".()"; ".[]"])
-      | uu____2693 when uu____2693 = (Prims.of_int (3)) ->
-          let uu____2694 = FStar_Ident.text_of_id op  in
-          FStar_List.mem uu____2694 [".()<-"; ".[]<-"]
-      | uu____2702 -> false
+      | uu____2695 when uu____2695 = (Prims.of_int (3)) ->
+          let uu____2696 = FStar_Ident.text_of_id op  in
+          FStar_List.mem uu____2696 [".()<-"; ".[]<-"]
+      | uu____2704 -> false
   
 type annotation_style =
   | Binders of (Prims.int * Prims.int * Prims.bool) 
   | Arrows of (Prims.int * Prims.int) 
 let (uu___is_Binders : annotation_style -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Binders _0 -> true | uu____2748 -> false
+    match projectee with | Binders _0 -> true | uu____2750 -> false
   
 let (__proj__Binders__item___0 :
   annotation_style -> (Prims.int * Prims.int * Prims.bool)) =
   fun projectee  -> match projectee with | Binders _0 -> _0 
 let (uu___is_Arrows : annotation_style -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Arrows _0 -> true | uu____2800 -> false
+    match projectee with | Arrows _0 -> true | uu____2802 -> false
   
 let (__proj__Arrows__item___0 : annotation_style -> (Prims.int * Prims.int))
   = fun projectee  -> match projectee with | Arrows _0 -> _0 
@@ -794,18 +795,18 @@ let (all_binders_annot : FStar_Parser_AST.term -> Prims.bool) =
   fun e  ->
     let is_binder_annot b =
       match b.FStar_Parser_AST.b with
-      | FStar_Parser_AST.Annotated uu____2842 -> true
-      | uu____2848 -> false  in
+      | FStar_Parser_AST.Annotated uu____2844 -> true
+      | uu____2850 -> false  in
     let rec all_binders e1 l =
       match e1.FStar_Parser_AST.tm with
       | FStar_Parser_AST.Product (bs,tgt) ->
-          let uu____2881 = FStar_List.for_all is_binder_annot bs  in
-          if uu____2881
+          let uu____2883 = FStar_List.for_all is_binder_annot bs  in
+          if uu____2883
           then all_binders tgt (l + (FStar_List.length bs))
           else (false, Prims.int_zero)
-      | uu____2896 -> (true, (l + Prims.int_one))  in
-    let uu____2901 = all_binders e Prims.int_zero  in
-    match uu____2901 with
+      | uu____2898 -> (true, (l + Prims.int_one))  in
+    let uu____2903 = all_binders e Prims.int_zero  in
+    match uu____2903 with
     | (b,l) -> if b && (l > Prims.int_one) then true else false
   
 type catf =
@@ -814,8 +815,8 @@ let (cat_with_colon :
   FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document) =
   fun x  ->
     fun y  ->
-      let uu____2940 = FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon y  in
-      FStar_Pprint.op_Hat_Hat x uu____2940
+      let uu____2942 = FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon y  in
+      FStar_Pprint.op_Hat_Hat x uu____2942
   
 let (comment_stack :
   (Prims.string * FStar_Range.range) Prims.list FStar_ST.ref) =
@@ -838,107 +839,107 @@ let (__proj__Mkdecl_meta__item__has_attrs : decl_meta -> Prims.bool) =
 let (dummy_meta : decl_meta) =
   { r = FStar_Range.dummyRange; has_qs = false; has_attrs = false } 
 let with_comment :
-  'uuuuuu3029 .
-    ('uuuuuu3029 -> FStar_Pprint.document) ->
-      'uuuuuu3029 -> FStar_Range.range -> FStar_Pprint.document
+  'uuuuuu3031 .
+    ('uuuuuu3031 -> FStar_Pprint.document) ->
+      'uuuuuu3031 -> FStar_Range.range -> FStar_Pprint.document
   =
   fun printer  ->
     fun tm  ->
       fun tmrange  ->
         let rec comments_before_pos acc print_pos lookahead_pos =
-          let uu____3071 = FStar_ST.op_Bang comment_stack  in
-          match uu____3071 with
+          let uu____3073 = FStar_ST.op_Bang comment_stack  in
+          match uu____3073 with
           | [] -> (acc, false)
           | (c,crange)::cs ->
               let comment =
-                let uu____3142 = str c  in
-                FStar_Pprint.op_Hat_Hat uu____3142 FStar_Pprint.hardline  in
-              let uu____3143 = FStar_Range.range_before_pos crange print_pos
+                let uu____3144 = str c  in
+                FStar_Pprint.op_Hat_Hat uu____3144 FStar_Pprint.hardline  in
+              let uu____3145 = FStar_Range.range_before_pos crange print_pos
                  in
-              if uu____3143
+              if uu____3145
               then
                 (FStar_ST.op_Colon_Equals comment_stack cs;
-                 (let uu____3185 = FStar_Pprint.op_Hat_Hat acc comment  in
-                  comments_before_pos uu____3185 print_pos lookahead_pos))
+                 (let uu____3187 = FStar_Pprint.op_Hat_Hat acc comment  in
+                  comments_before_pos uu____3187 print_pos lookahead_pos))
               else
-                (let uu____3188 =
+                (let uu____3190 =
                    FStar_Range.range_before_pos crange lookahead_pos  in
-                 (acc, uu____3188))
+                 (acc, uu____3190))
            in
-        let uu____3191 =
-          let uu____3197 =
-            let uu____3198 = FStar_Range.start_of_range tmrange  in
-            FStar_Range.end_of_line uu____3198  in
-          let uu____3199 = FStar_Range.end_of_range tmrange  in
-          comments_before_pos FStar_Pprint.empty uu____3197 uu____3199  in
-        match uu____3191 with
+        let uu____3193 =
+          let uu____3199 =
+            let uu____3200 = FStar_Range.start_of_range tmrange  in
+            FStar_Range.end_of_line uu____3200  in
+          let uu____3201 = FStar_Range.end_of_range tmrange  in
+          comments_before_pos FStar_Pprint.empty uu____3199 uu____3201  in
+        match uu____3193 with
         | (comments,has_lookahead) ->
             let printed_e = printer tm  in
             let comments1 =
               if has_lookahead
               then
                 let pos = FStar_Range.end_of_range tmrange  in
-                let uu____3208 = comments_before_pos comments pos pos  in
-                FStar_Pervasives_Native.fst uu____3208
+                let uu____3210 = comments_before_pos comments pos pos  in
+                FStar_Pervasives_Native.fst uu____3210
               else comments  in
             if comments1 = FStar_Pprint.empty
             then printed_e
             else
-              (let uu____3220 = FStar_Pprint.op_Hat_Hat comments1 printed_e
+              (let uu____3222 = FStar_Pprint.op_Hat_Hat comments1 printed_e
                   in
-               FStar_Pprint.group uu____3220)
+               FStar_Pprint.group uu____3222)
   
 let with_comment_sep :
-  'uuuuuu3232 'uuuuuu3233 .
-    ('uuuuuu3232 -> 'uuuuuu3233) ->
-      'uuuuuu3232 ->
-        FStar_Range.range -> (FStar_Pprint.document * 'uuuuuu3233)
+  'uuuuuu3234 'uuuuuu3235 .
+    ('uuuuuu3234 -> 'uuuuuu3235) ->
+      'uuuuuu3234 ->
+        FStar_Range.range -> (FStar_Pprint.document * 'uuuuuu3235)
   =
   fun printer  ->
     fun tm  ->
       fun tmrange  ->
         let rec comments_before_pos acc print_pos lookahead_pos =
-          let uu____3279 = FStar_ST.op_Bang comment_stack  in
-          match uu____3279 with
+          let uu____3281 = FStar_ST.op_Bang comment_stack  in
+          match uu____3281 with
           | [] -> (acc, false)
           | (c,crange)::cs ->
               let comment = str c  in
-              let uu____3350 = FStar_Range.range_before_pos crange print_pos
+              let uu____3352 = FStar_Range.range_before_pos crange print_pos
                  in
-              if uu____3350
+              if uu____3352
               then
                 (FStar_ST.op_Colon_Equals comment_stack cs;
-                 (let uu____3392 =
+                 (let uu____3394 =
                     if acc = FStar_Pprint.empty
                     then comment
                     else
-                      (let uu____3396 =
+                      (let uu____3398 =
                          FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline
                            comment
                           in
-                       FStar_Pprint.op_Hat_Hat acc uu____3396)
+                       FStar_Pprint.op_Hat_Hat acc uu____3398)
                      in
-                  comments_before_pos uu____3392 print_pos lookahead_pos))
+                  comments_before_pos uu____3394 print_pos lookahead_pos))
               else
-                (let uu____3399 =
+                (let uu____3401 =
                    FStar_Range.range_before_pos crange lookahead_pos  in
-                 (acc, uu____3399))
+                 (acc, uu____3401))
            in
-        let uu____3402 =
-          let uu____3408 =
-            let uu____3409 = FStar_Range.start_of_range tmrange  in
-            FStar_Range.end_of_line uu____3409  in
-          let uu____3410 = FStar_Range.end_of_range tmrange  in
-          comments_before_pos FStar_Pprint.empty uu____3408 uu____3410  in
-        match uu____3402 with
+        let uu____3404 =
+          let uu____3410 =
+            let uu____3411 = FStar_Range.start_of_range tmrange  in
+            FStar_Range.end_of_line uu____3411  in
+          let uu____3412 = FStar_Range.end_of_range tmrange  in
+          comments_before_pos FStar_Pprint.empty uu____3410 uu____3412  in
+        match uu____3404 with
         | (comments,has_lookahead) ->
             let printed_e = printer tm  in
             let comments1 =
               if has_lookahead
               then
                 let pos = FStar_Range.end_of_range tmrange  in
-                let uu____3423 = comments_before_pos comments pos pos  in
-                FStar_Pervasives_Native.fst uu____3423
+                let uu____3425 = comments_before_pos comments pos pos  in
+                FStar_Pervasives_Native.fst uu____3425
               else comments  in
             (comments1, printed_e)
   
@@ -957,40 +958,40 @@ let rec (place_comments_until_pos :
           fun doc  ->
             fun r  ->
               fun init  ->
-                let uu____3476 = FStar_ST.op_Bang comment_stack  in
-                match uu____3476 with
+                let uu____3478 = FStar_ST.op_Bang comment_stack  in
+                match uu____3478 with
                 | (comment,crange)::cs when
                     FStar_Range.range_before_pos crange pos ->
                     (FStar_ST.op_Colon_Equals comment_stack cs;
                      (let lnum =
-                        let uu____3570 =
-                          let uu____3572 =
-                            let uu____3574 =
+                        let uu____3572 =
+                          let uu____3574 =
+                            let uu____3576 =
                               FStar_Range.start_of_range crange  in
-                            FStar_Range.line_of_pos uu____3574  in
-                          uu____3572 - lbegin  in
-                        max k uu____3570  in
+                            FStar_Range.line_of_pos uu____3576  in
+                          uu____3574 - lbegin  in
+                        max k uu____3572  in
                       let lnum1 = min (Prims.of_int (2)) lnum  in
                       let doc1 =
-                        let uu____3579 =
-                          let uu____3580 =
+                        let uu____3581 =
+                          let uu____3582 =
                             FStar_Pprint.repeat lnum1 FStar_Pprint.hardline
                              in
-                          let uu____3581 = str comment  in
-                          FStar_Pprint.op_Hat_Hat uu____3580 uu____3581  in
-                        FStar_Pprint.op_Hat_Hat doc uu____3579  in
-                      let uu____3582 =
-                        let uu____3584 = FStar_Range.end_of_range crange  in
-                        FStar_Range.line_of_pos uu____3584  in
-                      place_comments_until_pos Prims.int_one uu____3582 pos
+                          let uu____3583 = str comment  in
+                          FStar_Pprint.op_Hat_Hat uu____3582 uu____3583  in
+                        FStar_Pprint.op_Hat_Hat doc uu____3581  in
+                      let uu____3584 =
+                        let uu____3586 = FStar_Range.end_of_range crange  in
+                        FStar_Range.line_of_pos uu____3586  in
+                      place_comments_until_pos Prims.int_one uu____3584 pos
                         meta_decl doc1 true init))
-                | uu____3587 ->
+                | uu____3589 ->
                     if doc = FStar_Pprint.empty
                     then FStar_Pprint.empty
                     else
                       (let lnum =
-                         let uu____3600 = FStar_Range.line_of_pos pos  in
-                         uu____3600 - lbegin  in
+                         let uu____3602 = FStar_Range.line_of_pos pos  in
+                         uu____3602 - lbegin  in
                        let lnum1 = min (Prims.of_int (3)) lnum  in
                        let lnum2 =
                          if meta_decl.has_qs || meta_decl.has_attrs
@@ -1003,174 +1004,175 @@ let rec (place_comments_until_pos :
                          else lnum3  in
                        let lnum5 = if init then (Prims.of_int (2)) else lnum4
                           in
-                       let uu____3628 =
+                       let uu____3630 =
                          FStar_Pprint.repeat lnum5 FStar_Pprint.hardline  in
-                       FStar_Pprint.op_Hat_Hat doc uu____3628)
+                       FStar_Pprint.op_Hat_Hat doc uu____3630)
   
 let separate_map_with_comments :
-  'uuuuuu3642 .
+  'uuuuuu3644 .
     FStar_Pprint.document ->
       FStar_Pprint.document ->
-        ('uuuuuu3642 -> FStar_Pprint.document) ->
-          'uuuuuu3642 Prims.list ->
-            ('uuuuuu3642 -> decl_meta) -> FStar_Pprint.document
+        ('uuuuuu3644 -> FStar_Pprint.document) ->
+          'uuuuuu3644 Prims.list ->
+            ('uuuuuu3644 -> decl_meta) -> FStar_Pprint.document
   =
   fun prefix  ->
     fun sep  ->
       fun f  ->
         fun xs  ->
           fun extract_meta  ->
-            let fold_fun uu____3701 x =
-              match uu____3701 with
+            let fold_fun uu____3703 x =
+              match uu____3703 with
               | (last_line,doc) ->
                   let meta_decl = extract_meta x  in
                   let r = meta_decl.r  in
                   let doc1 =
-                    let uu____3720 = FStar_Range.start_of_range r  in
+                    let uu____3722 = FStar_Range.start_of_range r  in
                     place_comments_until_pos Prims.int_one last_line
-                      uu____3720 meta_decl doc false false
+                      uu____3722 meta_decl doc false false
                      in
-                  let uu____3724 =
-                    let uu____3726 = FStar_Range.end_of_range r  in
-                    FStar_Range.line_of_pos uu____3726  in
-                  let uu____3727 =
-                    let uu____3728 =
-                      let uu____3729 = f x  in
-                      FStar_Pprint.op_Hat_Hat sep uu____3729  in
-                    FStar_Pprint.op_Hat_Hat doc1 uu____3728  in
-                  (uu____3724, uu____3727)
+                  let uu____3726 =
+                    let uu____3728 = FStar_Range.end_of_range r  in
+                    FStar_Range.line_of_pos uu____3728  in
+                  let uu____3729 =
+                    let uu____3730 =
+                      let uu____3731 = f x  in
+                      FStar_Pprint.op_Hat_Hat sep uu____3731  in
+                    FStar_Pprint.op_Hat_Hat doc1 uu____3730  in
+                  (uu____3726, uu____3729)
                in
-            let uu____3731 =
-              let uu____3738 = FStar_List.hd xs  in
-              let uu____3739 = FStar_List.tl xs  in (uu____3738, uu____3739)
+            let uu____3733 =
+              let uu____3740 = FStar_List.hd xs  in
+              let uu____3741 = FStar_List.tl xs  in (uu____3740, uu____3741)
                in
-            match uu____3731 with
+            match uu____3733 with
             | (x,xs1) ->
                 let init =
                   let meta_decl = extract_meta x  in
-                  let uu____3757 =
-                    let uu____3759 = FStar_Range.end_of_range meta_decl.r  in
-                    FStar_Range.line_of_pos uu____3759  in
-                  let uu____3760 =
-                    let uu____3761 = f x  in
-                    FStar_Pprint.op_Hat_Hat prefix uu____3761  in
-                  (uu____3757, uu____3760)  in
-                let uu____3763 = FStar_List.fold_left fold_fun init xs1  in
-                FStar_Pervasives_Native.snd uu____3763
+                  let uu____3759 =
+                    let uu____3761 = FStar_Range.end_of_range meta_decl.r  in
+                    FStar_Range.line_of_pos uu____3761  in
+                  let uu____3762 =
+                    let uu____3763 = f x  in
+                    FStar_Pprint.op_Hat_Hat prefix uu____3763  in
+                  (uu____3759, uu____3762)  in
+                let uu____3765 = FStar_List.fold_left fold_fun init xs1  in
+                FStar_Pervasives_Native.snd uu____3765
   
 let separate_map_with_comments_kw :
-  'uuuuuu3790 'uuuuuu3791 .
-    'uuuuuu3790 ->
-      'uuuuuu3790 ->
-        ('uuuuuu3790 -> 'uuuuuu3791 -> FStar_Pprint.document) ->
-          'uuuuuu3791 Prims.list ->
-            ('uuuuuu3791 -> decl_meta) -> FStar_Pprint.document
+  'uuuuuu3792 'uuuuuu3793 .
+    'uuuuuu3792 ->
+      'uuuuuu3792 ->
+        ('uuuuuu3792 -> 'uuuuuu3793 -> FStar_Pprint.document) ->
+          'uuuuuu3793 Prims.list ->
+            ('uuuuuu3793 -> decl_meta) -> FStar_Pprint.document
   =
   fun prefix  ->
     fun sep  ->
       fun f  ->
         fun xs  ->
           fun extract_meta  ->
-            let fold_fun uu____3855 x =
-              match uu____3855 with
+            let fold_fun uu____3857 x =
+              match uu____3857 with
               | (last_line,doc) ->
                   let meta_decl = extract_meta x  in
                   let r = meta_decl.r  in
                   let doc1 =
-                    let uu____3874 = FStar_Range.start_of_range r  in
+                    let uu____3876 = FStar_Range.start_of_range r  in
                     place_comments_until_pos Prims.int_one last_line
-                      uu____3874 meta_decl doc false false
+                      uu____3876 meta_decl doc false false
                      in
-                  let uu____3878 =
-                    let uu____3880 = FStar_Range.end_of_range r  in
-                    FStar_Range.line_of_pos uu____3880  in
-                  let uu____3881 =
-                    let uu____3882 = f sep x  in
-                    FStar_Pprint.op_Hat_Hat doc1 uu____3882  in
-                  (uu____3878, uu____3881)
+                  let uu____3880 =
+                    let uu____3882 = FStar_Range.end_of_range r  in
+                    FStar_Range.line_of_pos uu____3882  in
+                  let uu____3883 =
+                    let uu____3884 = f sep x  in
+                    FStar_Pprint.op_Hat_Hat doc1 uu____3884  in
+                  (uu____3880, uu____3883)
                in
-            let uu____3884 =
-              let uu____3891 = FStar_List.hd xs  in
-              let uu____3892 = FStar_List.tl xs  in (uu____3891, uu____3892)
+            let uu____3886 =
+              let uu____3893 = FStar_List.hd xs  in
+              let uu____3894 = FStar_List.tl xs  in (uu____3893, uu____3894)
                in
-            match uu____3884 with
+            match uu____3886 with
             | (x,xs1) ->
                 let init =
                   let meta_decl = extract_meta x  in
-                  let uu____3910 =
-                    let uu____3912 = FStar_Range.end_of_range meta_decl.r  in
-                    FStar_Range.line_of_pos uu____3912  in
-                  let uu____3913 = f prefix x  in (uu____3910, uu____3913)
+                  let uu____3912 =
+                    let uu____3914 = FStar_Range.end_of_range meta_decl.r  in
+                    FStar_Range.line_of_pos uu____3914  in
+                  let uu____3915 = f prefix x  in (uu____3912, uu____3915)
                    in
-                let uu____3915 = FStar_List.fold_left fold_fun init xs1  in
-                FStar_Pervasives_Native.snd uu____3915
+                let uu____3917 = FStar_List.fold_left fold_fun init xs1  in
+                FStar_Pervasives_Native.snd uu____3917
   
 let rec (p_decl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
   fun d  ->
     let qualifiers =
       match ((d.FStar_Parser_AST.quals), (d.FStar_Parser_AST.d)) with
       | ((FStar_Parser_AST.Assumption )::[],FStar_Parser_AST.Assume
-         (id,uu____4871)) ->
-          let uu____4874 =
-            let uu____4876 =
-              FStar_Util.char_at id.FStar_Ident.idText Prims.int_zero  in
-            FStar_All.pipe_right uu____4876 FStar_Util.is_upper  in
-          if uu____4874
+         (id,uu____4873)) ->
+          let uu____4876 =
+            let uu____4878 =
+              let uu____4880 = FStar_Ident.text_of_id id  in
+              FStar_Util.char_at uu____4880 Prims.int_zero  in
+            FStar_All.pipe_right uu____4878 FStar_Util.is_upper  in
+          if uu____4876
           then
-            let uu____4882 = p_qualifier FStar_Parser_AST.Assumption  in
-            FStar_Pprint.op_Hat_Hat uu____4882 FStar_Pprint.space
+            let uu____4886 = p_qualifier FStar_Parser_AST.Assumption  in
+            FStar_Pprint.op_Hat_Hat uu____4886 FStar_Pprint.space
           else p_qualifiers d.FStar_Parser_AST.quals
-      | uu____4885 -> p_qualifiers d.FStar_Parser_AST.quals  in
-    let uu____4892 = p_attributes d.FStar_Parser_AST.attrs  in
-    let uu____4893 =
-      let uu____4894 = p_rawDecl d  in
-      FStar_Pprint.op_Hat_Hat qualifiers uu____4894  in
-    FStar_Pprint.op_Hat_Hat uu____4892 uu____4893
+      | uu____4889 -> p_qualifiers d.FStar_Parser_AST.quals  in
+    let uu____4896 = p_attributes d.FStar_Parser_AST.attrs  in
+    let uu____4897 =
+      let uu____4898 = p_rawDecl d  in
+      FStar_Pprint.op_Hat_Hat qualifiers uu____4898  in
+    FStar_Pprint.op_Hat_Hat uu____4896 uu____4897
 
 and (p_attributes : FStar_Parser_AST.attributes_ -> FStar_Pprint.document) =
   fun attrs  ->
     match attrs with
     | [] -> FStar_Pprint.empty
-    | uu____4896 ->
-        let uu____4897 =
-          let uu____4898 = str "@ "  in
-          let uu____4900 =
-            let uu____4901 =
-              let uu____4902 =
-                let uu____4903 =
-                  let uu____4904 = FStar_List.map p_atomicTerm attrs  in
-                  FStar_Pprint.flow break1 uu____4904  in
-                FStar_Pprint.op_Hat_Hat uu____4903 FStar_Pprint.rbracket  in
-              FStar_Pprint.align uu____4902  in
-            FStar_Pprint.op_Hat_Hat uu____4901 FStar_Pprint.hardline  in
-          FStar_Pprint.op_Hat_Hat uu____4898 uu____4900  in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket uu____4897
+    | uu____4900 ->
+        let uu____4901 =
+          let uu____4902 = str "@ "  in
+          let uu____4904 =
+            let uu____4905 =
+              let uu____4906 =
+                let uu____4907 =
+                  let uu____4908 = FStar_List.map p_atomicTerm attrs  in
+                  FStar_Pprint.flow break1 uu____4908  in
+                FStar_Pprint.op_Hat_Hat uu____4907 FStar_Pprint.rbracket  in
+              FStar_Pprint.align uu____4906  in
+            FStar_Pprint.op_Hat_Hat uu____4905 FStar_Pprint.hardline  in
+          FStar_Pprint.op_Hat_Hat uu____4902 uu____4904  in
+        FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket uu____4901
 
 and (p_justSig : FStar_Parser_AST.decl -> FStar_Pprint.document) =
   fun d  ->
     match d.FStar_Parser_AST.d with
     | FStar_Parser_AST.Val (lid,t) ->
-        let uu____4910 =
-          let uu____4911 = str "val"  in
-          let uu____4913 =
-            let uu____4914 =
-              let uu____4915 = p_lident lid  in
-              let uu____4916 =
+        let uu____4914 =
+          let uu____4915 = str "val"  in
+          let uu____4917 =
+            let uu____4918 =
+              let uu____4919 = p_lident lid  in
+              let uu____4920 =
                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon
                  in
-              FStar_Pprint.op_Hat_Hat uu____4915 uu____4916  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4914  in
-          FStar_Pprint.op_Hat_Hat uu____4911 uu____4913  in
-        let uu____4917 = p_typ false false t  in
-        FStar_Pprint.op_Hat_Hat uu____4910 uu____4917
-    | FStar_Parser_AST.TopLevelLet (uu____4920,lbs) ->
+              FStar_Pprint.op_Hat_Hat uu____4919 uu____4920  in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4918  in
+          FStar_Pprint.op_Hat_Hat uu____4915 uu____4917  in
+        let uu____4921 = p_typ false false t  in
+        FStar_Pprint.op_Hat_Hat uu____4914 uu____4921
+    | FStar_Parser_AST.TopLevelLet (uu____4924,lbs) ->
         FStar_Pprint.separate_map FStar_Pprint.hardline
           (fun lb  ->
-             let uu____4945 =
-               let uu____4946 = str "let"  in p_letlhs uu____4946 lb false
+             let uu____4949 =
+               let uu____4950 = str "let"  in p_letlhs uu____4950 lb false
                 in
-             FStar_Pprint.group uu____4945) lbs
-    | uu____4949 -> FStar_Pprint.empty
+             FStar_Pprint.group uu____4949) lbs
+    | uu____4953 -> FStar_Pprint.empty
 
 and (p_list :
   (FStar_Ident.ident -> FStar_Pprint.document) ->
@@ -1180,263 +1182,264 @@ and (p_list :
   fun f  ->
     fun sep  ->
       fun l  ->
-        let rec p_list' uu___4_4964 =
-          match uu___4_4964 with
+        let rec p_list' uu___4_4968 =
+          match uu___4_4968 with
           | [] -> FStar_Pprint.empty
           | x::[] -> f x
           | x::xs ->
-              let uu____4972 = f x  in
-              let uu____4973 =
-                let uu____4974 = p_list' xs  in
-                FStar_Pprint.op_Hat_Hat sep uu____4974  in
-              FStar_Pprint.op_Hat_Hat uu____4972 uu____4973
+              let uu____4976 = f x  in
+              let uu____4977 =
+                let uu____4978 = p_list' xs  in
+                FStar_Pprint.op_Hat_Hat sep uu____4978  in
+              FStar_Pprint.op_Hat_Hat uu____4976 uu____4977
            in
-        let uu____4975 = str "["  in
-        let uu____4977 =
-          let uu____4978 = p_list' l  in
-          let uu____4979 = str "]"  in
-          FStar_Pprint.op_Hat_Hat uu____4978 uu____4979  in
-        FStar_Pprint.op_Hat_Hat uu____4975 uu____4977
+        let uu____4979 = str "["  in
+        let uu____4981 =
+          let uu____4982 = p_list' l  in
+          let uu____4983 = str "]"  in
+          FStar_Pprint.op_Hat_Hat uu____4982 uu____4983  in
+        FStar_Pprint.op_Hat_Hat uu____4979 uu____4981
 
 and (p_rawDecl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
   fun d  ->
     match d.FStar_Parser_AST.d with
     | FStar_Parser_AST.Open uid ->
-        let uu____4983 =
-          let uu____4984 = str "open"  in
-          let uu____4986 = p_quident uid  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____4984 uu____4986  in
-        FStar_Pprint.group uu____4983
+        let uu____4987 =
+          let uu____4988 = str "open"  in
+          let uu____4990 = p_quident uid  in
+          FStar_Pprint.op_Hat_Slash_Hat uu____4988 uu____4990  in
+        FStar_Pprint.group uu____4987
     | FStar_Parser_AST.Include uid ->
-        let uu____4988 =
-          let uu____4989 = str "include"  in
-          let uu____4991 = p_quident uid  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____4989 uu____4991  in
-        FStar_Pprint.group uu____4988
+        let uu____4992 =
+          let uu____4993 = str "include"  in
+          let uu____4995 = p_quident uid  in
+          FStar_Pprint.op_Hat_Slash_Hat uu____4993 uu____4995  in
+        FStar_Pprint.group uu____4992
     | FStar_Parser_AST.Friend uid ->
-        let uu____4993 =
-          let uu____4994 = str "friend"  in
-          let uu____4996 = p_quident uid  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____4994 uu____4996  in
-        FStar_Pprint.group uu____4993
+        let uu____4997 =
+          let uu____4998 = str "friend"  in
+          let uu____5000 = p_quident uid  in
+          FStar_Pprint.op_Hat_Slash_Hat uu____4998 uu____5000  in
+        FStar_Pprint.group uu____4997
     | FStar_Parser_AST.ModuleAbbrev (uid1,uid2) ->
-        let uu____4999 =
-          let uu____5000 = str "module"  in
-          let uu____5002 =
-            let uu____5003 =
-              let uu____5004 = p_uident uid1  in
-              let uu____5005 =
+        let uu____5003 =
+          let uu____5004 = str "module"  in
+          let uu____5006 =
+            let uu____5007 =
+              let uu____5008 = p_uident uid1  in
+              let uu____5009 =
                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                   FStar_Pprint.equals
                  in
-              FStar_Pprint.op_Hat_Hat uu____5004 uu____5005  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5003  in
-          FStar_Pprint.op_Hat_Hat uu____5000 uu____5002  in
-        let uu____5006 = p_quident uid2  in
-        op_Hat_Slash_Plus_Hat uu____4999 uu____5006
+              FStar_Pprint.op_Hat_Hat uu____5008 uu____5009  in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5007  in
+          FStar_Pprint.op_Hat_Hat uu____5004 uu____5006  in
+        let uu____5010 = p_quident uid2  in
+        op_Hat_Slash_Plus_Hat uu____5003 uu____5010
     | FStar_Parser_AST.TopLevelModule uid ->
-        let uu____5008 =
-          let uu____5009 = str "module"  in
-          let uu____5011 =
-            let uu____5012 = p_quident uid  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5012  in
-          FStar_Pprint.op_Hat_Hat uu____5009 uu____5011  in
-        FStar_Pprint.group uu____5008
+        let uu____5012 =
+          let uu____5013 = str "module"  in
+          let uu____5015 =
+            let uu____5016 = p_quident uid  in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5016  in
+          FStar_Pprint.op_Hat_Hat uu____5013 uu____5015  in
+        FStar_Pprint.group uu____5012
     | FStar_Parser_AST.Tycon
-        (true ,uu____5013,(FStar_Parser_AST.TyconAbbrev
+        (true ,uu____5017,(FStar_Parser_AST.TyconAbbrev
          (uid,tpars,FStar_Pervasives_Native.None ,t))::[])
         ->
         let effect_prefix_doc =
-          let uu____5030 = str "effect"  in
-          let uu____5032 =
-            let uu____5033 = p_uident uid  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5033  in
-          FStar_Pprint.op_Hat_Hat uu____5030 uu____5032  in
-        let uu____5034 =
-          let uu____5035 = p_typars tpars  in
+          let uu____5034 = str "effect"  in
+          let uu____5036 =
+            let uu____5037 = p_uident uid  in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5037  in
+          FStar_Pprint.op_Hat_Hat uu____5034 uu____5036  in
+        let uu____5038 =
+          let uu____5039 = p_typars tpars  in
           FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one
-            effect_prefix_doc uu____5035 FStar_Pprint.equals
+            effect_prefix_doc uu____5039 FStar_Pprint.equals
            in
-        let uu____5038 = p_typ false false t  in
-        op_Hat_Slash_Plus_Hat uu____5034 uu____5038
+        let uu____5042 = p_typ false false t  in
+        op_Hat_Slash_Plus_Hat uu____5038 uu____5042
     | FStar_Parser_AST.Tycon (false ,tc,tcdefs) ->
         let s = if tc then str "class" else str "type"  in
-        let uu____5057 =
-          let uu____5058 = FStar_List.hd tcdefs  in
-          p_typeDeclWithKw s uu____5058  in
-        let uu____5059 =
-          let uu____5060 = FStar_List.tl tcdefs  in
+        let uu____5061 =
+          let uu____5062 = FStar_List.hd tcdefs  in
+          p_typeDeclWithKw s uu____5062  in
+        let uu____5063 =
+          let uu____5064 = FStar_List.tl tcdefs  in
           FStar_All.pipe_left
             (FStar_Pprint.concat_map
                (fun x  ->
-                  let uu____5068 =
-                    let uu____5069 = str "and"  in
-                    p_typeDeclWithKw uu____5069 x  in
-                  FStar_Pprint.op_Hat_Hat break1 uu____5068)) uu____5060
+                  let uu____5072 =
+                    let uu____5073 = str "and"  in
+                    p_typeDeclWithKw uu____5073 x  in
+                  FStar_Pprint.op_Hat_Hat break1 uu____5072)) uu____5064
            in
-        FStar_Pprint.op_Hat_Hat uu____5057 uu____5059
+        FStar_Pprint.op_Hat_Hat uu____5061 uu____5063
     | FStar_Parser_AST.TopLevelLet (q,lbs) ->
         let let_doc =
-          let uu____5086 = str "let"  in
-          let uu____5088 = p_letqualifier q  in
-          FStar_Pprint.op_Hat_Hat uu____5086 uu____5088  in
-        let uu____5089 = str "and"  in
-        separate_map_with_comments_kw let_doc uu____5089 p_letbinding lbs
-          (fun uu____5099  ->
-             match uu____5099 with
+          let uu____5090 = str "let"  in
+          let uu____5092 = p_letqualifier q  in
+          FStar_Pprint.op_Hat_Hat uu____5090 uu____5092  in
+        let uu____5093 = str "and"  in
+        separate_map_with_comments_kw let_doc uu____5093 p_letbinding lbs
+          (fun uu____5103  ->
+             match uu____5103 with
              | (p,t) ->
-                 let uu____5106 =
+                 let uu____5110 =
                    FStar_Range.union_ranges p.FStar_Parser_AST.prange
                      t.FStar_Parser_AST.range
                     in
-                 { r = uu____5106; has_qs = false; has_attrs = false })
+                 { r = uu____5110; has_qs = false; has_attrs = false })
     | FStar_Parser_AST.Val (lid,t) ->
-        let uu____5111 =
-          let uu____5112 = str "val"  in
-          let uu____5114 =
-            let uu____5115 =
-              let uu____5116 = p_lident lid  in
-              let uu____5117 = sig_as_binders_if_possible t false  in
-              FStar_Pprint.op_Hat_Hat uu____5116 uu____5117  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5115  in
-          FStar_Pprint.op_Hat_Hat uu____5112 uu____5114  in
-        FStar_All.pipe_left FStar_Pprint.group uu____5111
+        let uu____5115 =
+          let uu____5116 = str "val"  in
+          let uu____5118 =
+            let uu____5119 =
+              let uu____5120 = p_lident lid  in
+              let uu____5121 = sig_as_binders_if_possible t false  in
+              FStar_Pprint.op_Hat_Hat uu____5120 uu____5121  in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5119  in
+          FStar_Pprint.op_Hat_Hat uu____5116 uu____5118  in
+        FStar_All.pipe_left FStar_Pprint.group uu____5115
     | FStar_Parser_AST.Assume (id,t) ->
         let decl_keyword =
-          let uu____5122 =
-            let uu____5124 =
-              FStar_Util.char_at id.FStar_Ident.idText Prims.int_zero  in
-            FStar_All.pipe_right uu____5124 FStar_Util.is_upper  in
-          if uu____5122
+          let uu____5126 =
+            let uu____5128 =
+              let uu____5130 = FStar_Ident.text_of_id id  in
+              FStar_Util.char_at uu____5130 Prims.int_zero  in
+            FStar_All.pipe_right uu____5128 FStar_Util.is_upper  in
+          if uu____5126
           then FStar_Pprint.empty
           else
-            (let uu____5132 = str "val"  in
-             FStar_Pprint.op_Hat_Hat uu____5132 FStar_Pprint.space)
+            (let uu____5138 = str "val"  in
+             FStar_Pprint.op_Hat_Hat uu____5138 FStar_Pprint.space)
            in
-        let uu____5134 =
-          let uu____5135 = p_ident id  in
-          let uu____5136 =
-            let uu____5137 =
-              let uu____5138 =
-                let uu____5139 = p_typ false false t  in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5139  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____5138  in
-            FStar_Pprint.group uu____5137  in
-          FStar_Pprint.op_Hat_Hat uu____5135 uu____5136  in
-        FStar_Pprint.op_Hat_Hat decl_keyword uu____5134
+        let uu____5140 =
+          let uu____5141 = p_ident id  in
+          let uu____5142 =
+            let uu____5143 =
+              let uu____5144 =
+                let uu____5145 = p_typ false false t  in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5145  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____5144  in
+            FStar_Pprint.group uu____5143  in
+          FStar_Pprint.op_Hat_Hat uu____5141 uu____5142  in
+        FStar_Pprint.op_Hat_Hat decl_keyword uu____5140
     | FStar_Parser_AST.Exception (uid,t_opt) ->
-        let uu____5148 = str "exception"  in
-        let uu____5150 =
-          let uu____5151 =
-            let uu____5152 = p_uident uid  in
-            let uu____5153 =
+        let uu____5154 = str "exception"  in
+        let uu____5156 =
+          let uu____5157 =
+            let uu____5158 = p_uident uid  in
+            let uu____5159 =
               FStar_Pprint.optional
                 (fun t  ->
-                   let uu____5157 =
-                     let uu____5158 = str "of"  in
-                     let uu____5160 = p_typ false false t  in
-                     op_Hat_Slash_Plus_Hat uu____5158 uu____5160  in
-                   FStar_Pprint.op_Hat_Hat break1 uu____5157) t_opt
+                   let uu____5163 =
+                     let uu____5164 = str "of"  in
+                     let uu____5166 = p_typ false false t  in
+                     op_Hat_Slash_Plus_Hat uu____5164 uu____5166  in
+                   FStar_Pprint.op_Hat_Hat break1 uu____5163) t_opt
                in
-            FStar_Pprint.op_Hat_Hat uu____5152 uu____5153  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5151  in
-        FStar_Pprint.op_Hat_Hat uu____5148 uu____5150
+            FStar_Pprint.op_Hat_Hat uu____5158 uu____5159  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5157  in
+        FStar_Pprint.op_Hat_Hat uu____5154 uu____5156
     | FStar_Parser_AST.NewEffect ne ->
-        let uu____5164 = str "new_effect"  in
-        let uu____5166 =
-          let uu____5167 = p_newEffect ne  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5167  in
-        FStar_Pprint.op_Hat_Hat uu____5164 uu____5166
+        let uu____5170 = str "new_effect"  in
+        let uu____5172 =
+          let uu____5173 = p_newEffect ne  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5173  in
+        FStar_Pprint.op_Hat_Hat uu____5170 uu____5172
     | FStar_Parser_AST.SubEffect se ->
-        let uu____5169 = str "sub_effect"  in
-        let uu____5171 =
-          let uu____5172 = p_subEffect se  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5172  in
-        FStar_Pprint.op_Hat_Hat uu____5169 uu____5171
+        let uu____5175 = str "sub_effect"  in
+        let uu____5177 =
+          let uu____5178 = p_subEffect se  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5178  in
+        FStar_Pprint.op_Hat_Hat uu____5175 uu____5177
     | FStar_Parser_AST.LayeredEffect ne ->
-        let uu____5174 = str "layered_effect"  in
-        let uu____5176 =
-          let uu____5177 = p_newEffect ne  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5177  in
-        FStar_Pprint.op_Hat_Hat uu____5174 uu____5176
+        let uu____5180 = str "layered_effect"  in
+        let uu____5182 =
+          let uu____5183 = p_newEffect ne  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5183  in
+        FStar_Pprint.op_Hat_Hat uu____5180 uu____5182
     | FStar_Parser_AST.Polymonadic_bind (l1,l2,l3,t) ->
-        let uu____5182 = str "polymonadic_bind"  in
-        let uu____5184 =
-          let uu____5185 =
-            let uu____5186 = p_quident l1  in
-            let uu____5187 =
-              let uu____5188 =
-                let uu____5189 =
-                  let uu____5190 = p_quident l2  in
-                  let uu____5191 =
-                    let uu____5192 =
-                      let uu____5193 = str "|>"  in
-                      let uu____5195 =
-                        let uu____5196 = p_quident l3  in
-                        let uu____5197 =
-                          let uu____5198 = p_simpleTerm false false t  in
+        let uu____5188 = str "polymonadic_bind"  in
+        let uu____5190 =
+          let uu____5191 =
+            let uu____5192 = p_quident l1  in
+            let uu____5193 =
+              let uu____5194 =
+                let uu____5195 =
+                  let uu____5196 = p_quident l2  in
+                  let uu____5197 =
+                    let uu____5198 =
+                      let uu____5199 = str "|>"  in
+                      let uu____5201 =
+                        let uu____5202 = p_quident l3  in
+                        let uu____5203 =
+                          let uu____5204 = p_simpleTerm false false t  in
                           FStar_Pprint.op_Hat_Hat FStar_Pprint.equals
-                            uu____5198
+                            uu____5204
                            in
-                        FStar_Pprint.op_Hat_Hat uu____5196 uu____5197  in
-                      FStar_Pprint.op_Hat_Hat uu____5193 uu____5195  in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.rparen uu____5192
+                        FStar_Pprint.op_Hat_Hat uu____5202 uu____5203  in
+                      FStar_Pprint.op_Hat_Hat uu____5199 uu____5201  in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.rparen uu____5198
                      in
-                  FStar_Pprint.op_Hat_Hat uu____5190 uu____5191  in
-                FStar_Pprint.op_Hat_Hat break1 uu____5189  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.comma uu____5188  in
-            FStar_Pprint.op_Hat_Hat uu____5186 uu____5187  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____5185  in
-        FStar_Pprint.op_Hat_Hat uu____5182 uu____5184
+                  FStar_Pprint.op_Hat_Hat uu____5196 uu____5197  in
+                FStar_Pprint.op_Hat_Hat break1 uu____5195  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.comma uu____5194  in
+            FStar_Pprint.op_Hat_Hat uu____5192 uu____5193  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____5191  in
+        FStar_Pprint.op_Hat_Hat uu____5188 uu____5190
     | FStar_Parser_AST.Pragma p -> p_pragma p
-    | FStar_Parser_AST.Main uu____5202 ->
+    | FStar_Parser_AST.Main uu____5208 ->
         failwith "*Main declaration* : Is that really still in use ??"
-    | FStar_Parser_AST.Tycon (true ,uu____5204,uu____5205) ->
+    | FStar_Parser_AST.Tycon (true ,uu____5210,uu____5211) ->
         failwith
           "Effect abbreviation is expected to be defined by an abbreviation"
     | FStar_Parser_AST.Splice (ids,t) ->
-        let uu____5221 = str "%splice"  in
-        let uu____5223 =
-          let uu____5224 =
-            let uu____5225 = str ";"  in p_list p_uident uu____5225 ids  in
-          let uu____5227 =
-            let uu____5228 = p_term false false t  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5228  in
-          FStar_Pprint.op_Hat_Hat uu____5224 uu____5227  in
-        FStar_Pprint.op_Hat_Hat uu____5221 uu____5223
+        let uu____5227 = str "%splice"  in
+        let uu____5229 =
+          let uu____5230 =
+            let uu____5231 = str ";"  in p_list p_uident uu____5231 ids  in
+          let uu____5233 =
+            let uu____5234 = p_term false false t  in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5234  in
+          FStar_Pprint.op_Hat_Hat uu____5230 uu____5233  in
+        FStar_Pprint.op_Hat_Hat uu____5227 uu____5229
 
 and (p_pragma : FStar_Parser_AST.pragma -> FStar_Pprint.document) =
-  fun uu___5_5231  ->
-    match uu___5_5231 with
+  fun uu___5_5237  ->
+    match uu___5_5237 with
     | FStar_Parser_AST.SetOptions s ->
-        let uu____5234 = str "#set-options"  in
-        let uu____5236 =
-          let uu____5237 =
-            let uu____5238 = str s  in FStar_Pprint.dquotes uu____5238  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5237  in
-        FStar_Pprint.op_Hat_Hat uu____5234 uu____5236
+        let uu____5240 = str "#set-options"  in
+        let uu____5242 =
+          let uu____5243 =
+            let uu____5244 = str s  in FStar_Pprint.dquotes uu____5244  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5243  in
+        FStar_Pprint.op_Hat_Hat uu____5240 uu____5242
     | FStar_Parser_AST.ResetOptions s_opt ->
-        let uu____5243 = str "#reset-options"  in
-        let uu____5245 =
+        let uu____5249 = str "#reset-options"  in
+        let uu____5251 =
           FStar_Pprint.optional
             (fun s  ->
-               let uu____5251 =
-                 let uu____5252 = str s  in FStar_Pprint.dquotes uu____5252
+               let uu____5257 =
+                 let uu____5258 = str s  in FStar_Pprint.dquotes uu____5258
                   in
-               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5251) s_opt
+               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5257) s_opt
            in
-        FStar_Pprint.op_Hat_Hat uu____5243 uu____5245
+        FStar_Pprint.op_Hat_Hat uu____5249 uu____5251
     | FStar_Parser_AST.PushOptions s_opt ->
-        let uu____5257 = str "#push-options"  in
-        let uu____5259 =
+        let uu____5263 = str "#push-options"  in
+        let uu____5265 =
           FStar_Pprint.optional
             (fun s  ->
-               let uu____5265 =
-                 let uu____5266 = str s  in FStar_Pprint.dquotes uu____5266
+               let uu____5271 =
+                 let uu____5272 = str s  in FStar_Pprint.dquotes uu____5272
                   in
-               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5265) s_opt
+               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5271) s_opt
            in
-        FStar_Pprint.op_Hat_Hat uu____5257 uu____5259
+        FStar_Pprint.op_Hat_Hat uu____5263 uu____5265
     | FStar_Parser_AST.PopOptions  -> str "#pop-options"
     | FStar_Parser_AST.RestartSolver  -> str "#restart-solver"
     | FStar_Parser_AST.LightOff  ->
@@ -1450,34 +1453,34 @@ and (p_typeDeclWithKw :
   FStar_Pprint.document -> FStar_Parser_AST.tycon -> FStar_Pprint.document) =
   fun kw  ->
     fun typedecl  ->
-      let uu____5299 = p_typeDecl kw typedecl  in
-      match uu____5299 with
+      let uu____5305 = p_typeDecl kw typedecl  in
+      match uu____5305 with
       | (comm,decl,body,pre) ->
           if comm = FStar_Pprint.empty
           then
-            let uu____5322 = pre body  in
-            FStar_Pprint.op_Hat_Hat decl uu____5322
+            let uu____5328 = pre body  in
+            FStar_Pprint.op_Hat_Hat decl uu____5328
           else
-            (let uu____5325 =
-               let uu____5326 =
-                 let uu____5327 =
-                   let uu____5328 = pre body  in
-                   FStar_Pprint.op_Hat_Slash_Hat uu____5328 comm  in
-                 FStar_Pprint.op_Hat_Hat decl uu____5327  in
-               let uu____5329 =
-                 let uu____5330 =
-                   let uu____5331 =
-                     let uu____5332 =
-                       let uu____5333 =
+            (let uu____5331 =
+               let uu____5332 =
+                 let uu____5333 =
+                   let uu____5334 = pre body  in
+                   FStar_Pprint.op_Hat_Slash_Hat uu____5334 comm  in
+                 FStar_Pprint.op_Hat_Hat decl uu____5333  in
+               let uu____5335 =
+                 let uu____5336 =
+                   let uu____5337 =
+                     let uu____5338 =
+                       let uu____5339 =
                          FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline body
                           in
-                       FStar_Pprint.op_Hat_Hat comm uu____5333  in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____5332
+                       FStar_Pprint.op_Hat_Hat comm uu____5339  in
+                     FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____5338
                       in
-                   FStar_Pprint.nest (Prims.of_int (2)) uu____5331  in
-                 FStar_Pprint.op_Hat_Hat decl uu____5330  in
-               FStar_Pprint.ifflat uu____5326 uu____5329  in
-             FStar_All.pipe_left FStar_Pprint.group uu____5325)
+                   FStar_Pprint.nest (Prims.of_int (2)) uu____5337  in
+                 FStar_Pprint.op_Hat_Hat decl uu____5336  in
+               FStar_Pprint.ifflat uu____5332 uu____5335  in
+             FStar_All.pipe_left FStar_Pprint.group uu____5331)
 
 and (p_typeDecl :
   FStar_Pprint.document ->
@@ -1486,31 +1489,31 @@ and (p_typeDecl :
         * (FStar_Pprint.document -> FStar_Pprint.document)))
   =
   fun pre  ->
-    fun uu___6_5336  ->
-      match uu___6_5336 with
+    fun uu___6_5342  ->
+      match uu___6_5342 with
       | FStar_Parser_AST.TyconAbstract (lid,bs,typ_opt) ->
-          let uu____5359 = p_typeDeclPrefix pre false lid bs typ_opt  in
-          (FStar_Pprint.empty, uu____5359, FStar_Pprint.empty,
+          let uu____5365 = p_typeDeclPrefix pre false lid bs typ_opt  in
+          (FStar_Pprint.empty, uu____5365, FStar_Pprint.empty,
             FStar_Pervasives.id)
       | FStar_Parser_AST.TyconAbbrev (lid,bs,typ_opt,t) ->
-          let uu____5376 = p_typ_sep false false t  in
-          (match uu____5376 with
+          let uu____5382 = p_typ_sep false false t  in
+          (match uu____5382 with
            | (comm,doc) ->
-               let uu____5396 = p_typeDeclPrefix pre true lid bs typ_opt  in
-               (comm, uu____5396, doc, jump2))
+               let uu____5402 = p_typeDeclPrefix pre true lid bs typ_opt  in
+               (comm, uu____5402, doc, jump2))
       | FStar_Parser_AST.TyconRecord (lid,bs,typ_opt,record_field_decls) ->
-          let p_recordField ps uu____5440 =
-            match uu____5440 with
+          let p_recordField ps uu____5446 =
+            match uu____5446 with
             | (lid1,t) ->
-                let uu____5448 =
-                  let uu____5453 =
+                let uu____5454 =
+                  let uu____5459 =
                     FStar_Range.extend_to_end_of_line
                       t.FStar_Parser_AST.range
                      in
                   with_comment_sep (p_recordFieldDecl ps) (lid1, t)
-                    uu____5453
+                    uu____5459
                    in
-                (match uu____5448 with
+                (match uu____5454 with
                  | (comm,field) ->
                      let sep =
                        if ps then FStar_Pprint.semi else FStar_Pprint.empty
@@ -1518,31 +1521,32 @@ and (p_typeDecl :
                      inline_comment_or_above comm field sep)
              in
           let p_fields =
-            let uu____5465 =
+            let uu____5471 =
               separate_map_last FStar_Pprint.hardline p_recordField
                 record_field_decls
                in
-            braces_with_nesting uu____5465  in
-          let uu____5470 = p_typeDeclPrefix pre true lid bs typ_opt  in
-          (FStar_Pprint.empty, uu____5470, p_fields,
+            braces_with_nesting uu____5471  in
+          let uu____5476 = p_typeDeclPrefix pre true lid bs typ_opt  in
+          (FStar_Pprint.empty, uu____5476, p_fields,
             ((fun d  -> FStar_Pprint.op_Hat_Hat FStar_Pprint.space d)))
       | FStar_Parser_AST.TyconVariant (lid,bs,typ_opt,ct_decls) ->
-          let p_constructorBranchAndComments uu____5525 =
-            match uu____5525 with
+          let p_constructorBranchAndComments uu____5531 =
+            match uu____5531 with
             | (uid,t_opt,use_of) ->
                 let range =
-                  let uu____5545 =
-                    let uu____5546 =
+                  let uu____5551 =
+                    let uu____5552 = FStar_Ident.range_of_id uid  in
+                    let uu____5553 =
                       FStar_Util.map_opt t_opt
                         (fun t  -> t.FStar_Parser_AST.range)
                        in
-                    FStar_Util.dflt uid.FStar_Ident.idRange uu____5546  in
-                  FStar_Range.extend_to_end_of_line uu____5545  in
-                let uu____5551 =
+                    FStar_Util.dflt uu____5552 uu____5553  in
+                  FStar_Range.extend_to_end_of_line uu____5551  in
+                let uu____5558 =
                   with_comment_sep p_constructorBranch (uid, t_opt, use_of)
                     range
                    in
-                (match uu____5551 with
+                (match uu____5558 with
                  | (comm,ctor) ->
                      inline_comment_or_above comm ctor FStar_Pprint.empty)
              in
@@ -1550,8 +1554,8 @@ and (p_typeDecl :
             FStar_Pprint.separate_map FStar_Pprint.hardline
               p_constructorBranchAndComments ct_decls
              in
-          let uu____5580 = p_typeDeclPrefix pre true lid bs typ_opt  in
-          (FStar_Pprint.empty, uu____5580, datacon_doc, jump2)
+          let uu____5587 = p_typeDeclPrefix pre true lid bs typ_opt  in
+          (FStar_Pprint.empty, uu____5587, datacon_doc, jump2)
 
 and (p_typeDeclPrefix :
   FStar_Pprint.document ->
@@ -1569,8 +1573,8 @@ and (p_typeDeclPrefix :
             let with_kw cont =
               let lid_doc = p_ident lid  in
               let kw_lid =
-                let uu____5608 = FStar_Pprint.op_Hat_Slash_Hat kw lid_doc  in
-                FStar_Pprint.group uu____5608  in
+                let uu____5615 = FStar_Pprint.op_Hat_Slash_Hat kw lid_doc  in
+                FStar_Pprint.group uu____5615  in
               cont kw_lid  in
             let typ =
               let maybe_eq =
@@ -1578,12 +1582,12 @@ and (p_typeDeclPrefix :
               match typ_opt with
               | FStar_Pervasives_Native.None  -> maybe_eq
               | FStar_Pervasives_Native.Some t ->
-                  let uu____5615 =
-                    let uu____5616 =
-                      let uu____5617 = p_typ false false t  in
-                      FStar_Pprint.op_Hat_Slash_Hat uu____5617 maybe_eq  in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5616  in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____5615
+                  let uu____5622 =
+                    let uu____5623 =
+                      let uu____5624 = p_typ false false t  in
+                      FStar_Pprint.op_Hat_Slash_Hat uu____5624 maybe_eq  in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5623  in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____5622
                in
             if bs = []
             then with_kw (fun n  -> prefix2 n typ)
@@ -1591,55 +1595,55 @@ and (p_typeDeclPrefix :
               (let binders = p_binders_list true bs  in
                with_kw
                  (fun n  ->
-                    let uu____5637 =
-                      let uu____5638 = FStar_Pprint.flow break1 binders  in
-                      prefix2 n uu____5638  in
-                    prefix2 uu____5637 typ))
+                    let uu____5644 =
+                      let uu____5645 = FStar_Pprint.flow break1 binders  in
+                      prefix2 n uu____5645  in
+                    prefix2 uu____5644 typ))
 
 and (p_recordFieldDecl :
   Prims.bool ->
     (FStar_Ident.ident * FStar_Parser_AST.term) -> FStar_Pprint.document)
   =
   fun ps  ->
-    fun uu____5640  ->
-      match uu____5640 with
+    fun uu____5647  ->
+      match uu____5647 with
       | (lid,t) ->
-          let uu____5648 =
-            let uu____5649 = p_lident lid  in
-            let uu____5650 =
-              let uu____5651 = p_typ ps false t  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____5651  in
-            FStar_Pprint.op_Hat_Hat uu____5649 uu____5650  in
-          FStar_Pprint.group uu____5648
+          let uu____5655 =
+            let uu____5656 = p_lident lid  in
+            let uu____5657 =
+              let uu____5658 = p_typ ps false t  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____5658  in
+            FStar_Pprint.op_Hat_Hat uu____5656 uu____5657  in
+          FStar_Pprint.group uu____5655
 
 and (p_constructorBranch :
   (FStar_Ident.ident * FStar_Parser_AST.term FStar_Pervasives_Native.option *
     Prims.bool) -> FStar_Pprint.document)
   =
-  fun uu____5653  ->
-    match uu____5653 with
+  fun uu____5660  ->
+    match uu____5660 with
     | (uid,t_opt,use_of) ->
         let sep = if use_of then str "of" else FStar_Pprint.colon  in
         let uid_doc =
-          let uu____5678 =
-            let uu____5679 =
-              let uu____5680 = p_uident uid  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5680  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____5679  in
-          FStar_Pprint.group uu____5678  in
+          let uu____5685 =
+            let uu____5686 =
+              let uu____5687 = p_uident uid  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5687  in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____5686  in
+          FStar_Pprint.group uu____5685  in
         default_or_map uid_doc
           (fun t  ->
-             let uu____5684 =
-               let uu____5685 =
-                 let uu____5686 =
-                   let uu____5687 =
-                     let uu____5688 = p_typ false false t  in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5688
+             let uu____5691 =
+               let uu____5692 =
+                 let uu____5693 =
+                   let uu____5694 =
+                     let uu____5695 = p_typ false false t  in
+                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5695
                       in
-                   FStar_Pprint.op_Hat_Hat sep uu____5687  in
-                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5686  in
-               FStar_Pprint.op_Hat_Hat uid_doc uu____5685  in
-             FStar_Pprint.group uu____5684) t_opt
+                   FStar_Pprint.op_Hat_Hat sep uu____5694  in
+                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5693  in
+               FStar_Pprint.op_Hat_Hat uid_doc uu____5692  in
+             FStar_Pprint.group uu____5691) t_opt
 
 and (p_letlhs :
   FStar_Pprint.document ->
@@ -1647,11 +1651,11 @@ and (p_letlhs :
       Prims.bool -> FStar_Pprint.document)
   =
   fun kw  ->
-    fun uu____5692  ->
+    fun uu____5699  ->
       fun inner_let  ->
-        match uu____5692 with
-        | (pat,uu____5700) ->
-            let uu____5701 =
+        match uu____5699 with
+        | (pat,uu____5707) ->
+            let uu____5708 =
               match pat.FStar_Parser_AST.pat with
               | FStar_Parser_AST.PatAscribed
                   (pat1,(t,FStar_Pervasives_Native.None )) ->
@@ -1659,102 +1663,102 @@ and (p_letlhs :
                     (FStar_Pervasives_Native.Some (t, FStar_Pprint.empty)))
               | FStar_Parser_AST.PatAscribed
                   (pat1,(t,FStar_Pervasives_Native.Some tac)) ->
-                  let uu____5753 =
-                    let uu____5760 =
-                      let uu____5765 =
-                        let uu____5766 =
-                          let uu____5767 =
-                            let uu____5768 = str "by"  in
-                            let uu____5770 =
-                              let uu____5771 =
+                  let uu____5760 =
+                    let uu____5767 =
+                      let uu____5772 =
+                        let uu____5773 =
+                          let uu____5774 =
+                            let uu____5775 = str "by"  in
+                            let uu____5777 =
+                              let uu____5778 =
                                 p_atomicTerm (maybe_unthunk tac)  in
                               FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                                uu____5771
+                                uu____5778
                                in
-                            FStar_Pprint.op_Hat_Hat uu____5768 uu____5770  in
+                            FStar_Pprint.op_Hat_Hat uu____5775 uu____5777  in
                           FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                            uu____5767
+                            uu____5774
                            in
-                        FStar_Pprint.group uu____5766  in
-                      (t, uu____5765)  in
-                    FStar_Pervasives_Native.Some uu____5760  in
-                  (pat1, uu____5753)
-              | uu____5782 -> (pat, FStar_Pervasives_Native.None)  in
-            (match uu____5701 with
+                        FStar_Pprint.group uu____5773  in
+                      (t, uu____5772)  in
+                    FStar_Pervasives_Native.Some uu____5767  in
+                  (pat1, uu____5760)
+              | uu____5789 -> (pat, FStar_Pervasives_Native.None)  in
+            (match uu____5708 with
              | (pat1,ascr) ->
                  (match pat1.FStar_Parser_AST.pat with
                   | FStar_Parser_AST.PatApp
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                           (lid,uu____5808);
-                         FStar_Parser_AST.prange = uu____5809;_},pats)
+                           (lid,uu____5815);
+                         FStar_Parser_AST.prange = uu____5816;_},pats)
                       ->
                       let ascr_doc =
                         match ascr with
                         | FStar_Pervasives_Native.Some (t,tac) ->
-                            let uu____5826 =
+                            let uu____5833 =
                               sig_as_binders_if_possible t true  in
-                            FStar_Pprint.op_Hat_Hat uu____5826 tac
+                            FStar_Pprint.op_Hat_Hat uu____5833 tac
                         | FStar_Pervasives_Native.None  -> FStar_Pprint.empty
                          in
-                      let uu____5832 =
+                      let uu____5839 =
                         if inner_let
                         then
-                          let uu____5846 = pats_as_binders_if_possible pats
+                          let uu____5853 = pats_as_binders_if_possible pats
                              in
-                          match uu____5846 with
+                          match uu____5853 with
                           | (bs,style) ->
                               ((FStar_List.append bs [ascr_doc]), style)
                         else
-                          (let uu____5869 = pats_as_binders_if_possible pats
+                          (let uu____5876 = pats_as_binders_if_possible pats
                               in
-                           match uu____5869 with
+                           match uu____5876 with
                            | (bs,style) ->
                                ((FStar_List.append bs [ascr_doc]), style))
                          in
-                      (match uu____5832 with
+                      (match uu____5839 with
                        | (terms,style) ->
-                           let uu____5896 =
-                             let uu____5897 =
-                               let uu____5898 =
-                                 let uu____5899 = p_lident lid  in
-                                 let uu____5900 =
+                           let uu____5903 =
+                             let uu____5904 =
+                               let uu____5905 =
+                                 let uu____5906 = p_lident lid  in
+                                 let uu____5907 =
                                    format_sig style terms true true  in
-                                 FStar_Pprint.op_Hat_Hat uu____5899
-                                   uu____5900
+                                 FStar_Pprint.op_Hat_Hat uu____5906
+                                   uu____5907
                                   in
                                FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                                 uu____5898
+                                 uu____5905
                                 in
-                             FStar_Pprint.op_Hat_Hat kw uu____5897  in
-                           FStar_All.pipe_left FStar_Pprint.group uu____5896)
-                  | uu____5903 ->
+                             FStar_Pprint.op_Hat_Hat kw uu____5904  in
+                           FStar_All.pipe_left FStar_Pprint.group uu____5903)
+                  | uu____5910 ->
                       let ascr_doc =
                         match ascr with
                         | FStar_Pervasives_Native.Some (t,tac) ->
-                            let uu____5911 =
-                              let uu____5912 =
-                                let uu____5913 =
+                            let uu____5918 =
+                              let uu____5919 =
+                                let uu____5920 =
                                   p_typ_top
                                     (Arrows
                                        ((Prims.of_int (2)),
                                          (Prims.of_int (2)))) false false t
                                    in
                                 FStar_Pprint.op_Hat_Hat FStar_Pprint.colon
-                                  uu____5913
+                                  uu____5920
                                  in
-                              FStar_Pprint.group uu____5912  in
-                            FStar_Pprint.op_Hat_Hat uu____5911 tac
+                              FStar_Pprint.group uu____5919  in
+                            FStar_Pprint.op_Hat_Hat uu____5918 tac
                         | FStar_Pervasives_Native.None  -> FStar_Pprint.empty
                          in
-                      let uu____5924 =
-                        let uu____5925 =
-                          let uu____5926 =
-                            let uu____5927 = p_tuplePattern pat1  in
-                            FStar_Pprint.op_Hat_Slash_Hat kw uu____5927  in
-                          FStar_Pprint.group uu____5926  in
-                        FStar_Pprint.op_Hat_Hat uu____5925 ascr_doc  in
-                      FStar_Pprint.group uu____5924))
+                      let uu____5931 =
+                        let uu____5932 =
+                          let uu____5933 =
+                            let uu____5934 = p_tuplePattern pat1  in
+                            FStar_Pprint.op_Hat_Slash_Hat kw uu____5934  in
+                          FStar_Pprint.group uu____5933  in
+                        FStar_Pprint.op_Hat_Hat uu____5932 ascr_doc  in
+                      FStar_Pprint.group uu____5931))
 
 and (p_letbinding :
   FStar_Pprint.document ->
@@ -1762,36 +1766,36 @@ and (p_letbinding :
       FStar_Pprint.document)
   =
   fun kw  ->
-    fun uu____5929  ->
-      match uu____5929 with
+    fun uu____5936  ->
+      match uu____5936 with
       | (pat,e) ->
           let doc_pat = p_letlhs kw (pat, e) false  in
-          let uu____5938 = p_term_sep false false e  in
-          (match uu____5938 with
+          let uu____5945 = p_term_sep false false e  in
+          (match uu____5945 with
            | (comm,doc_expr) ->
                let doc_expr1 =
                  inline_comment_or_above comm doc_expr FStar_Pprint.empty  in
-               let uu____5948 =
-                 let uu____5949 =
+               let uu____5955 =
+                 let uu____5956 =
                    FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.equals
                      doc_expr1
                     in
-                 FStar_Pprint.op_Hat_Slash_Hat doc_pat uu____5949  in
-               let uu____5950 =
-                 let uu____5951 =
-                   let uu____5952 =
-                     let uu____5953 =
-                       let uu____5954 = jump2 doc_expr1  in
-                       FStar_Pprint.op_Hat_Hat FStar_Pprint.equals uu____5954
+                 FStar_Pprint.op_Hat_Slash_Hat doc_pat uu____5956  in
+               let uu____5957 =
+                 let uu____5958 =
+                   let uu____5959 =
+                     let uu____5960 =
+                       let uu____5961 = jump2 doc_expr1  in
+                       FStar_Pprint.op_Hat_Hat FStar_Pprint.equals uu____5961
                         in
-                     FStar_Pprint.group uu____5953  in
-                   FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5952  in
-                 FStar_Pprint.op_Hat_Hat doc_pat uu____5951  in
-               FStar_Pprint.ifflat uu____5948 uu____5950)
+                     FStar_Pprint.group uu____5960  in
+                   FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5959  in
+                 FStar_Pprint.op_Hat_Hat doc_pat uu____5958  in
+               FStar_Pprint.ifflat uu____5955 uu____5957)
 
 and (p_newEffect : FStar_Parser_AST.effect_decl -> FStar_Pprint.document) =
-  fun uu___7_5955  ->
-    match uu___7_5955 with
+  fun uu___7_5962  ->
+    match uu___7_5962 with
     | FStar_Parser_AST.RedefineEffect (lid,bs,t) ->
         p_effectRedefinition lid bs t
     | FStar_Parser_AST.DefineEffect (lid,bs,t,eff_decls) ->
@@ -1805,13 +1809,13 @@ and (p_effectRedefinition :
   fun uid  ->
     fun bs  ->
       fun t  ->
-        let uu____5980 = p_uident uid  in
-        let uu____5981 = p_binders true bs  in
-        let uu____5983 =
-          let uu____5984 = p_simpleTerm false false t  in
-          prefix2 FStar_Pprint.equals uu____5984  in
-        surround_maybe_empty (Prims.of_int (2)) Prims.int_one uu____5980
-          uu____5981 uu____5983
+        let uu____5987 = p_uident uid  in
+        let uu____5988 = p_binders true bs  in
+        let uu____5990 =
+          let uu____5991 = p_simpleTerm false false t  in
+          prefix2 FStar_Pprint.equals uu____5991  in
+        surround_maybe_empty (Prims.of_int (2)) Prims.int_one uu____5987
+          uu____5988 uu____5990
 
 and (p_effectDefinition :
   FStar_Ident.ident ->
@@ -1824,39 +1828,39 @@ and (p_effectDefinition :
       fun t  ->
         fun eff_decls  ->
           let binders = p_binders true bs  in
-          let uu____5999 =
-            let uu____6000 =
-              let uu____6001 =
-                let uu____6002 = p_uident uid  in
-                let uu____6003 = p_binders true bs  in
-                let uu____6005 =
-                  let uu____6006 = p_typ false false t  in
-                  prefix2 FStar_Pprint.colon uu____6006  in
+          let uu____6006 =
+            let uu____6007 =
+              let uu____6008 =
+                let uu____6009 = p_uident uid  in
+                let uu____6010 = p_binders true bs  in
+                let uu____6012 =
+                  let uu____6013 = p_typ false false t  in
+                  prefix2 FStar_Pprint.colon uu____6013  in
                 surround_maybe_empty (Prims.of_int (2)) Prims.int_one
-                  uu____6002 uu____6003 uu____6005
+                  uu____6009 uu____6010 uu____6012
                  in
-              FStar_Pprint.group uu____6001  in
-            let uu____6011 =
-              let uu____6012 = str "with"  in
-              let uu____6014 =
-                let uu____6015 =
-                  let uu____6016 =
-                    let uu____6017 =
-                      let uu____6018 =
-                        let uu____6019 =
+              FStar_Pprint.group uu____6008  in
+            let uu____6018 =
+              let uu____6019 = str "with"  in
+              let uu____6021 =
+                let uu____6022 =
+                  let uu____6023 =
+                    let uu____6024 =
+                      let uu____6025 =
+                        let uu____6026 =
                           FStar_Pprint.op_Hat_Hat FStar_Pprint.semi
                             FStar_Pprint.space
                            in
                         FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline
-                          uu____6019
+                          uu____6026
                          in
-                      separate_map_last uu____6018 p_effectDecl eff_decls  in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6017  in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6016  in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____6015  in
-              FStar_Pprint.op_Hat_Hat uu____6012 uu____6014  in
-            FStar_Pprint.op_Hat_Slash_Hat uu____6000 uu____6011  in
-          braces_with_nesting uu____5999
+                      separate_map_last uu____6025 p_effectDecl eff_decls  in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6024  in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6023  in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____6022  in
+              FStar_Pprint.op_Hat_Hat uu____6019 uu____6021  in
+            FStar_Pprint.op_Hat_Slash_Hat uu____6007 uu____6018  in
+          braces_with_nesting uu____6006
 
 and (p_effectDecl :
   Prims.bool -> FStar_Parser_AST.decl -> FStar_Pprint.document) =
@@ -1864,25 +1868,25 @@ and (p_effectDecl :
     fun d  ->
       match d.FStar_Parser_AST.d with
       | FStar_Parser_AST.Tycon
-          (false ,uu____6023,(FStar_Parser_AST.TyconAbbrev
+          (false ,uu____6030,(FStar_Parser_AST.TyconAbbrev
            (lid,[],FStar_Pervasives_Native.None ,e))::[])
           ->
-          let uu____6036 =
-            let uu____6037 = p_lident lid  in
-            let uu____6038 =
+          let uu____6043 =
+            let uu____6044 = p_lident lid  in
+            let uu____6045 =
               FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.equals
                in
-            FStar_Pprint.op_Hat_Hat uu____6037 uu____6038  in
-          let uu____6039 = p_simpleTerm ps false e  in
-          prefix2 uu____6036 uu____6039
-      | uu____6041 ->
-          let uu____6042 =
-            let uu____6044 = FStar_Parser_AST.decl_to_string d  in
+            FStar_Pprint.op_Hat_Hat uu____6044 uu____6045  in
+          let uu____6046 = p_simpleTerm ps false e  in
+          prefix2 uu____6043 uu____6046
+      | uu____6048 ->
+          let uu____6049 =
+            let uu____6051 = FStar_Parser_AST.decl_to_string d  in
             FStar_Util.format1
               "Not a declaration of an effect member... or at least I hope so : %s"
-              uu____6044
+              uu____6051
              in
-          failwith uu____6042
+          failwith uu____6049
 
 and (p_subEffect : FStar_Parser_AST.lift -> FStar_Pprint.document) =
   fun lift  ->
@@ -1893,37 +1897,37 @@ and (p_subEffect : FStar_Parser_AST.lift -> FStar_Pprint.document) =
         | FStar_Parser_AST.ReifiableLift (t1,t2) ->
             [("lift_wp", t1); ("lift", t2)]
         | FStar_Parser_AST.LiftForFree t -> [("lift", t)]  in
-      let p_lift ps uu____6127 =
-        match uu____6127 with
+      let p_lift ps uu____6134 =
+        match uu____6134 with
         | (kwd,t) ->
-            let uu____6138 =
-              let uu____6139 = str kwd  in
-              let uu____6140 =
+            let uu____6145 =
+              let uu____6146 = str kwd  in
+              let uu____6147 =
                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                   FStar_Pprint.equals
                  in
-              FStar_Pprint.op_Hat_Hat uu____6139 uu____6140  in
-            let uu____6141 = p_simpleTerm ps false t  in
-            prefix2 uu____6138 uu____6141
+              FStar_Pprint.op_Hat_Hat uu____6146 uu____6147  in
+            let uu____6148 = p_simpleTerm ps false t  in
+            prefix2 uu____6145 uu____6148
          in
       separate_break_map_last FStar_Pprint.semi p_lift lifts  in
-    let uu____6148 =
-      let uu____6149 =
-        let uu____6150 = p_quident lift.FStar_Parser_AST.msource  in
-        let uu____6151 =
-          let uu____6152 = str "~>"  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6152  in
-        FStar_Pprint.op_Hat_Hat uu____6150 uu____6151  in
-      let uu____6154 = p_quident lift.FStar_Parser_AST.mdest  in
-      prefix2 uu____6149 uu____6154  in
     let uu____6155 =
-      let uu____6156 = braces_with_nesting lift_op_doc  in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6156  in
-    FStar_Pprint.op_Hat_Hat uu____6148 uu____6155
+      let uu____6156 =
+        let uu____6157 = p_quident lift.FStar_Parser_AST.msource  in
+        let uu____6158 =
+          let uu____6159 = str "~>"  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6159  in
+        FStar_Pprint.op_Hat_Hat uu____6157 uu____6158  in
+      let uu____6161 = p_quident lift.FStar_Parser_AST.mdest  in
+      prefix2 uu____6156 uu____6161  in
+    let uu____6162 =
+      let uu____6163 = braces_with_nesting lift_op_doc  in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6163  in
+    FStar_Pprint.op_Hat_Hat uu____6155 uu____6162
 
 and (p_qualifier : FStar_Parser_AST.qualifier -> FStar_Pprint.document) =
-  fun uu___8_6157  ->
-    match uu___8_6157 with
+  fun uu___8_6164  ->
+    match uu___8_6164 with
     | FStar_Parser_AST.Private  -> str "private"
     | FStar_Parser_AST.Abstract  -> str "abstract"
     | FStar_Parser_AST.Noeq  -> str "noeq"
@@ -1949,33 +1953,33 @@ and (p_qualifiers : FStar_Parser_AST.qualifiers -> FStar_Pprint.document) =
     match qs with
     | [] -> FStar_Pprint.empty
     | q::[] ->
-        let uu____6177 = p_qualifier q  in
-        FStar_Pprint.op_Hat_Hat uu____6177 FStar_Pprint.hardline
-    | uu____6178 ->
-        let uu____6179 =
-          let uu____6180 = FStar_List.map p_qualifier qs  in
-          FStar_Pprint.flow break1 uu____6180  in
-        FStar_Pprint.op_Hat_Hat uu____6179 FStar_Pprint.hardline
+        let uu____6184 = p_qualifier q  in
+        FStar_Pprint.op_Hat_Hat uu____6184 FStar_Pprint.hardline
+    | uu____6185 ->
+        let uu____6186 =
+          let uu____6187 = FStar_List.map p_qualifier qs  in
+          FStar_Pprint.flow break1 uu____6187  in
+        FStar_Pprint.op_Hat_Hat uu____6186 FStar_Pprint.hardline
 
 and (p_letqualifier :
   FStar_Parser_AST.let_qualifier -> FStar_Pprint.document) =
-  fun uu___9_6183  ->
-    match uu___9_6183 with
+  fun uu___9_6190  ->
+    match uu___9_6190 with
     | FStar_Parser_AST.Rec  ->
-        let uu____6184 = str "rec"  in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6184
+        let uu____6191 = str "rec"  in
+        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6191
     | FStar_Parser_AST.NoLetQualifier  -> FStar_Pprint.empty
 
 and (p_aqual : FStar_Parser_AST.arg_qualifier -> FStar_Pprint.document) =
-  fun uu___10_6186  ->
-    match uu___10_6186 with
+  fun uu___10_6193  ->
+    match uu___10_6193 with
     | FStar_Parser_AST.Implicit  -> str "#"
     | FStar_Parser_AST.Equality  -> str "$"
     | FStar_Parser_AST.Meta t ->
         let t1 =
           match t.FStar_Parser_AST.tm with
-          | FStar_Parser_AST.Abs (uu____6191,e) -> e
-          | uu____6197 ->
+          | FStar_Parser_AST.Abs (uu____6198,e) -> e
+          | uu____6204 ->
               FStar_Parser_AST.mk_term
                 (FStar_Parser_AST.App
                    (t,
@@ -1983,39 +1987,39 @@ and (p_aqual : FStar_Parser_AST.arg_qualifier -> FStar_Pprint.document) =
                      FStar_Parser_AST.Nothing)) t.FStar_Parser_AST.range
                 FStar_Parser_AST.Expr
            in
-        let uu____6198 = str "#["  in
-        let uu____6200 =
-          let uu____6201 = p_term false false t1  in
-          let uu____6204 =
-            let uu____6205 = str "]"  in
-            FStar_Pprint.op_Hat_Hat uu____6205 break1  in
-          FStar_Pprint.op_Hat_Hat uu____6201 uu____6204  in
-        FStar_Pprint.op_Hat_Hat uu____6198 uu____6200
+        let uu____6205 = str "#["  in
+        let uu____6207 =
+          let uu____6208 = p_term false false t1  in
+          let uu____6211 =
+            let uu____6212 = str "]"  in
+            FStar_Pprint.op_Hat_Hat uu____6212 break1  in
+          FStar_Pprint.op_Hat_Hat uu____6208 uu____6211  in
+        FStar_Pprint.op_Hat_Hat uu____6205 uu____6207
 
 and (p_disjunctivePattern :
   FStar_Parser_AST.pattern -> FStar_Pprint.document) =
   fun p  ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatOr pats ->
-        let uu____6211 =
-          let uu____6212 =
-            let uu____6213 =
+        let uu____6218 =
+          let uu____6219 =
+            let uu____6220 =
               FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.space  in
-            FStar_Pprint.op_Hat_Hat break1 uu____6213  in
-          FStar_Pprint.separate_map uu____6212 p_tuplePattern pats  in
-        FStar_Pprint.group uu____6211
-    | uu____6214 -> p_tuplePattern p
+            FStar_Pprint.op_Hat_Hat break1 uu____6220  in
+          FStar_Pprint.separate_map uu____6219 p_tuplePattern pats  in
+        FStar_Pprint.group uu____6218
+    | uu____6221 -> p_tuplePattern p
 
 and (p_tuplePattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
   fun p  ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatTuple (pats,false ) ->
-        let uu____6223 =
-          let uu____6224 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
+        let uu____6230 =
+          let uu____6231 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
              in
-          FStar_Pprint.separate_map uu____6224 p_constructorPattern pats  in
-        FStar_Pprint.group uu____6223
-    | uu____6225 -> p_constructorPattern p
+          FStar_Pprint.separate_map uu____6231 p_constructorPattern pats  in
+        FStar_Pprint.group uu____6230
+    | uu____6232 -> p_constructorPattern p
 
 and (p_constructorPattern :
   FStar_Parser_AST.pattern -> FStar_Pprint.document) =
@@ -2023,23 +2027,23 @@ and (p_constructorPattern :
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatApp
         ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName maybe_cons_lid;
-           FStar_Parser_AST.prange = uu____6228;_},hd::tl::[])
+           FStar_Parser_AST.prange = uu____6235;_},hd::tl::[])
         when
         FStar_Ident.lid_equals maybe_cons_lid FStar_Parser_Const.cons_lid ->
-        let uu____6233 =
+        let uu____6240 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.colon FStar_Pprint.colon  in
-        let uu____6234 = p_constructorPattern hd  in
-        let uu____6235 = p_constructorPattern tl  in
-        infix0 uu____6233 uu____6234 uu____6235
+        let uu____6241 = p_constructorPattern hd  in
+        let uu____6242 = p_constructorPattern tl  in
+        infix0 uu____6240 uu____6241 uu____6242
     | FStar_Parser_AST.PatApp
         ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName uid;
-           FStar_Parser_AST.prange = uu____6237;_},pats)
+           FStar_Parser_AST.prange = uu____6244;_},pats)
         ->
-        let uu____6243 = p_quident uid  in
-        let uu____6244 =
+        let uu____6250 = p_quident uid  in
+        let uu____6251 =
           FStar_Pprint.separate_map break1 p_atomicPattern pats  in
-        prefix2 uu____6243 uu____6244
-    | uu____6245 -> p_atomicPattern p
+        prefix2 uu____6250 uu____6251
+    | uu____6252 -> p_atomicPattern p
 
 and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
   fun p  ->
@@ -2048,117 +2052,120 @@ and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
         (match ((pat.FStar_Parser_AST.pat), (t.FStar_Parser_AST.tm)) with
          | (FStar_Parser_AST.PatVar (lid,aqual),FStar_Parser_AST.Refine
             ({ FStar_Parser_AST.b = FStar_Parser_AST.Annotated (lid',t1);
-               FStar_Parser_AST.brange = uu____6261;
-               FStar_Parser_AST.blevel = uu____6262;
-               FStar_Parser_AST.aqual = uu____6263;_},phi))
-             when lid.FStar_Ident.idText = lid'.FStar_Ident.idText ->
-             let uu____6272 =
-               let uu____6273 = p_ident lid  in
-               p_refinement aqual uu____6273 t1 phi  in
-             soft_parens_with_nesting uu____6272
+               FStar_Parser_AST.brange = uu____6268;
+               FStar_Parser_AST.blevel = uu____6269;
+               FStar_Parser_AST.aqual = uu____6270;_},phi))
+             when
+             let uu____6278 = FStar_Ident.text_of_id lid  in
+             let uu____6280 = FStar_Ident.text_of_id lid'  in
+             uu____6278 = uu____6280 ->
+             let uu____6283 =
+               let uu____6284 = p_ident lid  in
+               p_refinement aqual uu____6284 t1 phi  in
+             soft_parens_with_nesting uu____6283
          | (FStar_Parser_AST.PatWild aqual,FStar_Parser_AST.Refine
             ({ FStar_Parser_AST.b = FStar_Parser_AST.NoName t1;
-               FStar_Parser_AST.brange = uu____6276;
-               FStar_Parser_AST.blevel = uu____6277;
-               FStar_Parser_AST.aqual = uu____6278;_},phi))
+               FStar_Parser_AST.brange = uu____6287;
+               FStar_Parser_AST.blevel = uu____6288;
+               FStar_Parser_AST.aqual = uu____6289;_},phi))
              ->
-             let uu____6284 =
+             let uu____6295 =
                p_refinement aqual FStar_Pprint.underscore t1 phi  in
-             soft_parens_with_nesting uu____6284
-         | uu____6285 ->
-             let uu____6290 =
-               let uu____6291 = p_tuplePattern pat  in
-               let uu____6292 =
-                 let uu____6293 = p_tmEqNoRefinement t  in
-                 FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____6293
+             soft_parens_with_nesting uu____6295
+         | uu____6296 ->
+             let uu____6301 =
+               let uu____6302 = p_tuplePattern pat  in
+               let uu____6303 =
+                 let uu____6304 = p_tmEqNoRefinement t  in
+                 FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____6304
                   in
-               FStar_Pprint.op_Hat_Hat uu____6291 uu____6292  in
-             soft_parens_with_nesting uu____6290)
+               FStar_Pprint.op_Hat_Hat uu____6302 uu____6303  in
+             soft_parens_with_nesting uu____6301)
     | FStar_Parser_AST.PatList pats ->
-        let uu____6297 =
+        let uu____6308 =
           separate_break_map FStar_Pprint.semi p_tuplePattern pats  in
         FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero
-          FStar_Pprint.lbracket uu____6297 FStar_Pprint.rbracket
+          FStar_Pprint.lbracket uu____6308 FStar_Pprint.rbracket
     | FStar_Parser_AST.PatRecord pats ->
-        let p_recordFieldPat uu____6316 =
-          match uu____6316 with
+        let p_recordFieldPat uu____6327 =
+          match uu____6327 with
           | (lid,pat) ->
-              let uu____6323 = p_qlident lid  in
-              let uu____6324 = p_tuplePattern pat  in
-              infix2 FStar_Pprint.equals uu____6323 uu____6324
+              let uu____6334 = p_qlident lid  in
+              let uu____6335 = p_tuplePattern pat  in
+              infix2 FStar_Pprint.equals uu____6334 uu____6335
            in
-        let uu____6325 =
+        let uu____6336 =
           separate_break_map FStar_Pprint.semi p_recordFieldPat pats  in
-        soft_braces_with_nesting uu____6325
+        soft_braces_with_nesting uu____6336
     | FStar_Parser_AST.PatTuple (pats,true ) ->
-        let uu____6337 =
+        let uu____6348 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar  in
-        let uu____6338 =
+        let uu____6349 =
           separate_break_map FStar_Pprint.comma p_constructorPattern pats  in
-        let uu____6339 =
+        let uu____6350 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen  in
-        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu____6337
-          uu____6338 uu____6339
+        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu____6348
+          uu____6349 uu____6350
     | FStar_Parser_AST.PatTvar (tv,arg_qualifier_opt) -> p_tvar tv
     | FStar_Parser_AST.PatOp op ->
-        let uu____6350 =
-          let uu____6351 =
-            let uu____6352 =
-              let uu____6353 = FStar_Ident.text_of_id op  in str uu____6353
+        let uu____6361 =
+          let uu____6362 =
+            let uu____6363 =
+              let uu____6364 = FStar_Ident.text_of_id op  in str uu____6364
                in
-            let uu____6355 =
+            let uu____6366 =
               FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen
                in
-            FStar_Pprint.op_Hat_Hat uu____6352 uu____6355  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6351  in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____6350
+            FStar_Pprint.op_Hat_Hat uu____6363 uu____6366  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6362  in
+        FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____6361
     | FStar_Parser_AST.PatWild aqual ->
-        let uu____6359 = FStar_Pprint.optional p_aqual aqual  in
-        FStar_Pprint.op_Hat_Hat uu____6359 FStar_Pprint.underscore
+        let uu____6370 = FStar_Pprint.optional p_aqual aqual  in
+        FStar_Pprint.op_Hat_Hat uu____6370 FStar_Pprint.underscore
     | FStar_Parser_AST.PatConst c -> p_constant c
     | FStar_Parser_AST.PatVar (lid,aqual) ->
-        let uu____6367 = FStar_Pprint.optional p_aqual aqual  in
-        let uu____6368 = p_lident lid  in
-        FStar_Pprint.op_Hat_Hat uu____6367 uu____6368
+        let uu____6378 = FStar_Pprint.optional p_aqual aqual  in
+        let uu____6379 = p_lident lid  in
+        FStar_Pprint.op_Hat_Hat uu____6378 uu____6379
     | FStar_Parser_AST.PatName uid -> p_quident uid
-    | FStar_Parser_AST.PatOr uu____6370 -> failwith "Inner or pattern !"
+    | FStar_Parser_AST.PatOr uu____6381 -> failwith "Inner or pattern !"
     | FStar_Parser_AST.PatApp
-        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName uu____6374;
-           FStar_Parser_AST.prange = uu____6375;_},uu____6376)
+        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName uu____6385;
+           FStar_Parser_AST.prange = uu____6386;_},uu____6387)
         ->
-        let uu____6381 = p_tuplePattern p  in
-        soft_parens_with_nesting uu____6381
-    | FStar_Parser_AST.PatTuple (uu____6382,false ) ->
-        let uu____6389 = p_tuplePattern p  in
-        soft_parens_with_nesting uu____6389
-    | uu____6390 ->
-        let uu____6391 =
-          let uu____6393 = FStar_Parser_AST.pat_to_string p  in
-          FStar_Util.format1 "Invalid pattern %s" uu____6393  in
-        failwith uu____6391
+        let uu____6392 = p_tuplePattern p  in
+        soft_parens_with_nesting uu____6392
+    | FStar_Parser_AST.PatTuple (uu____6393,false ) ->
+        let uu____6400 = p_tuplePattern p  in
+        soft_parens_with_nesting uu____6400
+    | uu____6401 ->
+        let uu____6402 =
+          let uu____6404 = FStar_Parser_AST.pat_to_string p  in
+          FStar_Util.format1 "Invalid pattern %s" uu____6404  in
+        failwith uu____6402
 
 and (is_typ_tuple : FStar_Parser_AST.term -> Prims.bool) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Op
-        ({ FStar_Ident.idText = "*"; FStar_Ident.idRange = uu____6398;_},uu____6399)
-        -> true
-    | uu____6406 -> false
+    | FStar_Parser_AST.Op (id,uu____6410) when
+        let uu____6415 = FStar_Ident.text_of_id id  in uu____6415 = "*" ->
+        true
+    | uu____6420 -> false
 
 and (is_meta_qualifier :
   FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option -> Prims.bool)
   =
   fun aq  ->
     match aq with
-    | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta uu____6412) -> true
-    | uu____6414 -> false
+    | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta uu____6426) -> true
+    | uu____6428 -> false
 
 and (p_binder :
   Prims.bool -> FStar_Parser_AST.binder -> FStar_Pprint.document) =
   fun is_atomic  ->
     fun b  ->
-      let uu____6421 = p_binder' is_atomic b  in
-      match uu____6421 with
+      let uu____6435 = p_binder' is_atomic b  in
+      match uu____6435 with
       | (b',t',catf1) ->
           (match t' with
            | FStar_Pervasives_Native.Some typ -> catf1 b' typ
@@ -2174,94 +2181,97 @@ and (p_binder' :
     fun b  ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.Variable lid ->
-          let uu____6458 =
-            let uu____6459 =
+          let uu____6472 =
+            let uu____6473 =
               FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual  in
-            let uu____6460 = p_lident lid  in
-            FStar_Pprint.op_Hat_Hat uu____6459 uu____6460  in
-          (uu____6458, FStar_Pervasives_Native.None, cat_with_colon)
+            let uu____6474 = p_lident lid  in
+            FStar_Pprint.op_Hat_Hat uu____6473 uu____6474  in
+          (uu____6472, FStar_Pervasives_Native.None, cat_with_colon)
       | FStar_Parser_AST.TVariable lid ->
-          let uu____6466 = p_lident lid  in
-          (uu____6466, FStar_Pervasives_Native.None, cat_with_colon)
+          let uu____6480 = p_lident lid  in
+          (uu____6480, FStar_Pervasives_Native.None, cat_with_colon)
       | FStar_Parser_AST.Annotated (lid,t) ->
-          let uu____6473 =
+          let uu____6487 =
             match t.FStar_Parser_AST.tm with
             | FStar_Parser_AST.Refine
                 ({ FStar_Parser_AST.b = FStar_Parser_AST.Annotated (lid',t1);
-                   FStar_Parser_AST.brange = uu____6484;
-                   FStar_Parser_AST.blevel = uu____6485;
-                   FStar_Parser_AST.aqual = uu____6486;_},phi)
-                when lid.FStar_Ident.idText = lid'.FStar_Ident.idText ->
-                let uu____6491 = p_lident lid  in
-                p_refinement' b.FStar_Parser_AST.aqual uu____6491 t1 phi
-            | uu____6492 ->
+                   FStar_Parser_AST.brange = uu____6498;
+                   FStar_Parser_AST.blevel = uu____6499;
+                   FStar_Parser_AST.aqual = uu____6500;_},phi)
+                when
+                let uu____6504 = FStar_Ident.text_of_id lid  in
+                let uu____6506 = FStar_Ident.text_of_id lid'  in
+                uu____6504 = uu____6506 ->
+                let uu____6509 = p_lident lid  in
+                p_refinement' b.FStar_Parser_AST.aqual uu____6509 t1 phi
+            | uu____6510 ->
                 let t' =
-                  let uu____6494 = is_typ_tuple t  in
-                  if uu____6494
+                  let uu____6512 = is_typ_tuple t  in
+                  if uu____6512
                   then
-                    let uu____6497 = p_tmFormula t  in
-                    soft_parens_with_nesting uu____6497
+                    let uu____6515 = p_tmFormula t  in
+                    soft_parens_with_nesting uu____6515
                   else p_tmFormula t  in
-                let uu____6500 =
-                  let uu____6501 =
+                let uu____6518 =
+                  let uu____6519 =
                     FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual
                      in
-                  let uu____6502 = p_lident lid  in
-                  FStar_Pprint.op_Hat_Hat uu____6501 uu____6502  in
-                (uu____6500, t')
+                  let uu____6520 = p_lident lid  in
+                  FStar_Pprint.op_Hat_Hat uu____6519 uu____6520  in
+                (uu____6518, t')
              in
-          (match uu____6473 with
+          (match uu____6487 with
            | (b',t') ->
                let catf1 =
-                 let uu____6520 =
+                 let uu____6538 =
                    is_atomic || (is_meta_qualifier b.FStar_Parser_AST.aqual)
                     in
-                 if uu____6520
+                 if uu____6538
                  then
                    fun x  ->
                      fun y  ->
-                       let uu____6527 =
-                         let uu____6528 =
-                           let uu____6529 = cat_with_colon x y  in
-                           FStar_Pprint.op_Hat_Hat uu____6529
+                       let uu____6545 =
+                         let uu____6546 =
+                           let uu____6547 = cat_with_colon x y  in
+                           FStar_Pprint.op_Hat_Hat uu____6547
                              FStar_Pprint.rparen
                             in
                          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen
-                           uu____6528
+                           uu____6546
                           in
-                       FStar_Pprint.group uu____6527
+                       FStar_Pprint.group uu____6545
                  else
                    (fun x  ->
                       fun y  ->
-                        let uu____6534 = cat_with_colon x y  in
-                        FStar_Pprint.group uu____6534)
+                        let uu____6552 = cat_with_colon x y  in
+                        FStar_Pprint.group uu____6552)
                   in
                (b', (FStar_Pervasives_Native.Some t'), catf1))
-      | FStar_Parser_AST.TAnnotated uu____6539 ->
+      | FStar_Parser_AST.TAnnotated uu____6557 ->
           failwith "Is this still used ?"
       | FStar_Parser_AST.NoName t ->
           (match t.FStar_Parser_AST.tm with
            | FStar_Parser_AST.Refine
                ({ FStar_Parser_AST.b = FStar_Parser_AST.NoName t1;
-                  FStar_Parser_AST.brange = uu____6567;
-                  FStar_Parser_AST.blevel = uu____6568;
-                  FStar_Parser_AST.aqual = uu____6569;_},phi)
+                  FStar_Parser_AST.brange = uu____6585;
+                  FStar_Parser_AST.blevel = uu____6586;
+                  FStar_Parser_AST.aqual = uu____6587;_},phi)
                ->
-               let uu____6573 =
+               let uu____6591 =
                  p_refinement' b.FStar_Parser_AST.aqual
                    FStar_Pprint.underscore t1 phi
                   in
-               (match uu____6573 with
+               (match uu____6591 with
                 | (b',t') ->
                     (b', (FStar_Pervasives_Native.Some t'), cat_with_colon))
-           | uu____6594 ->
+           | uu____6612 ->
                if is_atomic
                then
-                 let uu____6606 = p_atomicTerm t  in
-                 (uu____6606, FStar_Pervasives_Native.None, cat_with_colon)
+                 let uu____6624 = p_atomicTerm t  in
+                 (uu____6624, FStar_Pervasives_Native.None, cat_with_colon)
                else
-                 (let uu____6613 = p_appTerm t  in
-                  (uu____6613, FStar_Pervasives_Native.None, cat_with_colon)))
+                 (let uu____6631 = p_appTerm t  in
+                  (uu____6631, FStar_Pervasives_Native.None, cat_with_colon)))
 
 and (p_refinement :
   FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
@@ -2272,8 +2282,8 @@ and (p_refinement :
     fun binder  ->
       fun t  ->
         fun phi  ->
-          let uu____6624 = p_refinement' aqual_opt binder t phi  in
-          match uu____6624 with | (b,typ) -> cat_with_colon b typ
+          let uu____6642 = p_refinement' aqual_opt binder t phi  in
+          match uu____6642 with | (b,typ) -> cat_with_colon b typ
 
 and (p_refinement' :
   FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
@@ -2288,40 +2298,40 @@ and (p_refinement' :
         fun phi  ->
           let is_t_atomic =
             match t.FStar_Parser_AST.tm with
-            | FStar_Parser_AST.Construct uu____6640 -> false
-            | FStar_Parser_AST.App uu____6652 -> false
-            | FStar_Parser_AST.Op uu____6660 -> false
-            | uu____6668 -> true  in
-          let uu____6670 = p_noSeqTerm false false phi  in
-          match uu____6670 with
+            | FStar_Parser_AST.Construct uu____6658 -> false
+            | FStar_Parser_AST.App uu____6670 -> false
+            | FStar_Parser_AST.Op uu____6678 -> false
+            | uu____6686 -> true  in
+          let uu____6688 = p_noSeqTerm false false phi  in
+          match uu____6688 with
           | (comm,phi1) ->
               let phi2 =
                 if comm = FStar_Pprint.empty
                 then phi1
                 else
-                  (let uu____6687 =
+                  (let uu____6705 =
                      FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline phi1  in
-                   FStar_Pprint.op_Hat_Hat comm uu____6687)
+                   FStar_Pprint.op_Hat_Hat comm uu____6705)
                  in
               let jump_break =
                 if is_t_atomic then Prims.int_zero else Prims.int_one  in
-              let uu____6696 =
-                let uu____6697 = FStar_Pprint.optional p_aqual aqual_opt  in
-                FStar_Pprint.op_Hat_Hat uu____6697 binder  in
-              let uu____6698 =
-                let uu____6699 = p_appTerm t  in
-                let uu____6700 =
-                  let uu____6701 =
-                    let uu____6702 =
-                      let uu____6703 = soft_braces_with_nesting_tight phi2
+              let uu____6714 =
+                let uu____6715 = FStar_Pprint.optional p_aqual aqual_opt  in
+                FStar_Pprint.op_Hat_Hat uu____6715 binder  in
+              let uu____6716 =
+                let uu____6717 = p_appTerm t  in
+                let uu____6718 =
+                  let uu____6719 =
+                    let uu____6720 =
+                      let uu____6721 = soft_braces_with_nesting_tight phi2
                          in
-                      let uu____6704 = soft_braces_with_nesting phi2  in
-                      FStar_Pprint.ifflat uu____6703 uu____6704  in
-                    FStar_Pprint.group uu____6702  in
-                  FStar_Pprint.jump (Prims.of_int (2)) jump_break uu____6701
+                      let uu____6722 = soft_braces_with_nesting phi2  in
+                      FStar_Pprint.ifflat uu____6721 uu____6722  in
+                    FStar_Pprint.group uu____6720  in
+                  FStar_Pprint.jump (Prims.of_int (2)) jump_break uu____6719
                    in
-                FStar_Pprint.op_Hat_Hat uu____6699 uu____6700  in
-              (uu____6696, uu____6698)
+                FStar_Pprint.op_Hat_Hat uu____6717 uu____6718  in
+              (uu____6714, uu____6716)
 
 and (p_binders_list :
   Prims.bool ->
@@ -2333,35 +2343,35 @@ and (p_binders :
   =
   fun is_atomic  ->
     fun bs  ->
-      let uu____6718 = p_binders_list is_atomic bs  in
-      separate_or_flow break1 uu____6718
+      let uu____6736 = p_binders_list is_atomic bs  in
+      separate_or_flow break1 uu____6736
 
 and (text_of_id_or_underscore : FStar_Ident.ident -> FStar_Pprint.document) =
   fun lid  ->
-    let uu____6722 =
-      (FStar_Util.starts_with lid.FStar_Ident.idText
-         FStar_Ident.reserved_prefix)
-        &&
-        (let uu____6725 = FStar_Options.print_real_names ()  in
-         Prims.op_Negation uu____6725)
+    let uu____6740 =
+      (let uu____6744 = FStar_Ident.text_of_id lid  in
+       FStar_Util.starts_with uu____6744 FStar_Ident.reserved_prefix) &&
+        (let uu____6747 = FStar_Options.print_real_names ()  in
+         Prims.op_Negation uu____6747)
        in
-    if uu____6722
+    if uu____6740
     then FStar_Pprint.underscore
-    else (let uu____6730 = FStar_Ident.text_of_id lid  in str uu____6730)
+    else (let uu____6752 = FStar_Ident.text_of_id lid  in str uu____6752)
 
 and (text_of_lid_or_underscore : FStar_Ident.lident -> FStar_Pprint.document)
   =
   fun lid  ->
-    let uu____6733 =
-      (FStar_Util.starts_with (lid.FStar_Ident.ident).FStar_Ident.idText
-         FStar_Ident.reserved_prefix)
-        &&
-        (let uu____6736 = FStar_Options.print_real_names ()  in
-         Prims.op_Negation uu____6736)
+    let uu____6755 =
+      (let uu____6759 =
+         let uu____6761 = FStar_Ident.ident_of_lid lid  in
+         FStar_Ident.text_of_id uu____6761  in
+       FStar_Util.starts_with uu____6759 FStar_Ident.reserved_prefix) &&
+        (let uu____6763 = FStar_Options.print_real_names ()  in
+         Prims.op_Negation uu____6763)
        in
-    if uu____6733
+    if uu____6755
     then FStar_Pprint.underscore
-    else (let uu____6741 = FStar_Ident.text_of_lid lid  in str uu____6741)
+    else (let uu____6768 = FStar_Ident.string_of_lid lid  in str uu____6768)
 
 and (p_qlident : FStar_Ident.lid -> FStar_Pprint.document) =
   fun lid  -> text_of_lid_or_underscore lid
@@ -2393,24 +2403,24 @@ and (inline_comment_or_above :
       fun sep  ->
         if comm = FStar_Pprint.empty
         then
-          let uu____6762 = FStar_Pprint.op_Hat_Hat doc sep  in
-          FStar_Pprint.group uu____6762
+          let uu____6789 = FStar_Pprint.op_Hat_Hat doc sep  in
+          FStar_Pprint.group uu____6789
         else
-          (let uu____6765 =
-             let uu____6766 =
-               let uu____6767 =
-                 let uu____6768 =
-                   let uu____6769 = FStar_Pprint.op_Hat_Hat break1 comm  in
-                   FStar_Pprint.op_Hat_Hat sep uu____6769  in
-                 FStar_Pprint.op_Hat_Hat doc uu____6768  in
-               FStar_Pprint.group uu____6767  in
-             let uu____6770 =
-               let uu____6771 =
-                 let uu____6772 = FStar_Pprint.op_Hat_Hat doc sep  in
-                 FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____6772  in
-               FStar_Pprint.op_Hat_Hat comm uu____6771  in
-             FStar_Pprint.ifflat uu____6766 uu____6770  in
-           FStar_All.pipe_left FStar_Pprint.group uu____6765)
+          (let uu____6792 =
+             let uu____6793 =
+               let uu____6794 =
+                 let uu____6795 =
+                   let uu____6796 = FStar_Pprint.op_Hat_Hat break1 comm  in
+                   FStar_Pprint.op_Hat_Hat sep uu____6796  in
+                 FStar_Pprint.op_Hat_Hat doc uu____6795  in
+               FStar_Pprint.group uu____6794  in
+             let uu____6797 =
+               let uu____6798 =
+                 let uu____6799 = FStar_Pprint.op_Hat_Hat doc sep  in
+                 FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____6799  in
+               FStar_Pprint.op_Hat_Hat comm uu____6798  in
+             FStar_Pprint.ifflat uu____6793 uu____6797  in
+           FStar_All.pipe_left FStar_Pprint.group uu____6792)
 
 and (p_term :
   Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
@@ -2420,40 +2430,40 @@ and (p_term :
       fun e  ->
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Seq (e1,e2) ->
-            let uu____6780 = p_noSeqTerm true false e1  in
-            (match uu____6780 with
+            let uu____6807 = p_noSeqTerm true false e1  in
+            (match uu____6807 with
              | (comm,t1) ->
-                 let uu____6789 =
+                 let uu____6816 =
                    inline_comment_or_above comm t1 FStar_Pprint.semi  in
-                 let uu____6790 =
-                   let uu____6791 = p_term ps pb e2  in
-                   FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____6791
+                 let uu____6817 =
+                   let uu____6818 = p_term ps pb e2  in
+                   FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____6818
                     in
-                 FStar_Pprint.op_Hat_Hat uu____6789 uu____6790)
+                 FStar_Pprint.op_Hat_Hat uu____6816 uu____6817)
         | FStar_Parser_AST.Bind (x,e1,e2) ->
-            let uu____6795 =
-              let uu____6796 =
-                let uu____6797 =
-                  let uu____6798 = p_lident x  in
-                  let uu____6799 =
+            let uu____6822 =
+              let uu____6823 =
+                let uu____6824 =
+                  let uu____6825 = p_lident x  in
+                  let uu____6826 =
                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                       FStar_Pprint.long_left_arrow
                      in
-                  FStar_Pprint.op_Hat_Hat uu____6798 uu____6799  in
-                let uu____6800 =
-                  let uu____6801 = p_noSeqTermAndComment true false e1  in
-                  let uu____6804 =
+                  FStar_Pprint.op_Hat_Hat uu____6825 uu____6826  in
+                let uu____6827 =
+                  let uu____6828 = p_noSeqTermAndComment true false e1  in
+                  let uu____6831 =
                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                       FStar_Pprint.semi
                      in
-                  FStar_Pprint.op_Hat_Hat uu____6801 uu____6804  in
-                op_Hat_Slash_Plus_Hat uu____6797 uu____6800  in
-              FStar_Pprint.group uu____6796  in
-            let uu____6805 = p_term ps pb e2  in
-            FStar_Pprint.op_Hat_Slash_Hat uu____6795 uu____6805
-        | uu____6806 ->
-            let uu____6807 = p_noSeqTermAndComment ps pb e  in
-            FStar_Pprint.group uu____6807
+                  FStar_Pprint.op_Hat_Hat uu____6828 uu____6831  in
+                op_Hat_Slash_Plus_Hat uu____6824 uu____6827  in
+              FStar_Pprint.group uu____6823  in
+            let uu____6832 = p_term ps pb e2  in
+            FStar_Pprint.op_Hat_Slash_Hat uu____6822 uu____6832
+        | uu____6833 ->
+            let uu____6834 = p_noSeqTermAndComment ps pb e  in
+            FStar_Pprint.group uu____6834
 
 and (p_term_sep :
   Prims.bool ->
@@ -2466,44 +2476,44 @@ and (p_term_sep :
       fun e  ->
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Seq (e1,e2) ->
-            let uu____6819 = p_noSeqTerm true false e1  in
-            (match uu____6819 with
+            let uu____6846 = p_noSeqTerm true false e1  in
+            (match uu____6846 with
              | (comm,t1) ->
-                 let uu____6832 =
-                   let uu____6833 =
-                     let uu____6834 =
+                 let uu____6859 =
+                   let uu____6860 =
+                     let uu____6861 =
                        FStar_Pprint.op_Hat_Hat t1 FStar_Pprint.semi  in
-                     FStar_Pprint.group uu____6834  in
-                   let uu____6835 =
-                     let uu____6836 = p_term ps pb e2  in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____6836
+                     FStar_Pprint.group uu____6861  in
+                   let uu____6862 =
+                     let uu____6863 = p_term ps pb e2  in
+                     FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____6863
                       in
-                   FStar_Pprint.op_Hat_Hat uu____6833 uu____6835  in
-                 (comm, uu____6832))
+                   FStar_Pprint.op_Hat_Hat uu____6860 uu____6862  in
+                 (comm, uu____6859))
         | FStar_Parser_AST.Bind (x,e1,e2) ->
-            let uu____6840 =
-              let uu____6841 =
-                let uu____6842 =
-                  let uu____6843 =
-                    let uu____6844 = p_lident x  in
-                    let uu____6845 =
+            let uu____6867 =
+              let uu____6868 =
+                let uu____6869 =
+                  let uu____6870 =
+                    let uu____6871 = p_lident x  in
+                    let uu____6872 =
                       FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                         FStar_Pprint.long_left_arrow
                        in
-                    FStar_Pprint.op_Hat_Hat uu____6844 uu____6845  in
-                  let uu____6846 =
-                    let uu____6847 = p_noSeqTermAndComment true false e1  in
-                    let uu____6850 =
+                    FStar_Pprint.op_Hat_Hat uu____6871 uu____6872  in
+                  let uu____6873 =
+                    let uu____6874 = p_noSeqTermAndComment true false e1  in
+                    let uu____6877 =
                       FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                         FStar_Pprint.semi
                        in
-                    FStar_Pprint.op_Hat_Hat uu____6847 uu____6850  in
-                  op_Hat_Slash_Plus_Hat uu____6843 uu____6846  in
-                FStar_Pprint.group uu____6842  in
-              let uu____6851 = p_term ps pb e2  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____6841 uu____6851  in
-            (FStar_Pprint.empty, uu____6840)
-        | uu____6852 -> p_noSeqTerm ps pb e
+                    FStar_Pprint.op_Hat_Hat uu____6874 uu____6877  in
+                  op_Hat_Slash_Plus_Hat uu____6870 uu____6873  in
+                FStar_Pprint.group uu____6869  in
+              let uu____6878 = p_term ps pb e2  in
+              FStar_Pprint.op_Hat_Slash_Hat uu____6868 uu____6878  in
+            (FStar_Pprint.empty, uu____6867)
+        | uu____6879 -> p_noSeqTerm ps pb e
 
 and (p_noSeqTerm :
   Prims.bool ->
@@ -2531,235 +2541,233 @@ and (p_noSeqTerm' :
       fun e  ->
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Ascribed (e1,t,FStar_Pervasives_Native.None ) ->
-            let uu____6872 =
-              let uu____6873 = p_tmIff e1  in
-              let uu____6874 =
-                let uu____6875 =
-                  let uu____6876 = p_typ ps pb t  in
-                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____6876
+            let uu____6899 =
+              let uu____6900 = p_tmIff e1  in
+              let uu____6901 =
+                let uu____6902 =
+                  let uu____6903 = p_typ ps pb t  in
+                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____6903
                    in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____6875  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____6873 uu____6874  in
-            FStar_Pprint.group uu____6872
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____6902  in
+              FStar_Pprint.op_Hat_Slash_Hat uu____6900 uu____6901  in
+            FStar_Pprint.group uu____6899
         | FStar_Parser_AST.Ascribed (e1,t,FStar_Pervasives_Native.Some tac)
             ->
-            let uu____6882 =
-              let uu____6883 = p_tmIff e1  in
-              let uu____6884 =
-                let uu____6885 =
-                  let uu____6886 =
-                    let uu____6887 = p_typ false false t  in
-                    let uu____6890 =
-                      let uu____6891 = str "by"  in
-                      let uu____6893 = p_typ ps pb (maybe_unthunk tac)  in
-                      FStar_Pprint.op_Hat_Slash_Hat uu____6891 uu____6893  in
-                    FStar_Pprint.op_Hat_Slash_Hat uu____6887 uu____6890  in
-                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____6886
+            let uu____6909 =
+              let uu____6910 = p_tmIff e1  in
+              let uu____6911 =
+                let uu____6912 =
+                  let uu____6913 =
+                    let uu____6914 = p_typ false false t  in
+                    let uu____6917 =
+                      let uu____6918 = str "by"  in
+                      let uu____6920 = p_typ ps pb (maybe_unthunk tac)  in
+                      FStar_Pprint.op_Hat_Slash_Hat uu____6918 uu____6920  in
+                    FStar_Pprint.op_Hat_Slash_Hat uu____6914 uu____6917  in
+                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____6913
                    in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____6885  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____6883 uu____6884  in
-            FStar_Pprint.group uu____6882
-        | FStar_Parser_AST.Op
-            ({ FStar_Ident.idText = ".()<-";
-               FStar_Ident.idRange = uu____6894;_},e1::e2::e3::[])
-            ->
-            let uu____6901 =
-              let uu____6902 =
-                let uu____6903 =
-                  let uu____6904 = p_atomicTermNotQUident e1  in
-                  let uu____6905 =
-                    let uu____6906 =
-                      let uu____6907 =
-                        let uu____6908 = p_term false false e2  in
-                        soft_parens_with_nesting uu____6908  in
-                      let uu____6911 =
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                          FStar_Pprint.larrow
-                         in
-                      FStar_Pprint.op_Hat_Hat uu____6907 uu____6911  in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____6906  in
-                  FStar_Pprint.op_Hat_Hat uu____6904 uu____6905  in
-                FStar_Pprint.group uu____6903  in
-              let uu____6912 =
-                let uu____6913 = p_noSeqTermAndComment ps pb e3  in
-                jump2 uu____6913  in
-              FStar_Pprint.op_Hat_Hat uu____6902 uu____6912  in
-            FStar_Pprint.group uu____6901
-        | FStar_Parser_AST.Op
-            ({ FStar_Ident.idText = ".[]<-";
-               FStar_Ident.idRange = uu____6914;_},e1::e2::e3::[])
-            ->
-            let uu____6921 =
-              let uu____6922 =
-                let uu____6923 =
-                  let uu____6924 = p_atomicTermNotQUident e1  in
-                  let uu____6925 =
-                    let uu____6926 =
-                      let uu____6927 =
-                        let uu____6928 = p_term false false e2  in
-                        soft_brackets_with_nesting uu____6928  in
-                      let uu____6931 =
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                          FStar_Pprint.larrow
-                         in
-                      FStar_Pprint.op_Hat_Hat uu____6927 uu____6931  in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____6926  in
-                  FStar_Pprint.op_Hat_Hat uu____6924 uu____6925  in
-                FStar_Pprint.group uu____6923  in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____6912  in
+              FStar_Pprint.op_Hat_Slash_Hat uu____6910 uu____6911  in
+            FStar_Pprint.group uu____6909
+        | FStar_Parser_AST.Op (id,e1::e2::e3::[]) when
+            let uu____6927 = FStar_Ident.text_of_id id  in
+            uu____6927 = ".()<-" ->
+            let uu____6931 =
               let uu____6932 =
-                let uu____6933 = p_noSeqTermAndComment ps pb e3  in
-                jump2 uu____6933  in
-              FStar_Pprint.op_Hat_Hat uu____6922 uu____6932  in
-            FStar_Pprint.group uu____6921
+                let uu____6933 =
+                  let uu____6934 = p_atomicTermNotQUident e1  in
+                  let uu____6935 =
+                    let uu____6936 =
+                      let uu____6937 =
+                        let uu____6938 = p_term false false e2  in
+                        soft_parens_with_nesting uu____6938  in
+                      let uu____6941 =
+                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space
+                          FStar_Pprint.larrow
+                         in
+                      FStar_Pprint.op_Hat_Hat uu____6937 uu____6941  in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____6936  in
+                  FStar_Pprint.op_Hat_Hat uu____6934 uu____6935  in
+                FStar_Pprint.group uu____6933  in
+              let uu____6942 =
+                let uu____6943 = p_noSeqTermAndComment ps pb e3  in
+                jump2 uu____6943  in
+              FStar_Pprint.op_Hat_Hat uu____6932 uu____6942  in
+            FStar_Pprint.group uu____6931
+        | FStar_Parser_AST.Op (id,e1::e2::e3::[]) when
+            let uu____6950 = FStar_Ident.text_of_id id  in
+            uu____6950 = ".[]<-" ->
+            let uu____6954 =
+              let uu____6955 =
+                let uu____6956 =
+                  let uu____6957 = p_atomicTermNotQUident e1  in
+                  let uu____6958 =
+                    let uu____6959 =
+                      let uu____6960 =
+                        let uu____6961 = p_term false false e2  in
+                        soft_brackets_with_nesting uu____6961  in
+                      let uu____6964 =
+                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space
+                          FStar_Pprint.larrow
+                         in
+                      FStar_Pprint.op_Hat_Hat uu____6960 uu____6964  in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____6959  in
+                  FStar_Pprint.op_Hat_Hat uu____6957 uu____6958  in
+                FStar_Pprint.group uu____6956  in
+              let uu____6965 =
+                let uu____6966 = p_noSeqTermAndComment ps pb e3  in
+                jump2 uu____6966  in
+              FStar_Pprint.op_Hat_Hat uu____6955 uu____6965  in
+            FStar_Pprint.group uu____6954
         | FStar_Parser_AST.Requires (e1,wtf) ->
-            let uu____6943 =
-              let uu____6944 = str "requires"  in
-              let uu____6946 = p_typ ps pb e1  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____6944 uu____6946  in
-            FStar_Pprint.group uu____6943
+            let uu____6976 =
+              let uu____6977 = str "requires"  in
+              let uu____6979 = p_typ ps pb e1  in
+              FStar_Pprint.op_Hat_Slash_Hat uu____6977 uu____6979  in
+            FStar_Pprint.group uu____6976
         | FStar_Parser_AST.Ensures (e1,wtf) ->
-            let uu____6956 =
-              let uu____6957 = str "ensures"  in
-              let uu____6959 = p_typ ps pb e1  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____6957 uu____6959  in
-            FStar_Pprint.group uu____6956
+            let uu____6989 =
+              let uu____6990 = str "ensures"  in
+              let uu____6992 = p_typ ps pb e1  in
+              FStar_Pprint.op_Hat_Slash_Hat uu____6990 uu____6992  in
+            FStar_Pprint.group uu____6989
         | FStar_Parser_AST.Attributes es ->
-            let uu____6963 =
-              let uu____6964 = str "attributes"  in
-              let uu____6966 =
+            let uu____6996 =
+              let uu____6997 = str "attributes"  in
+              let uu____6999 =
                 FStar_Pprint.separate_map break1 p_atomicTerm es  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____6964 uu____6966  in
-            FStar_Pprint.group uu____6963
+              FStar_Pprint.op_Hat_Slash_Hat uu____6997 uu____6999  in
+            FStar_Pprint.group uu____6996
         | FStar_Parser_AST.If (e1,e2,e3) ->
             if is_unit e3
             then
-              let uu____6971 =
-                let uu____6972 =
-                  let uu____6973 = str "if"  in
-                  let uu____6975 = p_noSeqTermAndComment false false e1  in
-                  op_Hat_Slash_Plus_Hat uu____6973 uu____6975  in
-                let uu____6978 =
-                  let uu____6979 = str "then"  in
-                  let uu____6981 = p_noSeqTermAndComment ps pb e2  in
-                  op_Hat_Slash_Plus_Hat uu____6979 uu____6981  in
-                FStar_Pprint.op_Hat_Slash_Hat uu____6972 uu____6978  in
-              FStar_Pprint.group uu____6971
+              let uu____7004 =
+                let uu____7005 =
+                  let uu____7006 = str "if"  in
+                  let uu____7008 = p_noSeqTermAndComment false false e1  in
+                  op_Hat_Slash_Plus_Hat uu____7006 uu____7008  in
+                let uu____7011 =
+                  let uu____7012 = str "then"  in
+                  let uu____7014 = p_noSeqTermAndComment ps pb e2  in
+                  op_Hat_Slash_Plus_Hat uu____7012 uu____7014  in
+                FStar_Pprint.op_Hat_Slash_Hat uu____7005 uu____7011  in
+              FStar_Pprint.group uu____7004
             else
               (let e2_doc =
                  match e2.FStar_Parser_AST.tm with
-                 | FStar_Parser_AST.If (uu____6985,uu____6986,e31) when
+                 | FStar_Parser_AST.If (uu____7018,uu____7019,e31) when
                      is_unit e31 ->
-                     let uu____6988 = p_noSeqTermAndComment false false e2
+                     let uu____7021 = p_noSeqTermAndComment false false e2
                         in
-                     soft_parens_with_nesting uu____6988
-                 | uu____6991 -> p_noSeqTermAndComment false false e2  in
-               let uu____6994 =
-                 let uu____6995 =
-                   let uu____6996 = str "if"  in
-                   let uu____6998 = p_noSeqTermAndComment false false e1  in
-                   op_Hat_Slash_Plus_Hat uu____6996 uu____6998  in
-                 let uu____7001 =
-                   let uu____7002 =
-                     let uu____7003 = str "then"  in
-                     op_Hat_Slash_Plus_Hat uu____7003 e2_doc  in
-                   let uu____7005 =
-                     let uu____7006 = str "else"  in
-                     let uu____7008 = p_noSeqTermAndComment ps pb e3  in
-                     op_Hat_Slash_Plus_Hat uu____7006 uu____7008  in
-                   FStar_Pprint.op_Hat_Slash_Hat uu____7002 uu____7005  in
-                 FStar_Pprint.op_Hat_Slash_Hat uu____6995 uu____7001  in
-               FStar_Pprint.group uu____6994)
+                     soft_parens_with_nesting uu____7021
+                 | uu____7024 -> p_noSeqTermAndComment false false e2  in
+               let uu____7027 =
+                 let uu____7028 =
+                   let uu____7029 = str "if"  in
+                   let uu____7031 = p_noSeqTermAndComment false false e1  in
+                   op_Hat_Slash_Plus_Hat uu____7029 uu____7031  in
+                 let uu____7034 =
+                   let uu____7035 =
+                     let uu____7036 = str "then"  in
+                     op_Hat_Slash_Plus_Hat uu____7036 e2_doc  in
+                   let uu____7038 =
+                     let uu____7039 = str "else"  in
+                     let uu____7041 = p_noSeqTermAndComment ps pb e3  in
+                     op_Hat_Slash_Plus_Hat uu____7039 uu____7041  in
+                   FStar_Pprint.op_Hat_Slash_Hat uu____7035 uu____7038  in
+                 FStar_Pprint.op_Hat_Slash_Hat uu____7028 uu____7034  in
+               FStar_Pprint.group uu____7027)
         | FStar_Parser_AST.TryWith (e1,branches) ->
-            let uu____7031 =
-              let uu____7032 =
-                let uu____7033 =
-                  let uu____7034 = str "try"  in
-                  let uu____7036 = p_noSeqTermAndComment false false e1  in
-                  prefix2 uu____7034 uu____7036  in
-                let uu____7039 =
-                  let uu____7040 = str "with"  in
-                  let uu____7042 =
+            let uu____7064 =
+              let uu____7065 =
+                let uu____7066 =
+                  let uu____7067 = str "try"  in
+                  let uu____7069 = p_noSeqTermAndComment false false e1  in
+                  prefix2 uu____7067 uu____7069  in
+                let uu____7072 =
+                  let uu____7073 = str "with"  in
+                  let uu____7075 =
                     separate_map_last FStar_Pprint.hardline p_patternBranch
                       branches
                      in
-                  FStar_Pprint.op_Hat_Slash_Hat uu____7040 uu____7042  in
-                FStar_Pprint.op_Hat_Slash_Hat uu____7033 uu____7039  in
-              FStar_Pprint.group uu____7032  in
-            let uu____7051 = paren_if (ps || pb)  in uu____7051 uu____7031
+                  FStar_Pprint.op_Hat_Slash_Hat uu____7073 uu____7075  in
+                FStar_Pprint.op_Hat_Slash_Hat uu____7066 uu____7072  in
+              FStar_Pprint.group uu____7065  in
+            let uu____7084 = paren_if (ps || pb)  in uu____7084 uu____7064
         | FStar_Parser_AST.Match (e1,branches) ->
-            let uu____7078 =
-              let uu____7079 =
-                let uu____7080 =
-                  let uu____7081 = str "match"  in
-                  let uu____7083 = p_noSeqTermAndComment false false e1  in
-                  let uu____7086 = str "with"  in
+            let uu____7111 =
+              let uu____7112 =
+                let uu____7113 =
+                  let uu____7114 = str "match"  in
+                  let uu____7116 = p_noSeqTermAndComment false false e1  in
+                  let uu____7119 = str "with"  in
                   FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one
-                    uu____7081 uu____7083 uu____7086
+                    uu____7114 uu____7116 uu____7119
                    in
-                let uu____7090 =
+                let uu____7123 =
                   separate_map_last FStar_Pprint.hardline p_patternBranch
                     branches
                    in
-                FStar_Pprint.op_Hat_Slash_Hat uu____7080 uu____7090  in
-              FStar_Pprint.group uu____7079  in
-            let uu____7099 = paren_if (ps || pb)  in uu____7099 uu____7078
+                FStar_Pprint.op_Hat_Slash_Hat uu____7113 uu____7123  in
+              FStar_Pprint.group uu____7112  in
+            let uu____7132 = paren_if (ps || pb)  in uu____7132 uu____7111
         | FStar_Parser_AST.LetOpen (uid,e1) ->
-            let uu____7106 =
-              let uu____7107 =
-                let uu____7108 =
-                  let uu____7109 = str "let open"  in
-                  let uu____7111 = p_quident uid  in
-                  let uu____7112 = str "in"  in
+            let uu____7139 =
+              let uu____7140 =
+                let uu____7141 =
+                  let uu____7142 = str "let open"  in
+                  let uu____7144 = p_quident uid  in
+                  let uu____7145 = str "in"  in
                   FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one
-                    uu____7109 uu____7111 uu____7112
+                    uu____7142 uu____7144 uu____7145
                    in
-                let uu____7116 = p_term false pb e1  in
-                FStar_Pprint.op_Hat_Slash_Hat uu____7108 uu____7116  in
-              FStar_Pprint.group uu____7107  in
-            let uu____7118 = paren_if ps  in uu____7118 uu____7106
+                let uu____7149 = p_term false pb e1  in
+                FStar_Pprint.op_Hat_Slash_Hat uu____7141 uu____7149  in
+              FStar_Pprint.group uu____7140  in
+            let uu____7151 = paren_if ps  in uu____7151 uu____7139
         | FStar_Parser_AST.Let (q,lbs,e1) ->
-            let p_lb q1 uu____7183 is_last =
-              match uu____7183 with
+            let p_lb q1 uu____7216 is_last =
+              match uu____7216 with
               | (a,(pat,e2)) ->
                   let attrs = p_attrs_opt a  in
                   let doc_let_or_and =
                     match q1 with
                     | FStar_Pervasives_Native.Some (FStar_Parser_AST.Rec ) ->
-                        let uu____7217 =
-                          let uu____7218 = str "let"  in
-                          let uu____7220 = str "rec"  in
-                          FStar_Pprint.op_Hat_Slash_Hat uu____7218 uu____7220
+                        let uu____7250 =
+                          let uu____7251 = str "let"  in
+                          let uu____7253 = str "rec"  in
+                          FStar_Pprint.op_Hat_Slash_Hat uu____7251 uu____7253
                            in
-                        FStar_Pprint.group uu____7217
+                        FStar_Pprint.group uu____7250
                     | FStar_Pervasives_Native.Some
                         (FStar_Parser_AST.NoLetQualifier ) -> str "let"
-                    | uu____7223 -> str "and"  in
+                    | uu____7256 -> str "and"  in
                   let doc_pat = p_letlhs doc_let_or_and (pat, e2) true  in
-                  let uu____7229 = p_term_sep false false e2  in
-                  (match uu____7229 with
+                  let uu____7262 = p_term_sep false false e2  in
+                  (match uu____7262 with
                    | (comm,doc_expr) ->
                        let doc_expr1 =
                          inline_comment_or_above comm doc_expr
                            FStar_Pprint.empty
                           in
-                       let uu____7239 =
+                       let uu____7272 =
                          if is_last
                          then
-                           let uu____7241 =
+                           let uu____7274 =
                              FStar_Pprint.flow break1
                                [doc_pat; FStar_Pprint.equals]
                               in
-                           let uu____7242 = str "in"  in
+                           let uu____7275 = str "in"  in
                            FStar_Pprint.surround (Prims.of_int (2))
-                             Prims.int_one uu____7241 doc_expr1 uu____7242
+                             Prims.int_one uu____7274 doc_expr1 uu____7275
                          else
-                           (let uu____7248 =
+                           (let uu____7281 =
                               FStar_Pprint.flow break1
                                 [doc_pat; FStar_Pprint.equals; doc_expr1]
                                in
-                            FStar_Pprint.hang (Prims.of_int (2)) uu____7248)
+                            FStar_Pprint.hang (Prims.of_int (2)) uu____7281)
                           in
-                       FStar_Pprint.op_Hat_Hat attrs uu____7239)
+                       FStar_Pprint.op_Hat_Hat attrs uu____7272)
                in
             let l = FStar_List.length lbs  in
             let lbs_docs =
@@ -2768,181 +2776,181 @@ and (p_noSeqTerm' :
                    fun lb  ->
                      if i = Prims.int_zero
                      then
-                       let uu____7299 =
+                       let uu____7332 =
                          p_lb (FStar_Pervasives_Native.Some q) lb
                            (i = (l - Prims.int_one))
                           in
-                       FStar_Pprint.group uu____7299
+                       FStar_Pprint.group uu____7332
                      else
-                       (let uu____7304 =
+                       (let uu____7337 =
                           p_lb FStar_Pervasives_Native.None lb
                             (i = (l - Prims.int_one))
                            in
-                        FStar_Pprint.group uu____7304)) lbs
+                        FStar_Pprint.group uu____7337)) lbs
                in
             let lbs_doc =
-              let uu____7308 = FStar_Pprint.separate break1 lbs_docs  in
-              FStar_Pprint.group uu____7308  in
-            let uu____7309 =
-              let uu____7310 =
-                let uu____7311 =
-                  let uu____7312 = p_term false pb e1  in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____7312
+              let uu____7341 = FStar_Pprint.separate break1 lbs_docs  in
+              FStar_Pprint.group uu____7341  in
+            let uu____7342 =
+              let uu____7343 =
+                let uu____7344 =
+                  let uu____7345 = p_term false pb e1  in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____7345
                    in
-                FStar_Pprint.op_Hat_Hat lbs_doc uu____7311  in
-              FStar_Pprint.group uu____7310  in
-            let uu____7314 = paren_if ps  in uu____7314 uu____7309
+                FStar_Pprint.op_Hat_Hat lbs_doc uu____7344  in
+              FStar_Pprint.group uu____7343  in
+            let uu____7347 = paren_if ps  in uu____7347 uu____7342
         | FStar_Parser_AST.Abs
             ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (x,typ_opt);
-               FStar_Parser_AST.prange = uu____7321;_}::[],{
+               FStar_Parser_AST.prange = uu____7354;_}::[],{
                                                              FStar_Parser_AST.tm
                                                                =
                                                                FStar_Parser_AST.Match
                                                                (maybe_x,branches);
                                                              FStar_Parser_AST.range
-                                                               = uu____7324;
+                                                               = uu____7357;
                                                              FStar_Parser_AST.level
-                                                               = uu____7325;_})
+                                                               = uu____7358;_})
             when matches_var maybe_x x ->
-            let uu____7352 =
-              let uu____7353 =
-                let uu____7354 = str "function"  in
-                let uu____7356 =
+            let uu____7385 =
+              let uu____7386 =
+                let uu____7387 = str "function"  in
+                let uu____7389 =
                   separate_map_last FStar_Pprint.hardline p_patternBranch
                     branches
                    in
-                FStar_Pprint.op_Hat_Slash_Hat uu____7354 uu____7356  in
-              FStar_Pprint.group uu____7353  in
-            let uu____7365 = paren_if (ps || pb)  in uu____7365 uu____7352
+                FStar_Pprint.op_Hat_Slash_Hat uu____7387 uu____7389  in
+              FStar_Pprint.group uu____7386  in
+            let uu____7398 = paren_if (ps || pb)  in uu____7398 uu____7385
         | FStar_Parser_AST.Quote (e1,FStar_Parser_AST.Dynamic ) ->
-            let uu____7371 =
-              let uu____7372 = str "quote"  in
-              let uu____7374 = p_noSeqTermAndComment ps pb e1  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____7372 uu____7374  in
-            FStar_Pprint.group uu____7371
+            let uu____7404 =
+              let uu____7405 = str "quote"  in
+              let uu____7407 = p_noSeqTermAndComment ps pb e1  in
+              FStar_Pprint.op_Hat_Slash_Hat uu____7405 uu____7407  in
+            FStar_Pprint.group uu____7404
         | FStar_Parser_AST.Quote (e1,FStar_Parser_AST.Static ) ->
-            let uu____7376 =
-              let uu____7377 = str "`"  in
-              let uu____7379 = p_noSeqTermAndComment ps pb e1  in
-              FStar_Pprint.op_Hat_Hat uu____7377 uu____7379  in
-            FStar_Pprint.group uu____7376
+            let uu____7409 =
+              let uu____7410 = str "`"  in
+              let uu____7412 = p_noSeqTermAndComment ps pb e1  in
+              FStar_Pprint.op_Hat_Hat uu____7410 uu____7412  in
+            FStar_Pprint.group uu____7409
         | FStar_Parser_AST.VQuote e1 ->
-            let uu____7381 =
-              let uu____7382 = str "`%"  in
-              let uu____7384 = p_noSeqTermAndComment ps pb e1  in
-              FStar_Pprint.op_Hat_Hat uu____7382 uu____7384  in
-            FStar_Pprint.group uu____7381
+            let uu____7414 =
+              let uu____7415 = str "`%"  in
+              let uu____7417 = p_noSeqTermAndComment ps pb e1  in
+              FStar_Pprint.op_Hat_Hat uu____7415 uu____7417  in
+            FStar_Pprint.group uu____7414
         | FStar_Parser_AST.Antiquote
             {
               FStar_Parser_AST.tm = FStar_Parser_AST.Quote
                 (e1,FStar_Parser_AST.Dynamic );
-              FStar_Parser_AST.range = uu____7386;
-              FStar_Parser_AST.level = uu____7387;_}
+              FStar_Parser_AST.range = uu____7419;
+              FStar_Parser_AST.level = uu____7420;_}
             ->
-            let uu____7388 =
-              let uu____7389 = str "`@"  in
-              let uu____7391 = p_noSeqTermAndComment ps pb e1  in
-              FStar_Pprint.op_Hat_Hat uu____7389 uu____7391  in
-            FStar_Pprint.group uu____7388
+            let uu____7421 =
+              let uu____7422 = str "`@"  in
+              let uu____7424 = p_noSeqTermAndComment ps pb e1  in
+              FStar_Pprint.op_Hat_Hat uu____7422 uu____7424  in
+            FStar_Pprint.group uu____7421
         | FStar_Parser_AST.Antiquote e1 ->
-            let uu____7393 =
-              let uu____7394 = str "`#"  in
-              let uu____7396 = p_noSeqTermAndComment ps pb e1  in
-              FStar_Pprint.op_Hat_Hat uu____7394 uu____7396  in
-            FStar_Pprint.group uu____7393
+            let uu____7426 =
+              let uu____7427 = str "`#"  in
+              let uu____7429 = p_noSeqTermAndComment ps pb e1  in
+              FStar_Pprint.op_Hat_Hat uu____7427 uu____7429  in
+            FStar_Pprint.group uu____7426
         | FStar_Parser_AST.CalcProof (rel,init,steps) ->
             let head =
-              let uu____7405 = str "calc"  in
-              let uu____7407 =
-                let uu____7408 =
-                  let uu____7409 = p_noSeqTermAndComment false false rel  in
-                  let uu____7412 =
+              let uu____7438 = str "calc"  in
+              let uu____7440 =
+                let uu____7441 =
+                  let uu____7442 = p_noSeqTermAndComment false false rel  in
+                  let uu____7445 =
                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                       FStar_Pprint.lbrace
                      in
-                  FStar_Pprint.op_Hat_Hat uu____7409 uu____7412  in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____7408  in
-              FStar_Pprint.op_Hat_Hat uu____7405 uu____7407  in
+                  FStar_Pprint.op_Hat_Hat uu____7442 uu____7445  in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____7441  in
+              FStar_Pprint.op_Hat_Hat uu____7438 uu____7440  in
             let bot = FStar_Pprint.rbrace  in
-            let uu____7414 =
+            let uu____7447 =
               FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline bot  in
-            let uu____7415 =
-              let uu____7416 =
-                let uu____7417 =
-                  let uu____7418 = p_noSeqTermAndComment false false init  in
-                  let uu____7421 =
-                    let uu____7422 = str ";"  in
-                    let uu____7424 =
-                      let uu____7425 =
+            let uu____7448 =
+              let uu____7449 =
+                let uu____7450 =
+                  let uu____7451 = p_noSeqTermAndComment false false init  in
+                  let uu____7454 =
+                    let uu____7455 = str ";"  in
+                    let uu____7457 =
+                      let uu____7458 =
                         separate_map_last FStar_Pprint.hardline p_calcStep
                           steps
                          in
                       FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline
-                        uu____7425
+                        uu____7458
                        in
-                    FStar_Pprint.op_Hat_Hat uu____7422 uu____7424  in
-                  FStar_Pprint.op_Hat_Hat uu____7418 uu____7421  in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____7417  in
+                    FStar_Pprint.op_Hat_Hat uu____7455 uu____7457  in
+                  FStar_Pprint.op_Hat_Hat uu____7451 uu____7454  in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____7450  in
               FStar_All.pipe_left (FStar_Pprint.nest (Prims.of_int (2)))
-                uu____7416
+                uu____7449
                in
-            FStar_Pprint.enclose head uu____7414 uu____7415
-        | uu____7427 -> p_typ ps pb e
+            FStar_Pprint.enclose head uu____7447 uu____7448
+        | uu____7460 -> p_typ ps pb e
 
 and (p_calcStep :
   Prims.bool -> FStar_Parser_AST.calc_step -> FStar_Pprint.document) =
-  fun uu____7428  ->
-    fun uu____7429  ->
-      match uu____7429 with
+  fun uu____7461  ->
+    fun uu____7462  ->
+      match uu____7462 with
       | FStar_Parser_AST.CalcStep (rel,just,next) ->
-          let uu____7434 =
-            let uu____7435 = p_noSeqTermAndComment false false rel  in
-            let uu____7438 =
-              let uu____7439 =
-                let uu____7440 =
-                  let uu____7441 =
-                    let uu____7442 = p_noSeqTermAndComment false false just
+          let uu____7467 =
+            let uu____7468 = p_noSeqTermAndComment false false rel  in
+            let uu____7471 =
+              let uu____7472 =
+                let uu____7473 =
+                  let uu____7474 =
+                    let uu____7475 = p_noSeqTermAndComment false false just
                        in
-                    let uu____7445 =
-                      let uu____7446 =
-                        let uu____7447 =
-                          let uu____7448 =
-                            let uu____7449 =
+                    let uu____7478 =
+                      let uu____7479 =
+                        let uu____7480 =
+                          let uu____7481 =
+                            let uu____7482 =
                               p_noSeqTermAndComment false false next  in
-                            let uu____7452 = str ";"  in
-                            FStar_Pprint.op_Hat_Hat uu____7449 uu____7452  in
+                            let uu____7485 = str ";"  in
+                            FStar_Pprint.op_Hat_Hat uu____7482 uu____7485  in
                           FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline
-                            uu____7448
+                            uu____7481
                            in
                         FStar_Pprint.op_Hat_Hat FStar_Pprint.rbrace
-                          uu____7447
+                          uu____7480
                          in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____7446
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____7479
                        in
-                    FStar_Pprint.op_Hat_Hat uu____7442 uu____7445  in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____7441  in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu____7440  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____7439  in
-            FStar_Pprint.op_Hat_Hat uu____7435 uu____7438  in
-          FStar_Pprint.group uu____7434
+                    FStar_Pprint.op_Hat_Hat uu____7475 uu____7478  in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____7474  in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu____7473  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____7472  in
+            FStar_Pprint.op_Hat_Hat uu____7468 uu____7471  in
+          FStar_Pprint.group uu____7467
 
 and (p_attrs_opt :
   FStar_Parser_AST.term Prims.list FStar_Pervasives_Native.option ->
     FStar_Pprint.document)
   =
-  fun uu___11_7454  ->
-    match uu___11_7454 with
+  fun uu___11_7487  ->
+    match uu___11_7487 with
     | FStar_Pervasives_Native.None  -> FStar_Pprint.empty
     | FStar_Pervasives_Native.Some terms ->
-        let uu____7466 =
-          let uu____7467 = str "[@"  in
-          let uu____7469 =
-            let uu____7470 =
+        let uu____7499 =
+          let uu____7500 = str "[@"  in
+          let uu____7502 =
+            let uu____7503 =
               FStar_Pprint.separate_map break1 p_atomicTerm terms  in
-            let uu____7471 = str "]"  in
-            FStar_Pprint.op_Hat_Slash_Hat uu____7470 uu____7471  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____7467 uu____7469  in
-        FStar_Pprint.group uu____7466
+            let uu____7504 = str "]"  in
+            FStar_Pprint.op_Hat_Slash_Hat uu____7503 uu____7504  in
+          FStar_Pprint.op_Hat_Slash_Hat uu____7500 uu____7502  in
+        FStar_Pprint.group uu____7499
 
 and (p_typ :
   Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
@@ -2968,69 +2976,69 @@ and (p_typ' :
     fun pb  ->
       fun e  ->
         match e.FStar_Parser_AST.tm with
-        | FStar_Parser_AST.QForall (bs,(uu____7489,trigger),e1) ->
+        | FStar_Parser_AST.QForall (bs,(uu____7522,trigger),e1) ->
             let binders_doc = p_binders true bs  in
             let term_doc = p_noSeqTermAndComment ps pb e1  in
             (match trigger with
              | [] ->
-                 let uu____7523 =
-                   let uu____7524 =
-                     let uu____7525 = p_quantifier e  in
-                     FStar_Pprint.op_Hat_Hat uu____7525 FStar_Pprint.space
+                 let uu____7556 =
+                   let uu____7557 =
+                     let uu____7558 = p_quantifier e  in
+                     FStar_Pprint.op_Hat_Hat uu____7558 FStar_Pprint.space
                       in
                    FStar_Pprint.soft_surround (Prims.of_int (2))
-                     Prims.int_zero uu____7524 binders_doc FStar_Pprint.dot
+                     Prims.int_zero uu____7557 binders_doc FStar_Pprint.dot
                     in
-                 prefix2 uu____7523 term_doc
+                 prefix2 uu____7556 term_doc
              | pats ->
-                 let uu____7533 =
-                   let uu____7534 =
-                     let uu____7535 =
-                       let uu____7536 =
-                         let uu____7537 = p_quantifier e  in
-                         FStar_Pprint.op_Hat_Hat uu____7537
+                 let uu____7566 =
+                   let uu____7567 =
+                     let uu____7568 =
+                       let uu____7569 =
+                         let uu____7570 = p_quantifier e  in
+                         FStar_Pprint.op_Hat_Hat uu____7570
                            FStar_Pprint.space
                           in
                        FStar_Pprint.soft_surround (Prims.of_int (2))
-                         Prims.int_zero uu____7536 binders_doc
+                         Prims.int_zero uu____7569 binders_doc
                          FStar_Pprint.dot
                         in
-                     let uu____7540 = p_trigger trigger  in
-                     prefix2 uu____7535 uu____7540  in
-                   FStar_Pprint.group uu____7534  in
-                 prefix2 uu____7533 term_doc)
-        | FStar_Parser_AST.QExists (bs,(uu____7542,trigger),e1) ->
+                     let uu____7573 = p_trigger trigger  in
+                     prefix2 uu____7568 uu____7573  in
+                   FStar_Pprint.group uu____7567  in
+                 prefix2 uu____7566 term_doc)
+        | FStar_Parser_AST.QExists (bs,(uu____7575,trigger),e1) ->
             let binders_doc = p_binders true bs  in
             let term_doc = p_noSeqTermAndComment ps pb e1  in
             (match trigger with
              | [] ->
-                 let uu____7576 =
-                   let uu____7577 =
-                     let uu____7578 = p_quantifier e  in
-                     FStar_Pprint.op_Hat_Hat uu____7578 FStar_Pprint.space
+                 let uu____7609 =
+                   let uu____7610 =
+                     let uu____7611 = p_quantifier e  in
+                     FStar_Pprint.op_Hat_Hat uu____7611 FStar_Pprint.space
                       in
                    FStar_Pprint.soft_surround (Prims.of_int (2))
-                     Prims.int_zero uu____7577 binders_doc FStar_Pprint.dot
+                     Prims.int_zero uu____7610 binders_doc FStar_Pprint.dot
                     in
-                 prefix2 uu____7576 term_doc
+                 prefix2 uu____7609 term_doc
              | pats ->
-                 let uu____7586 =
-                   let uu____7587 =
-                     let uu____7588 =
-                       let uu____7589 =
-                         let uu____7590 = p_quantifier e  in
-                         FStar_Pprint.op_Hat_Hat uu____7590
+                 let uu____7619 =
+                   let uu____7620 =
+                     let uu____7621 =
+                       let uu____7622 =
+                         let uu____7623 = p_quantifier e  in
+                         FStar_Pprint.op_Hat_Hat uu____7623
                            FStar_Pprint.space
                           in
                        FStar_Pprint.soft_surround (Prims.of_int (2))
-                         Prims.int_zero uu____7589 binders_doc
+                         Prims.int_zero uu____7622 binders_doc
                          FStar_Pprint.dot
                         in
-                     let uu____7593 = p_trigger trigger  in
-                     prefix2 uu____7588 uu____7593  in
-                   FStar_Pprint.group uu____7587  in
-                 prefix2 uu____7586 term_doc)
-        | uu____7594 -> p_simpleTerm ps pb e
+                     let uu____7626 = p_trigger trigger  in
+                     prefix2 uu____7621 uu____7626  in
+                   FStar_Pprint.group uu____7620  in
+                 prefix2 uu____7619 term_doc)
+        | uu____7627 -> p_simpleTerm ps pb e
 
 and (p_typ_top :
   annotation_style ->
@@ -3057,24 +3065,24 @@ and (sig_as_binders_if_possible :
     fun extra_space  ->
       let s = if extra_space then FStar_Pprint.space else FStar_Pprint.empty
          in
-      let uu____7615 = all_binders_annot t  in
-      if uu____7615
+      let uu____7648 = all_binders_annot t  in
+      if uu____7648
       then
-        let uu____7618 =
+        let uu____7651 =
           p_typ_top (Binders ((Prims.of_int (4)), Prims.int_zero, true))
             false false t
            in
-        FStar_Pprint.op_Hat_Hat s uu____7618
+        FStar_Pprint.op_Hat_Hat s uu____7651
       else
-        (let uu____7629 =
-           let uu____7630 =
-             let uu____7631 =
+        (let uu____7662 =
+           let uu____7663 =
+             let uu____7664 =
                p_typ_top (Arrows ((Prims.of_int (2)), (Prims.of_int (2))))
                  false false t
                 in
-             FStar_Pprint.op_Hat_Hat s uu____7631  in
-           FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____7630  in
-         FStar_Pprint.group uu____7629)
+             FStar_Pprint.op_Hat_Hat s uu____7664  in
+           FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____7663  in
+         FStar_Pprint.group uu____7662)
 
 and (collapse_pats :
   (FStar_Pprint.document * FStar_Pprint.document) Prims.list ->
@@ -3082,36 +3090,36 @@ and (collapse_pats :
   =
   fun pats  ->
     let fold_fun bs x =
-      let uu____7690 = x  in
-      match uu____7690 with
+      let uu____7723 = x  in
+      match uu____7723 with
       | (b1,t1) ->
           (match bs with
            | [] -> [([b1], t1)]
            | hd::tl ->
-               let uu____7755 = hd  in
-               (match uu____7755 with
+               let uu____7788 = hd  in
+               (match uu____7788 with
                 | (b2s,t2) ->
                     if t1 = t2
                     then ((FStar_List.append b2s [b1]), t1) :: tl
                     else ([b1], t1) :: hd :: tl))
        in
     let p_collapsed_binder cb =
-      let uu____7827 = cb  in
-      match uu____7827 with
+      let uu____7860 = cb  in
+      match uu____7860 with
       | (bs,typ) ->
           (match bs with
            | [] -> failwith "Impossible"
            | b::[] -> cat_with_colon b typ
            | hd::tl ->
-               let uu____7846 =
+               let uu____7879 =
                  FStar_List.fold_left
                    (fun x  ->
                       fun y  ->
-                        let uu____7852 =
+                        let uu____7885 =
                           FStar_Pprint.op_Hat_Hat FStar_Pprint.space y  in
-                        FStar_Pprint.op_Hat_Hat x uu____7852) hd tl
+                        FStar_Pprint.op_Hat_Hat x uu____7885) hd tl
                   in
-               cat_with_colon uu____7846 typ)
+               cat_with_colon uu____7879 typ)
        in
     let binders = FStar_List.fold_left fold_fun [] (FStar_List.rev pats)  in
     map_rev p_collapsed_binder binders
@@ -3128,81 +3136,84 @@ and (pats_as_binders_if_possible :
           (match ((pat.FStar_Parser_AST.pat), (t.FStar_Parser_AST.tm)) with
            | (FStar_Parser_AST.PatVar (lid,aqual),FStar_Parser_AST.Refine
               ({ FStar_Parser_AST.b = FStar_Parser_AST.Annotated (lid',t1);
-                 FStar_Parser_AST.brange = uu____7931;
-                 FStar_Parser_AST.blevel = uu____7932;
-                 FStar_Parser_AST.aqual = uu____7933;_},phi))
-               when lid.FStar_Ident.idText = lid'.FStar_Ident.idText ->
-               let uu____7942 =
-                 let uu____7947 = p_ident lid  in
-                 p_refinement' aqual uu____7947 t1 phi  in
-               FStar_Pervasives_Native.Some uu____7942
-           | (FStar_Parser_AST.PatVar (lid,aqual),uu____7954) ->
-               let uu____7959 =
-                 let uu____7964 =
-                   let uu____7965 = FStar_Pprint.optional p_aqual aqual  in
-                   let uu____7966 = p_ident lid  in
-                   FStar_Pprint.op_Hat_Hat uu____7965 uu____7966  in
-                 let uu____7967 = p_tmEqNoRefinement t  in
-                 (uu____7964, uu____7967)  in
-               FStar_Pervasives_Native.Some uu____7959
-           | uu____7972 -> FStar_Pervasives_Native.None)
-      | uu____7981 -> FStar_Pervasives_Native.None  in
+                 FStar_Parser_AST.brange = uu____7964;
+                 FStar_Parser_AST.blevel = uu____7965;
+                 FStar_Parser_AST.aqual = uu____7966;_},phi))
+               when
+               let uu____7974 = FStar_Ident.text_of_id lid  in
+               let uu____7976 = FStar_Ident.text_of_id lid'  in
+               uu____7974 = uu____7976 ->
+               let uu____7979 =
+                 let uu____7984 = p_ident lid  in
+                 p_refinement' aqual uu____7984 t1 phi  in
+               FStar_Pervasives_Native.Some uu____7979
+           | (FStar_Parser_AST.PatVar (lid,aqual),uu____7991) ->
+               let uu____7996 =
+                 let uu____8001 =
+                   let uu____8002 = FStar_Pprint.optional p_aqual aqual  in
+                   let uu____8003 = p_ident lid  in
+                   FStar_Pprint.op_Hat_Hat uu____8002 uu____8003  in
+                 let uu____8004 = p_tmEqNoRefinement t  in
+                 (uu____8001, uu____8004)  in
+               FStar_Pervasives_Native.Some uu____7996
+           | uu____8009 -> FStar_Pervasives_Native.None)
+      | uu____8018 -> FStar_Pervasives_Native.None  in
     let all_unbound p =
       match p.FStar_Parser_AST.pat with
-      | FStar_Parser_AST.PatAscribed uu____7994 -> false
-      | uu____8006 -> true  in
-    let uu____8008 = map_if_all all_binders pats  in
-    match uu____8008 with
+      | FStar_Parser_AST.PatAscribed uu____8031 -> false
+      | uu____8043 -> true  in
+    let uu____8045 = map_if_all all_binders pats  in
+    match uu____8045 with
     | FStar_Pervasives_Native.Some bs ->
-        let uu____8040 = collapse_pats bs  in
-        (uu____8040, (Binders ((Prims.of_int (4)), Prims.int_zero, true)))
+        let uu____8077 = collapse_pats bs  in
+        (uu____8077, (Binders ((Prims.of_int (4)), Prims.int_zero, true)))
     | FStar_Pervasives_Native.None  ->
-        let uu____8057 = FStar_List.map p_atomicPattern pats  in
-        (uu____8057, (Binders ((Prims.of_int (4)), Prims.int_zero, false)))
+        let uu____8094 = FStar_List.map p_atomicPattern pats  in
+        (uu____8094, (Binders ((Prims.of_int (4)), Prims.int_zero, false)))
 
 and (p_quantifier : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.QForall uu____8069 -> str "forall"
-    | FStar_Parser_AST.QExists uu____8089 -> str "exists"
-    | uu____8109 ->
+    | FStar_Parser_AST.QForall uu____8106 -> str "forall"
+    | FStar_Parser_AST.QExists uu____8126 -> str "exists"
+    | uu____8146 ->
         failwith "Imposible : p_quantifier called on a non-quantifier term"
 
 and (p_trigger :
   FStar_Parser_AST.term Prims.list Prims.list -> FStar_Pprint.document) =
-  fun uu___12_8111  ->
-    match uu___12_8111 with
+  fun uu___12_8148  ->
+    match uu___12_8148 with
     | [] -> FStar_Pprint.empty
     | pats ->
-        let uu____8123 =
-          let uu____8124 =
-            let uu____8125 =
-              let uu____8126 = str "pattern"  in
-              let uu____8128 =
-                let uu____8129 =
-                  let uu____8130 = p_disjunctivePats pats  in
+        let uu____8160 =
+          let uu____8161 =
+            let uu____8162 =
+              let uu____8163 = str "pattern"  in
+              let uu____8165 =
+                let uu____8166 =
+                  let uu____8167 = p_disjunctivePats pats  in
                   FStar_Pprint.jump (Prims.of_int (2)) Prims.int_zero
-                    uu____8130
+                    uu____8167
                    in
-                FStar_Pprint.op_Hat_Hat uu____8129 FStar_Pprint.rbrace  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____8126 uu____8128  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____8125  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu____8124  in
-        FStar_Pprint.group uu____8123
+                FStar_Pprint.op_Hat_Hat uu____8166 FStar_Pprint.rbrace  in
+              FStar_Pprint.op_Hat_Slash_Hat uu____8163 uu____8165  in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____8162  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu____8161  in
+        FStar_Pprint.group uu____8160
 
 and (p_disjunctivePats :
   FStar_Parser_AST.term Prims.list Prims.list -> FStar_Pprint.document) =
   fun pats  ->
-    let uu____8138 = str "\\/"  in
-    FStar_Pprint.separate_map uu____8138 p_conjunctivePats pats
+    let uu____8175 = str "\\/"  in
+    FStar_Pprint.separate_map uu____8175 p_conjunctivePats pats
 
 and (p_conjunctivePats :
   FStar_Parser_AST.term Prims.list -> FStar_Pprint.document) =
   fun pats  ->
-    let uu____8145 =
-      let uu____8146 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1  in
-      FStar_Pprint.separate_map uu____8146 p_appTerm pats  in
-    FStar_Pprint.group uu____8145
+    let uu____8182 =
+      let uu____8183 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1  in
+      FStar_Pprint.separate_map uu____8183 p_appTerm pats  in
+    FStar_Pprint.group uu____8182
 
 and (p_simpleTerm :
   Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
@@ -3212,38 +3223,38 @@ and (p_simpleTerm :
       fun e  ->
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Abs (pats,e1) ->
-            let uu____8158 = p_term_sep false pb e1  in
-            (match uu____8158 with
+            let uu____8195 = p_term_sep false pb e1  in
+            (match uu____8195 with
              | (comm,doc) ->
                  let prefix =
-                   let uu____8167 = str "fun"  in
-                   let uu____8169 =
-                     let uu____8170 =
+                   let uu____8204 = str "fun"  in
+                   let uu____8206 =
+                     let uu____8207 =
                        FStar_Pprint.separate_map break1 p_atomicPattern pats
                         in
-                     FStar_Pprint.op_Hat_Slash_Hat uu____8170
+                     FStar_Pprint.op_Hat_Slash_Hat uu____8207
                        FStar_Pprint.rarrow
                       in
-                   op_Hat_Slash_Plus_Hat uu____8167 uu____8169  in
-                 let uu____8171 =
+                   op_Hat_Slash_Plus_Hat uu____8204 uu____8206  in
+                 let uu____8208 =
                    if comm <> FStar_Pprint.empty
                    then
-                     let uu____8173 =
-                       let uu____8174 =
-                         let uu____8175 =
+                     let uu____8210 =
+                       let uu____8211 =
+                         let uu____8212 =
                            FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline doc
                             in
-                         FStar_Pprint.op_Hat_Hat comm uu____8175  in
+                         FStar_Pprint.op_Hat_Hat comm uu____8212  in
                        FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline
-                         uu____8174
+                         uu____8211
                         in
-                     FStar_Pprint.op_Hat_Hat prefix uu____8173
+                     FStar_Pprint.op_Hat_Hat prefix uu____8210
                    else
-                     (let uu____8178 = op_Hat_Slash_Plus_Hat prefix doc  in
-                      FStar_Pprint.group uu____8178)
+                     (let uu____8215 = op_Hat_Slash_Plus_Hat prefix doc  in
+                      FStar_Pprint.group uu____8215)
                     in
-                 let uu____8179 = paren_if ps  in uu____8179 uu____8171)
-        | uu____8184 -> p_tmIff e
+                 let uu____8216 = paren_if ps  in uu____8216 uu____8208)
+        | uu____8221 -> p_tmIff e
 
 and (p_maybeFocusArrow : Prims.bool -> FStar_Pprint.document) =
   fun b  -> if b then str "~>" else FStar_Pprint.rarrow
@@ -3255,88 +3266,88 @@ and (p_patternBranch :
       FStar_Pprint.document)
   =
   fun pb  ->
-    fun uu____8192  ->
-      match uu____8192 with
+    fun uu____8229  ->
+      match uu____8229 with
       | (pat,when_opt,e) ->
           let one_pattern_branch p =
             let branch =
               match when_opt with
               | FStar_Pervasives_Native.None  ->
-                  let uu____8216 =
-                    let uu____8217 =
-                      let uu____8218 =
-                        let uu____8219 = p_tuplePattern p  in
-                        let uu____8220 =
+                  let uu____8253 =
+                    let uu____8254 =
+                      let uu____8255 =
+                        let uu____8256 = p_tuplePattern p  in
+                        let uu____8257 =
                           FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                             FStar_Pprint.rarrow
                            in
-                        FStar_Pprint.op_Hat_Hat uu____8219 uu____8220  in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____8218
+                        FStar_Pprint.op_Hat_Hat uu____8256 uu____8257  in
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____8255
                        in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____8217  in
-                  FStar_Pprint.group uu____8216
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____8254  in
+                  FStar_Pprint.group uu____8253
               | FStar_Pervasives_Native.Some f ->
-                  let uu____8222 =
-                    let uu____8223 =
-                      let uu____8224 =
-                        let uu____8225 =
-                          let uu____8226 =
-                            let uu____8227 = p_tuplePattern p  in
-                            let uu____8228 = str "when"  in
-                            FStar_Pprint.op_Hat_Slash_Hat uu____8227
-                              uu____8228
+                  let uu____8259 =
+                    let uu____8260 =
+                      let uu____8261 =
+                        let uu____8262 =
+                          let uu____8263 =
+                            let uu____8264 = p_tuplePattern p  in
+                            let uu____8265 = str "when"  in
+                            FStar_Pprint.op_Hat_Slash_Hat uu____8264
+                              uu____8265
                              in
-                          FStar_Pprint.group uu____8226  in
-                        let uu____8230 =
-                          let uu____8231 =
-                            let uu____8234 = p_tmFormula f  in
-                            [uu____8234; FStar_Pprint.rarrow]  in
-                          FStar_Pprint.flow break1 uu____8231  in
-                        FStar_Pprint.op_Hat_Slash_Hat uu____8225 uu____8230
+                          FStar_Pprint.group uu____8263  in
+                        let uu____8267 =
+                          let uu____8268 =
+                            let uu____8271 = p_tmFormula f  in
+                            [uu____8271; FStar_Pprint.rarrow]  in
+                          FStar_Pprint.flow break1 uu____8268  in
+                        FStar_Pprint.op_Hat_Slash_Hat uu____8262 uu____8267
                          in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____8224
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____8261
                        in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____8223  in
-                  FStar_Pprint.hang (Prims.of_int (2)) uu____8222
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____8260  in
+                  FStar_Pprint.hang (Prims.of_int (2)) uu____8259
                in
-            let uu____8236 = p_term_sep false pb e  in
-            match uu____8236 with
+            let uu____8273 = p_term_sep false pb e  in
+            match uu____8273 with
             | (comm,doc) ->
                 if pb
                 then
                   (if comm = FStar_Pprint.empty
                    then
-                     let uu____8246 = op_Hat_Slash_Plus_Hat branch doc  in
-                     FStar_Pprint.group uu____8246
+                     let uu____8283 = op_Hat_Slash_Plus_Hat branch doc  in
+                     FStar_Pprint.group uu____8283
                    else
-                     (let uu____8249 =
-                        let uu____8250 =
-                          let uu____8251 =
-                            let uu____8252 =
-                              let uu____8253 =
+                     (let uu____8286 =
+                        let uu____8287 =
+                          let uu____8288 =
+                            let uu____8289 =
+                              let uu____8290 =
                                 FStar_Pprint.op_Hat_Hat break1 comm  in
-                              FStar_Pprint.op_Hat_Hat doc uu____8253  in
-                            op_Hat_Slash_Plus_Hat branch uu____8252  in
-                          FStar_Pprint.group uu____8251  in
-                        let uu____8254 =
-                          let uu____8255 =
-                            let uu____8256 =
+                              FStar_Pprint.op_Hat_Hat doc uu____8290  in
+                            op_Hat_Slash_Plus_Hat branch uu____8289  in
+                          FStar_Pprint.group uu____8288  in
+                        let uu____8291 =
+                          let uu____8292 =
+                            let uu____8293 =
                               inline_comment_or_above comm doc
                                 FStar_Pprint.empty
                                in
-                            jump2 uu____8256  in
-                          FStar_Pprint.op_Hat_Hat branch uu____8255  in
-                        FStar_Pprint.ifflat uu____8250 uu____8254  in
-                      FStar_Pprint.group uu____8249))
+                            jump2 uu____8293  in
+                          FStar_Pprint.op_Hat_Hat branch uu____8292  in
+                        FStar_Pprint.ifflat uu____8287 uu____8291  in
+                      FStar_Pprint.group uu____8286))
                 else
                   if comm <> FStar_Pprint.empty
                   then
-                    (let uu____8260 =
-                       let uu____8261 =
+                    (let uu____8297 =
+                       let uu____8298 =
                          FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline doc
                           in
-                       FStar_Pprint.op_Hat_Hat comm uu____8261  in
-                     op_Hat_Slash_Plus_Hat branch uu____8260)
+                       FStar_Pprint.op_Hat_Hat comm uu____8298  in
+                     op_Hat_Slash_Plus_Hat branch uu____8297)
                   else op_Hat_Slash_Plus_Hat branch doc
              in
           (match pat.FStar_Parser_AST.pat with
@@ -3344,56 +3355,54 @@ and (p_patternBranch :
                (match FStar_List.rev pats with
                 | hd::tl ->
                     let last_pat_branch = one_pattern_branch hd  in
-                    let uu____8272 =
-                      let uu____8273 =
-                        let uu____8274 =
-                          let uu____8275 =
-                            let uu____8276 =
-                              let uu____8277 =
+                    let uu____8309 =
+                      let uu____8310 =
+                        let uu____8311 =
+                          let uu____8312 =
+                            let uu____8313 =
+                              let uu____8314 =
                                 FStar_Pprint.op_Hat_Hat FStar_Pprint.bar
                                   FStar_Pprint.space
                                  in
-                              FStar_Pprint.op_Hat_Hat break1 uu____8277  in
-                            FStar_Pprint.separate_map uu____8276
+                              FStar_Pprint.op_Hat_Hat break1 uu____8314  in
+                            FStar_Pprint.separate_map uu____8313
                               p_tuplePattern (FStar_List.rev tl)
                              in
-                          FStar_Pprint.op_Hat_Slash_Hat uu____8275
+                          FStar_Pprint.op_Hat_Slash_Hat uu____8312
                             last_pat_branch
                            in
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____8274
+                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____8311
                          in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____8273  in
-                    FStar_Pprint.group uu____8272
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____8310  in
+                    FStar_Pprint.group uu____8309
                 | [] ->
                     failwith "Impossible: disjunctive pattern can't be empty")
-           | uu____8279 -> one_pattern_branch pat)
+           | uu____8316 -> one_pattern_branch pat)
 
 and (p_tmIff : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Op
-        ({ FStar_Ident.idText = "<==>"; FStar_Ident.idRange = uu____8281;_},e1::e2::[])
-        ->
-        let uu____8287 = str "<==>"  in
-        let uu____8289 = p_tmImplies e1  in
-        let uu____8290 = p_tmIff e2  in
-        infix0 uu____8287 uu____8289 uu____8290
-    | uu____8291 -> p_tmImplies e
+    | FStar_Parser_AST.Op (id,e1::e2::[]) when
+        let uu____8323 = FStar_Ident.text_of_id id  in uu____8323 = "<==>" ->
+        let uu____8327 = str "<==>"  in
+        let uu____8329 = p_tmImplies e1  in
+        let uu____8330 = p_tmIff e2  in
+        infix0 uu____8327 uu____8329 uu____8330
+    | uu____8331 -> p_tmImplies e
 
 and (p_tmImplies : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Op
-        ({ FStar_Ident.idText = "==>"; FStar_Ident.idRange = uu____8293;_},e1::e2::[])
-        ->
-        let uu____8299 = str "==>"  in
-        let uu____8301 =
+    | FStar_Parser_AST.Op (id,e1::e2::[]) when
+        let uu____8338 = FStar_Ident.text_of_id id  in uu____8338 = "==>" ->
+        let uu____8342 = str "==>"  in
+        let uu____8344 =
           p_tmArrow (Arrows ((Prims.of_int (2)), (Prims.of_int (2)))) false
             p_tmFormula e1
            in
-        let uu____8307 = p_tmImplies e2  in
-        infix0 uu____8299 uu____8301 uu____8307
-    | uu____8308 ->
+        let uu____8350 = p_tmImplies e2  in
+        infix0 uu____8342 uu____8344 uu____8350
+    | uu____8351 ->
         p_tmArrow (Arrows ((Prims.of_int (2)), (Prims.of_int (2)))) false
           p_tmFormula e
 
@@ -3406,38 +3415,38 @@ and (format_sig :
     fun terms  ->
       fun no_last_op  ->
         fun flat_space  ->
-          let uu____8322 =
+          let uu____8365 =
             FStar_List.splitAt ((FStar_List.length terms) - Prims.int_one)
               terms
              in
-          match uu____8322 with
+          match uu____8365 with
           | (terms',last) ->
-              let uu____8342 =
+              let uu____8385 =
                 match style with
                 | Arrows (n,ln) ->
-                    let uu____8377 =
-                      let uu____8378 =
+                    let uu____8420 =
+                      let uu____8421 =
                         FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow break1
                          in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____8378
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____8421
                        in
-                    let uu____8379 =
+                    let uu____8422 =
                       FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow
                         FStar_Pprint.space
                        in
-                    (n, ln, terms', uu____8377, uu____8379)
+                    (n, ln, terms', uu____8420, uu____8422)
                 | Binders (n,ln,parens) ->
-                    let uu____8393 =
+                    let uu____8436 =
                       if parens
                       then FStar_List.map soft_parens_with_nesting terms'
                       else terms'  in
-                    let uu____8401 =
+                    let uu____8444 =
                       FStar_Pprint.op_Hat_Hat FStar_Pprint.colon
                         FStar_Pprint.space
                        in
-                    (n, ln, uu____8393, break1, uu____8401)
+                    (n, ln, uu____8436, break1, uu____8444)
                  in
-              (match uu____8342 with
+              (match uu____8385 with
                | (n,last_n,terms'1,sep,last_op) ->
                    let last1 = FStar_List.hd last  in
                    let last_op1 =
@@ -3459,67 +3468,67 @@ and (format_sig :
                      then FStar_Pprint.space
                      else FStar_Pprint.empty  in
                    (match FStar_List.length terms with
-                    | uu____8434 when uu____8434 = Prims.int_one ->
+                    | uu____8477 when uu____8477 = Prims.int_one ->
                         FStar_List.hd terms
-                    | uu____8435 ->
-                        let uu____8436 =
-                          let uu____8437 =
-                            let uu____8438 =
-                              let uu____8439 =
+                    | uu____8478 ->
+                        let uu____8479 =
+                          let uu____8480 =
+                            let uu____8481 =
+                              let uu____8482 =
                                 FStar_Pprint.separate sep terms'1  in
-                              let uu____8440 =
-                                let uu____8441 =
+                              let uu____8483 =
+                                let uu____8484 =
                                   FStar_Pprint.op_Hat_Hat last_op1 last1  in
                                 FStar_Pprint.op_Hat_Hat one_line_space
-                                  uu____8441
+                                  uu____8484
                                  in
-                              FStar_Pprint.op_Hat_Hat uu____8439 uu____8440
+                              FStar_Pprint.op_Hat_Hat uu____8482 uu____8483
                                in
-                            FStar_Pprint.op_Hat_Hat fs uu____8438  in
-                          let uu____8442 =
-                            let uu____8443 =
-                              let uu____8444 =
-                                let uu____8445 =
-                                  let uu____8446 =
+                            FStar_Pprint.op_Hat_Hat fs uu____8481  in
+                          let uu____8485 =
+                            let uu____8486 =
+                              let uu____8487 =
+                                let uu____8488 =
+                                  let uu____8489 =
                                     FStar_Pprint.separate sep terms'1  in
-                                  FStar_Pprint.op_Hat_Hat fs uu____8446  in
-                                let uu____8447 =
-                                  let uu____8448 =
-                                    let uu____8449 =
-                                      let uu____8450 =
+                                  FStar_Pprint.op_Hat_Hat fs uu____8489  in
+                                let uu____8490 =
+                                  let uu____8491 =
+                                    let uu____8492 =
+                                      let uu____8493 =
                                         FStar_Pprint.op_Hat_Hat sep
                                           single_line_arg_indent
                                          in
-                                      let uu____8451 =
+                                      let uu____8494 =
                                         FStar_List.map
                                           (fun x  ->
-                                             let uu____8457 =
+                                             let uu____8500 =
                                                FStar_Pprint.hang
                                                  (Prims.of_int (2)) x
                                                 in
-                                             FStar_Pprint.align uu____8457)
+                                             FStar_Pprint.align uu____8500)
                                           terms'1
                                          in
-                                      FStar_Pprint.separate uu____8450
-                                        uu____8451
+                                      FStar_Pprint.separate uu____8493
+                                        uu____8494
                                        in
                                     FStar_Pprint.op_Hat_Hat
-                                      single_line_arg_indent uu____8449
+                                      single_line_arg_indent uu____8492
                                      in
-                                  jump2 uu____8448  in
-                                FStar_Pprint.ifflat uu____8445 uu____8447  in
-                              FStar_Pprint.group uu____8444  in
-                            let uu____8459 =
-                              let uu____8460 =
-                                let uu____8461 =
+                                  jump2 uu____8491  in
+                                FStar_Pprint.ifflat uu____8488 uu____8490  in
+                              FStar_Pprint.group uu____8487  in
+                            let uu____8502 =
+                              let uu____8503 =
+                                let uu____8504 =
                                   FStar_Pprint.op_Hat_Hat last_op1 last1  in
-                                FStar_Pprint.hang last_n uu____8461  in
-                              FStar_Pprint.align uu____8460  in
-                            FStar_Pprint.prefix n Prims.int_one uu____8443
-                              uu____8459
+                                FStar_Pprint.hang last_n uu____8504  in
+                              FStar_Pprint.align uu____8503  in
+                            FStar_Pprint.prefix n Prims.int_one uu____8486
+                              uu____8502
                              in
-                          FStar_Pprint.ifflat uu____8437 uu____8442  in
-                        FStar_Pprint.group uu____8436))
+                          FStar_Pprint.ifflat uu____8480 uu____8485  in
+                        FStar_Pprint.group uu____8479))
 
 and (p_tmArrow :
   annotation_style ->
@@ -3533,8 +3542,8 @@ and (p_tmArrow :
         fun e  ->
           let terms =
             match style with
-            | Arrows uu____8475 -> p_tmArrow' p_Tm e
-            | Binders uu____8482 -> collapse_binders p_Tm e  in
+            | Arrows uu____8518 -> p_tmArrow' p_Tm e
+            | Binders uu____8525 -> collapse_binders p_Tm e  in
           format_sig style terms false flat_space
 
 and (p_tmArrow' :
@@ -3545,10 +3554,10 @@ and (p_tmArrow' :
     fun e  ->
       match e.FStar_Parser_AST.tm with
       | FStar_Parser_AST.Product (bs,tgt) ->
-          let uu____8505 = FStar_List.map (fun b  -> p_binder false b) bs  in
-          let uu____8511 = p_tmArrow' p_Tm tgt  in
-          FStar_List.append uu____8505 uu____8511
-      | uu____8514 -> let uu____8515 = p_Tm e  in [uu____8515]
+          let uu____8548 = FStar_List.map (fun b  -> p_binder false b) bs  in
+          let uu____8554 = p_tmArrow' p_Tm tgt  in
+          FStar_List.append uu____8548 uu____8554
+      | uu____8557 -> let uu____8558 = p_Tm e  in [uu____8558]
 
 and (collapse_binders :
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
@@ -3559,76 +3568,76 @@ and (collapse_binders :
       let rec accumulate_binders p_Tm1 e1 =
         match e1.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Product (bs,tgt) ->
-            let uu____8568 = FStar_List.map (fun b  -> p_binder' false b) bs
+            let uu____8611 = FStar_List.map (fun b  -> p_binder' false b) bs
                in
-            let uu____8594 = accumulate_binders p_Tm1 tgt  in
-            FStar_List.append uu____8568 uu____8594
-        | uu____8617 ->
-            let uu____8618 =
-              let uu____8629 = p_Tm1 e1  in
-              (uu____8629, FStar_Pervasives_Native.None, cat_with_colon)  in
-            [uu____8618]
+            let uu____8637 = accumulate_binders p_Tm1 tgt  in
+            FStar_List.append uu____8611 uu____8637
+        | uu____8660 ->
+            let uu____8661 =
+              let uu____8672 = p_Tm1 e1  in
+              (uu____8672, FStar_Pervasives_Native.None, cat_with_colon)  in
+            [uu____8661]
          in
       let fold_fun bs x =
-        let uu____8727 = x  in
-        match uu____8727 with
+        let uu____8770 = x  in
+        match uu____8770 with
         | (b1,t1,f1) ->
             (match bs with
              | [] -> [([b1], t1, f1)]
              | hd::tl ->
-                 let uu____8859 = hd  in
-                 (match uu____8859 with
-                  | (b2s,t2,uu____8888) ->
+                 let uu____8902 = hd  in
+                 (match uu____8902 with
+                  | (b2s,t2,uu____8931) ->
                       (match (t1, t2) with
                        | (FStar_Pervasives_Native.Some
                           typ1,FStar_Pervasives_Native.Some typ2) ->
                            if typ1 = typ2
                            then ((FStar_List.append b2s [b1]), t1, f1) :: tl
                            else ([b1], t1, f1) :: hd :: tl
-                       | uu____8990 -> ([b1], t1, f1) :: bs)))
+                       | uu____9033 -> ([b1], t1, f1) :: bs)))
          in
       let p_collapsed_binder cb =
-        let uu____9047 = cb  in
-        match uu____9047 with
+        let uu____9090 = cb  in
+        match uu____9090 with
         | (bs,t,f) ->
             (match t with
              | FStar_Pervasives_Native.None  ->
                  (match bs with
                   | b::[] -> b
-                  | uu____9076 -> failwith "Impossible")
+                  | uu____9119 -> failwith "Impossible")
              | FStar_Pervasives_Native.Some typ ->
                  (match bs with
                   | [] -> failwith "Impossible"
                   | b::[] -> f b typ
                   | hd::tl ->
-                      let uu____9087 =
+                      let uu____9130 =
                         FStar_List.fold_left
                           (fun x  ->
                              fun y  ->
-                               let uu____9093 =
+                               let uu____9136 =
                                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space y
                                   in
-                               FStar_Pprint.op_Hat_Hat x uu____9093) hd tl
+                               FStar_Pprint.op_Hat_Hat x uu____9136) hd tl
                          in
-                      f uu____9087 typ))
+                      f uu____9130 typ))
          in
       let binders =
-        let uu____9109 = accumulate_binders p_Tm e  in
-        FStar_List.fold_left fold_fun [] uu____9109  in
+        let uu____9152 = accumulate_binders p_Tm e  in
+        FStar_List.fold_left fold_fun [] uu____9152  in
       map_rev p_collapsed_binder binders
 
 and (p_tmFormula : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  ->
     let conj =
-      let uu____9172 =
-        let uu____9173 = str "/\\"  in
-        FStar_Pprint.op_Hat_Hat uu____9173 break1  in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____9172  in
+      let uu____9215 =
+        let uu____9216 = str "/\\"  in
+        FStar_Pprint.op_Hat_Hat uu____9216 break1  in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____9215  in
     let disj =
-      let uu____9176 =
-        let uu____9177 = str "\\/"  in
-        FStar_Pprint.op_Hat_Hat uu____9177 break1  in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____9176  in
+      let uu____9219 =
+        let uu____9220 = str "\\/"  in
+        FStar_Pprint.op_Hat_Hat uu____9220 break1  in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____9219  in
     let formula = p_tmDisjunction e  in
     FStar_Pprint.flow_map disj
       (fun d  ->
@@ -3639,26 +3648,24 @@ and (p_tmDisjunction :
   FStar_Parser_AST.term -> FStar_Pprint.document Prims.list Prims.list) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Op
-        ({ FStar_Ident.idText = "\\/"; FStar_Ident.idRange = uu____9197;_},e1::e2::[])
-        ->
-        let uu____9203 = p_tmDisjunction e1  in
-        let uu____9208 = let uu____9213 = p_tmConjunction e2  in [uu____9213]
+    | FStar_Parser_AST.Op (id,e1::e2::[]) when
+        let uu____9245 = FStar_Ident.text_of_id id  in uu____9245 = "\\/" ->
+        let uu____9249 = p_tmDisjunction e1  in
+        let uu____9254 = let uu____9259 = p_tmConjunction e2  in [uu____9259]
            in
-        FStar_List.append uu____9203 uu____9208
-    | uu____9222 -> let uu____9223 = p_tmConjunction e  in [uu____9223]
+        FStar_List.append uu____9249 uu____9254
+    | uu____9268 -> let uu____9269 = p_tmConjunction e  in [uu____9269]
 
 and (p_tmConjunction :
   FStar_Parser_AST.term -> FStar_Pprint.document Prims.list) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Op
-        ({ FStar_Ident.idText = "/\\"; FStar_Ident.idRange = uu____9233;_},e1::e2::[])
-        ->
-        let uu____9239 = p_tmConjunction e1  in
-        let uu____9242 = let uu____9245 = p_tmTuple e2  in [uu____9245]  in
-        FStar_List.append uu____9239 uu____9242
-    | uu____9246 -> let uu____9247 = p_tmTuple e  in [uu____9247]
+    | FStar_Parser_AST.Op (id,e1::e2::[]) when
+        let uu____9284 = FStar_Ident.text_of_id id  in uu____9284 = "/\\" ->
+        let uu____9288 = p_tmConjunction e1  in
+        let uu____9291 = let uu____9294 = p_tmTuple e2  in [uu____9294]  in
+        FStar_List.append uu____9288 uu____9291
+    | uu____9295 -> let uu____9296 = p_tmTuple e  in [uu____9296]
 
 and (p_tmTuple : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  -> with_comment p_tmTuple' e e.FStar_Parser_AST.range
@@ -3668,12 +3675,12 @@ and (p_tmTuple' : FStar_Parser_AST.term -> FStar_Pprint.document) =
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Construct (lid,args) when
         (is_tuple_constructor lid) && (all1_explicit args) ->
-        let uu____9264 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
+        let uu____9313 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
            in
-        FStar_Pprint.separate_map uu____9264
-          (fun uu____9272  ->
-             match uu____9272 with | (e1,uu____9278) -> p_tmEq e1) args
-    | uu____9279 -> p_tmEq e
+        FStar_Pprint.separate_map uu____9313
+          (fun uu____9321  ->
+             match uu____9321 with | (e1,uu____9327) -> p_tmEq e1) args
+    | uu____9328 -> p_tmEq e
 
 and (paren_if_gt :
   Prims.int -> Prims.int -> FStar_Pprint.document -> FStar_Pprint.document) =
@@ -3683,11 +3690,11 @@ and (paren_if_gt :
         if mine <= curr
         then doc
         else
-          (let uu____9288 =
-             let uu____9289 = FStar_Pprint.op_Hat_Hat doc FStar_Pprint.rparen
+          (let uu____9337 =
+             let uu____9338 = FStar_Pprint.op_Hat_Hat doc FStar_Pprint.rparen
                 in
-             FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____9289  in
-           FStar_Pprint.group uu____9288)
+             FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____9338  in
+           FStar_Pprint.group uu____9337)
 
 and (p_tmEqWith :
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
@@ -3711,45 +3718,45 @@ and (p_tmEqWith' :
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Op (op,e1::e2::[]) when
             ((is_operatorInfix0ad12 op) ||
-               (let uu____9308 = FStar_Ident.text_of_id op  in
-                uu____9308 = "="))
+               (let uu____9357 = FStar_Ident.text_of_id op  in
+                uu____9357 = "="))
               ||
-              (let uu____9313 = FStar_Ident.text_of_id op  in
-               uu____9313 = "|>")
+              (let uu____9362 = FStar_Ident.text_of_id op  in
+               uu____9362 = "|>")
             ->
             let op1 = FStar_Ident.text_of_id op  in
-            let uu____9319 = levels op1  in
-            (match uu____9319 with
+            let uu____9368 = levels op1  in
+            (match uu____9368 with
              | (left,mine,right) ->
-                 let uu____9338 =
-                   let uu____9339 = FStar_All.pipe_left str op1  in
-                   let uu____9341 = p_tmEqWith' p_X left e1  in
-                   let uu____9342 = p_tmEqWith' p_X right e2  in
-                   infix0 uu____9339 uu____9341 uu____9342  in
-                 paren_if_gt curr mine uu____9338)
-        | FStar_Parser_AST.Op
-            ({ FStar_Ident.idText = ":="; FStar_Ident.idRange = uu____9343;_},e1::e2::[])
+                 let uu____9387 =
+                   let uu____9388 = FStar_All.pipe_left str op1  in
+                   let uu____9390 = p_tmEqWith' p_X left e1  in
+                   let uu____9391 = p_tmEqWith' p_X right e2  in
+                   infix0 uu____9388 uu____9390 uu____9391  in
+                 paren_if_gt curr mine uu____9387)
+        | FStar_Parser_AST.Op (id,e1::e2::[]) when
+            let uu____9397 = FStar_Ident.text_of_id id  in uu____9397 = ":="
             ->
-            let uu____9349 =
-              let uu____9350 = p_tmEqWith p_X e1  in
-              let uu____9351 =
-                let uu____9352 =
-                  let uu____9353 =
-                    let uu____9354 = p_tmEqWith p_X e2  in
-                    op_Hat_Slash_Plus_Hat FStar_Pprint.equals uu____9354  in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____9353  in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____9352  in
-              FStar_Pprint.op_Hat_Hat uu____9350 uu____9351  in
-            FStar_Pprint.group uu____9349
-        | FStar_Parser_AST.Op
-            ({ FStar_Ident.idText = "-"; FStar_Ident.idRange = uu____9355;_},e1::[])
+            let uu____9401 =
+              let uu____9402 = p_tmEqWith p_X e1  in
+              let uu____9403 =
+                let uu____9404 =
+                  let uu____9405 =
+                    let uu____9406 = p_tmEqWith p_X e2  in
+                    op_Hat_Slash_Plus_Hat FStar_Pprint.equals uu____9406  in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____9405  in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____9404  in
+              FStar_Pprint.op_Hat_Hat uu____9402 uu____9403  in
+            FStar_Pprint.group uu____9401
+        | FStar_Parser_AST.Op (id,e1::[]) when
+            let uu____9411 = FStar_Ident.text_of_id id  in uu____9411 = "-"
             ->
-            let uu____9360 = levels "-"  in
-            (match uu____9360 with
+            let uu____9415 = levels "-"  in
+            (match uu____9415 with
              | (left,mine,right) ->
-                 let uu____9380 = p_tmEqWith' p_X mine e1  in
-                 FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.minus uu____9380)
-        | uu____9381 -> p_tmNoEqWith p_X e
+                 let uu____9435 = p_tmEqWith' p_X mine e1  in
+                 FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.minus uu____9435)
+        | uu____9436 -> p_tmNoEqWith p_X e
 
 and (p_tmNoEqWith :
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
@@ -3771,125 +3778,123 @@ and (p_tmNoEqWith' :
         fun e  ->
           match e.FStar_Parser_AST.tm with
           | FStar_Parser_AST.Construct
-              (lid,(e1,uu____9429)::(e2,uu____9431)::[]) when
+              (lid,(e1,uu____9484)::(e2,uu____9486)::[]) when
               (FStar_Ident.lid_equals lid FStar_Parser_Const.cons_lid) &&
-                (let uu____9451 = is_list e  in Prims.op_Negation uu____9451)
+                (let uu____9506 = is_list e  in Prims.op_Negation uu____9506)
               ->
               let op = "::"  in
-              let uu____9456 = levels op  in
-              (match uu____9456 with
+              let uu____9511 = levels op  in
+              (match uu____9511 with
                | (left,mine,right) ->
-                   let uu____9475 =
-                     let uu____9476 = str op  in
-                     let uu____9477 = p_tmNoEqWith' false p_X left e1  in
-                     let uu____9479 = p_tmNoEqWith' false p_X right e2  in
-                     infix0 uu____9476 uu____9477 uu____9479  in
-                   paren_if_gt curr mine uu____9475)
+                   let uu____9530 =
+                     let uu____9531 = str op  in
+                     let uu____9532 = p_tmNoEqWith' false p_X left e1  in
+                     let uu____9534 = p_tmNoEqWith' false p_X right e2  in
+                     infix0 uu____9531 uu____9532 uu____9534  in
+                   paren_if_gt curr mine uu____9530)
           | FStar_Parser_AST.Sum (binders,res) ->
               let op = "&"  in
-              let uu____9498 = levels op  in
-              (match uu____9498 with
+              let uu____9553 = levels op  in
+              (match uu____9553 with
                | (left,mine,right) ->
                    let p_dsumfst bt =
                      match bt with
                      | FStar_Util.Inl b ->
-                         let uu____9532 = p_binder false b  in
-                         let uu____9534 =
-                           let uu____9535 =
-                             let uu____9536 = str op  in
-                             FStar_Pprint.op_Hat_Hat uu____9536 break1  in
+                         let uu____9587 = p_binder false b  in
+                         let uu____9589 =
+                           let uu____9590 =
+                             let uu____9591 = str op  in
+                             FStar_Pprint.op_Hat_Hat uu____9591 break1  in
                            FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                             uu____9535
+                             uu____9590
                             in
-                         FStar_Pprint.op_Hat_Hat uu____9532 uu____9534
+                         FStar_Pprint.op_Hat_Hat uu____9587 uu____9589
                      | FStar_Util.Inr t ->
-                         let uu____9538 = p_tmNoEqWith' false p_X left t  in
-                         let uu____9540 =
-                           let uu____9541 =
-                             let uu____9542 = str op  in
-                             FStar_Pprint.op_Hat_Hat uu____9542 break1  in
+                         let uu____9593 = p_tmNoEqWith' false p_X left t  in
+                         let uu____9595 =
+                           let uu____9596 =
+                             let uu____9597 = str op  in
+                             FStar_Pprint.op_Hat_Hat uu____9597 break1  in
                            FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                             uu____9541
+                             uu____9596
                             in
-                         FStar_Pprint.op_Hat_Hat uu____9538 uu____9540
+                         FStar_Pprint.op_Hat_Hat uu____9593 uu____9595
                       in
-                   let uu____9543 =
-                     let uu____9544 =
+                   let uu____9598 =
+                     let uu____9599 =
                        FStar_Pprint.concat_map p_dsumfst binders  in
-                     let uu____9549 = p_tmNoEqWith' false p_X right res  in
-                     FStar_Pprint.op_Hat_Hat uu____9544 uu____9549  in
-                   paren_if_gt curr mine uu____9543)
-          | FStar_Parser_AST.Op
-              ({ FStar_Ident.idText = "*";
-                 FStar_Ident.idRange = uu____9551;_},e1::e2::[])
-              when FStar_ST.op_Bang unfold_tuples ->
+                     let uu____9604 = p_tmNoEqWith' false p_X right res  in
+                     FStar_Pprint.op_Hat_Hat uu____9599 uu____9604  in
+                   paren_if_gt curr mine uu____9598)
+          | FStar_Parser_AST.Op (id,e1::e2::[]) when
+              (let uu____9613 = FStar_Ident.text_of_id id  in
+               uu____9613 = "*") && (FStar_ST.op_Bang unfold_tuples)
+              ->
               let op = "*"  in
-              let uu____9581 = levels op  in
-              (match uu____9581 with
+              let uu____9641 = levels op  in
+              (match uu____9641 with
                | (left,mine,right) ->
                    if inside_tuple
                    then
-                     let uu____9601 = str op  in
-                     let uu____9602 = p_tmNoEqWith' true p_X left e1  in
-                     let uu____9604 = p_tmNoEqWith' true p_X right e2  in
-                     infix0 uu____9601 uu____9602 uu____9604
+                     let uu____9661 = str op  in
+                     let uu____9662 = p_tmNoEqWith' true p_X left e1  in
+                     let uu____9664 = p_tmNoEqWith' true p_X right e2  in
+                     infix0 uu____9661 uu____9662 uu____9664
                    else
-                     (let uu____9608 =
-                        let uu____9609 = str op  in
-                        let uu____9610 = p_tmNoEqWith' true p_X left e1  in
-                        let uu____9612 = p_tmNoEqWith' true p_X right e2  in
-                        infix0 uu____9609 uu____9610 uu____9612  in
-                      paren_if_gt curr mine uu____9608))
+                     (let uu____9668 =
+                        let uu____9669 = str op  in
+                        let uu____9670 = p_tmNoEqWith' true p_X left e1  in
+                        let uu____9672 = p_tmNoEqWith' true p_X right e2  in
+                        infix0 uu____9669 uu____9670 uu____9672  in
+                      paren_if_gt curr mine uu____9668))
           | FStar_Parser_AST.Op (op,e1::e2::[]) when is_operatorInfix34 op ->
               let op1 = FStar_Ident.text_of_id op  in
-              let uu____9621 = levels op1  in
-              (match uu____9621 with
+              let uu____9681 = levels op1  in
+              (match uu____9681 with
                | (left,mine,right) ->
-                   let uu____9640 =
-                     let uu____9641 = str op1  in
-                     let uu____9642 = p_tmNoEqWith' false p_X left e1  in
-                     let uu____9644 = p_tmNoEqWith' false p_X right e2  in
-                     infix0 uu____9641 uu____9642 uu____9644  in
-                   paren_if_gt curr mine uu____9640)
+                   let uu____9700 =
+                     let uu____9701 = str op1  in
+                     let uu____9702 = p_tmNoEqWith' false p_X left e1  in
+                     let uu____9704 = p_tmNoEqWith' false p_X right e2  in
+                     infix0 uu____9701 uu____9702 uu____9704  in
+                   paren_if_gt curr mine uu____9700)
           | FStar_Parser_AST.Record (with_opt,record_fields) ->
-              let uu____9664 =
-                let uu____9665 =
+              let uu____9724 =
+                let uu____9725 =
                   default_or_map FStar_Pprint.empty p_with_clause with_opt
                    in
-                let uu____9666 =
-                  let uu____9667 =
+                let uu____9726 =
+                  let uu____9727 =
                     FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1  in
-                  separate_map_last uu____9667 p_simpleDef record_fields  in
-                FStar_Pprint.op_Hat_Hat uu____9665 uu____9666  in
-              braces_with_nesting uu____9664
-          | FStar_Parser_AST.Op
-              ({ FStar_Ident.idText = "~";
-                 FStar_Ident.idRange = uu____9672;_},e1::[])
+                  separate_map_last uu____9727 p_simpleDef record_fields  in
+                FStar_Pprint.op_Hat_Hat uu____9725 uu____9726  in
+              braces_with_nesting uu____9724
+          | FStar_Parser_AST.Op (id,e1::[]) when
+              let uu____9736 = FStar_Ident.text_of_id id  in uu____9736 = "~"
               ->
-              let uu____9677 =
-                let uu____9678 = str "~"  in
-                let uu____9680 = p_atomicTerm e1  in
-                FStar_Pprint.op_Hat_Hat uu____9678 uu____9680  in
-              FStar_Pprint.group uu____9677
+              let uu____9740 =
+                let uu____9741 = str "~"  in
+                let uu____9743 = p_atomicTerm e1  in
+                FStar_Pprint.op_Hat_Hat uu____9741 uu____9743  in
+              FStar_Pprint.group uu____9740
           | FStar_Parser_AST.Paren p when inside_tuple ->
               (match p.FStar_Parser_AST.tm with
-               | FStar_Parser_AST.Op
-                   ({ FStar_Ident.idText = "*";
-                      FStar_Ident.idRange = uu____9682;_},e1::e2::[])
-                   ->
+               | FStar_Parser_AST.Op (id,e1::e2::[]) when
+                   let uu____9750 = FStar_Ident.text_of_id id  in
+                   uu____9750 = "*" ->
                    let op = "*"  in
-                   let uu____9691 = levels op  in
-                   (match uu____9691 with
+                   let uu____9757 = levels op  in
+                   (match uu____9757 with
                     | (left,mine,right) ->
-                        let uu____9710 =
-                          let uu____9711 = str op  in
-                          let uu____9712 = p_tmNoEqWith' true p_X left e1  in
-                          let uu____9714 = p_tmNoEqWith' true p_X right e2
+                        let uu____9776 =
+                          let uu____9777 = str op  in
+                          let uu____9778 = p_tmNoEqWith' true p_X left e1  in
+                          let uu____9780 = p_tmNoEqWith' true p_X right e2
                              in
-                          infix0 uu____9711 uu____9712 uu____9714  in
-                        paren_if_gt curr mine uu____9710)
-               | uu____9716 -> p_X e)
-          | uu____9717 -> p_X e
+                          infix0 uu____9777 uu____9778 uu____9780  in
+                        paren_if_gt curr mine uu____9776)
+               | uu____9782 -> p_X e)
+          | uu____9783 -> p_X e
 
 and (p_tmEqNoRefinement : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  -> p_tmEqWith p_appTerm e
@@ -3904,25 +3909,25 @@ and (p_tmRefinement : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.NamedTyp (lid,e1) ->
-        let uu____9724 =
-          let uu____9725 = p_lident lid  in
-          let uu____9726 =
-            let uu____9727 = p_appTerm e1  in
-            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____9727  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____9725 uu____9726  in
-        FStar_Pprint.group uu____9724
+        let uu____9790 =
+          let uu____9791 = p_lident lid  in
+          let uu____9792 =
+            let uu____9793 = p_appTerm e1  in
+            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____9793  in
+          FStar_Pprint.op_Hat_Slash_Hat uu____9791 uu____9792  in
+        FStar_Pprint.group uu____9790
     | FStar_Parser_AST.Refine (b,phi) -> p_refinedBinder b phi
-    | uu____9730 -> p_appTerm e
+    | uu____9796 -> p_appTerm e
 
 and (p_with_clause : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  ->
-    let uu____9732 = p_appTerm e  in
-    let uu____9733 =
-      let uu____9734 =
-        let uu____9735 = str "with"  in
-        FStar_Pprint.op_Hat_Hat uu____9735 break1  in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____9734  in
-    FStar_Pprint.op_Hat_Hat uu____9732 uu____9733
+    let uu____9798 = p_appTerm e  in
+    let uu____9799 =
+      let uu____9800 =
+        let uu____9801 = str "with"  in
+        FStar_Pprint.op_Hat_Hat uu____9801 break1  in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____9800  in
+    FStar_Pprint.op_Hat_Hat uu____9798 uu____9799
 
 and (p_refinedBinder :
   FStar_Parser_AST.binder -> FStar_Parser_AST.term -> FStar_Pprint.document)
@@ -3931,151 +3936,152 @@ and (p_refinedBinder :
     fun phi  ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.Annotated (lid,t) ->
-          let uu____9741 = p_lident lid  in
-          p_refinement b.FStar_Parser_AST.aqual uu____9741 t phi
-      | FStar_Parser_AST.TAnnotated uu____9742 ->
+          let uu____9807 = p_lident lid  in
+          p_refinement b.FStar_Parser_AST.aqual uu____9807 t phi
+      | FStar_Parser_AST.TAnnotated uu____9808 ->
           failwith "Is this still used ?"
-      | FStar_Parser_AST.Variable uu____9748 ->
-          let uu____9749 =
-            let uu____9751 = FStar_Parser_AST.binder_to_string b  in
+      | FStar_Parser_AST.Variable uu____9814 ->
+          let uu____9815 =
+            let uu____9817 = FStar_Parser_AST.binder_to_string b  in
             FStar_Util.format1
               "Imposible : a refined binder ought to be annotated %s"
-              uu____9751
+              uu____9817
              in
-          failwith uu____9749
-      | FStar_Parser_AST.TVariable uu____9754 ->
-          let uu____9755 =
-            let uu____9757 = FStar_Parser_AST.binder_to_string b  in
+          failwith uu____9815
+      | FStar_Parser_AST.TVariable uu____9820 ->
+          let uu____9821 =
+            let uu____9823 = FStar_Parser_AST.binder_to_string b  in
             FStar_Util.format1
               "Imposible : a refined binder ought to be annotated %s"
-              uu____9757
+              uu____9823
              in
-          failwith uu____9755
-      | FStar_Parser_AST.NoName uu____9760 ->
-          let uu____9761 =
-            let uu____9763 = FStar_Parser_AST.binder_to_string b  in
+          failwith uu____9821
+      | FStar_Parser_AST.NoName uu____9826 ->
+          let uu____9827 =
+            let uu____9829 = FStar_Parser_AST.binder_to_string b  in
             FStar_Util.format1
               "Imposible : a refined binder ought to be annotated %s"
-              uu____9763
+              uu____9829
              in
-          failwith uu____9761
+          failwith uu____9827
 
 and (p_simpleDef :
   Prims.bool ->
     (FStar_Ident.lid * FStar_Parser_AST.term) -> FStar_Pprint.document)
   =
   fun ps  ->
-    fun uu____9767  ->
-      match uu____9767 with
+    fun uu____9833  ->
+      match uu____9833 with
       | (lid,e) ->
-          let uu____9775 =
-            let uu____9776 = p_qlident lid  in
-            let uu____9777 =
-              let uu____9778 = p_noSeqTermAndComment ps false e  in
-              FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.equals uu____9778
+          let uu____9841 =
+            let uu____9842 = p_qlident lid  in
+            let uu____9843 =
+              let uu____9844 = p_noSeqTermAndComment ps false e  in
+              FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.equals uu____9844
                in
-            FStar_Pprint.op_Hat_Slash_Hat uu____9776 uu____9777  in
-          FStar_Pprint.group uu____9775
+            FStar_Pprint.op_Hat_Slash_Hat uu____9842 uu____9843  in
+          FStar_Pprint.group uu____9841
 
 and (p_appTerm : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.App uu____9781 when is_general_application e ->
-        let uu____9788 = head_and_args e  in
-        (match uu____9788 with
+    | FStar_Parser_AST.App uu____9847 when is_general_application e ->
+        let uu____9854 = head_and_args e  in
+        (match uu____9854 with
          | (head,args) ->
              (match args with
               | e1::e2::[] when
                   (FStar_Pervasives_Native.snd e1) = FStar_Parser_AST.Infix
                   ->
-                  let uu____9835 = p_argTerm e1  in
-                  let uu____9836 =
-                    let uu____9837 =
-                      let uu____9838 =
-                        let uu____9839 = str "`"  in
-                        let uu____9841 =
-                          let uu____9842 = p_indexingTerm head  in
-                          let uu____9843 = str "`"  in
-                          FStar_Pprint.op_Hat_Hat uu____9842 uu____9843  in
-                        FStar_Pprint.op_Hat_Hat uu____9839 uu____9841  in
-                      FStar_Pprint.group uu____9838  in
-                    let uu____9845 = p_argTerm e2  in
-                    FStar_Pprint.op_Hat_Slash_Hat uu____9837 uu____9845  in
-                  FStar_Pprint.op_Hat_Slash_Hat uu____9835 uu____9836
-              | uu____9846 ->
-                  let uu____9853 =
-                    let uu____9864 = FStar_ST.op_Bang should_print_fs_typ_app
+                  let uu____9901 = p_argTerm e1  in
+                  let uu____9902 =
+                    let uu____9903 =
+                      let uu____9904 =
+                        let uu____9905 = str "`"  in
+                        let uu____9907 =
+                          let uu____9908 = p_indexingTerm head  in
+                          let uu____9909 = str "`"  in
+                          FStar_Pprint.op_Hat_Hat uu____9908 uu____9909  in
+                        FStar_Pprint.op_Hat_Hat uu____9905 uu____9907  in
+                      FStar_Pprint.group uu____9904  in
+                    let uu____9911 = p_argTerm e2  in
+                    FStar_Pprint.op_Hat_Slash_Hat uu____9903 uu____9911  in
+                  FStar_Pprint.op_Hat_Slash_Hat uu____9901 uu____9902
+              | uu____9912 ->
+                  let uu____9919 =
+                    let uu____9930 = FStar_ST.op_Bang should_print_fs_typ_app
                        in
-                    if uu____9864
+                    if uu____9930
                     then
-                      let uu____9898 =
+                      let uu____9964 =
                         FStar_Util.take
-                          (fun uu____9922  ->
-                             match uu____9922 with
-                             | (uu____9928,aq) ->
+                          (fun uu____9988  ->
+                             match uu____9988 with
+                             | (uu____9994,aq) ->
                                  aq = FStar_Parser_AST.FsTypApp) args
                          in
-                      match uu____9898 with
+                      match uu____9964 with
                       | (fs_typ_args,args1) ->
-                          let uu____9966 =
-                            let uu____9967 = p_indexingTerm head  in
-                            let uu____9968 =
-                              let uu____9969 =
+                          let uu____10032 =
+                            let uu____10033 = p_indexingTerm head  in
+                            let uu____10034 =
+                              let uu____10035 =
                                 FStar_Pprint.op_Hat_Hat FStar_Pprint.comma
                                   break1
                                  in
                               soft_surround_map_or_flow (Prims.of_int (2))
                                 Prims.int_zero FStar_Pprint.empty
-                                FStar_Pprint.langle uu____9969
+                                FStar_Pprint.langle uu____10035
                                 FStar_Pprint.rangle p_fsTypArg fs_typ_args
                                in
-                            FStar_Pprint.op_Hat_Hat uu____9967 uu____9968  in
-                          (uu____9966, args1)
+                            FStar_Pprint.op_Hat_Hat uu____10033 uu____10034
+                             in
+                          (uu____10032, args1)
                     else
-                      (let uu____9984 = p_indexingTerm head  in
-                       (uu____9984, args))
+                      (let uu____10050 = p_indexingTerm head  in
+                       (uu____10050, args))
                      in
-                  (match uu____9853 with
+                  (match uu____9919 with
                    | (head_doc,args1) ->
-                       let uu____10005 =
-                         let uu____10006 =
+                       let uu____10071 =
+                         let uu____10072 =
                            FStar_Pprint.op_Hat_Hat head_doc
                              FStar_Pprint.space
                             in
                          soft_surround_map_or_flow (Prims.of_int (2))
-                           Prims.int_zero head_doc uu____10006 break1
+                           Prims.int_zero head_doc uu____10072 break1
                            FStar_Pprint.empty p_argTerm args1
                           in
-                       FStar_Pprint.group uu____10005)))
+                       FStar_Pprint.group uu____10071)))
     | FStar_Parser_AST.Construct (lid,args) when
         (is_general_construction e) &&
-          (let uu____10028 =
+          (let uu____10094 =
              (is_dtuple_constructor lid) && (all1_explicit args)  in
-           Prims.op_Negation uu____10028)
+           Prims.op_Negation uu____10094)
         ->
         (match args with
          | [] -> p_quident lid
          | arg::[] ->
-             let uu____10047 =
-               let uu____10048 = p_quident lid  in
-               let uu____10049 = p_argTerm arg  in
-               FStar_Pprint.op_Hat_Slash_Hat uu____10048 uu____10049  in
-             FStar_Pprint.group uu____10047
+             let uu____10113 =
+               let uu____10114 = p_quident lid  in
+               let uu____10115 = p_argTerm arg  in
+               FStar_Pprint.op_Hat_Slash_Hat uu____10114 uu____10115  in
+             FStar_Pprint.group uu____10113
          | hd::tl ->
-             let uu____10066 =
-               let uu____10067 =
-                 let uu____10068 =
-                   let uu____10069 = p_quident lid  in
-                   let uu____10070 = p_argTerm hd  in
-                   prefix2 uu____10069 uu____10070  in
-                 FStar_Pprint.group uu____10068  in
-               let uu____10071 =
-                 let uu____10072 =
+             let uu____10132 =
+               let uu____10133 =
+                 let uu____10134 =
+                   let uu____10135 = p_quident lid  in
+                   let uu____10136 = p_argTerm hd  in
+                   prefix2 uu____10135 uu____10136  in
+                 FStar_Pprint.group uu____10134  in
+               let uu____10137 =
+                 let uu____10138 =
                    FStar_Pprint.separate_map break1 p_argTerm tl  in
-                 jump2 uu____10072  in
-               FStar_Pprint.op_Hat_Hat uu____10067 uu____10071  in
-             FStar_Pprint.group uu____10066)
-    | uu____10077 -> p_indexingTerm e
+                 jump2 uu____10138  in
+               FStar_Pprint.op_Hat_Hat uu____10133 uu____10137  in
+             FStar_Pprint.group uu____10132)
+    | uu____10143 -> p_indexingTerm e
 
 and (p_argTerm :
   (FStar_Parser_AST.term * FStar_Parser_AST.imp) -> FStar_Pprint.document) =
@@ -4086,30 +4092,30 @@ and (p_argTerm :
         (FStar_Errors.log_issue e.FStar_Parser_AST.range
            (FStar_Errors.Warning_UnexpectedFsTypApp,
              "Unexpected FsTypApp, output might not be formatted correctly.");
-         (let uu____10088 = p_indexingTerm e  in
+         (let uu____10154 = p_indexingTerm e  in
           FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one
-            FStar_Pprint.langle uu____10088 FStar_Pprint.rangle))
+            FStar_Pprint.langle uu____10154 FStar_Pprint.rangle))
     | (e,FStar_Parser_AST.Hash ) ->
-        let uu____10092 = str "#"  in
-        let uu____10094 = p_indexingTerm e  in
-        FStar_Pprint.op_Hat_Hat uu____10092 uu____10094
+        let uu____10158 = str "#"  in
+        let uu____10160 = p_indexingTerm e  in
+        FStar_Pprint.op_Hat_Hat uu____10158 uu____10160
     | (e,FStar_Parser_AST.HashBrace t) ->
-        let uu____10097 = str "#["  in
-        let uu____10099 =
-          let uu____10100 = p_indexingTerm t  in
-          let uu____10101 =
-            let uu____10102 = str "]"  in
-            let uu____10104 = p_indexingTerm e  in
-            FStar_Pprint.op_Hat_Hat uu____10102 uu____10104  in
-          FStar_Pprint.op_Hat_Hat uu____10100 uu____10101  in
-        FStar_Pprint.op_Hat_Hat uu____10097 uu____10099
+        let uu____10163 = str "#["  in
+        let uu____10165 =
+          let uu____10166 = p_indexingTerm t  in
+          let uu____10167 =
+            let uu____10168 = str "]"  in
+            let uu____10170 = p_indexingTerm e  in
+            FStar_Pprint.op_Hat_Hat uu____10168 uu____10170  in
+          FStar_Pprint.op_Hat_Hat uu____10166 uu____10167  in
+        FStar_Pprint.op_Hat_Hat uu____10163 uu____10165
     | (e,FStar_Parser_AST.Infix ) -> p_indexingTerm e
     | (e,FStar_Parser_AST.Nothing ) -> p_indexingTerm e
 
 and (p_fsTypArg :
   (FStar_Parser_AST.term * FStar_Parser_AST.imp) -> FStar_Pprint.document) =
-  fun uu____10107  ->
-    match uu____10107 with | (e,uu____10113) -> p_indexingTerm e
+  fun uu____10173  ->
+    match uu____10173 with | (e,uu____10179) -> p_indexingTerm e
 
 and (p_indexingTerm_aux :
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
@@ -4118,33 +4124,33 @@ and (p_indexingTerm_aux :
   fun exit  ->
     fun e  ->
       match e.FStar_Parser_AST.tm with
-      | FStar_Parser_AST.Op
-          ({ FStar_Ident.idText = ".()"; FStar_Ident.idRange = uu____10118;_},e1::e2::[])
+      | FStar_Parser_AST.Op (id,e1::e2::[]) when
+          let uu____10189 = FStar_Ident.text_of_id id  in uu____10189 = ".()"
           ->
-          let uu____10124 =
-            let uu____10125 = p_indexingTerm_aux p_atomicTermNotQUident e1
+          let uu____10193 =
+            let uu____10194 = p_indexingTerm_aux p_atomicTermNotQUident e1
                in
-            let uu____10126 =
-              let uu____10127 =
-                let uu____10128 = p_term false false e2  in
-                soft_parens_with_nesting uu____10128  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10127  in
-            FStar_Pprint.op_Hat_Hat uu____10125 uu____10126  in
-          FStar_Pprint.group uu____10124
-      | FStar_Parser_AST.Op
-          ({ FStar_Ident.idText = ".[]"; FStar_Ident.idRange = uu____10131;_},e1::e2::[])
+            let uu____10195 =
+              let uu____10196 =
+                let uu____10197 = p_term false false e2  in
+                soft_parens_with_nesting uu____10197  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10196  in
+            FStar_Pprint.op_Hat_Hat uu____10194 uu____10195  in
+          FStar_Pprint.group uu____10193
+      | FStar_Parser_AST.Op (id,e1::e2::[]) when
+          let uu____10205 = FStar_Ident.text_of_id id  in uu____10205 = ".[]"
           ->
-          let uu____10137 =
-            let uu____10138 = p_indexingTerm_aux p_atomicTermNotQUident e1
+          let uu____10209 =
+            let uu____10210 = p_indexingTerm_aux p_atomicTermNotQUident e1
                in
-            let uu____10139 =
-              let uu____10140 =
-                let uu____10141 = p_term false false e2  in
-                soft_brackets_with_nesting uu____10141  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10140  in
-            FStar_Pprint.op_Hat_Hat uu____10138 uu____10139  in
-          FStar_Pprint.group uu____10137
-      | uu____10144 -> exit e
+            let uu____10211 =
+              let uu____10212 =
+                let uu____10213 = p_term false false e2  in
+                soft_brackets_with_nesting uu____10213  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10212  in
+            FStar_Pprint.op_Hat_Hat uu____10210 uu____10211  in
+          FStar_Pprint.group uu____10209
+      | uu____10216 -> exit e
 
 and (p_indexingTerm : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  -> p_indexingTerm_aux p_atomicTerm e
@@ -4153,20 +4159,20 @@ and (p_atomicTerm : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.LetOpen (lid,e1) ->
-        let uu____10149 = p_quident lid  in
-        let uu____10150 =
-          let uu____10151 =
-            let uu____10152 = p_term false false e1  in
-            soft_parens_with_nesting uu____10152  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10151  in
-        FStar_Pprint.op_Hat_Hat uu____10149 uu____10150
+        let uu____10221 = p_quident lid  in
+        let uu____10222 =
+          let uu____10223 =
+            let uu____10224 = p_term false false e1  in
+            soft_parens_with_nesting uu____10224  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10223  in
+        FStar_Pprint.op_Hat_Hat uu____10221 uu____10222
     | FStar_Parser_AST.Name lid -> p_quident lid
     | FStar_Parser_AST.Op (op,e1::[]) when is_general_prefix_op op ->
-        let uu____10160 =
-          let uu____10161 = FStar_Ident.text_of_id op  in str uu____10161  in
-        let uu____10163 = p_atomicTerm e1  in
-        FStar_Pprint.op_Hat_Hat uu____10160 uu____10163
-    | uu____10164 -> p_atomicTermNotQUident e
+        let uu____10232 =
+          let uu____10233 = FStar_Ident.text_of_id op  in str uu____10233  in
+        let uu____10235 = p_atomicTerm e1  in
+        FStar_Pprint.op_Hat_Hat uu____10232 uu____10235
+    | uu____10236 -> p_atomicTermNotQUident e
 
 and (p_atomicTermNotQUident : FStar_Parser_AST.term -> FStar_Pprint.document)
   =
@@ -4183,351 +4189,350 @@ and (p_atomicTermNotQUident : FStar_Parser_AST.term -> FStar_Pprint.document)
     | FStar_Parser_AST.Const c ->
         (match c with
          | FStar_Const.Const_char x when x = 10 -> str "0x0Az"
-         | uu____10177 -> p_constant c)
+         | uu____10249 -> p_constant c)
     | FStar_Parser_AST.Name lid when
         FStar_Ident.lid_equals lid FStar_Parser_Const.true_lid -> str "True"
     | FStar_Parser_AST.Name lid when
         FStar_Ident.lid_equals lid FStar_Parser_Const.false_lid ->
         str "False"
     | FStar_Parser_AST.Op (op,e1::[]) when is_general_prefix_op op ->
-        let uu____10186 =
-          let uu____10187 = FStar_Ident.text_of_id op  in str uu____10187  in
-        let uu____10189 = p_atomicTermNotQUident e1  in
-        FStar_Pprint.op_Hat_Hat uu____10186 uu____10189
+        let uu____10258 =
+          let uu____10259 = FStar_Ident.text_of_id op  in str uu____10259  in
+        let uu____10261 = p_atomicTermNotQUident e1  in
+        FStar_Pprint.op_Hat_Hat uu____10258 uu____10261
     | FStar_Parser_AST.Op (op,[]) ->
-        let uu____10193 =
-          let uu____10194 =
-            let uu____10195 =
-              let uu____10196 = FStar_Ident.text_of_id op  in str uu____10196
+        let uu____10265 =
+          let uu____10266 =
+            let uu____10267 =
+              let uu____10268 = FStar_Ident.text_of_id op  in str uu____10268
                in
-            let uu____10198 =
+            let uu____10270 =
               FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen
                in
-            FStar_Pprint.op_Hat_Hat uu____10195 uu____10198  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____10194  in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____10193
+            FStar_Pprint.op_Hat_Hat uu____10267 uu____10270  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____10266  in
+        FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____10265
     | FStar_Parser_AST.Construct (lid,args) when
         (is_dtuple_constructor lid) && (all1_explicit args) ->
-        let uu____10213 =
+        let uu____10285 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar  in
-        let uu____10214 =
-          let uu____10215 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
+        let uu____10286 =
+          let uu____10287 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
              in
-          FStar_Pprint.separate_map uu____10215
-            (fun uu____10223  ->
-               match uu____10223 with | (e1,uu____10229) -> p_tmEq e1) args
+          FStar_Pprint.separate_map uu____10287
+            (fun uu____10295  ->
+               match uu____10295 with | (e1,uu____10301) -> p_tmEq e1) args
            in
-        let uu____10230 =
+        let uu____10302 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen  in
-        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu____10213
-          uu____10214 uu____10230
+        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu____10285
+          uu____10286 uu____10302
     | FStar_Parser_AST.Project (e1,lid) ->
-        let uu____10235 =
-          let uu____10236 = p_atomicTermNotQUident e1  in
-          let uu____10237 =
-            let uu____10238 = p_qlident lid  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10238  in
-          FStar_Pprint.prefix (Prims.of_int (2)) Prims.int_zero uu____10236
-            uu____10237
+        let uu____10307 =
+          let uu____10308 = p_atomicTermNotQUident e1  in
+          let uu____10309 =
+            let uu____10310 = p_qlident lid  in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10310  in
+          FStar_Pprint.prefix (Prims.of_int (2)) Prims.int_zero uu____10308
+            uu____10309
            in
-        FStar_Pprint.group uu____10235
-    | uu____10241 -> p_projectionLHS e
+        FStar_Pprint.group uu____10307
+    | uu____10313 -> p_projectionLHS e
 
 and (p_projectionLHS : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Var lid -> p_qlident lid
     | FStar_Parser_AST.Projector (constr_lid,field_lid) ->
-        let uu____10246 = p_quident constr_lid  in
-        let uu____10247 =
-          let uu____10248 =
-            let uu____10249 = p_lident field_lid  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10249  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____10248  in
-        FStar_Pprint.op_Hat_Hat uu____10246 uu____10247
+        let uu____10318 = p_quident constr_lid  in
+        let uu____10319 =
+          let uu____10320 =
+            let uu____10321 = p_lident field_lid  in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10321  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____10320  in
+        FStar_Pprint.op_Hat_Hat uu____10318 uu____10319
     | FStar_Parser_AST.Discrim constr_lid ->
-        let uu____10251 = p_quident constr_lid  in
-        FStar_Pprint.op_Hat_Hat uu____10251 FStar_Pprint.qmark
+        let uu____10323 = p_quident constr_lid  in
+        FStar_Pprint.op_Hat_Hat uu____10323 FStar_Pprint.qmark
     | FStar_Parser_AST.Paren e1 ->
-        let uu____10253 = p_term_sep false false e1  in
-        (match uu____10253 with
+        let uu____10325 = p_term_sep false false e1  in
+        (match uu____10325 with
          | (comm,t) ->
              let doc = soft_parens_with_nesting t  in
              if comm = FStar_Pprint.empty
              then doc
              else
-               (let uu____10266 =
+               (let uu____10338 =
                   FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline doc  in
-                FStar_Pprint.op_Hat_Hat comm uu____10266))
-    | uu____10267 when is_array e ->
+                FStar_Pprint.op_Hat_Hat comm uu____10338))
+    | uu____10339 when is_array e ->
         let es = extract_from_list e  in
-        let uu____10271 =
+        let uu____10343 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket FStar_Pprint.bar  in
-        let uu____10272 =
-          let uu____10273 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1
+        let uu____10344 =
+          let uu____10345 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1
              in
-          separate_map_or_flow_last uu____10273
+          separate_map_or_flow_last uu____10345
             (fun ps  -> p_noSeqTermAndComment ps false) es
            in
-        let uu____10278 =
+        let uu____10350 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rbracket  in
-        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero uu____10271
-          uu____10272 uu____10278
-    | uu____10281 when is_list e ->
-        let uu____10282 =
-          let uu____10283 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1
+        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero uu____10343
+          uu____10344 uu____10350
+    | uu____10353 when is_list e ->
+        let uu____10354 =
+          let uu____10355 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1
              in
-          let uu____10284 = extract_from_list e  in
-          separate_map_or_flow_last uu____10283
-            (fun ps  -> p_noSeqTermAndComment ps false) uu____10284
+          let uu____10356 = extract_from_list e  in
+          separate_map_or_flow_last uu____10355
+            (fun ps  -> p_noSeqTermAndComment ps false) uu____10356
            in
         FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero
-          FStar_Pprint.lbracket uu____10282 FStar_Pprint.rbracket
-    | uu____10293 when is_lex_list e ->
-        let uu____10294 =
+          FStar_Pprint.lbracket uu____10354 FStar_Pprint.rbracket
+    | uu____10365 when is_lex_list e ->
+        let uu____10366 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.percent FStar_Pprint.lbracket
            in
-        let uu____10295 =
-          let uu____10296 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1
+        let uu____10367 =
+          let uu____10368 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1
              in
-          let uu____10297 = extract_from_list e  in
-          separate_map_or_flow_last uu____10296
-            (fun ps  -> p_noSeqTermAndComment ps false) uu____10297
+          let uu____10369 = extract_from_list e  in
+          separate_map_or_flow_last uu____10368
+            (fun ps  -> p_noSeqTermAndComment ps false) uu____10369
            in
-        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu____10294
-          uu____10295 FStar_Pprint.rbracket
-    | uu____10306 when is_ref_set e ->
+        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu____10366
+          uu____10367 FStar_Pprint.rbracket
+    | uu____10378 when is_ref_set e ->
         let es = extract_from_ref_set e  in
-        let uu____10310 =
+        let uu____10382 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.bang FStar_Pprint.lbrace  in
-        let uu____10311 =
-          let uu____10312 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
+        let uu____10383 =
+          let uu____10384 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
              in
-          separate_map_or_flow uu____10312 p_appTerm es  in
-        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero uu____10310
-          uu____10311 FStar_Pprint.rbrace
+          separate_map_or_flow uu____10384 p_appTerm es  in
+        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero uu____10382
+          uu____10383 FStar_Pprint.rbrace
     | FStar_Parser_AST.Labeled (e1,s,b) ->
-        let uu____10322 = str (Prims.op_Hat "(*" (Prims.op_Hat s "*)"))  in
-        let uu____10325 = p_term false false e1  in
-        FStar_Pprint.op_Hat_Slash_Hat uu____10322 uu____10325
+        let uu____10394 = str (Prims.op_Hat "(*" (Prims.op_Hat s "*)"))  in
+        let uu____10397 = p_term false false e1  in
+        FStar_Pprint.op_Hat_Slash_Hat uu____10394 uu____10397
     | FStar_Parser_AST.Op (op,args) when
-        let uu____10334 = handleable_op op args  in
-        Prims.op_Negation uu____10334 ->
-        let uu____10336 =
-          let uu____10338 =
-            let uu____10340 = FStar_Ident.text_of_id op  in
-            let uu____10342 =
-              let uu____10344 =
-                let uu____10346 =
+        let uu____10406 = handleable_op op args  in
+        Prims.op_Negation uu____10406 ->
+        let uu____10408 =
+          let uu____10410 =
+            let uu____10412 = FStar_Ident.text_of_id op  in
+            let uu____10414 =
+              let uu____10416 =
+                let uu____10418 =
                   FStar_Util.string_of_int (FStar_List.length args)  in
-                Prims.op_Hat uu____10346
+                Prims.op_Hat uu____10418
                   " arguments couldn't be handled by the pretty printer"
                  in
-              Prims.op_Hat " with " uu____10344  in
-            Prims.op_Hat uu____10340 uu____10342  in
-          Prims.op_Hat "Operation " uu____10338  in
-        failwith uu____10336
+              Prims.op_Hat " with " uu____10416  in
+            Prims.op_Hat uu____10412 uu____10414  in
+          Prims.op_Hat "Operation " uu____10410  in
+        failwith uu____10408
     | FStar_Parser_AST.Uvar id ->
         failwith "Unexpected universe variable out of universe context"
     | FStar_Parser_AST.Wild  ->
-        let uu____10353 = p_term false false e  in
-        soft_parens_with_nesting uu____10353
-    | FStar_Parser_AST.Const uu____10356 ->
-        let uu____10357 = p_term false false e  in
-        soft_parens_with_nesting uu____10357
-    | FStar_Parser_AST.Op uu____10360 ->
-        let uu____10367 = p_term false false e  in
-        soft_parens_with_nesting uu____10367
-    | FStar_Parser_AST.Tvar uu____10370 ->
-        let uu____10371 = p_term false false e  in
-        soft_parens_with_nesting uu____10371
-    | FStar_Parser_AST.Var uu____10374 ->
-        let uu____10375 = p_term false false e  in
-        soft_parens_with_nesting uu____10375
-    | FStar_Parser_AST.Name uu____10378 ->
-        let uu____10379 = p_term false false e  in
-        soft_parens_with_nesting uu____10379
-    | FStar_Parser_AST.Construct uu____10382 ->
-        let uu____10393 = p_term false false e  in
-        soft_parens_with_nesting uu____10393
-    | FStar_Parser_AST.Abs uu____10396 ->
-        let uu____10403 = p_term false false e  in
-        soft_parens_with_nesting uu____10403
-    | FStar_Parser_AST.App uu____10406 ->
-        let uu____10413 = p_term false false e  in
-        soft_parens_with_nesting uu____10413
-    | FStar_Parser_AST.Let uu____10416 ->
-        let uu____10437 = p_term false false e  in
-        soft_parens_with_nesting uu____10437
-    | FStar_Parser_AST.LetOpen uu____10440 ->
-        let uu____10445 = p_term false false e  in
-        soft_parens_with_nesting uu____10445
-    | FStar_Parser_AST.Seq uu____10448 ->
-        let uu____10453 = p_term false false e  in
-        soft_parens_with_nesting uu____10453
-    | FStar_Parser_AST.Bind uu____10456 ->
-        let uu____10463 = p_term false false e  in
-        soft_parens_with_nesting uu____10463
-    | FStar_Parser_AST.If uu____10466 ->
-        let uu____10473 = p_term false false e  in
-        soft_parens_with_nesting uu____10473
-    | FStar_Parser_AST.Match uu____10476 ->
-        let uu____10491 = p_term false false e  in
-        soft_parens_with_nesting uu____10491
-    | FStar_Parser_AST.TryWith uu____10494 ->
+        let uu____10425 = p_term false false e  in
+        soft_parens_with_nesting uu____10425
+    | FStar_Parser_AST.Const uu____10428 ->
+        let uu____10429 = p_term false false e  in
+        soft_parens_with_nesting uu____10429
+    | FStar_Parser_AST.Op uu____10432 ->
+        let uu____10439 = p_term false false e  in
+        soft_parens_with_nesting uu____10439
+    | FStar_Parser_AST.Tvar uu____10442 ->
+        let uu____10443 = p_term false false e  in
+        soft_parens_with_nesting uu____10443
+    | FStar_Parser_AST.Var uu____10446 ->
+        let uu____10447 = p_term false false e  in
+        soft_parens_with_nesting uu____10447
+    | FStar_Parser_AST.Name uu____10450 ->
+        let uu____10451 = p_term false false e  in
+        soft_parens_with_nesting uu____10451
+    | FStar_Parser_AST.Construct uu____10454 ->
+        let uu____10465 = p_term false false e  in
+        soft_parens_with_nesting uu____10465
+    | FStar_Parser_AST.Abs uu____10468 ->
+        let uu____10475 = p_term false false e  in
+        soft_parens_with_nesting uu____10475
+    | FStar_Parser_AST.App uu____10478 ->
+        let uu____10485 = p_term false false e  in
+        soft_parens_with_nesting uu____10485
+    | FStar_Parser_AST.Let uu____10488 ->
         let uu____10509 = p_term false false e  in
         soft_parens_with_nesting uu____10509
-    | FStar_Parser_AST.Ascribed uu____10512 ->
-        let uu____10521 = p_term false false e  in
-        soft_parens_with_nesting uu____10521
-    | FStar_Parser_AST.Record uu____10524 ->
-        let uu____10537 = p_term false false e  in
-        soft_parens_with_nesting uu____10537
-    | FStar_Parser_AST.Project uu____10540 ->
+    | FStar_Parser_AST.LetOpen uu____10512 ->
+        let uu____10517 = p_term false false e  in
+        soft_parens_with_nesting uu____10517
+    | FStar_Parser_AST.Seq uu____10520 ->
+        let uu____10525 = p_term false false e  in
+        soft_parens_with_nesting uu____10525
+    | FStar_Parser_AST.Bind uu____10528 ->
+        let uu____10535 = p_term false false e  in
+        soft_parens_with_nesting uu____10535
+    | FStar_Parser_AST.If uu____10538 ->
         let uu____10545 = p_term false false e  in
         soft_parens_with_nesting uu____10545
-    | FStar_Parser_AST.Product uu____10548 ->
-        let uu____10555 = p_term false false e  in
-        soft_parens_with_nesting uu____10555
-    | FStar_Parser_AST.Sum uu____10558 ->
-        let uu____10569 = p_term false false e  in
-        soft_parens_with_nesting uu____10569
-    | FStar_Parser_AST.QForall uu____10572 ->
-        let uu____10591 = p_term false false e  in
-        soft_parens_with_nesting uu____10591
-    | FStar_Parser_AST.QExists uu____10594 ->
-        let uu____10613 = p_term false false e  in
-        soft_parens_with_nesting uu____10613
-    | FStar_Parser_AST.Refine uu____10616 ->
-        let uu____10621 = p_term false false e  in
-        soft_parens_with_nesting uu____10621
-    | FStar_Parser_AST.NamedTyp uu____10624 ->
-        let uu____10629 = p_term false false e  in
-        soft_parens_with_nesting uu____10629
-    | FStar_Parser_AST.Requires uu____10632 ->
-        let uu____10640 = p_term false false e  in
-        soft_parens_with_nesting uu____10640
-    | FStar_Parser_AST.Ensures uu____10643 ->
-        let uu____10651 = p_term false false e  in
-        soft_parens_with_nesting uu____10651
-    | FStar_Parser_AST.Attributes uu____10654 ->
-        let uu____10657 = p_term false false e  in
-        soft_parens_with_nesting uu____10657
-    | FStar_Parser_AST.Quote uu____10660 ->
-        let uu____10665 = p_term false false e  in
-        soft_parens_with_nesting uu____10665
-    | FStar_Parser_AST.VQuote uu____10668 ->
-        let uu____10669 = p_term false false e  in
-        soft_parens_with_nesting uu____10669
-    | FStar_Parser_AST.Antiquote uu____10672 ->
-        let uu____10673 = p_term false false e  in
-        soft_parens_with_nesting uu____10673
-    | FStar_Parser_AST.CalcProof uu____10676 ->
+    | FStar_Parser_AST.Match uu____10548 ->
+        let uu____10563 = p_term false false e  in
+        soft_parens_with_nesting uu____10563
+    | FStar_Parser_AST.TryWith uu____10566 ->
+        let uu____10581 = p_term false false e  in
+        soft_parens_with_nesting uu____10581
+    | FStar_Parser_AST.Ascribed uu____10584 ->
+        let uu____10593 = p_term false false e  in
+        soft_parens_with_nesting uu____10593
+    | FStar_Parser_AST.Record uu____10596 ->
+        let uu____10609 = p_term false false e  in
+        soft_parens_with_nesting uu____10609
+    | FStar_Parser_AST.Project uu____10612 ->
+        let uu____10617 = p_term false false e  in
+        soft_parens_with_nesting uu____10617
+    | FStar_Parser_AST.Product uu____10620 ->
+        let uu____10627 = p_term false false e  in
+        soft_parens_with_nesting uu____10627
+    | FStar_Parser_AST.Sum uu____10630 ->
+        let uu____10641 = p_term false false e  in
+        soft_parens_with_nesting uu____10641
+    | FStar_Parser_AST.QForall uu____10644 ->
+        let uu____10663 = p_term false false e  in
+        soft_parens_with_nesting uu____10663
+    | FStar_Parser_AST.QExists uu____10666 ->
         let uu____10685 = p_term false false e  in
         soft_parens_with_nesting uu____10685
+    | FStar_Parser_AST.Refine uu____10688 ->
+        let uu____10693 = p_term false false e  in
+        soft_parens_with_nesting uu____10693
+    | FStar_Parser_AST.NamedTyp uu____10696 ->
+        let uu____10701 = p_term false false e  in
+        soft_parens_with_nesting uu____10701
+    | FStar_Parser_AST.Requires uu____10704 ->
+        let uu____10712 = p_term false false e  in
+        soft_parens_with_nesting uu____10712
+    | FStar_Parser_AST.Ensures uu____10715 ->
+        let uu____10723 = p_term false false e  in
+        soft_parens_with_nesting uu____10723
+    | FStar_Parser_AST.Attributes uu____10726 ->
+        let uu____10729 = p_term false false e  in
+        soft_parens_with_nesting uu____10729
+    | FStar_Parser_AST.Quote uu____10732 ->
+        let uu____10737 = p_term false false e  in
+        soft_parens_with_nesting uu____10737
+    | FStar_Parser_AST.VQuote uu____10740 ->
+        let uu____10741 = p_term false false e  in
+        soft_parens_with_nesting uu____10741
+    | FStar_Parser_AST.Antiquote uu____10744 ->
+        let uu____10745 = p_term false false e  in
+        soft_parens_with_nesting uu____10745
+    | FStar_Parser_AST.CalcProof uu____10748 ->
+        let uu____10757 = p_term false false e  in
+        soft_parens_with_nesting uu____10757
 
 and (p_constant : FStar_Const.sconst -> FStar_Pprint.document) =
-  fun uu___15_10688  ->
-    match uu___15_10688 with
+  fun uu___15_10760  ->
+    match uu___15_10760 with
     | FStar_Const.Const_effect  -> str "Effect"
     | FStar_Const.Const_unit  -> str "()"
     | FStar_Const.Const_bool b -> FStar_Pprint.doc_of_bool b
     | FStar_Const.Const_real r -> str (Prims.op_Hat r "R")
     | FStar_Const.Const_float x -> str (FStar_Util.string_of_float x)
     | FStar_Const.Const_char x -> FStar_Pprint.doc_of_char x
-    | FStar_Const.Const_string (s,uu____10700) ->
-        let uu____10703 = str (FStar_String.escaped s)  in
-        FStar_Pprint.dquotes uu____10703
-    | FStar_Const.Const_bytearray (bytes,uu____10705) ->
-        let uu____10712 =
-          let uu____10713 = str (FStar_Util.string_of_bytes bytes)  in
-          FStar_Pprint.dquotes uu____10713  in
-        let uu____10714 = str "B"  in
-        FStar_Pprint.op_Hat_Hat uu____10712 uu____10714
+    | FStar_Const.Const_string (s,uu____10772) ->
+        let uu____10775 = str (FStar_String.escaped s)  in
+        FStar_Pprint.dquotes uu____10775
+    | FStar_Const.Const_bytearray (bytes,uu____10777) ->
+        let uu____10784 =
+          let uu____10785 = str (FStar_Util.string_of_bytes bytes)  in
+          FStar_Pprint.dquotes uu____10785  in
+        let uu____10786 = str "B"  in
+        FStar_Pprint.op_Hat_Hat uu____10784 uu____10786
     | FStar_Const.Const_int (repr,sign_width_opt) ->
-        let signedness uu___13_10737 =
-          match uu___13_10737 with
+        let signedness uu___13_10809 =
+          match uu___13_10809 with
           | FStar_Const.Unsigned  -> str "u"
           | FStar_Const.Signed  -> FStar_Pprint.empty  in
-        let width uu___14_10744 =
-          match uu___14_10744 with
+        let width uu___14_10816 =
+          match uu___14_10816 with
           | FStar_Const.Int8  -> str "y"
           | FStar_Const.Int16  -> str "s"
           | FStar_Const.Int32  -> str "l"
           | FStar_Const.Int64  -> str "L"  in
         let ending =
           default_or_map FStar_Pprint.empty
-            (fun uu____10759  ->
-               match uu____10759 with
+            (fun uu____10831  ->
+               match uu____10831 with
                | (s,w) ->
-                   let uu____10766 = signedness s  in
-                   let uu____10767 = width w  in
-                   FStar_Pprint.op_Hat_Hat uu____10766 uu____10767)
+                   let uu____10838 = signedness s  in
+                   let uu____10839 = width w  in
+                   FStar_Pprint.op_Hat_Hat uu____10838 uu____10839)
             sign_width_opt
            in
-        let uu____10768 = str repr  in
-        FStar_Pprint.op_Hat_Hat uu____10768 ending
+        let uu____10840 = str repr  in
+        FStar_Pprint.op_Hat_Hat uu____10840 ending
     | FStar_Const.Const_range_of  -> str "range_of"
     | FStar_Const.Const_set_range_of  -> str "set_range_of"
     | FStar_Const.Const_range r ->
-        let uu____10772 = FStar_Range.string_of_range r  in str uu____10772
+        let uu____10844 = FStar_Range.string_of_range r  in str uu____10844
     | FStar_Const.Const_reify  -> str "reify"
     | FStar_Const.Const_reflect lid ->
-        let uu____10776 = p_quident lid  in
-        let uu____10777 =
-          let uu____10778 =
-            let uu____10779 = str "reflect"  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10779  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____10778  in
-        FStar_Pprint.op_Hat_Hat uu____10776 uu____10777
+        let uu____10848 = p_quident lid  in
+        let uu____10849 =
+          let uu____10850 =
+            let uu____10851 = str "reflect"  in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____10851  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____10850  in
+        FStar_Pprint.op_Hat_Hat uu____10848 uu____10849
 
 and (p_universe : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun u  ->
-    let uu____10782 = str "u#"  in
-    let uu____10784 = p_atomicUniverse u  in
-    FStar_Pprint.op_Hat_Hat uu____10782 uu____10784
+    let uu____10854 = str "u#"  in
+    let uu____10856 = p_atomicUniverse u  in
+    FStar_Pprint.op_Hat_Hat uu____10854 uu____10856
 
 and (p_universeFrom : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun u  ->
     match u.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Op
-        ({ FStar_Ident.idText = "+"; FStar_Ident.idRange = uu____10786;_},u1::u2::[])
-        ->
-        let uu____10792 =
-          let uu____10793 = p_universeFrom u1  in
-          let uu____10794 =
-            let uu____10795 = p_universeFrom u2  in
-            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.plus uu____10795  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____10793 uu____10794  in
-        FStar_Pprint.group uu____10792
-    | FStar_Parser_AST.App uu____10796 ->
-        let uu____10803 = head_and_args u  in
-        (match uu____10803 with
+    | FStar_Parser_AST.Op (id,u1::u2::[]) when
+        let uu____10863 = FStar_Ident.text_of_id id  in uu____10863 = "+" ->
+        let uu____10867 =
+          let uu____10868 = p_universeFrom u1  in
+          let uu____10869 =
+            let uu____10870 = p_universeFrom u2  in
+            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.plus uu____10870  in
+          FStar_Pprint.op_Hat_Slash_Hat uu____10868 uu____10869  in
+        FStar_Pprint.group uu____10867
+    | FStar_Parser_AST.App uu____10871 ->
+        let uu____10878 = head_and_args u  in
+        (match uu____10878 with
          | (head,args) ->
              (match head.FStar_Parser_AST.tm with
               | FStar_Parser_AST.Var maybe_max_lid when
                   FStar_Ident.lid_equals maybe_max_lid
                     FStar_Parser_Const.max_lid
                   ->
-                  let uu____10829 =
-                    let uu____10830 = p_qlident FStar_Parser_Const.max_lid
+                  let uu____10904 =
+                    let uu____10905 = p_qlident FStar_Parser_Const.max_lid
                        in
-                    let uu____10831 =
+                    let uu____10906 =
                       FStar_Pprint.separate_map FStar_Pprint.space
-                        (fun uu____10839  ->
-                           match uu____10839 with
-                           | (u1,uu____10845) -> p_atomicUniverse u1) args
+                        (fun uu____10914  ->
+                           match uu____10914 with
+                           | (u1,uu____10920) -> p_atomicUniverse u1) args
                        in
-                    op_Hat_Slash_Plus_Hat uu____10830 uu____10831  in
-                  FStar_Pprint.group uu____10829
-              | uu____10846 ->
-                  let uu____10847 =
-                    let uu____10849 = FStar_Parser_AST.term_to_string u  in
+                    op_Hat_Slash_Plus_Hat uu____10905 uu____10906  in
+                  FStar_Pprint.group uu____10904
+              | uu____10921 ->
+                  let uu____10922 =
+                    let uu____10924 = FStar_Parser_AST.term_to_string u  in
                     FStar_Util.format1 "Invalid term in universe context %s"
-                      uu____10849
+                      uu____10924
                      in
-                  failwith uu____10847))
-    | uu____10852 -> p_atomicUniverse u
+                  failwith uu____10922))
+    | uu____10927 -> p_atomicUniverse u
 
 and (p_atomicUniverse : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun u  ->
@@ -4536,25 +4541,24 @@ and (p_atomicUniverse : FStar_Parser_AST.term -> FStar_Pprint.document) =
     | FStar_Parser_AST.Const (FStar_Const.Const_int (r,sw)) ->
         p_constant (FStar_Const.Const_int (r, sw))
     | FStar_Parser_AST.Uvar id ->
-        let uu____10878 = FStar_Ident.text_of_id id  in str uu____10878
+        let uu____10953 = FStar_Ident.text_of_id id  in str uu____10953
     | FStar_Parser_AST.Paren u1 ->
-        let uu____10881 = p_universeFrom u1  in
-        soft_parens_with_nesting uu____10881
-    | FStar_Parser_AST.Op
-        ({ FStar_Ident.idText = "+"; FStar_Ident.idRange = uu____10882;_},uu____10883::uu____10884::[])
-        ->
-        let uu____10888 = p_universeFrom u  in
-        soft_parens_with_nesting uu____10888
-    | FStar_Parser_AST.App uu____10889 ->
-        let uu____10896 = p_universeFrom u  in
-        soft_parens_with_nesting uu____10896
-    | uu____10897 ->
-        let uu____10898 =
-          let uu____10900 = FStar_Parser_AST.term_to_string u  in
+        let uu____10956 = p_universeFrom u1  in
+        soft_parens_with_nesting uu____10956
+    | FStar_Parser_AST.App uu____10957 ->
+        let uu____10964 = p_universeFrom u  in
+        soft_parens_with_nesting uu____10964
+    | FStar_Parser_AST.Op (id,uu____10966::uu____10967::[]) when
+        let uu____10970 = FStar_Ident.text_of_id id  in uu____10970 = "+" ->
+        let uu____10974 = p_universeFrom u  in
+        soft_parens_with_nesting uu____10974
+    | uu____10975 ->
+        let uu____10976 =
+          let uu____10978 = FStar_Parser_AST.term_to_string u  in
           FStar_Util.format1 "Invalid term in universe context %s"
-            uu____10900
+            uu____10978
            in
-        failwith uu____10898
+        failwith uu____10976
 
 let (term_to_document : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e  ->
@@ -4573,15 +4577,15 @@ let (modul_to_document : FStar_Parser_AST.modul -> FStar_Pprint.document) =
     FStar_ST.op_Colon_Equals should_print_fs_typ_app false;
     (let res =
        match m with
-       | FStar_Parser_AST.Module (uu____10989,decls) ->
-           let uu____10995 =
+       | FStar_Parser_AST.Module (uu____11067,decls) ->
+           let uu____11073 =
              FStar_All.pipe_right decls (FStar_List.map decl_to_document)  in
-           FStar_All.pipe_right uu____10995
+           FStar_All.pipe_right uu____11073
              (FStar_Pprint.separate FStar_Pprint.hardline)
-       | FStar_Parser_AST.Interface (uu____11004,decls,uu____11006) ->
-           let uu____11013 =
+       | FStar_Parser_AST.Interface (uu____11082,decls,uu____11084) ->
+           let uu____11091 =
              FStar_All.pipe_right decls (FStar_List.map decl_to_document)  in
-           FStar_All.pipe_right uu____11013
+           FStar_All.pipe_right uu____11091
              (FStar_Pprint.separate FStar_Pprint.hardline)
         in
      FStar_ST.op_Colon_Equals should_print_fs_typ_app false; res)
@@ -4590,17 +4594,17 @@ let (comments_to_document :
   (Prims.string * FStar_Range.range) Prims.list -> FStar_Pprint.document) =
   fun comments  ->
     FStar_Pprint.separate_map FStar_Pprint.hardline
-      (fun uu____11073  ->
-         match uu____11073 with | (comment,range) -> str comment) comments
+      (fun uu____11151  ->
+         match uu____11151 with | (comment,range) -> str comment) comments
   
 let (extract_decl_range : FStar_Parser_AST.decl -> decl_meta) =
   fun d  ->
     let has_qs =
       match ((d.FStar_Parser_AST.quals), (d.FStar_Parser_AST.d)) with
       | ((FStar_Parser_AST.Assumption )::[],FStar_Parser_AST.Assume
-         (id,uu____11095)) -> false
-      | ([],uu____11099) -> false
-      | uu____11103 -> true  in
+         (id,uu____11173)) -> false
+      | ([],uu____11177) -> false
+      | uu____11181 -> true  in
     {
       r = (d.FStar_Parser_AST.drange);
       has_qs;
@@ -4617,37 +4621,37 @@ let (modul_with_comments_to_document :
     fun comments  ->
       let decls =
         match m with
-        | FStar_Parser_AST.Module (uu____11152,decls) -> decls
-        | FStar_Parser_AST.Interface (uu____11158,decls,uu____11160) -> decls
+        | FStar_Parser_AST.Module (uu____11230,decls) -> decls
+        | FStar_Parser_AST.Interface (uu____11236,decls,uu____11238) -> decls
          in
       FStar_ST.op_Colon_Equals should_print_fs_typ_app false;
       (match decls with
        | [] -> (FStar_Pprint.empty, comments)
        | d::ds ->
-           let uu____11212 =
+           let uu____11290 =
              match ds with
              | {
                  FStar_Parser_AST.d = FStar_Parser_AST.Pragma
                    (FStar_Parser_AST.LightOff );
-                 FStar_Parser_AST.drange = uu____11225;
-                 FStar_Parser_AST.quals = uu____11226;
-                 FStar_Parser_AST.attrs = uu____11227;_}::uu____11228 ->
+                 FStar_Parser_AST.drange = uu____11303;
+                 FStar_Parser_AST.quals = uu____11304;
+                 FStar_Parser_AST.attrs = uu____11305;_}::uu____11306 ->
                  let d0 = FStar_List.hd ds  in
-                 let uu____11232 =
-                   let uu____11235 =
-                     let uu____11238 = FStar_List.tl ds  in d :: uu____11238
+                 let uu____11310 =
+                   let uu____11313 =
+                     let uu____11316 = FStar_List.tl ds  in d :: uu____11316
                       in
-                   d0 :: uu____11235  in
-                 (uu____11232, (d0.FStar_Parser_AST.drange))
-             | uu____11243 -> ((d :: ds), (d.FStar_Parser_AST.drange))  in
-           (match uu____11212 with
+                   d0 :: uu____11313  in
+                 (uu____11310, (d0.FStar_Parser_AST.drange))
+             | uu____11321 -> ((d :: ds), (d.FStar_Parser_AST.drange))  in
+           (match uu____11290 with
             | (decls1,first_range) ->
                 (FStar_ST.op_Colon_Equals comment_stack comments;
                  (let initial_comment =
-                    let uu____11300 = FStar_Range.start_of_range first_range
+                    let uu____11378 = FStar_Range.start_of_range first_range
                        in
                     place_comments_until_pos Prims.int_zero Prims.int_one
-                      uu____11300 dummy_meta FStar_Pprint.empty false true
+                      uu____11378 dummy_meta FStar_Pprint.empty false true
                      in
                   let doc =
                     separate_map_with_comments FStar_Pprint.empty
@@ -4656,7 +4660,7 @@ let (modul_with_comments_to_document :
                   let comments1 = FStar_ST.op_Bang comment_stack  in
                   FStar_ST.op_Colon_Equals comment_stack [];
                   FStar_ST.op_Colon_Equals should_print_fs_typ_app false;
-                  (let uu____11409 =
+                  (let uu____11487 =
                      FStar_Pprint.op_Hat_Hat initial_comment doc  in
-                   (uu____11409, comments1))))))
+                   (uu____11487, comments1))))))
   

--- a/src/ocaml-output/FStar_Reflection_Basic.ml
+++ b/src/ocaml-output/FStar_Reflection_Basic.ml
@@ -537,7 +537,7 @@ let (lookup_attr :
           let ses =
             let uu____1823 =
               let uu____1825 = FStar_Syntax_Syntax.lid_of_fv fv  in
-              FStar_Ident.text_of_lid uu____1825  in
+              FStar_Ident.string_of_lid uu____1825  in
             FStar_TypeChecker_Env.lookup_attr env uu____1823  in
           FStar_List.concatMap
             (fun se  ->
@@ -577,7 +577,7 @@ let (defs_in_module :
                let uu____1880 = FStar_Ident.ids_of_lid l  in
                FStar_All.pipe_right uu____1880 init  in
              FStar_All.pipe_right uu____1877
-               (FStar_List.map FStar_Ident.string_of_ident)
+               (FStar_List.map FStar_Ident.text_of_id)
               in
            if ns = modul
            then
@@ -828,8 +828,7 @@ let (pack_sigelt :
   
 let (inspect_bv : FStar_Syntax_Syntax.bv -> FStar_Reflection_Data.bv_view) =
   fun bv  ->
-    let uu____2359 =
-      FStar_Ident.string_of_ident bv.FStar_Syntax_Syntax.ppname  in
+    let uu____2359 = FStar_Ident.text_of_id bv.FStar_Syntax_Syntax.ppname  in
     let uu____2361 = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index  in
     {
       FStar_Reflection_Data.bv_ppname = uu____2359;

--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -1076,7 +1076,7 @@ let (primitive_type_axioms :
       let uu____4543 =
         let uu____4544 =
           let uu____4550 =
-            FStar_Ident.text_of_lid FStar_Parser_Const.lex_t_lid  in
+            FStar_Ident.string_of_lid FStar_Parser_Const.lex_t_lid  in
           (uu____4550, FStar_SMTEncoding_Term.Term_sort)  in
         FStar_SMTEncoding_Term.mk_fv uu____4544  in
       FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____4543  in
@@ -1207,7 +1207,7 @@ let (primitive_type_axioms :
       let uu____4888 =
         let uu____4889 =
           let uu____4895 =
-            FStar_Ident.text_of_lid FStar_Parser_Const.lex_t_lid  in
+            FStar_Ident.string_of_lid FStar_Parser_Const.lex_t_lid  in
           (uu____4895, FStar_SMTEncoding_Term.Term_sort)  in
         FStar_SMTEncoding_Term.mk_fv uu____4889  in
       FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____4888  in
@@ -1755,12 +1755,17 @@ let (encode_smt_lemma :
             let uu____7204 =
               let uu____7207 =
                 let uu____7210 =
-                  FStar_SMTEncoding_Util.mkAssume
-                    (form,
-                      (FStar_Pervasives_Native.Some
-                         (Prims.op_Hat "Lemma: " lid.FStar_Ident.str)),
-                      (Prims.op_Hat "lemma_" lid.FStar_Ident.str))
-                   in
+                  let uu____7211 =
+                    let uu____7219 =
+                      let uu____7220 =
+                        let uu____7222 = FStar_Ident.string_of_lid lid  in
+                        Prims.op_Hat "Lemma: " uu____7222  in
+                      FStar_Pervasives_Native.Some uu____7220  in
+                    let uu____7226 =
+                      let uu____7228 = FStar_Ident.string_of_lid lid  in
+                      Prims.op_Hat "lemma_" uu____7228  in
+                    (form, uu____7219, uu____7226)  in
+                  FStar_SMTEncoding_Util.mkAssume uu____7211  in
                 [uu____7210]  in
               FStar_All.pipe_right uu____7207
                 FStar_SMTEncoding_Term.mk_decls_trivial
@@ -1784,35 +1789,35 @@ let (encode_free_var :
             fun quals  ->
               let lid =
                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-              let uu____7269 =
-                ((let uu____7273 =
+              let uu____7286 =
+                ((let uu____7290 =
                     (FStar_Syntax_Util.is_pure_or_ghost_function t_norm) ||
                       (FStar_SMTEncoding_Util.is_smt_reifiable_function
                          env.FStar_SMTEncoding_Env.tcenv t_norm)
                      in
-                  FStar_All.pipe_left Prims.op_Negation uu____7273) ||
+                  FStar_All.pipe_left Prims.op_Negation uu____7290) ||
                    (FStar_Syntax_Util.is_lemma t_norm))
                   || uninterpreted
                  in
-              if uu____7269
+              if uu____7286
               then
                 let arg_sorts =
-                  let uu____7285 =
-                    let uu____7286 = FStar_Syntax_Subst.compress t_norm  in
-                    uu____7286.FStar_Syntax_Syntax.n  in
-                  match uu____7285 with
-                  | FStar_Syntax_Syntax.Tm_arrow (binders,uu____7292) ->
+                  let uu____7302 =
+                    let uu____7303 = FStar_Syntax_Subst.compress t_norm  in
+                    uu____7303.FStar_Syntax_Syntax.n  in
+                  match uu____7302 with
+                  | FStar_Syntax_Syntax.Tm_arrow (binders,uu____7309) ->
                       FStar_All.pipe_right binders
                         (FStar_List.map
-                           (fun uu____7330  ->
+                           (fun uu____7347  ->
                               FStar_SMTEncoding_Term.Term_sort))
-                  | uu____7337 -> []  in
+                  | uu____7354 -> []  in
                 let arity = FStar_List.length arg_sorts  in
-                let uu____7339 =
+                let uu____7356 =
                   FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                     env lid arity
                    in
-                match uu____7339 with
+                match uu____7356 with
                 | (vname,vtok,env1) ->
                     let d =
                       FStar_SMTEncoding_Term.DeclFun
@@ -1826,260 +1831,277 @@ let (encode_free_var :
                           (FStar_Pervasives_Native.Some
                              "Uninterpreted name for impure function"))
                        in
-                    let uu____7371 =
+                    let uu____7388 =
                       FStar_All.pipe_right [d; dd]
                         FStar_SMTEncoding_Term.mk_decls_trivial
                        in
-                    (uu____7371, env1)
+                    (uu____7388, env1)
               else
-                (let uu____7376 = prims.is lid  in
-                 if uu____7376
+                (let uu____7393 = prims.is lid  in
+                 if uu____7393
                  then
                    let vname =
                      FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
                        lid
                       in
-                   let uu____7385 = prims.mk lid vname  in
-                   match uu____7385 with
+                   let uu____7402 = prims.mk lid vname  in
+                   match uu____7402 with
                    | (tok,arity,definition) ->
                        let env1 =
                          FStar_SMTEncoding_Env.push_free_var env lid arity
                            vname (FStar_Pervasives_Native.Some tok)
                           in
-                       let uu____7409 =
+                       let uu____7426 =
                          FStar_All.pipe_right definition
                            FStar_SMTEncoding_Term.mk_decls_trivial
                           in
-                       (uu____7409, env1)
+                       (uu____7426, env1)
                  else
                    (let encode_non_total_function_typ =
-                      lid.FStar_Ident.nsstr <> "Prims"  in
-                    let uu____7418 =
-                      let uu____7437 =
+                      let uu____7433 = FStar_Ident.nsstr lid  in
+                      uu____7433 <> "Prims"  in
+                    let uu____7437 =
+                      let uu____7456 =
                         FStar_SMTEncoding_EncodeTerm.curried_arrow_formals_comp
                           t_norm
                          in
-                      match uu____7437 with
+                      match uu____7456 with
                       | (args,comp) ->
                           let comp1 =
-                            let uu____7465 =
+                            let uu____7484 =
                               FStar_SMTEncoding_Util.is_smt_reifiable_comp
                                 env.FStar_SMTEncoding_Env.tcenv comp
                                in
-                            if uu____7465
+                            if uu____7484
                             then
-                              let uu____7470 =
+                              let uu____7489 =
                                 FStar_TypeChecker_Env.reify_comp
-                                  (let uu___316_7473 =
+                                  (let uu___316_7492 =
                                      env.FStar_SMTEncoding_Env.tcenv  in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___316_7473.FStar_TypeChecker_Env.solver);
+                                       (uu___316_7492.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___316_7473.FStar_TypeChecker_Env.range);
+                                       (uu___316_7492.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___316_7473.FStar_TypeChecker_Env.curmodule);
+                                       (uu___316_7492.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___316_7473.FStar_TypeChecker_Env.gamma);
+                                       (uu___316_7492.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___316_7473.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___316_7492.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___316_7473.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___316_7492.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___316_7473.FStar_TypeChecker_Env.modules);
+                                       (uu___316_7492.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___316_7473.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___316_7492.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___316_7473.FStar_TypeChecker_Env.sigtab);
+                                       (uu___316_7492.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___316_7473.FStar_TypeChecker_Env.attrtab);
+                                       (uu___316_7492.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___316_7473.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___316_7492.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___316_7473.FStar_TypeChecker_Env.effects);
+                                       (uu___316_7492.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___316_7473.FStar_TypeChecker_Env.generalize);
+                                       (uu___316_7492.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
-                                       (uu___316_7473.FStar_TypeChecker_Env.letrecs);
+                                       (uu___316_7492.FStar_TypeChecker_Env.letrecs);
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___316_7473.FStar_TypeChecker_Env.top_level);
+                                       (uu___316_7492.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___316_7473.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___316_7492.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
-                                       (uu___316_7473.FStar_TypeChecker_Env.use_eq);
+                                       (uu___316_7492.FStar_TypeChecker_Env.use_eq);
                                      FStar_TypeChecker_Env.use_eq_strict =
-                                       (uu___316_7473.FStar_TypeChecker_Env.use_eq_strict);
+                                       (uu___316_7492.FStar_TypeChecker_Env.use_eq_strict);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___316_7473.FStar_TypeChecker_Env.is_iface);
+                                       (uu___316_7492.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___316_7473.FStar_TypeChecker_Env.admit);
+                                       (uu___316_7492.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax = true;
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___316_7473.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___316_7492.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___316_7473.FStar_TypeChecker_Env.phase1);
+                                       (uu___316_7492.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___316_7473.FStar_TypeChecker_Env.failhard);
+                                       (uu___316_7492.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___316_7473.FStar_TypeChecker_Env.nosynth);
+                                       (uu___316_7492.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___316_7473.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___316_7492.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___316_7473.FStar_TypeChecker_Env.tc_term);
+                                       (uu___316_7492.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___316_7473.FStar_TypeChecker_Env.type_of);
+                                       (uu___316_7492.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___316_7473.FStar_TypeChecker_Env.universe_of);
+                                       (uu___316_7492.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___316_7473.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___316_7492.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___316_7473.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___316_7492.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___316_7473.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___316_7492.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___316_7473.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___316_7492.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___316_7473.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___316_7492.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___316_7473.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___316_7492.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___316_7473.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___316_7492.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.try_solve_implicits_hook
                                        =
-                                       (uu___316_7473.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                       (uu___316_7492.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___316_7473.FStar_TypeChecker_Env.splice);
+                                       (uu___316_7492.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.mpreprocess =
-                                       (uu___316_7473.FStar_TypeChecker_Env.mpreprocess);
+                                       (uu___316_7492.FStar_TypeChecker_Env.mpreprocess);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___316_7473.FStar_TypeChecker_Env.postprocess);
+                                       (uu___316_7492.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.is_native_tactic =
-                                       (uu___316_7473.FStar_TypeChecker_Env.is_native_tactic);
+                                       (uu___316_7492.FStar_TypeChecker_Env.is_native_tactic);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___316_7473.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___316_7492.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___316_7473.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___316_7492.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___316_7473.FStar_TypeChecker_Env.dsenv);
+                                       (uu___316_7492.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___316_7473.FStar_TypeChecker_Env.nbe);
+                                       (uu___316_7492.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___316_7473.FStar_TypeChecker_Env.strict_args_tab);
+                                       (uu___316_7492.FStar_TypeChecker_Env.strict_args_tab);
                                      FStar_TypeChecker_Env.erasable_types_tab
                                        =
-                                       (uu___316_7473.FStar_TypeChecker_Env.erasable_types_tab)
+                                       (uu___316_7492.FStar_TypeChecker_Env.erasable_types_tab)
                                    }) comp FStar_Syntax_Syntax.U_unknown
                                  in
-                              FStar_Syntax_Syntax.mk_Total uu____7470
+                              FStar_Syntax_Syntax.mk_Total uu____7489
                             else comp  in
                           if encode_non_total_function_typ
                           then
-                            let uu____7496 =
+                            let uu____7515 =
                               FStar_TypeChecker_Util.pure_or_ghost_pre_and_post
                                 env.FStar_SMTEncoding_Env.tcenv comp1
                                in
-                            (args, uu____7496)
+                            (args, uu____7515)
                           else
                             (args,
                               (FStar_Pervasives_Native.None,
                                 (FStar_Syntax_Util.comp_result comp1)))
                        in
-                    match uu____7418 with
+                    match uu____7437 with
                     | (formals,(pre_opt,res_t)) ->
                         let mk_disc_proj_axioms guard encoded_res_t vapp vars
                           =
                           FStar_All.pipe_right quals
                             (FStar_List.collect
-                               (fun uu___0_7602  ->
-                                  match uu___0_7602 with
+                               (fun uu___0_7621  ->
+                                  match uu___0_7621 with
                                   | FStar_Syntax_Syntax.Discriminator d ->
-                                      let uu____7606 = FStar_Util.prefix vars
+                                      let uu____7625 = FStar_Util.prefix vars
                                          in
-                                      (match uu____7606 with
-                                       | (uu____7639,xxv) ->
+                                      (match uu____7625 with
+                                       | (uu____7658,xxv) ->
                                            let xx =
-                                             let uu____7678 =
-                                               let uu____7679 =
-                                                 let uu____7685 =
+                                             let uu____7697 =
+                                               let uu____7698 =
+                                                 let uu____7704 =
                                                    FStar_SMTEncoding_Term.fv_name
                                                      xxv
                                                     in
-                                                 (uu____7685,
+                                                 (uu____7704,
                                                    FStar_SMTEncoding_Term.Term_sort)
                                                   in
                                                FStar_SMTEncoding_Term.mk_fv
-                                                 uu____7679
+                                                 uu____7698
                                                 in
                                              FStar_All.pipe_left
                                                FStar_SMTEncoding_Util.mkFreeV
-                                               uu____7678
+                                               uu____7697
                                               in
-                                           let uu____7688 =
-                                             let uu____7689 =
-                                               let uu____7697 =
-                                                 let uu____7698 =
+                                           let uu____7707 =
+                                             let uu____7708 =
+                                               let uu____7716 =
+                                                 let uu____7717 =
                                                    FStar_Syntax_Syntax.range_of_fv
                                                      fv
                                                     in
-                                                 let uu____7699 =
-                                                   let uu____7710 =
-                                                     let uu____7711 =
-                                                       let uu____7716 =
-                                                         let uu____7717 =
+                                                 let uu____7718 =
+                                                   let uu____7729 =
+                                                     let uu____7730 =
+                                                       let uu____7735 =
+                                                         let uu____7736 =
+                                                           let uu____7737 =
+                                                             let uu____7739 =
+                                                               FStar_Ident.string_of_lid
+                                                                 d
+                                                                in
+                                                             FStar_SMTEncoding_Env.escape
+                                                               uu____7739
+                                                              in
                                                            FStar_SMTEncoding_Term.mk_tester
-                                                             (FStar_SMTEncoding_Env.escape
-                                                                d.FStar_Ident.str)
-                                                             xx
+                                                             uu____7737 xx
                                                             in
                                                          FStar_All.pipe_left
                                                            FStar_SMTEncoding_Term.boxBool
-                                                           uu____7717
+                                                           uu____7736
                                                           in
-                                                       (vapp, uu____7716)  in
+                                                       (vapp, uu____7735)  in
                                                      FStar_SMTEncoding_Util.mkEq
-                                                       uu____7711
+                                                       uu____7730
                                                       in
                                                    ([[vapp]], vars,
-                                                     uu____7710)
+                                                     uu____7729)
                                                     in
                                                  FStar_SMTEncoding_Term.mkForall
-                                                   uu____7698 uu____7699
+                                                   uu____7717 uu____7718
                                                   in
-                                               (uu____7697,
+                                               let uu____7749 =
+                                                 let uu____7751 =
+                                                   let uu____7753 =
+                                                     FStar_Ident.string_of_lid
+                                                       d
+                                                      in
+                                                   FStar_SMTEncoding_Env.escape
+                                                     uu____7753
+                                                    in
+                                                 Prims.op_Hat
+                                                   "disc_equation_"
+                                                   uu____7751
+                                                  in
+                                               (uu____7716,
                                                  (FStar_Pervasives_Native.Some
                                                     "Discriminator equation"),
-                                                 (Prims.op_Hat
-                                                    "disc_equation_"
-                                                    (FStar_SMTEncoding_Env.escape
-                                                       d.FStar_Ident.str)))
+                                                 uu____7749)
                                                 in
                                              FStar_SMTEncoding_Util.mkAssume
-                                               uu____7689
+                                               uu____7708
                                               in
-                                           [uu____7688])
+                                           [uu____7707])
                                   | FStar_Syntax_Syntax.Projector (d,f) ->
-                                      let uu____7732 = FStar_Util.prefix vars
+                                      let uu____7761 = FStar_Util.prefix vars
                                          in
-                                      (match uu____7732 with
-                                       | (uu____7765,xxv) ->
+                                      (match uu____7761 with
+                                       | (uu____7794,xxv) ->
                                            let xx =
-                                             let uu____7804 =
-                                               let uu____7805 =
-                                                 let uu____7811 =
+                                             let uu____7833 =
+                                               let uu____7834 =
+                                                 let uu____7840 =
                                                    FStar_SMTEncoding_Term.fv_name
                                                      xxv
                                                     in
-                                                 (uu____7811,
+                                                 (uu____7840,
                                                    FStar_SMTEncoding_Term.Term_sort)
                                                   in
                                                FStar_SMTEncoding_Term.mk_fv
-                                                 uu____7805
+                                                 uu____7834
                                                 in
                                              FStar_All.pipe_left
                                                FStar_SMTEncoding_Util.mkFreeV
-                                               uu____7804
+                                               uu____7833
                                               in
                                            let f1 =
                                              {
@@ -2097,64 +2119,64 @@ let (encode_free_var :
                                              FStar_SMTEncoding_Util.mkApp
                                                (tp_name, [xx])
                                               in
-                                           let uu____7822 =
-                                             let uu____7823 =
-                                               let uu____7831 =
-                                                 let uu____7832 =
+                                           let uu____7851 =
+                                             let uu____7852 =
+                                               let uu____7860 =
+                                                 let uu____7861 =
                                                    FStar_Syntax_Syntax.range_of_fv
                                                      fv
                                                     in
-                                                 let uu____7833 =
-                                                   let uu____7844 =
+                                                 let uu____7862 =
+                                                   let uu____7873 =
                                                      FStar_SMTEncoding_Util.mkEq
                                                        (vapp, prim_app)
                                                       in
                                                    ([[vapp]], vars,
-                                                     uu____7844)
+                                                     uu____7873)
                                                     in
                                                  FStar_SMTEncoding_Term.mkForall
-                                                   uu____7832 uu____7833
+                                                   uu____7861 uu____7862
                                                   in
-                                               (uu____7831,
+                                               (uu____7860,
                                                  (FStar_Pervasives_Native.Some
                                                     "Projector equation"),
                                                  (Prims.op_Hat
                                                     "proj_equation_" tp_name))
                                                 in
                                              FStar_SMTEncoding_Util.mkAssume
-                                               uu____7823
+                                               uu____7852
                                               in
-                                           [uu____7822])
-                                  | uu____7857 -> []))
+                                           [uu____7851])
+                                  | uu____7886 -> []))
                            in
-                        let uu____7858 =
+                        let uu____7887 =
                           FStar_SMTEncoding_EncodeTerm.encode_binders
                             FStar_Pervasives_Native.None formals env
                            in
-                        (match uu____7858 with
-                         | (vars,guards,env',decls1,uu____7883) ->
-                             let uu____7896 =
+                        (match uu____7887 with
+                         | (vars,guards,env',decls1,uu____7912) ->
+                             let uu____7925 =
                                match pre_opt with
                                | FStar_Pervasives_Native.None  ->
-                                   let uu____7909 =
+                                   let uu____7938 =
                                      FStar_SMTEncoding_Util.mk_and_l guards
                                       in
-                                   (uu____7909, decls1)
+                                   (uu____7938, decls1)
                                | FStar_Pervasives_Native.Some p ->
-                                   let uu____7913 =
+                                   let uu____7942 =
                                      FStar_SMTEncoding_EncodeTerm.encode_formula
                                        p env'
                                       in
-                                   (match uu____7913 with
+                                   (match uu____7942 with
                                     | (g,ds) ->
-                                        let uu____7926 =
+                                        let uu____7955 =
                                           FStar_SMTEncoding_Util.mk_and_l (g
                                             :: guards)
                                            in
-                                        (uu____7926,
+                                        (uu____7955,
                                           (FStar_List.append decls1 ds)))
                                 in
-                             (match uu____7896 with
+                             (match uu____7925 with
                               | (guard,decls11) ->
                                   let dummy_var =
                                     FStar_SMTEncoding_Term.mk_fv
@@ -2165,28 +2187,28 @@ let (encode_free_var :
                                     FStar_SMTEncoding_Term.mkFreeV dummy_var
                                       FStar_Range.dummyRange
                                      in
-                                  let should_thunk uu____7949 =
+                                  let should_thunk uu____7978 =
                                     let is_type t =
-                                      let uu____7957 =
-                                        let uu____7958 =
+                                      let uu____7986 =
+                                        let uu____7987 =
                                           FStar_Syntax_Subst.compress t  in
-                                        uu____7958.FStar_Syntax_Syntax.n  in
-                                      match uu____7957 with
+                                        uu____7987.FStar_Syntax_Syntax.n  in
+                                      match uu____7986 with
                                       | FStar_Syntax_Syntax.Tm_type
-                                          uu____7962 -> true
-                                      | uu____7964 -> false  in
+                                          uu____7991 -> true
+                                      | uu____7993 -> false  in
                                     let is_squash t =
-                                      let uu____7973 =
+                                      let uu____8002 =
                                         FStar_Syntax_Util.head_and_args t  in
-                                      match uu____7973 with
-                                      | (head,uu____7992) ->
-                                          let uu____8017 =
-                                            let uu____8018 =
+                                      match uu____8002 with
+                                      | (head,uu____8021) ->
+                                          let uu____8046 =
+                                            let uu____8047 =
                                               FStar_Syntax_Util.un_uinst head
                                                in
-                                            uu____8018.FStar_Syntax_Syntax.n
+                                            uu____8047.FStar_Syntax_Syntax.n
                                              in
-                                          (match uu____8017 with
+                                          (match uu____8046 with
                                            | FStar_Syntax_Syntax.Tm_fvar fv1
                                                ->
                                                FStar_Syntax_Syntax.fv_eq_lid
@@ -2195,54 +2217,56 @@ let (encode_free_var :
                                            | FStar_Syntax_Syntax.Tm_refine
                                                ({
                                                   FStar_Syntax_Syntax.ppname
-                                                    = uu____8023;
+                                                    = uu____8052;
                                                   FStar_Syntax_Syntax.index =
-                                                    uu____8024;
+                                                    uu____8053;
                                                   FStar_Syntax_Syntax.sort =
                                                     {
                                                       FStar_Syntax_Syntax.n =
                                                         FStar_Syntax_Syntax.Tm_fvar
                                                         fv1;
                                                       FStar_Syntax_Syntax.pos
-                                                        = uu____8026;
+                                                        = uu____8055;
                                                       FStar_Syntax_Syntax.vars
-                                                        = uu____8027;_};_},uu____8028)
+                                                        = uu____8056;_};_},uu____8057)
                                                ->
                                                FStar_Syntax_Syntax.fv_eq_lid
                                                  fv1
                                                  FStar_Parser_Const.unit_lid
-                                           | uu____8036 -> false)
+                                           | uu____8065 -> false)
                                        in
-                                    (((lid.FStar_Ident.nsstr <> "Prims") &&
-                                        (let uu____8041 =
+                                    (((let uu____8069 = FStar_Ident.nsstr lid
+                                          in
+                                       uu____8069 <> "Prims") &&
+                                        (let uu____8074 =
                                            FStar_All.pipe_right quals
                                              (FStar_List.contains
                                                 FStar_Syntax_Syntax.Logic)
                                             in
-                                         Prims.op_Negation uu____8041))
+                                         Prims.op_Negation uu____8074))
                                        &&
-                                       (let uu____8047 = is_squash t_norm  in
-                                        Prims.op_Negation uu____8047))
+                                       (let uu____8080 = is_squash t_norm  in
+                                        Prims.op_Negation uu____8080))
                                       &&
-                                      (let uu____8050 = is_type t_norm  in
-                                       Prims.op_Negation uu____8050)
+                                      (let uu____8083 = is_type t_norm  in
+                                       Prims.op_Negation uu____8083)
                                      in
-                                  let uu____8052 =
+                                  let uu____8085 =
                                     match vars with
                                     | [] when should_thunk () ->
                                         (true, [dummy_var])
-                                    | uu____8111 -> (false, vars)  in
-                                  (match uu____8052 with
+                                    | uu____8144 -> (false, vars)  in
+                                  (match uu____8085 with
                                    | (thunked,vars1) ->
                                        let arity = FStar_List.length formals
                                           in
-                                       let uu____8161 =
+                                       let uu____8194 =
                                          FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid_maybe_thunked
                                            env lid arity thunked
                                           in
-                                       (match uu____8161 with
+                                       (match uu____8194 with
                                         | (vname,vtok_opt,env1) ->
-                                            let get_vtok uu____8193 =
+                                            let get_vtok uu____8226 =
                                               FStar_Option.get vtok_opt  in
                                             let vtok_tm =
                                               match formals with
@@ -2254,93 +2278,93 @@ let (encode_free_var :
                                               | [] when thunked ->
                                                   FStar_SMTEncoding_Util.mkApp
                                                     (vname, [dummy_tm])
-                                              | uu____8214 ->
-                                                  let uu____8223 =
-                                                    let uu____8231 =
+                                              | uu____8247 ->
+                                                  let uu____8256 =
+                                                    let uu____8264 =
                                                       get_vtok ()  in
-                                                    (uu____8231, [])  in
+                                                    (uu____8264, [])  in
                                                   FStar_SMTEncoding_Util.mkApp
-                                                    uu____8223
+                                                    uu____8256
                                                in
                                             let vtok_app =
                                               FStar_SMTEncoding_EncodeTerm.mk_Apply
                                                 vtok_tm vars1
                                                in
                                             let vapp =
-                                              let uu____8238 =
-                                                let uu____8246 =
+                                              let uu____8271 =
+                                                let uu____8279 =
                                                   FStar_List.map
                                                     FStar_SMTEncoding_Util.mkFreeV
                                                     vars1
                                                    in
-                                                (vname, uu____8246)  in
+                                                (vname, uu____8279)  in
                                               FStar_SMTEncoding_Util.mkApp
-                                                uu____8238
+                                                uu____8271
                                                in
-                                            let uu____8260 =
+                                            let uu____8293 =
                                               let vname_decl =
-                                                let uu____8268 =
-                                                  let uu____8280 =
+                                                let uu____8301 =
+                                                  let uu____8313 =
                                                     FStar_All.pipe_right
                                                       vars1
                                                       (FStar_List.map
                                                          FStar_SMTEncoding_Term.fv_sort)
                                                      in
-                                                  (vname, uu____8280,
+                                                  (vname, uu____8313,
                                                     FStar_SMTEncoding_Term.Term_sort,
                                                     FStar_Pervasives_Native.None)
                                                    in
                                                 FStar_SMTEncoding_Term.DeclFun
-                                                  uu____8268
+                                                  uu____8301
                                                  in
-                                              let uu____8291 =
+                                              let uu____8324 =
                                                 let env2 =
-                                                  let uu___411_8297 = env1
+                                                  let uu___411_8330 = env1
                                                      in
                                                   {
                                                     FStar_SMTEncoding_Env.bvar_bindings
                                                       =
-                                                      (uu___411_8297.FStar_SMTEncoding_Env.bvar_bindings);
+                                                      (uu___411_8330.FStar_SMTEncoding_Env.bvar_bindings);
                                                     FStar_SMTEncoding_Env.fvar_bindings
                                                       =
-                                                      (uu___411_8297.FStar_SMTEncoding_Env.fvar_bindings);
+                                                      (uu___411_8330.FStar_SMTEncoding_Env.fvar_bindings);
                                                     FStar_SMTEncoding_Env.depth
                                                       =
-                                                      (uu___411_8297.FStar_SMTEncoding_Env.depth);
+                                                      (uu___411_8330.FStar_SMTEncoding_Env.depth);
                                                     FStar_SMTEncoding_Env.tcenv
                                                       =
-                                                      (uu___411_8297.FStar_SMTEncoding_Env.tcenv);
+                                                      (uu___411_8330.FStar_SMTEncoding_Env.tcenv);
                                                     FStar_SMTEncoding_Env.warn
                                                       =
-                                                      (uu___411_8297.FStar_SMTEncoding_Env.warn);
+                                                      (uu___411_8330.FStar_SMTEncoding_Env.warn);
                                                     FStar_SMTEncoding_Env.nolabels
                                                       =
-                                                      (uu___411_8297.FStar_SMTEncoding_Env.nolabels);
+                                                      (uu___411_8330.FStar_SMTEncoding_Env.nolabels);
                                                     FStar_SMTEncoding_Env.use_zfuel_name
                                                       =
-                                                      (uu___411_8297.FStar_SMTEncoding_Env.use_zfuel_name);
+                                                      (uu___411_8330.FStar_SMTEncoding_Env.use_zfuel_name);
                                                     FStar_SMTEncoding_Env.encode_non_total_function_typ
                                                       =
                                                       encode_non_total_function_typ;
                                                     FStar_SMTEncoding_Env.current_module_name
                                                       =
-                                                      (uu___411_8297.FStar_SMTEncoding_Env.current_module_name);
+                                                      (uu___411_8330.FStar_SMTEncoding_Env.current_module_name);
                                                     FStar_SMTEncoding_Env.encoding_quantifier
                                                       =
-                                                      (uu___411_8297.FStar_SMTEncoding_Env.encoding_quantifier);
+                                                      (uu___411_8330.FStar_SMTEncoding_Env.encoding_quantifier);
                                                     FStar_SMTEncoding_Env.global_cache
                                                       =
-                                                      (uu___411_8297.FStar_SMTEncoding_Env.global_cache)
+                                                      (uu___411_8330.FStar_SMTEncoding_Env.global_cache)
                                                   }  in
-                                                let uu____8298 =
-                                                  let uu____8300 =
+                                                let uu____8331 =
+                                                  let uu____8333 =
                                                     FStar_SMTEncoding_EncodeTerm.head_normal
                                                       env2 tt
                                                      in
                                                   Prims.op_Negation
-                                                    uu____8300
+                                                    uu____8333
                                                    in
-                                                if uu____8298
+                                                if uu____8331
                                                 then
                                                   FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                                     FStar_Pervasives_Native.None
@@ -2350,9 +2374,9 @@ let (encode_free_var :
                                                     FStar_Pervasives_Native.None
                                                     t_norm env2 vtok_tm
                                                  in
-                                              match uu____8291 with
+                                              match uu____8324 with
                                               | (tok_typing,decls2) ->
-                                                  let uu____8317 =
+                                                  let uu____8350 =
                                                     match vars1 with
                                                     | [] ->
                                                         let tok_typing1 =
@@ -2364,37 +2388,37 @@ let (encode_free_var :
                                                                  "function_token_typing_"
                                                                  vname))
                                                            in
-                                                        let uu____8343 =
-                                                          let uu____8346 =
+                                                        let uu____8376 =
+                                                          let uu____8379 =
                                                             FStar_All.pipe_right
                                                               [tok_typing1]
                                                               FStar_SMTEncoding_Term.mk_decls_trivial
                                                              in
                                                           FStar_List.append
-                                                            decls2 uu____8346
+                                                            decls2 uu____8379
                                                            in
-                                                        let uu____8353 =
-                                                          let uu____8354 =
-                                                            let uu____8357 =
+                                                        let uu____8386 =
+                                                          let uu____8387 =
+                                                            let uu____8390 =
                                                               FStar_SMTEncoding_Util.mkApp
                                                                 (vname, [])
                                                                in
                                                             FStar_All.pipe_left
-                                                              (fun uu____8363
+                                                              (fun uu____8396
                                                                   ->
                                                                  FStar_Pervasives_Native.Some
-                                                                   uu____8363)
-                                                              uu____8357
+                                                                   uu____8396)
+                                                              uu____8390
                                                              in
                                                           FStar_SMTEncoding_Env.push_free_var
                                                             env1 lid arity
-                                                            vname uu____8354
+                                                            vname uu____8387
                                                            in
-                                                        (uu____8343,
-                                                          uu____8353)
-                                                    | uu____8366 when thunked
+                                                        (uu____8376,
+                                                          uu____8386)
+                                                    | uu____8399 when thunked
                                                         -> (decls2, env1)
-                                                    | uu____8379 ->
+                                                    | uu____8412 ->
                                                         let vtok =
                                                           get_vtok ()  in
                                                         let vtok_decl =
@@ -2405,30 +2429,30 @@ let (encode_free_var :
                                                            in
                                                         let name_tok_corr_formula
                                                           pat =
-                                                          let uu____8403 =
+                                                          let uu____8436 =
                                                             FStar_Syntax_Syntax.range_of_fv
                                                               fv
                                                              in
-                                                          let uu____8404 =
-                                                            let uu____8415 =
+                                                          let uu____8437 =
+                                                            let uu____8448 =
                                                               FStar_SMTEncoding_Util.mkEq
                                                                 (vtok_app,
                                                                   vapp)
                                                                in
                                                             ([[pat]], vars1,
-                                                              uu____8415)
+                                                              uu____8448)
                                                              in
                                                           FStar_SMTEncoding_Term.mkForall
-                                                            uu____8403
-                                                            uu____8404
+                                                            uu____8436
+                                                            uu____8437
                                                            in
                                                         let name_tok_corr =
-                                                          let uu____8425 =
-                                                            let uu____8433 =
+                                                          let uu____8458 =
+                                                            let uu____8466 =
                                                               name_tok_corr_formula
                                                                 vtok_app
                                                                in
-                                                            (uu____8433,
+                                                            (uu____8466,
                                                               (FStar_Pervasives_Native.Some
                                                                  "Name-token correspondence"),
                                                               (Prims.op_Hat
@@ -2436,7 +2460,7 @@ let (encode_free_var :
                                                                  vname))
                                                              in
                                                           FStar_SMTEncoding_Util.mkAssume
-                                                            uu____8425
+                                                            uu____8458
                                                            in
                                                         let tok_typing1 =
                                                           let ff =
@@ -2449,52 +2473,52 @@ let (encode_free_var :
                                                               ff
                                                              in
                                                           let vtok_app_r =
-                                                            let uu____8444 =
-                                                              let uu____8445
+                                                            let uu____8477 =
+                                                              let uu____8478
                                                                 =
                                                                 FStar_SMTEncoding_Term.mk_fv
                                                                   (vtok,
                                                                     FStar_SMTEncoding_Term.Term_sort)
                                                                  in
-                                                              [uu____8445]
+                                                              [uu____8478]
                                                                in
                                                             FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                                              f uu____8444
+                                                              f uu____8477
                                                              in
                                                           let guarded_tok_typing
                                                             =
-                                                            let uu____8472 =
+                                                            let uu____8505 =
                                                               FStar_Syntax_Syntax.range_of_fv
                                                                 fv
                                                                in
-                                                            let uu____8473 =
-                                                              let uu____8484
+                                                            let uu____8506 =
+                                                              let uu____8517
                                                                 =
-                                                                let uu____8485
+                                                                let uu____8518
                                                                   =
-                                                                  let uu____8490
+                                                                  let uu____8523
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_NoHoist
                                                                     f
                                                                     tok_typing
                                                                      in
-                                                                  let uu____8491
+                                                                  let uu____8524
                                                                     =
                                                                     name_tok_corr_formula
                                                                     vapp  in
-                                                                  (uu____8490,
-                                                                    uu____8491)
+                                                                  (uu____8523,
+                                                                    uu____8524)
                                                                    in
                                                                 FStar_SMTEncoding_Util.mkAnd
-                                                                  uu____8485
+                                                                  uu____8518
                                                                  in
                                                               ([[vtok_app_r]],
                                                                 [ff],
-                                                                uu____8484)
+                                                                uu____8517)
                                                                in
                                                             FStar_SMTEncoding_Term.mkForall
-                                                              uu____8472
-                                                              uu____8473
+                                                              uu____8505
+                                                              uu____8506
                                                              in
                                                           FStar_SMTEncoding_Util.mkAssume
                                                             (guarded_tok_typing,
@@ -2504,8 +2528,8 @@ let (encode_free_var :
                                                                  "function_token_typing_"
                                                                  vname))
                                                            in
-                                                        let uu____8520 =
-                                                          let uu____8523 =
+                                                        let uu____8553 =
+                                                          let uu____8556 =
                                                             FStar_All.pipe_right
                                                               [vtok_decl;
                                                               name_tok_corr;
@@ -2513,56 +2537,56 @@ let (encode_free_var :
                                                               FStar_SMTEncoding_Term.mk_decls_trivial
                                                              in
                                                           FStar_List.append
-                                                            decls2 uu____8523
+                                                            decls2 uu____8556
                                                            in
-                                                        (uu____8520, env1)
+                                                        (uu____8553, env1)
                                                      in
-                                                  (match uu____8317 with
+                                                  (match uu____8350 with
                                                    | (tok_decl,env2) ->
-                                                       let uu____8544 =
-                                                         let uu____8547 =
+                                                       let uu____8577 =
+                                                         let uu____8580 =
                                                            FStar_All.pipe_right
                                                              [vname_decl]
                                                              FStar_SMTEncoding_Term.mk_decls_trivial
                                                             in
                                                          FStar_List.append
-                                                           uu____8547
+                                                           uu____8580
                                                            tok_decl
                                                           in
-                                                       (uu____8544, env2))
+                                                       (uu____8577, env2))
                                                in
-                                            (match uu____8260 with
+                                            (match uu____8293 with
                                              | (decls2,env2) ->
-                                                 let uu____8566 =
+                                                 let uu____8599 =
                                                    let res_t1 =
                                                      FStar_Syntax_Subst.compress
                                                        res_t
                                                       in
-                                                   let uu____8576 =
+                                                   let uu____8609 =
                                                      FStar_SMTEncoding_EncodeTerm.encode_term
                                                        res_t1 env'
                                                       in
-                                                   match uu____8576 with
+                                                   match uu____8609 with
                                                    | (encoded_res_t,decls) ->
-                                                       let uu____8591 =
+                                                       let uu____8624 =
                                                          FStar_SMTEncoding_Term.mk_HasType
                                                            vapp encoded_res_t
                                                           in
                                                        (encoded_res_t,
-                                                         uu____8591, decls)
+                                                         uu____8624, decls)
                                                     in
-                                                 (match uu____8566 with
+                                                 (match uu____8599 with
                                                   | (encoded_res_t,ty_pred,decls3)
                                                       ->
                                                       let typingAx =
-                                                        let uu____8606 =
-                                                          let uu____8614 =
-                                                            let uu____8615 =
+                                                        let uu____8639 =
+                                                          let uu____8647 =
+                                                            let uu____8648 =
                                                               FStar_Syntax_Syntax.range_of_fv
                                                                 fv
                                                                in
-                                                            let uu____8616 =
-                                                              let uu____8627
+                                                            let uu____8649 =
+                                                              let uu____8660
                                                                 =
                                                                 FStar_SMTEncoding_Util.mkImp
                                                                   (guard,
@@ -2570,13 +2594,13 @@ let (encode_free_var :
                                                                  in
                                                               ([[vapp]],
                                                                 vars1,
-                                                                uu____8627)
+                                                                uu____8660)
                                                                in
                                                             FStar_SMTEncoding_Term.mkForall
-                                                              uu____8615
-                                                              uu____8616
+                                                              uu____8648
+                                                              uu____8649
                                                              in
-                                                          (uu____8614,
+                                                          (uu____8647,
                                                             (FStar_Pervasives_Native.Some
                                                                "free var typing"),
                                                             (Prims.op_Hat
@@ -2584,69 +2608,69 @@ let (encode_free_var :
                                                                vname))
                                                            in
                                                         FStar_SMTEncoding_Util.mkAssume
-                                                          uu____8606
+                                                          uu____8639
                                                          in
                                                       let freshness =
-                                                        let uu____8643 =
+                                                        let uu____8676 =
                                                           FStar_All.pipe_right
                                                             quals
                                                             (FStar_List.contains
                                                                FStar_Syntax_Syntax.New)
                                                            in
-                                                        if uu____8643
+                                                        if uu____8676
                                                         then
-                                                          let uu____8651 =
-                                                            let uu____8652 =
+                                                          let uu____8684 =
+                                                            let uu____8685 =
                                                               FStar_Syntax_Syntax.range_of_fv
                                                                 fv
                                                                in
-                                                            let uu____8653 =
-                                                              let uu____8666
+                                                            let uu____8686 =
+                                                              let uu____8699
                                                                 =
                                                                 FStar_All.pipe_right
                                                                   vars1
                                                                   (FStar_List.map
                                                                     FStar_SMTEncoding_Term.fv_sort)
                                                                  in
-                                                              let uu____8673
+                                                              let uu____8706
                                                                 =
                                                                 FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                                                   ()
                                                                  in
                                                               (vname,
-                                                                uu____8666,
+                                                                uu____8699,
                                                                 FStar_SMTEncoding_Term.Term_sort,
-                                                                uu____8673)
+                                                                uu____8706)
                                                                in
                                                             FStar_SMTEncoding_Term.fresh_constructor
-                                                              uu____8652
-                                                              uu____8653
+                                                              uu____8685
+                                                              uu____8686
                                                              in
-                                                          let uu____8679 =
-                                                            let uu____8682 =
-                                                              let uu____8683
+                                                          let uu____8712 =
+                                                            let uu____8715 =
+                                                              let uu____8716
                                                                 =
                                                                 FStar_Syntax_Syntax.range_of_fv
                                                                   fv
                                                                  in
                                                               pretype_axiom
-                                                                uu____8683
+                                                                uu____8716
                                                                 env2 vapp
                                                                 vars1
                                                                in
-                                                            [uu____8682]  in
-                                                          uu____8651 ::
-                                                            uu____8679
+                                                            [uu____8715]  in
+                                                          uu____8684 ::
+                                                            uu____8712
                                                         else []  in
                                                       let g =
-                                                        let uu____8689 =
-                                                          let uu____8692 =
-                                                            let uu____8695 =
-                                                              let uu____8698
+                                                        let uu____8722 =
+                                                          let uu____8725 =
+                                                            let uu____8728 =
+                                                              let uu____8731
                                                                 =
-                                                                let uu____8701
+                                                                let uu____8734
                                                                   =
-                                                                  let uu____8704
+                                                                  let uu____8737
                                                                     =
                                                                     mk_disc_proj_axioms
                                                                     guard
@@ -2654,25 +2678,25 @@ let (encode_free_var :
                                                                     vapp
                                                                     vars1  in
                                                                   typingAx ::
-                                                                    uu____8704
+                                                                    uu____8737
                                                                    in
                                                                 FStar_List.append
                                                                   freshness
-                                                                  uu____8701
+                                                                  uu____8734
                                                                  in
                                                               FStar_All.pipe_right
-                                                                uu____8698
+                                                                uu____8731
                                                                 FStar_SMTEncoding_Term.mk_decls_trivial
                                                                in
                                                             FStar_List.append
                                                               decls3
-                                                              uu____8695
+                                                              uu____8728
                                                              in
                                                           FStar_List.append
-                                                            decls2 uu____8692
+                                                            decls2 uu____8725
                                                            in
                                                         FStar_List.append
-                                                          decls11 uu____8689
+                                                          decls11 uu____8722
                                                          in
                                                       (g, env2)))))))))
   
@@ -2689,14 +2713,14 @@ let (declare_top_level_let :
     fun x  ->
       fun t  ->
         fun t_norm  ->
-          let uu____8744 =
+          let uu____8777 =
             FStar_SMTEncoding_Env.lookup_fvar_binding env
               (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          match uu____8744 with
+          match uu____8777 with
           | FStar_Pervasives_Native.None  ->
-              let uu____8755 = encode_free_var false env x t t_norm []  in
-              (match uu____8755 with
+              let uu____8788 = encode_free_var false env x t t_norm []  in
+              (match uu____8788 with
                | (decls,env1) ->
                    let fvb =
                      FStar_SMTEncoding_Env.lookup_lid env1
@@ -2719,17 +2743,17 @@ let (encode_top_level_val :
         fun t  ->
           fun quals  ->
             let tt = norm_before_encoding env t  in
-            let uu____8818 = encode_free_var uninterpreted env lid t tt quals
+            let uu____8851 = encode_free_var uninterpreted env lid t tt quals
                in
-            match uu____8818 with
+            match uu____8851 with
             | (decls,env1) ->
-                let uu____8829 = FStar_Syntax_Util.is_smt_lemma t  in
-                if uu____8829
+                let uu____8862 = FStar_Syntax_Util.is_smt_lemma t  in
+                if uu____8862
                 then
-                  let uu____8836 =
-                    let uu____8837 = encode_smt_lemma env1 lid tt  in
-                    FStar_List.append decls uu____8837  in
-                  (uu____8836, env1)
+                  let uu____8869 =
+                    let uu____8870 = encode_smt_lemma env1 lid tt  in
+                    FStar_List.append decls uu____8870  in
+                  (uu____8869, env1)
                 else (decls, env1)
   
 let (encode_top_level_vals :
@@ -2744,17 +2768,17 @@ let (encode_top_level_vals :
       fun quals  ->
         FStar_All.pipe_right bindings
           (FStar_List.fold_left
-             (fun uu____8893  ->
+             (fun uu____8926  ->
                 fun lb  ->
-                  match uu____8893 with
+                  match uu____8926 with
                   | (decls,env1) ->
-                      let uu____8913 =
-                        let uu____8918 =
+                      let uu____8946 =
+                        let uu____8951 =
                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-                        encode_top_level_val false env1 uu____8918
+                        encode_top_level_val false env1 uu____8951
                           lb.FStar_Syntax_Syntax.lbtyp quals
                          in
-                      (match uu____8913 with
+                      (match uu____8946 with
                        | (decls',env2) ->
                            ((FStar_List.append decls decls'), env2)))
              ([], env))
@@ -2763,55 +2787,55 @@ let (is_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
     let fstar_tactics_tactic_lid =
       FStar_Parser_Const.p2l ["FStar"; "Tactics"; "tactic"]  in
-    let uu____8947 = FStar_Syntax_Util.head_and_args t  in
-    match uu____8947 with
+    let uu____8980 = FStar_Syntax_Util.head_and_args t  in
+    match uu____8980 with
     | (hd,args) ->
-        let uu____8991 =
-          let uu____8992 = FStar_Syntax_Util.un_uinst hd  in
-          uu____8992.FStar_Syntax_Syntax.n  in
-        (match uu____8991 with
+        let uu____9024 =
+          let uu____9025 = FStar_Syntax_Util.un_uinst hd  in
+          uu____9025.FStar_Syntax_Syntax.n  in
+        (match uu____9024 with
          | FStar_Syntax_Syntax.Tm_fvar fv when
              FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_tactic_lid ->
              true
-         | FStar_Syntax_Syntax.Tm_arrow (uu____8998,c) ->
+         | FStar_Syntax_Syntax.Tm_arrow (uu____9031,c) ->
              let effect_name = FStar_Syntax_Util.comp_effect_name c  in
-             FStar_Util.starts_with "FStar.Tactics"
-               effect_name.FStar_Ident.str
-         | uu____9022 -> false)
+             let uu____9054 = FStar_Ident.string_of_lid effect_name  in
+             FStar_Util.starts_with "FStar.Tactics" uu____9054
+         | uu____9057 -> false)
   
 exception Let_rec_unencodeable 
 let (uu___is_Let_rec_unencodeable : Prims.exn -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | Let_rec_unencodeable  -> true
-    | uu____9033 -> false
+    | uu____9068 -> false
   
 let (copy_env : FStar_SMTEncoding_Env.env_t -> FStar_SMTEncoding_Env.env_t) =
   fun en  ->
-    let uu___495_9041 = en  in
-    let uu____9042 =
+    let uu___495_9076 = en  in
+    let uu____9077 =
       FStar_Util.smap_copy en.FStar_SMTEncoding_Env.global_cache  in
     {
       FStar_SMTEncoding_Env.bvar_bindings =
-        (uu___495_9041.FStar_SMTEncoding_Env.bvar_bindings);
+        (uu___495_9076.FStar_SMTEncoding_Env.bvar_bindings);
       FStar_SMTEncoding_Env.fvar_bindings =
-        (uu___495_9041.FStar_SMTEncoding_Env.fvar_bindings);
+        (uu___495_9076.FStar_SMTEncoding_Env.fvar_bindings);
       FStar_SMTEncoding_Env.depth =
-        (uu___495_9041.FStar_SMTEncoding_Env.depth);
+        (uu___495_9076.FStar_SMTEncoding_Env.depth);
       FStar_SMTEncoding_Env.tcenv =
-        (uu___495_9041.FStar_SMTEncoding_Env.tcenv);
-      FStar_SMTEncoding_Env.warn = (uu___495_9041.FStar_SMTEncoding_Env.warn);
+        (uu___495_9076.FStar_SMTEncoding_Env.tcenv);
+      FStar_SMTEncoding_Env.warn = (uu___495_9076.FStar_SMTEncoding_Env.warn);
       FStar_SMTEncoding_Env.nolabels =
-        (uu___495_9041.FStar_SMTEncoding_Env.nolabels);
+        (uu___495_9076.FStar_SMTEncoding_Env.nolabels);
       FStar_SMTEncoding_Env.use_zfuel_name =
-        (uu___495_9041.FStar_SMTEncoding_Env.use_zfuel_name);
+        (uu___495_9076.FStar_SMTEncoding_Env.use_zfuel_name);
       FStar_SMTEncoding_Env.encode_non_total_function_typ =
-        (uu___495_9041.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+        (uu___495_9076.FStar_SMTEncoding_Env.encode_non_total_function_typ);
       FStar_SMTEncoding_Env.current_module_name =
-        (uu___495_9041.FStar_SMTEncoding_Env.current_module_name);
+        (uu___495_9076.FStar_SMTEncoding_Env.current_module_name);
       FStar_SMTEncoding_Env.encoding_quantifier =
-        (uu___495_9041.FStar_SMTEncoding_Env.encoding_quantifier);
-      FStar_SMTEncoding_Env.global_cache = uu____9042
+        (uu___495_9076.FStar_SMTEncoding_Env.encoding_quantifier);
+      FStar_SMTEncoding_Env.global_cache = uu____9077
     }
   
 let (encode_top_level_let :
@@ -2821,195 +2845,195 @@ let (encode_top_level_let :
         (FStar_SMTEncoding_Term.decls_t * FStar_SMTEncoding_Env.env_t))
   =
   fun env  ->
-    fun uu____9072  ->
+    fun uu____9107  ->
       fun quals  ->
-        match uu____9072 with
+        match uu____9107 with
         | (is_rec,bindings) ->
             let eta_expand binders formals body t =
               let nbinders = FStar_List.length binders  in
-              let uu____9177 = FStar_Util.first_N nbinders formals  in
-              match uu____9177 with
+              let uu____9212 = FStar_Util.first_N nbinders formals  in
+              match uu____9212 with
               | (formals1,extra_formals) ->
                   let subst =
                     FStar_List.map2
-                      (fun uu____9274  ->
-                         fun uu____9275  ->
-                           match (uu____9274, uu____9275) with
-                           | ((formal,uu____9301),(binder,uu____9303)) ->
-                               let uu____9324 =
-                                 let uu____9331 =
+                      (fun uu____9309  ->
+                         fun uu____9310  ->
+                           match (uu____9309, uu____9310) with
+                           | ((formal,uu____9336),(binder,uu____9338)) ->
+                               let uu____9359 =
+                                 let uu____9366 =
                                    FStar_Syntax_Syntax.bv_to_name binder  in
-                                 (formal, uu____9331)  in
-                               FStar_Syntax_Syntax.NT uu____9324) formals1
+                                 (formal, uu____9366)  in
+                               FStar_Syntax_Syntax.NT uu____9359) formals1
                       binders
                      in
                   let extra_formals1 =
-                    let uu____9345 =
+                    let uu____9380 =
                       FStar_All.pipe_right extra_formals
                         (FStar_List.map
-                           (fun uu____9386  ->
-                              match uu____9386 with
+                           (fun uu____9421  ->
+                              match uu____9421 with
                               | (x,i) ->
-                                  let uu____9405 =
-                                    let uu___521_9406 = x  in
-                                    let uu____9407 =
+                                  let uu____9440 =
+                                    let uu___521_9441 = x  in
+                                    let uu____9442 =
                                       FStar_Syntax_Subst.subst subst
                                         x.FStar_Syntax_Syntax.sort
                                        in
                                     {
                                       FStar_Syntax_Syntax.ppname =
-                                        (uu___521_9406.FStar_Syntax_Syntax.ppname);
+                                        (uu___521_9441.FStar_Syntax_Syntax.ppname);
                                       FStar_Syntax_Syntax.index =
-                                        (uu___521_9406.FStar_Syntax_Syntax.index);
-                                      FStar_Syntax_Syntax.sort = uu____9407
+                                        (uu___521_9441.FStar_Syntax_Syntax.index);
+                                      FStar_Syntax_Syntax.sort = uu____9442
                                     }  in
-                                  (uu____9405, i)))
+                                  (uu____9440, i)))
                        in
-                    FStar_All.pipe_right uu____9345
+                    FStar_All.pipe_right uu____9380
                       FStar_Syntax_Util.name_binders
                      in
                   let body1 =
-                    let uu____9431 =
-                      let uu____9436 = FStar_Syntax_Subst.compress body  in
-                      let uu____9437 =
-                        let uu____9438 =
+                    let uu____9466 =
+                      let uu____9471 = FStar_Syntax_Subst.compress body  in
+                      let uu____9472 =
+                        let uu____9473 =
                           FStar_Syntax_Util.args_of_binders extra_formals1
                            in
                         FStar_All.pipe_left FStar_Pervasives_Native.snd
-                          uu____9438
+                          uu____9473
                          in
-                      FStar_Syntax_Syntax.extend_app_n uu____9436 uu____9437
+                      FStar_Syntax_Syntax.extend_app_n uu____9471 uu____9472
                        in
-                    uu____9431 FStar_Pervasives_Native.None
+                    uu____9466 FStar_Pervasives_Native.None
                       body.FStar_Syntax_Syntax.pos
                      in
                   ((FStar_List.append binders extra_formals1), body1)
                in
             let destruct_bound_function t e =
               let tcenv =
-                let uu___528_9487 = env.FStar_SMTEncoding_Env.tcenv  in
+                let uu___528_9522 = env.FStar_SMTEncoding_Env.tcenv  in
                 {
                   FStar_TypeChecker_Env.solver =
-                    (uu___528_9487.FStar_TypeChecker_Env.solver);
+                    (uu___528_9522.FStar_TypeChecker_Env.solver);
                   FStar_TypeChecker_Env.range =
-                    (uu___528_9487.FStar_TypeChecker_Env.range);
+                    (uu___528_9522.FStar_TypeChecker_Env.range);
                   FStar_TypeChecker_Env.curmodule =
-                    (uu___528_9487.FStar_TypeChecker_Env.curmodule);
+                    (uu___528_9522.FStar_TypeChecker_Env.curmodule);
                   FStar_TypeChecker_Env.gamma =
-                    (uu___528_9487.FStar_TypeChecker_Env.gamma);
+                    (uu___528_9522.FStar_TypeChecker_Env.gamma);
                   FStar_TypeChecker_Env.gamma_sig =
-                    (uu___528_9487.FStar_TypeChecker_Env.gamma_sig);
+                    (uu___528_9522.FStar_TypeChecker_Env.gamma_sig);
                   FStar_TypeChecker_Env.gamma_cache =
-                    (uu___528_9487.FStar_TypeChecker_Env.gamma_cache);
+                    (uu___528_9522.FStar_TypeChecker_Env.gamma_cache);
                   FStar_TypeChecker_Env.modules =
-                    (uu___528_9487.FStar_TypeChecker_Env.modules);
+                    (uu___528_9522.FStar_TypeChecker_Env.modules);
                   FStar_TypeChecker_Env.expected_typ =
-                    (uu___528_9487.FStar_TypeChecker_Env.expected_typ);
+                    (uu___528_9522.FStar_TypeChecker_Env.expected_typ);
                   FStar_TypeChecker_Env.sigtab =
-                    (uu___528_9487.FStar_TypeChecker_Env.sigtab);
+                    (uu___528_9522.FStar_TypeChecker_Env.sigtab);
                   FStar_TypeChecker_Env.attrtab =
-                    (uu___528_9487.FStar_TypeChecker_Env.attrtab);
+                    (uu___528_9522.FStar_TypeChecker_Env.attrtab);
                   FStar_TypeChecker_Env.instantiate_imp =
-                    (uu___528_9487.FStar_TypeChecker_Env.instantiate_imp);
+                    (uu___528_9522.FStar_TypeChecker_Env.instantiate_imp);
                   FStar_TypeChecker_Env.effects =
-                    (uu___528_9487.FStar_TypeChecker_Env.effects);
+                    (uu___528_9522.FStar_TypeChecker_Env.effects);
                   FStar_TypeChecker_Env.generalize =
-                    (uu___528_9487.FStar_TypeChecker_Env.generalize);
+                    (uu___528_9522.FStar_TypeChecker_Env.generalize);
                   FStar_TypeChecker_Env.letrecs =
-                    (uu___528_9487.FStar_TypeChecker_Env.letrecs);
+                    (uu___528_9522.FStar_TypeChecker_Env.letrecs);
                   FStar_TypeChecker_Env.top_level =
-                    (uu___528_9487.FStar_TypeChecker_Env.top_level);
+                    (uu___528_9522.FStar_TypeChecker_Env.top_level);
                   FStar_TypeChecker_Env.check_uvars =
-                    (uu___528_9487.FStar_TypeChecker_Env.check_uvars);
+                    (uu___528_9522.FStar_TypeChecker_Env.check_uvars);
                   FStar_TypeChecker_Env.use_eq =
-                    (uu___528_9487.FStar_TypeChecker_Env.use_eq);
+                    (uu___528_9522.FStar_TypeChecker_Env.use_eq);
                   FStar_TypeChecker_Env.use_eq_strict =
-                    (uu___528_9487.FStar_TypeChecker_Env.use_eq_strict);
+                    (uu___528_9522.FStar_TypeChecker_Env.use_eq_strict);
                   FStar_TypeChecker_Env.is_iface =
-                    (uu___528_9487.FStar_TypeChecker_Env.is_iface);
+                    (uu___528_9522.FStar_TypeChecker_Env.is_iface);
                   FStar_TypeChecker_Env.admit =
-                    (uu___528_9487.FStar_TypeChecker_Env.admit);
+                    (uu___528_9522.FStar_TypeChecker_Env.admit);
                   FStar_TypeChecker_Env.lax = true;
                   FStar_TypeChecker_Env.lax_universes =
-                    (uu___528_9487.FStar_TypeChecker_Env.lax_universes);
+                    (uu___528_9522.FStar_TypeChecker_Env.lax_universes);
                   FStar_TypeChecker_Env.phase1 =
-                    (uu___528_9487.FStar_TypeChecker_Env.phase1);
+                    (uu___528_9522.FStar_TypeChecker_Env.phase1);
                   FStar_TypeChecker_Env.failhard =
-                    (uu___528_9487.FStar_TypeChecker_Env.failhard);
+                    (uu___528_9522.FStar_TypeChecker_Env.failhard);
                   FStar_TypeChecker_Env.nosynth =
-                    (uu___528_9487.FStar_TypeChecker_Env.nosynth);
+                    (uu___528_9522.FStar_TypeChecker_Env.nosynth);
                   FStar_TypeChecker_Env.uvar_subtyping =
-                    (uu___528_9487.FStar_TypeChecker_Env.uvar_subtyping);
+                    (uu___528_9522.FStar_TypeChecker_Env.uvar_subtyping);
                   FStar_TypeChecker_Env.tc_term =
-                    (uu___528_9487.FStar_TypeChecker_Env.tc_term);
+                    (uu___528_9522.FStar_TypeChecker_Env.tc_term);
                   FStar_TypeChecker_Env.type_of =
-                    (uu___528_9487.FStar_TypeChecker_Env.type_of);
+                    (uu___528_9522.FStar_TypeChecker_Env.type_of);
                   FStar_TypeChecker_Env.universe_of =
-                    (uu___528_9487.FStar_TypeChecker_Env.universe_of);
+                    (uu___528_9522.FStar_TypeChecker_Env.universe_of);
                   FStar_TypeChecker_Env.check_type_of =
-                    (uu___528_9487.FStar_TypeChecker_Env.check_type_of);
+                    (uu___528_9522.FStar_TypeChecker_Env.check_type_of);
                   FStar_TypeChecker_Env.use_bv_sorts =
-                    (uu___528_9487.FStar_TypeChecker_Env.use_bv_sorts);
+                    (uu___528_9522.FStar_TypeChecker_Env.use_bv_sorts);
                   FStar_TypeChecker_Env.qtbl_name_and_index =
-                    (uu___528_9487.FStar_TypeChecker_Env.qtbl_name_and_index);
+                    (uu___528_9522.FStar_TypeChecker_Env.qtbl_name_and_index);
                   FStar_TypeChecker_Env.normalized_eff_names =
-                    (uu___528_9487.FStar_TypeChecker_Env.normalized_eff_names);
+                    (uu___528_9522.FStar_TypeChecker_Env.normalized_eff_names);
                   FStar_TypeChecker_Env.fv_delta_depths =
-                    (uu___528_9487.FStar_TypeChecker_Env.fv_delta_depths);
+                    (uu___528_9522.FStar_TypeChecker_Env.fv_delta_depths);
                   FStar_TypeChecker_Env.proof_ns =
-                    (uu___528_9487.FStar_TypeChecker_Env.proof_ns);
+                    (uu___528_9522.FStar_TypeChecker_Env.proof_ns);
                   FStar_TypeChecker_Env.synth_hook =
-                    (uu___528_9487.FStar_TypeChecker_Env.synth_hook);
+                    (uu___528_9522.FStar_TypeChecker_Env.synth_hook);
                   FStar_TypeChecker_Env.try_solve_implicits_hook =
-                    (uu___528_9487.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                    (uu___528_9522.FStar_TypeChecker_Env.try_solve_implicits_hook);
                   FStar_TypeChecker_Env.splice =
-                    (uu___528_9487.FStar_TypeChecker_Env.splice);
+                    (uu___528_9522.FStar_TypeChecker_Env.splice);
                   FStar_TypeChecker_Env.mpreprocess =
-                    (uu___528_9487.FStar_TypeChecker_Env.mpreprocess);
+                    (uu___528_9522.FStar_TypeChecker_Env.mpreprocess);
                   FStar_TypeChecker_Env.postprocess =
-                    (uu___528_9487.FStar_TypeChecker_Env.postprocess);
+                    (uu___528_9522.FStar_TypeChecker_Env.postprocess);
                   FStar_TypeChecker_Env.is_native_tactic =
-                    (uu___528_9487.FStar_TypeChecker_Env.is_native_tactic);
+                    (uu___528_9522.FStar_TypeChecker_Env.is_native_tactic);
                   FStar_TypeChecker_Env.identifier_info =
-                    (uu___528_9487.FStar_TypeChecker_Env.identifier_info);
+                    (uu___528_9522.FStar_TypeChecker_Env.identifier_info);
                   FStar_TypeChecker_Env.tc_hooks =
-                    (uu___528_9487.FStar_TypeChecker_Env.tc_hooks);
+                    (uu___528_9522.FStar_TypeChecker_Env.tc_hooks);
                   FStar_TypeChecker_Env.dsenv =
-                    (uu___528_9487.FStar_TypeChecker_Env.dsenv);
+                    (uu___528_9522.FStar_TypeChecker_Env.dsenv);
                   FStar_TypeChecker_Env.nbe =
-                    (uu___528_9487.FStar_TypeChecker_Env.nbe);
+                    (uu___528_9522.FStar_TypeChecker_Env.nbe);
                   FStar_TypeChecker_Env.strict_args_tab =
-                    (uu___528_9487.FStar_TypeChecker_Env.strict_args_tab);
+                    (uu___528_9522.FStar_TypeChecker_Env.strict_args_tab);
                   FStar_TypeChecker_Env.erasable_types_tab =
-                    (uu___528_9487.FStar_TypeChecker_Env.erasable_types_tab)
+                    (uu___528_9522.FStar_TypeChecker_Env.erasable_types_tab)
                 }  in
               let subst_comp formals actuals comp =
                 let subst =
                   FStar_List.map2
-                    (fun uu____9559  ->
-                       fun uu____9560  ->
-                         match (uu____9559, uu____9560) with
-                         | ((x,uu____9586),(b,uu____9588)) ->
-                             let uu____9609 =
-                               let uu____9616 =
+                    (fun uu____9594  ->
+                       fun uu____9595  ->
+                         match (uu____9594, uu____9595) with
+                         | ((x,uu____9621),(b,uu____9623)) ->
+                             let uu____9644 =
+                               let uu____9651 =
                                  FStar_Syntax_Syntax.bv_to_name b  in
-                               (x, uu____9616)  in
-                             FStar_Syntax_Syntax.NT uu____9609) formals
+                               (x, uu____9651)  in
+                             FStar_Syntax_Syntax.NT uu____9644) formals
                     actuals
                    in
                 FStar_Syntax_Subst.subst_comp subst comp  in
               let rec arrow_formals_comp_norm norm t1 =
                 let t2 =
-                  let uu____9641 = FStar_Syntax_Subst.compress t1  in
-                  FStar_All.pipe_left FStar_Syntax_Util.unascribe uu____9641
+                  let uu____9676 = FStar_Syntax_Subst.compress t1  in
+                  FStar_All.pipe_left FStar_Syntax_Util.unascribe uu____9676
                    in
                 match t2.FStar_Syntax_Syntax.n with
                 | FStar_Syntax_Syntax.Tm_arrow (formals,comp) ->
                     FStar_Syntax_Subst.open_comp formals comp
-                | FStar_Syntax_Syntax.Tm_refine uu____9670 ->
-                    let uu____9677 = FStar_Syntax_Util.unrefine t2  in
-                    arrow_formals_comp_norm norm uu____9677
-                | uu____9678 when Prims.op_Negation norm ->
+                | FStar_Syntax_Syntax.Tm_refine uu____9705 ->
+                    let uu____9712 = FStar_Syntax_Util.unrefine t2  in
+                    arrow_formals_comp_norm norm uu____9712
+                | uu____9713 when Prims.op_Negation norm ->
                     let t_norm =
                       norm_with_steps
                         [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -3023,63 +3047,63 @@ let (encode_top_level_let :
                         FStar_TypeChecker_Env.EraseUniverses] tcenv t2
                        in
                     arrow_formals_comp_norm true t_norm
-                | uu____9681 ->
-                    let uu____9682 = FStar_Syntax_Syntax.mk_Total t2  in
-                    ([], uu____9682)
+                | uu____9716 ->
+                    let uu____9717 = FStar_Syntax_Syntax.mk_Total t2  in
+                    ([], uu____9717)
                  in
               let aux t1 e1 =
-                let uu____9724 = FStar_Syntax_Util.abs_formals e1  in
-                match uu____9724 with
+                let uu____9759 = FStar_Syntax_Util.abs_formals e1  in
+                match uu____9759 with
                 | (binders,body,lopt) ->
-                    let uu____9756 =
+                    let uu____9791 =
                       match binders with
                       | [] -> arrow_formals_comp_norm true t1
-                      | uu____9772 -> arrow_formals_comp_norm false t1  in
-                    (match uu____9756 with
+                      | uu____9807 -> arrow_formals_comp_norm false t1  in
+                    (match uu____9791 with
                      | (formals,comp) ->
                          let nformals = FStar_List.length formals  in
                          let nbinders = FStar_List.length binders  in
-                         let uu____9806 =
+                         let uu____9841 =
                            if nformals < nbinders
                            then
-                             let uu____9840 =
+                             let uu____9875 =
                                FStar_Util.first_N nformals binders  in
-                             match uu____9840 with
+                             match uu____9875 with
                              | (bs0,rest) ->
                                  let body1 =
                                    FStar_Syntax_Util.abs rest body lopt  in
-                                 let uu____9920 = subst_comp formals bs0 comp
+                                 let uu____9955 = subst_comp formals bs0 comp
                                     in
-                                 (bs0, body1, uu____9920)
+                                 (bs0, body1, uu____9955)
                            else
                              if nformals > nbinders
                              then
-                               (let uu____9950 =
+                               (let uu____9985 =
                                   eta_expand binders formals body
                                     (FStar_Syntax_Util.comp_result comp)
                                    in
-                                match uu____9950 with
+                                match uu____9985 with
                                 | (binders1,body1) ->
-                                    let uu____10003 =
+                                    let uu____10038 =
                                       subst_comp formals binders1 comp  in
-                                    (binders1, body1, uu____10003))
+                                    (binders1, body1, uu____10038))
                              else
-                               (let uu____10016 =
+                               (let uu____10051 =
                                   subst_comp formals binders comp  in
-                                (binders, body, uu____10016))
+                                (binders, body, uu____10051))
                             in
-                         (match uu____9806 with
+                         (match uu____9841 with
                           | (binders1,body1,comp1) ->
                               (binders1, body1, comp1)))
                  in
-              let uu____10076 = aux t e  in
-              match uu____10076 with
+              let uu____10111 = aux t e  in
+              match uu____10111 with
               | (binders,body,comp) ->
-                  let uu____10122 =
-                    let uu____10133 =
+                  let uu____10157 =
+                    let uu____10168 =
                       FStar_SMTEncoding_Util.is_smt_reifiable_comp tcenv comp
                        in
-                    if uu____10133
+                    if uu____10168
                     then
                       let comp1 =
                         FStar_TypeChecker_Env.reify_comp tcenv comp
@@ -3087,27 +3111,27 @@ let (encode_top_level_let :
                          in
                       let body1 =
                         FStar_TypeChecker_Util.reify_body tcenv [] body  in
-                      let uu____10148 = aux comp1 body1  in
-                      match uu____10148 with
+                      let uu____10183 = aux comp1 body1  in
+                      match uu____10183 with
                       | (more_binders,body2,comp2) ->
                           ((FStar_List.append binders more_binders), body2,
                             comp2)
                     else (binders, body, comp)  in
-                  (match uu____10122 with
+                  (match uu____10157 with
                    | (binders1,body1,comp1) ->
-                       let uu____10231 =
+                       let uu____10266 =
                          FStar_Syntax_Util.ascribe body1
                            ((FStar_Util.Inl
                                (FStar_Syntax_Util.comp_result comp1)),
                              FStar_Pervasives_Native.None)
                           in
-                       (binders1, uu____10231, comp1))
+                       (binders1, uu____10266, comp1))
                in
             (try
-               (fun uu___598_10258  ->
+               (fun uu___598_10293  ->
                   match () with
                   | () ->
-                      let uu____10265 =
+                      let uu____10300 =
                         FStar_All.pipe_right bindings
                           (FStar_Util.for_all
                              (fun lb  ->
@@ -3115,21 +3139,21 @@ let (encode_top_level_let :
                                    lb.FStar_Syntax_Syntax.lbtyp)
                                   || (is_tactic lb.FStar_Syntax_Syntax.lbtyp)))
                          in
-                      if uu____10265
+                      if uu____10300
                       then encode_top_level_vals env bindings quals
                       else
-                        (let uu____10281 =
+                        (let uu____10316 =
                            FStar_All.pipe_right bindings
                              (FStar_List.fold_left
-                                (fun uu____10344  ->
+                                (fun uu____10379  ->
                                    fun lb  ->
-                                     match uu____10344 with
+                                     match uu____10379 with
                                      | (toks,typs,decls,env1) ->
-                                         ((let uu____10399 =
+                                         ((let uu____10434 =
                                              FStar_Syntax_Util.is_lemma
                                                lb.FStar_Syntax_Syntax.lbtyp
                                               in
-                                           if uu____10399
+                                           if uu____10434
                                            then
                                              FStar_Exn.raise
                                                Let_rec_unencodeable
@@ -3138,23 +3162,23 @@ let (encode_top_level_let :
                                              norm_before_encoding env1
                                                lb.FStar_Syntax_Syntax.lbtyp
                                               in
-                                           let uu____10405 =
-                                             let uu____10414 =
+                                           let uu____10440 =
+                                             let uu____10449 =
                                                FStar_Util.right
                                                  lb.FStar_Syntax_Syntax.lbname
                                                 in
                                              declare_top_level_let env1
-                                               uu____10414
+                                               uu____10449
                                                lb.FStar_Syntax_Syntax.lbtyp
                                                t_norm
                                               in
-                                           match uu____10405 with
+                                           match uu____10440 with
                                            | (tok,decl,env2) ->
                                                ((tok :: toks), (t_norm ::
                                                  typs), (decl :: decls),
                                                  env2)))) ([], [], [], env))
                             in
-                         match uu____10281 with
+                         match uu____10316 with
                          | (toks,typs,decls,env1) ->
                              let toks_fvbs = FStar_List.rev toks  in
                              let decls1 =
@@ -3168,107 +3192,107 @@ let (encode_top_level_let :
                                match (bindings1, typs2, toks1) with
                                | ({ FStar_Syntax_Syntax.lbname = lbn;
                                     FStar_Syntax_Syntax.lbunivs = uvs;
-                                    FStar_Syntax_Syntax.lbtyp = uu____10555;
-                                    FStar_Syntax_Syntax.lbeff = uu____10556;
+                                    FStar_Syntax_Syntax.lbtyp = uu____10590;
+                                    FStar_Syntax_Syntax.lbeff = uu____10591;
                                     FStar_Syntax_Syntax.lbdef = e;
-                                    FStar_Syntax_Syntax.lbattrs = uu____10558;
-                                    FStar_Syntax_Syntax.lbpos = uu____10559;_}::[],t_norm::[],fvb::[])
+                                    FStar_Syntax_Syntax.lbattrs = uu____10593;
+                                    FStar_Syntax_Syntax.lbpos = uu____10594;_}::[],t_norm::[],fvb::[])
                                    ->
                                    let flid =
                                      fvb.FStar_SMTEncoding_Env.fvar_lid  in
-                                   let uu____10583 =
-                                     let uu____10590 =
+                                   let uu____10618 =
+                                     let uu____10625 =
                                        FStar_TypeChecker_Env.open_universes_in
                                          env2.FStar_SMTEncoding_Env.tcenv uvs
                                          [e; t_norm]
                                         in
-                                     match uu____10590 with
-                                     | (tcenv',uu____10606,e_t) ->
-                                         let uu____10612 =
+                                     match uu____10625 with
+                                     | (tcenv',uu____10641,e_t) ->
+                                         let uu____10647 =
                                            match e_t with
                                            | e1::t_norm1::[] -> (e1, t_norm1)
-                                           | uu____10623 ->
+                                           | uu____10658 ->
                                                failwith "Impossible"
                                             in
-                                         (match uu____10612 with
+                                         (match uu____10647 with
                                           | (e1,t_norm1) ->
-                                              ((let uu___661_10640 = env2  in
+                                              ((let uu___661_10675 = env2  in
                                                 {
                                                   FStar_SMTEncoding_Env.bvar_bindings
                                                     =
-                                                    (uu___661_10640.FStar_SMTEncoding_Env.bvar_bindings);
+                                                    (uu___661_10675.FStar_SMTEncoding_Env.bvar_bindings);
                                                   FStar_SMTEncoding_Env.fvar_bindings
                                                     =
-                                                    (uu___661_10640.FStar_SMTEncoding_Env.fvar_bindings);
+                                                    (uu___661_10675.FStar_SMTEncoding_Env.fvar_bindings);
                                                   FStar_SMTEncoding_Env.depth
                                                     =
-                                                    (uu___661_10640.FStar_SMTEncoding_Env.depth);
+                                                    (uu___661_10675.FStar_SMTEncoding_Env.depth);
                                                   FStar_SMTEncoding_Env.tcenv
                                                     = tcenv';
                                                   FStar_SMTEncoding_Env.warn
                                                     =
-                                                    (uu___661_10640.FStar_SMTEncoding_Env.warn);
+                                                    (uu___661_10675.FStar_SMTEncoding_Env.warn);
                                                   FStar_SMTEncoding_Env.nolabels
                                                     =
-                                                    (uu___661_10640.FStar_SMTEncoding_Env.nolabels);
+                                                    (uu___661_10675.FStar_SMTEncoding_Env.nolabels);
                                                   FStar_SMTEncoding_Env.use_zfuel_name
                                                     =
-                                                    (uu___661_10640.FStar_SMTEncoding_Env.use_zfuel_name);
+                                                    (uu___661_10675.FStar_SMTEncoding_Env.use_zfuel_name);
                                                   FStar_SMTEncoding_Env.encode_non_total_function_typ
                                                     =
-                                                    (uu___661_10640.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                                                    (uu___661_10675.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                                                   FStar_SMTEncoding_Env.current_module_name
                                                     =
-                                                    (uu___661_10640.FStar_SMTEncoding_Env.current_module_name);
+                                                    (uu___661_10675.FStar_SMTEncoding_Env.current_module_name);
                                                   FStar_SMTEncoding_Env.encoding_quantifier
                                                     =
-                                                    (uu___661_10640.FStar_SMTEncoding_Env.encoding_quantifier);
+                                                    (uu___661_10675.FStar_SMTEncoding_Env.encoding_quantifier);
                                                   FStar_SMTEncoding_Env.global_cache
                                                     =
-                                                    (uu___661_10640.FStar_SMTEncoding_Env.global_cache)
+                                                    (uu___661_10675.FStar_SMTEncoding_Env.global_cache)
                                                 }), e1, t_norm1))
                                       in
-                                   (match uu____10583 with
+                                   (match uu____10618 with
                                     | (env',e1,t_norm1) ->
-                                        let uu____10650 =
+                                        let uu____10685 =
                                           destruct_bound_function t_norm1 e1
                                            in
-                                        (match uu____10650 with
+                                        (match uu____10685 with
                                          | (binders,body,t_body_comp) ->
                                              let t_body =
                                                FStar_Syntax_Util.comp_result
                                                  t_body_comp
                                                 in
-                                             ((let uu____10670 =
+                                             ((let uu____10705 =
                                                  FStar_All.pipe_left
                                                    (FStar_TypeChecker_Env.debug
                                                       env2.FStar_SMTEncoding_Env.tcenv)
                                                    (FStar_Options.Other
                                                       "SMTEncoding")
                                                   in
-                                               if uu____10670
+                                               if uu____10705
                                                then
-                                                 let uu____10675 =
+                                                 let uu____10710 =
                                                    FStar_Syntax_Print.binders_to_string
                                                      ", " binders
                                                     in
-                                                 let uu____10678 =
+                                                 let uu____10713 =
                                                    FStar_Syntax_Print.term_to_string
                                                      body
                                                     in
                                                  FStar_Util.print2
                                                    "Encoding let : binders=[%s], body=%s\n"
-                                                   uu____10675 uu____10678
+                                                   uu____10710 uu____10713
                                                else ());
-                                              (let uu____10683 =
+                                              (let uu____10718 =
                                                  FStar_SMTEncoding_EncodeTerm.encode_binders
                                                    FStar_Pervasives_Native.None
                                                    binders env'
                                                   in
-                                               match uu____10683 with
-                                               | (vars,_guards,env'1,binder_decls,uu____10710)
+                                               match uu____10718 with
+                                               | (vars,_guards,env'1,binder_decls,uu____10745)
                                                    ->
-                                                   let uu____10723 =
+                                                   let uu____10758 =
                                                      if
                                                        fvb.FStar_SMTEncoding_Env.fvb_thunked
                                                          && (vars = [])
@@ -3284,46 +3308,46 @@ let (encode_top_level_let :
                                                            FStar_Range.dummyRange
                                                           in
                                                        let app =
-                                                         let uu____10740 =
+                                                         let uu____10775 =
                                                            FStar_Syntax_Util.range_of_lbname
                                                              lbn
                                                             in
                                                          FStar_SMTEncoding_Term.mkApp
                                                            ((fvb.FStar_SMTEncoding_Env.smt_id),
                                                              [dummy_tm])
-                                                           uu____10740
+                                                           uu____10775
                                                           in
                                                        ([dummy_var], app)
                                                      else
-                                                       (let uu____10762 =
-                                                          let uu____10763 =
+                                                       (let uu____10797 =
+                                                          let uu____10798 =
                                                             FStar_Syntax_Util.range_of_lbname
                                                               lbn
                                                              in
-                                                          let uu____10764 =
+                                                          let uu____10799 =
                                                             FStar_List.map
                                                               FStar_SMTEncoding_Util.mkFreeV
                                                               vars
                                                              in
                                                           FStar_SMTEncoding_EncodeTerm.maybe_curry_fvb
-                                                            uu____10763 fvb
-                                                            uu____10764
+                                                            uu____10798 fvb
+                                                            uu____10799
                                                            in
-                                                        (vars, uu____10762))
+                                                        (vars, uu____10797))
                                                       in
-                                                   (match uu____10723 with
+                                                   (match uu____10758 with
                                                     | (vars1,app) ->
-                                                        let uu____10775 =
+                                                        let uu____10810 =
                                                           let is_logical =
-                                                            let uu____10788 =
-                                                              let uu____10789
+                                                            let uu____10823 =
+                                                              let uu____10824
                                                                 =
                                                                 FStar_Syntax_Subst.compress
                                                                   t_body
                                                                  in
-                                                              uu____10789.FStar_Syntax_Syntax.n
+                                                              uu____10824.FStar_Syntax_Syntax.n
                                                                in
-                                                            match uu____10788
+                                                            match uu____10823
                                                             with
                                                             | FStar_Syntax_Syntax.Tm_fvar
                                                                 fv when
@@ -3331,34 +3355,38 @@ let (encode_top_level_let :
                                                                   fv
                                                                   FStar_Parser_Const.logical_lid
                                                                 -> true
-                                                            | uu____10795 ->
+                                                            | uu____10830 ->
                                                                 false
                                                              in
                                                           let is_prims =
-                                                            let uu____10799 =
-                                                              let uu____10800
+                                                            let uu____10834 =
+                                                              let uu____10835
                                                                 =
                                                                 FStar_All.pipe_right
                                                                   lbn
                                                                   FStar_Util.right
                                                                  in
                                                               FStar_All.pipe_right
-                                                                uu____10800
+                                                                uu____10835
                                                                 FStar_Syntax_Syntax.lid_of_fv
                                                                in
                                                             FStar_All.pipe_right
-                                                              uu____10799
+                                                              uu____10834
                                                               (fun lid  ->
-                                                                 let uu____10809
+                                                                 let uu____10844
                                                                    =
+                                                                   let uu____10845
+                                                                    =
+                                                                    FStar_Ident.ns_of_lid
+                                                                    lid  in
                                                                    FStar_Ident.lid_of_ids
-                                                                    lid.FStar_Ident.ns
+                                                                    uu____10845
                                                                     in
                                                                  FStar_Ident.lid_equals
-                                                                   uu____10809
+                                                                   uu____10844
                                                                    FStar_Parser_Const.prims_lid)
                                                              in
-                                                          let uu____10810 =
+                                                          let uu____10846 =
                                                             (Prims.op_Negation
                                                                is_prims)
                                                               &&
@@ -3369,45 +3397,45 @@ let (encode_top_level_let :
                                                                  ||
                                                                  is_logical)
                                                              in
-                                                          if uu____10810
+                                                          if uu____10846
                                                           then
-                                                            let uu____10826 =
+                                                            let uu____10862 =
                                                               FStar_SMTEncoding_Term.mk_Valid
                                                                 app
                                                                in
-                                                            let uu____10827 =
+                                                            let uu____10863 =
                                                               FStar_SMTEncoding_EncodeTerm.encode_formula
                                                                 body env'1
                                                                in
                                                             (app,
-                                                              uu____10826,
-                                                              uu____10827)
+                                                              uu____10862,
+                                                              uu____10863)
                                                           else
-                                                            (let uu____10838
+                                                            (let uu____10874
                                                                =
                                                                FStar_SMTEncoding_EncodeTerm.encode_term
                                                                  body env'1
                                                                 in
                                                              (app, app,
-                                                               uu____10838))
+                                                               uu____10874))
                                                            in
-                                                        (match uu____10775
+                                                        (match uu____10810
                                                          with
                                                          | (pat,app1,
                                                             (body1,decls2))
                                                              ->
                                                              let eqn =
-                                                               let uu____10862
+                                                               let uu____10898
                                                                  =
-                                                                 let uu____10870
+                                                                 let uu____10906
                                                                    =
-                                                                   let uu____10871
+                                                                   let uu____10907
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
-                                                                   let uu____10872
+                                                                   let uu____10908
                                                                     =
-                                                                    let uu____10883
+                                                                    let uu____10919
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (app1,
@@ -3415,43 +3443,47 @@ let (encode_top_level_let :
                                                                      in
                                                                     ([[pat]],
                                                                     vars1,
-                                                                    uu____10883)
+                                                                    uu____10919)
                                                                      in
                                                                    FStar_SMTEncoding_Term.mkForall
-                                                                    uu____10871
-                                                                    uu____10872
+                                                                    uu____10907
+                                                                    uu____10908
                                                                     in
-                                                                 let uu____10892
+                                                                 let uu____10928
                                                                    =
-                                                                   let uu____10893
+                                                                   let uu____10929
                                                                     =
+                                                                    let uu____10931
+                                                                    =
+                                                                    FStar_Ident.string_of_lid
+                                                                    flid  in
                                                                     FStar_Util.format1
                                                                     "Equation for %s"
-                                                                    flid.FStar_Ident.str
+                                                                    uu____10931
                                                                      in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____10893
+                                                                    uu____10929
                                                                     in
-                                                                 (uu____10870,
-                                                                   uu____10892,
+                                                                 (uu____10906,
+                                                                   uu____10928,
                                                                    (Prims.op_Hat
                                                                     "equation_"
                                                                     fvb.FStar_SMTEncoding_Env.smt_id))
                                                                   in
                                                                FStar_SMTEncoding_Util.mkAssume
-                                                                 uu____10862
+                                                                 uu____10898
                                                                 in
-                                                             let uu____10899
+                                                             let uu____10937
                                                                =
-                                                               let uu____10902
+                                                               let uu____10940
                                                                  =
-                                                                 let uu____10905
+                                                                 let uu____10943
                                                                    =
-                                                                   let uu____10908
+                                                                   let uu____10946
                                                                     =
-                                                                    let uu____10911
+                                                                    let uu____10949
                                                                     =
-                                                                    let uu____10914
+                                                                    let uu____10952
                                                                     =
                                                                     primitive_type_axioms
                                                                     env2.FStar_SMTEncoding_Env.tcenv
@@ -3459,199 +3491,199 @@ let (encode_top_level_let :
                                                                     fvb.FStar_SMTEncoding_Env.smt_id
                                                                     app1  in
                                                                     eqn ::
-                                                                    uu____10914
+                                                                    uu____10952
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____10911
+                                                                    uu____10949
                                                                     FStar_SMTEncoding_Term.mk_decls_trivial
                                                                      in
                                                                    FStar_List.append
                                                                     decls2
-                                                                    uu____10908
+                                                                    uu____10946
                                                                     in
                                                                  FStar_List.append
                                                                    binder_decls
-                                                                   uu____10905
+                                                                   uu____10943
                                                                   in
                                                                FStar_List.append
                                                                  decls1
-                                                                 uu____10902
+                                                                 uu____10940
                                                                 in
-                                                             (uu____10899,
+                                                             (uu____10937,
                                                                env2)))))))
-                               | uu____10923 -> failwith "Impossible"  in
+                               | uu____10961 -> failwith "Impossible"  in
                              let encode_rec_lbdefs bindings1 typs2 toks1 env2
                                =
                                let fuel =
-                                 let uu____10983 =
-                                   let uu____10989 =
+                                 let uu____11021 =
+                                   let uu____11027 =
                                      FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.fresh
                                        env2.FStar_SMTEncoding_Env.current_module_name
                                        "fuel"
                                       in
-                                   (uu____10989,
+                                   (uu____11027,
                                      FStar_SMTEncoding_Term.Fuel_sort)
                                     in
-                                 FStar_SMTEncoding_Term.mk_fv uu____10983  in
+                                 FStar_SMTEncoding_Term.mk_fv uu____11021  in
                                let fuel_tm =
                                  FStar_SMTEncoding_Util.mkFreeV fuel  in
                                let env0 = env2  in
-                               let uu____10995 =
+                               let uu____11033 =
                                  FStar_All.pipe_right toks1
                                    (FStar_List.fold_left
-                                      (fun uu____11048  ->
+                                      (fun uu____11086  ->
                                          fun fvb  ->
-                                           match uu____11048 with
+                                           match uu____11086 with
                                            | (gtoks,env3) ->
                                                let flid =
                                                  fvb.FStar_SMTEncoding_Env.fvar_lid
                                                   in
                                                let g =
-                                                 let uu____11103 =
+                                                 let uu____11141 =
                                                    FStar_Ident.lid_add_suffix
                                                      flid "fuel_instrumented"
                                                     in
                                                  FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
-                                                   uu____11103
+                                                   uu____11141
                                                   in
                                                let gtok =
-                                                 let uu____11107 =
+                                                 let uu____11145 =
                                                    FStar_Ident.lid_add_suffix
                                                      flid
                                                      "fuel_instrumented_token"
                                                     in
                                                  FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
-                                                   uu____11107
+                                                   uu____11145
                                                   in
                                                let env4 =
-                                                 let uu____11110 =
-                                                   let uu____11113 =
+                                                 let uu____11148 =
+                                                   let uu____11151 =
                                                      FStar_SMTEncoding_Util.mkApp
                                                        (g, [fuel_tm])
                                                       in
                                                    FStar_All.pipe_left
-                                                     (fun uu____11119  ->
+                                                     (fun uu____11157  ->
                                                         FStar_Pervasives_Native.Some
-                                                          uu____11119)
-                                                     uu____11113
+                                                          uu____11157)
+                                                     uu____11151
                                                     in
                                                  FStar_SMTEncoding_Env.push_free_var
                                                    env3 flid
                                                    fvb.FStar_SMTEncoding_Env.smt_arity
-                                                   gtok uu____11110
+                                                   gtok uu____11148
                                                   in
                                                (((fvb, g, gtok) :: gtoks),
                                                  env4)) ([], env2))
                                   in
-                               match uu____10995 with
+                               match uu____11033 with
                                | (gtoks,env3) ->
                                    let gtoks1 = FStar_List.rev gtoks  in
-                                   let encode_one_binding env01 uu____11239
-                                     t_norm uu____11241 =
-                                     match (uu____11239, uu____11241) with
+                                   let encode_one_binding env01 uu____11277
+                                     t_norm uu____11279 =
+                                     match (uu____11277, uu____11279) with
                                      | ((fvb,g,gtok),{
                                                        FStar_Syntax_Syntax.lbname
                                                          = lbn;
                                                        FStar_Syntax_Syntax.lbunivs
                                                          = uvs;
                                                        FStar_Syntax_Syntax.lbtyp
-                                                         = uu____11271;
+                                                         = uu____11309;
                                                        FStar_Syntax_Syntax.lbeff
-                                                         = uu____11272;
+                                                         = uu____11310;
                                                        FStar_Syntax_Syntax.lbdef
                                                          = e;
                                                        FStar_Syntax_Syntax.lbattrs
-                                                         = uu____11274;
+                                                         = uu____11312;
                                                        FStar_Syntax_Syntax.lbpos
-                                                         = uu____11275;_})
+                                                         = uu____11313;_})
                                          ->
-                                         let uu____11302 =
-                                           let uu____11309 =
+                                         let uu____11340 =
+                                           let uu____11347 =
                                              FStar_TypeChecker_Env.open_universes_in
                                                env3.FStar_SMTEncoding_Env.tcenv
                                                uvs [e; t_norm]
                                               in
-                                           match uu____11309 with
-                                           | (tcenv',uu____11325,e_t) ->
-                                               let uu____11331 =
+                                           match uu____11347 with
+                                           | (tcenv',uu____11363,e_t) ->
+                                               let uu____11369 =
                                                  match e_t with
                                                  | e1::t_norm1::[] ->
                                                      (e1, t_norm1)
-                                                 | uu____11342 ->
+                                                 | uu____11380 ->
                                                      failwith "Impossible"
                                                   in
-                                               (match uu____11331 with
+                                               (match uu____11369 with
                                                 | (e1,t_norm1) ->
-                                                    ((let uu___748_11359 =
+                                                    ((let uu___748_11397 =
                                                         env3  in
                                                       {
                                                         FStar_SMTEncoding_Env.bvar_bindings
                                                           =
-                                                          (uu___748_11359.FStar_SMTEncoding_Env.bvar_bindings);
+                                                          (uu___748_11397.FStar_SMTEncoding_Env.bvar_bindings);
                                                         FStar_SMTEncoding_Env.fvar_bindings
                                                           =
-                                                          (uu___748_11359.FStar_SMTEncoding_Env.fvar_bindings);
+                                                          (uu___748_11397.FStar_SMTEncoding_Env.fvar_bindings);
                                                         FStar_SMTEncoding_Env.depth
                                                           =
-                                                          (uu___748_11359.FStar_SMTEncoding_Env.depth);
+                                                          (uu___748_11397.FStar_SMTEncoding_Env.depth);
                                                         FStar_SMTEncoding_Env.tcenv
                                                           = tcenv';
                                                         FStar_SMTEncoding_Env.warn
                                                           =
-                                                          (uu___748_11359.FStar_SMTEncoding_Env.warn);
+                                                          (uu___748_11397.FStar_SMTEncoding_Env.warn);
                                                         FStar_SMTEncoding_Env.nolabels
                                                           =
-                                                          (uu___748_11359.FStar_SMTEncoding_Env.nolabels);
+                                                          (uu___748_11397.FStar_SMTEncoding_Env.nolabels);
                                                         FStar_SMTEncoding_Env.use_zfuel_name
                                                           =
-                                                          (uu___748_11359.FStar_SMTEncoding_Env.use_zfuel_name);
+                                                          (uu___748_11397.FStar_SMTEncoding_Env.use_zfuel_name);
                                                         FStar_SMTEncoding_Env.encode_non_total_function_typ
                                                           =
-                                                          (uu___748_11359.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                                                          (uu___748_11397.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                                                         FStar_SMTEncoding_Env.current_module_name
                                                           =
-                                                          (uu___748_11359.FStar_SMTEncoding_Env.current_module_name);
+                                                          (uu___748_11397.FStar_SMTEncoding_Env.current_module_name);
                                                         FStar_SMTEncoding_Env.encoding_quantifier
                                                           =
-                                                          (uu___748_11359.FStar_SMTEncoding_Env.encoding_quantifier);
+                                                          (uu___748_11397.FStar_SMTEncoding_Env.encoding_quantifier);
                                                         FStar_SMTEncoding_Env.global_cache
                                                           =
-                                                          (uu___748_11359.FStar_SMTEncoding_Env.global_cache)
+                                                          (uu___748_11397.FStar_SMTEncoding_Env.global_cache)
                                                       }), e1, t_norm1))
                                             in
-                                         (match uu____11302 with
+                                         (match uu____11340 with
                                           | (env',e1,t_norm1) ->
-                                              ((let uu____11372 =
+                                              ((let uu____11410 =
                                                   FStar_All.pipe_left
                                                     (FStar_TypeChecker_Env.debug
                                                        env01.FStar_SMTEncoding_Env.tcenv)
                                                     (FStar_Options.Other
                                                        "SMTEncoding")
                                                    in
-                                                if uu____11372
+                                                if uu____11410
                                                 then
-                                                  let uu____11377 =
+                                                  let uu____11415 =
                                                     FStar_Syntax_Print.lbname_to_string
                                                       lbn
                                                      in
-                                                  let uu____11379 =
+                                                  let uu____11417 =
                                                     FStar_Syntax_Print.term_to_string
                                                       t_norm1
                                                      in
-                                                  let uu____11381 =
+                                                  let uu____11419 =
                                                     FStar_Syntax_Print.term_to_string
                                                       e1
                                                      in
                                                   FStar_Util.print3
                                                     "Encoding let rec %s : %s = %s\n"
-                                                    uu____11377 uu____11379
-                                                    uu____11381
+                                                    uu____11415 uu____11417
+                                                    uu____11419
                                                 else ());
-                                               (let uu____11386 =
+                                               (let uu____11424 =
                                                   destruct_bound_function
                                                     t_norm1 e1
                                                    in
-                                                match uu____11386 with
+                                                match uu____11424 with
                                                 | (binders,body,tres_comp) ->
                                                     let curry =
                                                       fvb.FStar_SMTEncoding_Env.smt_arity
@@ -3659,94 +3691,94 @@ let (encode_top_level_let :
                                                         (FStar_List.length
                                                            binders)
                                                        in
-                                                    let uu____11413 =
+                                                    let uu____11451 =
                                                       FStar_TypeChecker_Util.pure_or_ghost_pre_and_post
                                                         env3.FStar_SMTEncoding_Env.tcenv
                                                         tres_comp
                                                        in
-                                                    (match uu____11413 with
+                                                    (match uu____11451 with
                                                      | (pre_opt,tres) ->
-                                                         ((let uu____11435 =
+                                                         ((let uu____11473 =
                                                              FStar_All.pipe_left
                                                                (FStar_TypeChecker_Env.debug
                                                                   env01.FStar_SMTEncoding_Env.tcenv)
                                                                (FStar_Options.Other
                                                                   "SMTEncodingReify")
                                                               in
-                                                           if uu____11435
+                                                           if uu____11473
                                                            then
-                                                             let uu____11440
+                                                             let uu____11478
                                                                =
                                                                FStar_Syntax_Print.lbname_to_string
                                                                  lbn
                                                                 in
-                                                             let uu____11442
+                                                             let uu____11480
                                                                =
                                                                FStar_Syntax_Print.binders_to_string
                                                                  ", " binders
                                                                 in
-                                                             let uu____11445
+                                                             let uu____11483
                                                                =
                                                                FStar_Syntax_Print.term_to_string
                                                                  body
                                                                 in
-                                                             let uu____11447
+                                                             let uu____11485
                                                                =
                                                                FStar_Syntax_Print.comp_to_string
                                                                  tres_comp
                                                                 in
                                                              FStar_Util.print4
                                                                "Encoding let rec %s: \n\tbinders=[%s], \n\tbody=%s, \n\ttres=%s\n"
-                                                               uu____11440
-                                                               uu____11442
-                                                               uu____11445
-                                                               uu____11447
+                                                               uu____11478
+                                                               uu____11480
+                                                               uu____11483
+                                                               uu____11485
                                                            else ());
-                                                          (let uu____11452 =
+                                                          (let uu____11490 =
                                                              FStar_SMTEncoding_EncodeTerm.encode_binders
                                                                FStar_Pervasives_Native.None
                                                                binders env'
                                                               in
-                                                           match uu____11452
+                                                           match uu____11490
                                                            with
-                                                           | (vars,guards,env'1,binder_decls,uu____11481)
+                                                           | (vars,guards,env'1,binder_decls,uu____11519)
                                                                ->
-                                                               let uu____11494
+                                                               let uu____11532
                                                                  =
                                                                  match pre_opt
                                                                  with
                                                                  | FStar_Pervasives_Native.None
                                                                      ->
-                                                                    let uu____11507
+                                                                    let uu____11545
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     guards
                                                                      in
-                                                                    (uu____11507,
+                                                                    (uu____11545,
                                                                     [])
                                                                  | FStar_Pervasives_Native.Some
                                                                     pre ->
-                                                                    let uu____11511
+                                                                    let uu____11549
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_formula
                                                                     pre env'1
                                                                      in
-                                                                    (match uu____11511
+                                                                    (match uu____11549
                                                                     with
                                                                     | 
                                                                     (guard,decls0)
                                                                     ->
-                                                                    let uu____11524
+                                                                    let uu____11562
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
                                                                     guards
                                                                     [guard])
                                                                      in
-                                                                    (uu____11524,
+                                                                    (uu____11562,
                                                                     decls0))
                                                                   in
-                                                               (match uu____11494
+                                                               (match uu____11532
                                                                 with
                                                                 | (guard,guard_decls)
                                                                     ->
@@ -3758,38 +3790,38 @@ let (encode_top_level_let :
                                                                      in
                                                                     let decl_g
                                                                     =
-                                                                    let uu____11545
+                                                                    let uu____11583
                                                                     =
-                                                                    let uu____11557
+                                                                    let uu____11595
                                                                     =
-                                                                    let uu____11560
+                                                                    let uu____11598
                                                                     =
-                                                                    let uu____11563
+                                                                    let uu____11601
                                                                     =
-                                                                    let uu____11566
+                                                                    let uu____11604
                                                                     =
                                                                     FStar_Util.first_N
                                                                     fvb.FStar_SMTEncoding_Env.smt_arity
                                                                     vars  in
                                                                     FStar_Pervasives_Native.fst
-                                                                    uu____11566
+                                                                    uu____11604
                                                                      in
                                                                     FStar_List.map
                                                                     FStar_SMTEncoding_Term.fv_sort
-                                                                    uu____11563
+                                                                    uu____11601
                                                                      in
                                                                     FStar_SMTEncoding_Term.Fuel_sort
                                                                     ::
-                                                                    uu____11560
+                                                                    uu____11598
                                                                      in
                                                                     (g,
-                                                                    uu____11557,
+                                                                    uu____11595,
                                                                     FStar_SMTEncoding_Term.Term_sort,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Fuel-instrumented function name"))
                                                                      in
                                                                     FStar_SMTEncoding_Term.DeclFun
-                                                                    uu____11545
+                                                                    uu____11583
                                                                      in
                                                                     let env02
                                                                     =
@@ -3815,14 +3847,14 @@ let (encode_top_level_let :
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
                                                                     let app =
-                                                                    let uu____11596
+                                                                    let uu____11634
                                                                     =
                                                                     FStar_List.map
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     vars  in
                                                                     FStar_SMTEncoding_EncodeTerm.maybe_curry_fvb
                                                                     rng fvb
-                                                                    uu____11596
+                                                                    uu____11634
                                                                      in
                                                                     let mk_g_app
                                                                     args =
@@ -3837,74 +3869,74 @@ let (encode_top_level_let :
                                                                     args  in
                                                                     let gsapp
                                                                     =
-                                                                    let uu____11611
+                                                                    let uu____11649
                                                                     =
-                                                                    let uu____11614
+                                                                    let uu____11652
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkApp
                                                                     ("SFuel",
                                                                     [fuel_tm])
                                                                      in
-                                                                    uu____11614
+                                                                    uu____11652
                                                                     ::
                                                                     vars_tm
                                                                      in
                                                                     mk_g_app
-                                                                    uu____11611
+                                                                    uu____11649
                                                                      in
                                                                     let gmax
                                                                     =
-                                                                    let uu____11620
+                                                                    let uu____11658
                                                                     =
-                                                                    let uu____11623
+                                                                    let uu____11661
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkApp
                                                                     ("MaxFuel",
                                                                     [])  in
-                                                                    uu____11623
+                                                                    uu____11661
                                                                     ::
                                                                     vars_tm
                                                                      in
                                                                     mk_g_app
-                                                                    uu____11620
+                                                                    uu____11658
                                                                      in
-                                                                    let uu____11628
+                                                                    let uu____11666
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_term
                                                                     body
                                                                     env'1  in
-                                                                    (match uu____11628
+                                                                    (match uu____11666
                                                                     with
                                                                     | 
                                                                     (body_tm,decls2)
                                                                     ->
                                                                     let eqn_g
                                                                     =
-                                                                    let uu____11644
+                                                                    let uu____11682
                                                                     =
-                                                                    let uu____11652
+                                                                    let uu____11690
                                                                     =
-                                                                    let uu____11653
+                                                                    let uu____11691
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
-                                                                    let uu____11654
+                                                                    let uu____11692
                                                                     =
-                                                                    let uu____11670
+                                                                    let uu____11708
                                                                     =
-                                                                    let uu____11671
+                                                                    let uu____11709
                                                                     =
-                                                                    let uu____11676
+                                                                    let uu____11714
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (gsapp,
                                                                     body_tm)
                                                                      in
                                                                     (guard,
-                                                                    uu____11676)
+                                                                    uu____11714)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____11671
+                                                                    uu____11709
                                                                      in
                                                                     ([
                                                                     [gsapp]],
@@ -3912,123 +3944,128 @@ let (encode_top_level_let :
                                                                     Prims.int_zero),
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____11670)
+                                                                    uu____11708)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall'
-                                                                    uu____11653
-                                                                    uu____11654
+                                                                    uu____11691
+                                                                    uu____11692
                                                                      in
-                                                                    let uu____11690
+                                                                    let uu____11728
                                                                     =
-                                                                    let uu____11691
+                                                                    let uu____11729
                                                                     =
+                                                                    let uu____11731
+                                                                    =
+                                                                    FStar_Ident.string_of_lid
+                                                                    fvb.FStar_SMTEncoding_Env.fvar_lid
+                                                                     in
                                                                     FStar_Util.format1
                                                                     "Equation for fuel-instrumented recursive function: %s"
-                                                                    (fvb.FStar_SMTEncoding_Env.fvar_lid).FStar_Ident.str
+                                                                    uu____11731
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____11691
+                                                                    uu____11729
                                                                      in
-                                                                    (uu____11652,
-                                                                    uu____11690,
+                                                                    (uu____11690,
+                                                                    uu____11728,
                                                                     (Prims.op_Hat
                                                                     "equation_with_fuel_"
                                                                     g))  in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____11644
+                                                                    uu____11682
                                                                      in
                                                                     let eqn_f
                                                                     =
-                                                                    let uu____11698
+                                                                    let uu____11738
                                                                     =
-                                                                    let uu____11706
+                                                                    let uu____11746
                                                                     =
-                                                                    let uu____11707
+                                                                    let uu____11747
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
-                                                                    let uu____11708
+                                                                    let uu____11748
                                                                     =
-                                                                    let uu____11719
+                                                                    let uu____11759
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (app,
                                                                     gmax)  in
                                                                     ([[app]],
                                                                     vars,
-                                                                    uu____11719)
+                                                                    uu____11759)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____11707
-                                                                    uu____11708
+                                                                    uu____11747
+                                                                    uu____11748
                                                                      in
-                                                                    (uu____11706,
+                                                                    (uu____11746,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Correspondence of recursive function to instrumented version"),
                                                                     (Prims.op_Hat
                                                                     "@fuel_correspondence_"
                                                                     g))  in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____11698
+                                                                    uu____11738
                                                                      in
                                                                     let eqn_g'
                                                                     =
-                                                                    let uu____11733
+                                                                    let uu____11773
                                                                     =
-                                                                    let uu____11741
+                                                                    let uu____11781
                                                                     =
-                                                                    let uu____11742
+                                                                    let uu____11782
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
-                                                                    let uu____11743
+                                                                    let uu____11783
                                                                     =
-                                                                    let uu____11754
+                                                                    let uu____11794
                                                                     =
-                                                                    let uu____11755
+                                                                    let uu____11795
                                                                     =
-                                                                    let uu____11760
+                                                                    let uu____11800
                                                                     =
-                                                                    let uu____11761
+                                                                    let uu____11801
                                                                     =
-                                                                    let uu____11764
+                                                                    let uu____11804
                                                                     =
                                                                     FStar_SMTEncoding_Term.n_fuel
                                                                     Prims.int_zero
                                                                      in
-                                                                    uu____11764
+                                                                    uu____11804
                                                                     ::
                                                                     vars_tm
                                                                      in
                                                                     mk_g_app
-                                                                    uu____11761
+                                                                    uu____11801
                                                                      in
                                                                     (gsapp,
-                                                                    uu____11760)
+                                                                    uu____11800)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkEq
-                                                                    uu____11755
+                                                                    uu____11795
                                                                      in
                                                                     ([
                                                                     [gsapp]],
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____11754)
+                                                                    uu____11794)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____11742
-                                                                    uu____11743
+                                                                    uu____11782
+                                                                    uu____11783
                                                                      in
-                                                                    (uu____11741,
+                                                                    (uu____11781,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Fuel irrelevance"),
                                                                     (Prims.op_Hat
                                                                     "@fuel_irrelevance_"
                                                                     g))  in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____11733
+                                                                    uu____11773
                                                                      in
-                                                                    let uu____11778
+                                                                    let uu____11818
                                                                     =
                                                                     let gapp
                                                                     =
@@ -4041,9 +4078,9 @@ let (encode_top_level_let :
                                                                     =
                                                                     let tok_app
                                                                     =
-                                                                    let uu____11790
+                                                                    let uu____11830
                                                                     =
-                                                                    let uu____11791
+                                                                    let uu____11831
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (gtok,
@@ -4051,17 +4088,17 @@ let (encode_top_level_let :
                                                                      in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____11791
+                                                                    uu____11831
                                                                      in
                                                                     FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                                                    uu____11790
+                                                                    uu____11830
                                                                     (fuel ::
                                                                     vars)  in
                                                                     let tot_fun_axioms
                                                                     =
                                                                     let head
                                                                     =
-                                                                    let uu____11795
+                                                                    let uu____11835
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (gtok,
@@ -4069,7 +4106,7 @@ let (encode_top_level_let :
                                                                      in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____11795
+                                                                    uu____11835
                                                                      in
                                                                     let vars1
                                                                     = fuel ::
@@ -4078,11 +4115,11 @@ let (encode_top_level_let :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____11804
+                                                                    uu____11844
                                                                      ->
                                                                     FStar_SMTEncoding_Util.mkTrue)
                                                                     vars1  in
-                                                                    let uu____11805
+                                                                    let uu____11845
                                                                     =
                                                                     FStar_Syntax_Util.is_pure_comp
                                                                     tres_comp
@@ -4091,23 +4128,23 @@ let (encode_top_level_let :
                                                                     rng head
                                                                     vars1
                                                                     guards1
-                                                                    uu____11805
+                                                                    uu____11845
                                                                      in
-                                                                    let uu____11807
+                                                                    let uu____11847
                                                                     =
-                                                                    let uu____11815
+                                                                    let uu____11855
                                                                     =
-                                                                    let uu____11816
+                                                                    let uu____11856
                                                                     =
-                                                                    let uu____11821
+                                                                    let uu____11861
                                                                     =
-                                                                    let uu____11822
+                                                                    let uu____11862
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
-                                                                    let uu____11823
+                                                                    let uu____11863
                                                                     =
-                                                                    let uu____11834
+                                                                    let uu____11874
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (tok_app,
@@ -4116,19 +4153,19 @@ let (encode_top_level_let :
                                                                     [tok_app]],
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____11834)
+                                                                    uu____11874)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____11822
-                                                                    uu____11823
+                                                                    uu____11862
+                                                                    uu____11863
                                                                      in
-                                                                    (uu____11821,
+                                                                    (uu____11861,
                                                                     tot_fun_axioms)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAnd
-                                                                    uu____11816
+                                                                    uu____11856
                                                                      in
-                                                                    (uu____11815,
+                                                                    (uu____11855,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Fuel token correspondence"),
                                                                     (Prims.op_Hat
@@ -4136,37 +4173,37 @@ let (encode_top_level_let :
                                                                     gtok))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____11807
+                                                                    uu____11847
                                                                      in
-                                                                    let uu____11847
+                                                                    let uu____11887
                                                                     =
-                                                                    let uu____11856
+                                                                    let uu____11896
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                                                     FStar_Pervasives_Native.None
                                                                     tres
                                                                     env'1
                                                                     gapp  in
-                                                                    match uu____11856
+                                                                    match uu____11896
                                                                     with
                                                                     | 
                                                                     (g_typing,d3)
                                                                     ->
-                                                                    let uu____11871
+                                                                    let uu____11911
                                                                     =
-                                                                    let uu____11874
+                                                                    let uu____11914
                                                                     =
-                                                                    let uu____11875
+                                                                    let uu____11915
                                                                     =
-                                                                    let uu____11883
+                                                                    let uu____11923
                                                                     =
-                                                                    let uu____11884
+                                                                    let uu____11924
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
-                                                                    let uu____11885
+                                                                    let uu____11925
                                                                     =
-                                                                    let uu____11896
+                                                                    let uu____11936
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkImp
                                                                     (guard,
@@ -4175,27 +4212,27 @@ let (encode_top_level_let :
                                                                     ([[gapp]],
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____11896)
+                                                                    uu____11936)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____11884
-                                                                    uu____11885
+                                                                    uu____11924
+                                                                    uu____11925
                                                                      in
-                                                                    (uu____11883,
+                                                                    (uu____11923,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Typing correspondence of token to term"),
                                                                     (Prims.op_Hat
                                                                     "token_correspondence_"
                                                                     g))  in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____11875
+                                                                    uu____11915
                                                                      in
-                                                                    [uu____11874]
+                                                                    [uu____11914]
                                                                      in
                                                                     (d3,
-                                                                    uu____11871)
+                                                                    uu____11911)
                                                                      in
-                                                                    match uu____11847
+                                                                    match uu____11887
                                                                     with
                                                                     | 
                                                                     (aux_decls,typing_corr)
@@ -4205,18 +4242,18 @@ let (encode_top_level_let :
                                                                     typing_corr
                                                                     [tok_corr]))
                                                                      in
-                                                                    (match uu____11778
+                                                                    (match uu____11818
                                                                     with
                                                                     | 
                                                                     (aux_decls,g_typing)
                                                                     ->
-                                                                    let uu____11953
+                                                                    let uu____11993
                                                                     =
-                                                                    let uu____11956
+                                                                    let uu____11996
                                                                     =
-                                                                    let uu____11959
+                                                                    let uu____11999
                                                                     =
-                                                                    let uu____11962
+                                                                    let uu____12002
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     [decl_g;
@@ -4225,17 +4262,17 @@ let (encode_top_level_let :
                                                                      in
                                                                     FStar_List.append
                                                                     aux_decls
-                                                                    uu____11962
+                                                                    uu____12002
                                                                      in
                                                                     FStar_List.append
                                                                     decls2
-                                                                    uu____11959
+                                                                    uu____11999
                                                                      in
                                                                     FStar_List.append
                                                                     binder_decls1
-                                                                    uu____11956
+                                                                    uu____11996
                                                                      in
-                                                                    let uu____11969
+                                                                    let uu____12009
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     (FStar_List.append
@@ -4245,55 +4282,55 @@ let (encode_top_level_let :
                                                                     g_typing)
                                                                     FStar_SMTEncoding_Term.mk_decls_trivial
                                                                      in
-                                                                    (uu____11953,
-                                                                    uu____11969,
+                                                                    (uu____11993,
+                                                                    uu____12009,
                                                                     env02))))))))))
                                       in
-                                   let uu____11974 =
-                                     let uu____11987 =
+                                   let uu____12014 =
+                                     let uu____12027 =
                                        FStar_List.zip3 gtoks1 typs2 bindings1
                                         in
                                      FStar_List.fold_left
-                                       (fun uu____12050  ->
-                                          fun uu____12051  ->
-                                            match (uu____12050, uu____12051)
+                                       (fun uu____12090  ->
+                                          fun uu____12091  ->
+                                            match (uu____12090, uu____12091)
                                             with
                                             | ((decls2,eqns,env01),(gtok,ty,lb))
                                                 ->
-                                                let uu____12176 =
+                                                let uu____12216 =
                                                   encode_one_binding env01
                                                     gtok ty lb
                                                    in
-                                                (match uu____12176 with
+                                                (match uu____12216 with
                                                  | (decls',eqns',env02) ->
                                                      ((decls' :: decls2),
                                                        (FStar_List.append
                                                           eqns' eqns), env02)))
-                                       ([decls1], [], env0) uu____11987
+                                       ([decls1], [], env0) uu____12027
                                       in
-                                   (match uu____11974 with
+                                   (match uu____12014 with
                                     | (decls2,eqns,env01) ->
-                                        let uu____12243 =
-                                          let isDeclFun uu___1_12260 =
-                                            match uu___1_12260 with
+                                        let uu____12283 =
+                                          let isDeclFun uu___1_12300 =
+                                            match uu___1_12300 with
                                             | FStar_SMTEncoding_Term.DeclFun
-                                                uu____12262 -> true
-                                            | uu____12275 -> false  in
-                                          let uu____12277 =
+                                                uu____12302 -> true
+                                            | uu____12315 -> false  in
+                                          let uu____12317 =
                                             FStar_All.pipe_right decls2
                                               FStar_List.flatten
                                              in
-                                          FStar_All.pipe_right uu____12277
+                                          FStar_All.pipe_right uu____12317
                                             (fun decls3  ->
-                                               let uu____12307 =
+                                               let uu____12347 =
                                                  FStar_List.fold_left
-                                                   (fun uu____12338  ->
+                                                   (fun uu____12378  ->
                                                       fun elt  ->
-                                                        match uu____12338
+                                                        match uu____12378
                                                         with
                                                         | (prefix_decls,elts,rest)
                                                             ->
-                                                            let uu____12379 =
+                                                            let uu____12419 =
                                                               (FStar_All.pipe_right
                                                                  elt.FStar_SMTEncoding_Term.key
                                                                  FStar_Util.is_some)
@@ -4302,7 +4339,7 @@ let (encode_top_level_let :
                                                                    isDeclFun
                                                                    elt.FStar_SMTEncoding_Term.decls)
                                                                in
-                                                            if uu____12379
+                                                            if uu____12419
                                                             then
                                                               (prefix_decls,
                                                                 (FStar_List.append
@@ -4310,13 +4347,13 @@ let (encode_top_level_let :
                                                                    [elt]),
                                                                 rest)
                                                             else
-                                                              (let uu____12407
+                                                              (let uu____12447
                                                                  =
                                                                  FStar_List.partition
                                                                    isDeclFun
                                                                    elt.FStar_SMTEncoding_Term.decls
                                                                   in
-                                                               match uu____12407
+                                                               match uu____12447
                                                                with
                                                                | (elt_decl_funs,elt_rest)
                                                                    ->
@@ -4327,34 +4364,34 @@ let (encode_top_level_let :
                                                                     (FStar_List.append
                                                                     rest
                                                                     [(
-                                                                    let uu___846_12445
+                                                                    let uu___846_12485
                                                                     = elt  in
                                                                     {
                                                                     FStar_SMTEncoding_Term.sym_name
                                                                     =
-                                                                    (uu___846_12445.FStar_SMTEncoding_Term.sym_name);
+                                                                    (uu___846_12485.FStar_SMTEncoding_Term.sym_name);
                                                                     FStar_SMTEncoding_Term.key
                                                                     =
-                                                                    (uu___846_12445.FStar_SMTEncoding_Term.key);
+                                                                    (uu___846_12485.FStar_SMTEncoding_Term.key);
                                                                     FStar_SMTEncoding_Term.decls
                                                                     =
                                                                     elt_rest;
                                                                     FStar_SMTEncoding_Term.a_names
                                                                     =
-                                                                    (uu___846_12445.FStar_SMTEncoding_Term.a_names)
+                                                                    (uu___846_12485.FStar_SMTEncoding_Term.a_names)
                                                                     })]))))
                                                    ([], [], []) decls3
                                                   in
-                                               match uu____12307 with
+                                               match uu____12347 with
                                                | (prefix_decls,elts,rest) ->
-                                                   let uu____12477 =
+                                                   let uu____12517 =
                                                      FStar_All.pipe_right
                                                        prefix_decls
                                                        FStar_SMTEncoding_Term.mk_decls_trivial
                                                       in
-                                                   (uu____12477, elts, rest))
+                                                   (uu____12517, elts, rest))
                                            in
-                                        (match uu____12243 with
+                                        (match uu____12283 with
                                          | (prefix_decls,elts,rest) ->
                                              let eqns1 = FStar_List.rev eqns
                                                 in
@@ -4363,19 +4400,19 @@ let (encode_top_level_let :
                                                     (FStar_List.append rest
                                                        eqns1))), env01)))
                                 in
-                             let uu____12506 =
+                             let uu____12546 =
                                (FStar_All.pipe_right quals
                                   (FStar_Util.for_some
-                                     (fun uu___2_12512  ->
-                                        match uu___2_12512 with
+                                     (fun uu___2_12552  ->
+                                        match uu___2_12552 with
                                         | FStar_Syntax_Syntax.HasMaskedEffect
                                              -> true
-                                        | uu____12515 -> false)))
+                                        | uu____12555 -> false)))
                                  ||
                                  (FStar_All.pipe_right typs1
                                     (FStar_Util.for_some
                                        (fun t  ->
-                                          let uu____12523 =
+                                          let uu____12563 =
                                             (FStar_Syntax_Util.is_pure_or_ghost_function
                                                t)
                                               ||
@@ -4384,13 +4421,13 @@ let (encode_top_level_let :
                                                  t)
                                              in
                                           FStar_All.pipe_left
-                                            Prims.op_Negation uu____12523)))
+                                            Prims.op_Negation uu____12563)))
                                 in
-                             if uu____12506
+                             if uu____12546
                              then (decls1, env_decls)
                              else
                                (try
-                                  (fun uu___863_12545  ->
+                                  (fun uu___863_12585  ->
                                      match () with
                                      | () ->
                                          if Prims.op_Negation is_rec
@@ -4408,62 +4445,62 @@ let (encode_top_level_let :
                                         Prims.int_one
                                        in
                                     let r =
-                                      let uu____12590 = FStar_List.hd names
+                                      let uu____12630 = FStar_List.hd names
                                          in
-                                      FStar_All.pipe_right uu____12590
+                                      FStar_All.pipe_right uu____12630
                                         FStar_Pervasives_Native.snd
                                        in
-                                    ((let uu____12608 =
-                                        let uu____12618 =
-                                          let uu____12626 =
-                                            let uu____12628 =
-                                              let uu____12630 =
+                                    ((let uu____12648 =
+                                        let uu____12658 =
+                                          let uu____12666 =
+                                            let uu____12668 =
+                                              let uu____12670 =
                                                 FStar_List.map
                                                   FStar_Pervasives_Native.fst
                                                   names
                                                  in
                                               FStar_All.pipe_right
-                                                uu____12630
+                                                uu____12670
                                                 (FStar_String.concat ",")
                                                in
                                             FStar_Util.format3
                                               "Definitions of inner let-rec%s %s and %s enclosing top-level letbinding are not encoded to the solver, you will only be able to reason with their types"
                                               (if plural then "s" else "")
-                                              uu____12628
+                                              uu____12668
                                               (if plural
                                                then "their"
                                                else "its")
                                              in
                                           (FStar_Errors.Warning_DefinitionNotTranslated,
-                                            uu____12626, r)
+                                            uu____12666, r)
                                            in
-                                        [uu____12618]  in
+                                        [uu____12658]  in
                                       FStar_TypeChecker_Err.add_errors
                                         env1.FStar_SMTEncoding_Env.tcenv
-                                        uu____12608);
+                                        uu____12648);
                                      (decls1, env_decls))))) ()
              with
              | Let_rec_unencodeable  ->
                  let msg =
-                   let uu____12689 =
+                   let uu____12729 =
                      FStar_All.pipe_right bindings
                        (FStar_List.map
                           (fun lb  ->
                              FStar_Syntax_Print.lbname_to_string
                                lb.FStar_Syntax_Syntax.lbname))
                       in
-                   FStar_All.pipe_right uu____12689
+                   FStar_All.pipe_right uu____12729
                      (FStar_String.concat " and ")
                     in
                  let decl =
                    FStar_SMTEncoding_Term.Caption
                      (Prims.op_Hat "let rec unencodeable: Skipping: " msg)
                     in
-                 let uu____12708 =
+                 let uu____12748 =
                    FStar_All.pipe_right [decl]
                      FStar_SMTEncoding_Term.mk_decls_trivial
                     in
-                 (uu____12708, env))
+                 (uu____12748, env))
   
 let rec (encode_sigelt :
   FStar_SMTEncoding_Env.env_t ->
@@ -4473,48 +4510,48 @@ let rec (encode_sigelt :
   fun env  ->
     fun se  ->
       let nm =
-        let uu____12764 = FStar_Syntax_Util.lid_of_sigelt se  in
-        match uu____12764 with
+        let uu____12804 = FStar_Syntax_Util.lid_of_sigelt se  in
+        match uu____12804 with
         | FStar_Pervasives_Native.None  -> ""
-        | FStar_Pervasives_Native.Some l -> l.FStar_Ident.str  in
-      let uu____12770 = encode_sigelt' env se  in
-      match uu____12770 with
+        | FStar_Pervasives_Native.Some l -> FStar_Ident.string_of_lid l  in
+      let uu____12810 = encode_sigelt' env se  in
+      match uu____12810 with
       | (g,env1) ->
           let g1 =
             match g with
             | [] ->
-                let uu____12782 =
-                  let uu____12785 =
-                    let uu____12786 = FStar_Util.format1 "<Skipped %s/>" nm
+                let uu____12822 =
+                  let uu____12825 =
+                    let uu____12826 = FStar_Util.format1 "<Skipped %s/>" nm
                        in
-                    FStar_SMTEncoding_Term.Caption uu____12786  in
-                  [uu____12785]  in
-                FStar_All.pipe_right uu____12782
+                    FStar_SMTEncoding_Term.Caption uu____12826  in
+                  [uu____12825]  in
+                FStar_All.pipe_right uu____12822
                   FStar_SMTEncoding_Term.mk_decls_trivial
-            | uu____12791 ->
-                let uu____12792 =
-                  let uu____12795 =
-                    let uu____12798 =
-                      let uu____12799 =
+            | uu____12831 ->
+                let uu____12832 =
+                  let uu____12835 =
+                    let uu____12838 =
+                      let uu____12839 =
                         FStar_Util.format1 "<Start encoding %s>" nm  in
-                      FStar_SMTEncoding_Term.Caption uu____12799  in
-                    [uu____12798]  in
-                  FStar_All.pipe_right uu____12795
+                      FStar_SMTEncoding_Term.Caption uu____12839  in
+                    [uu____12838]  in
+                  FStar_All.pipe_right uu____12835
                     FStar_SMTEncoding_Term.mk_decls_trivial
                    in
-                let uu____12806 =
-                  let uu____12809 =
-                    let uu____12812 =
-                      let uu____12815 =
-                        let uu____12816 =
+                let uu____12846 =
+                  let uu____12849 =
+                    let uu____12852 =
+                      let uu____12855 =
+                        let uu____12856 =
                           FStar_Util.format1 "</end encoding %s>" nm  in
-                        FStar_SMTEncoding_Term.Caption uu____12816  in
-                      [uu____12815]  in
-                    FStar_All.pipe_right uu____12812
+                        FStar_SMTEncoding_Term.Caption uu____12856  in
+                      [uu____12855]  in
+                    FStar_All.pipe_right uu____12852
                       FStar_SMTEncoding_Term.mk_decls_trivial
                      in
-                  FStar_List.append g uu____12809  in
-                FStar_List.append uu____12792 uu____12806
+                  FStar_List.append g uu____12849  in
+                FStar_List.append uu____12832 uu____12846
              in
           (g1, env1)
 
@@ -4525,57 +4562,57 @@ and (encode_sigelt' :
   =
   fun env  ->
     fun se  ->
-      (let uu____12830 =
+      (let uu____12870 =
          FStar_All.pipe_left
            (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
            (FStar_Options.Other "SMTEncoding")
           in
-       if uu____12830
+       if uu____12870
        then
-         let uu____12835 = FStar_Syntax_Print.sigelt_to_string se  in
-         FStar_Util.print1 "@@@Encoding sigelt %s\n" uu____12835
+         let uu____12875 = FStar_Syntax_Print.sigelt_to_string se  in
+         FStar_Util.print1 "@@@Encoding sigelt %s\n" uu____12875
        else ());
       (let is_opaque_to_smt t =
-         let uu____12847 =
-           let uu____12848 = FStar_Syntax_Subst.compress t  in
-           uu____12848.FStar_Syntax_Syntax.n  in
-         match uu____12847 with
+         let uu____12887 =
+           let uu____12888 = FStar_Syntax_Subst.compress t  in
+           uu____12888.FStar_Syntax_Syntax.n  in
+         match uu____12887 with
          | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
-             (s,uu____12853)) -> s = "opaque_to_smt"
-         | uu____12858 -> false  in
+             (s,uu____12893)) -> s = "opaque_to_smt"
+         | uu____12898 -> false  in
        let is_uninterpreted_by_smt t =
-         let uu____12867 =
-           let uu____12868 = FStar_Syntax_Subst.compress t  in
-           uu____12868.FStar_Syntax_Syntax.n  in
-         match uu____12867 with
+         let uu____12907 =
+           let uu____12908 = FStar_Syntax_Subst.compress t  in
+           uu____12908.FStar_Syntax_Syntax.n  in
+         match uu____12907 with
          | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
-             (s,uu____12873)) -> s = "uninterpreted_by_smt"
-         | uu____12878 -> false  in
+             (s,uu____12913)) -> s = "uninterpreted_by_smt"
+         | uu____12918 -> false  in
        match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_splice uu____12884 ->
+       | FStar_Syntax_Syntax.Sig_splice uu____12924 ->
            failwith "impossible -- splice should have been removed by Tc.fs"
-       | FStar_Syntax_Syntax.Sig_fail uu____12896 ->
+       | FStar_Syntax_Syntax.Sig_fail uu____12936 ->
            failwith
              "impossible -- Sig_fail should have been removed by Tc.fs"
-       | FStar_Syntax_Syntax.Sig_pragma uu____12914 -> ([], env)
-       | FStar_Syntax_Syntax.Sig_main uu____12915 -> ([], env)
-       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____12916 -> ([], env)
-       | FStar_Syntax_Syntax.Sig_sub_effect uu____12929 -> ([], env)
-       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____12930 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_pragma uu____12954 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_main uu____12955 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____12956 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_sub_effect uu____12969 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____12970 -> ([], env)
        | FStar_Syntax_Syntax.Sig_new_effect ed ->
-           let uu____12942 =
-             let uu____12944 =
+           let uu____12982 =
+             let uu____12984 =
                FStar_SMTEncoding_Util.is_smt_reifiable_effect
                  env.FStar_SMTEncoding_Env.tcenv ed.FStar_Syntax_Syntax.mname
                 in
-             Prims.op_Negation uu____12944  in
-           if uu____12942
+             Prims.op_Negation uu____12984  in
+           if uu____12982
            then ([], env)
            else
              (let close_effect_params tm =
                 match ed.FStar_Syntax_Syntax.binders with
                 | [] -> tm
-                | uu____12973 ->
+                | uu____13013 ->
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_abs
                          ((ed.FStar_Syntax_Syntax.binders), tm,
@@ -4588,189 +4625,189 @@ and (encode_sigelt' :
                  in
               let encode_action env1 a =
                 let action_defn =
-                  let uu____13006 =
+                  let uu____13046 =
                     close_effect_params a.FStar_Syntax_Syntax.action_defn  in
-                  norm_before_encoding env1 uu____13006  in
-                let uu____13007 =
+                  norm_before_encoding env1 uu____13046  in
+                let uu____13047 =
                   FStar_Syntax_Util.arrow_formals_comp
                     a.FStar_Syntax_Syntax.action_typ
                    in
-                match uu____13007 with
-                | (formals,uu____13019) ->
+                match uu____13047 with
+                | (formals,uu____13059) ->
                     let arity = FStar_List.length formals  in
-                    let uu____13027 =
+                    let uu____13067 =
                       FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                         env1 a.FStar_Syntax_Syntax.action_name arity
                        in
-                    (match uu____13027 with
+                    (match uu____13067 with
                      | (aname,atok,env2) ->
-                         let uu____13049 =
+                         let uu____13089 =
                            FStar_SMTEncoding_EncodeTerm.encode_term
                              action_defn env2
                             in
-                         (match uu____13049 with
+                         (match uu____13089 with
                           | (tm,decls) ->
                               let a_decls =
-                                let uu____13065 =
-                                  let uu____13066 =
-                                    let uu____13078 =
+                                let uu____13105 =
+                                  let uu____13106 =
+                                    let uu____13118 =
                                       FStar_All.pipe_right formals
                                         (FStar_List.map
-                                           (fun uu____13098  ->
+                                           (fun uu____13138  ->
                                               FStar_SMTEncoding_Term.Term_sort))
                                        in
-                                    (aname, uu____13078,
+                                    (aname, uu____13118,
                                       FStar_SMTEncoding_Term.Term_sort,
                                       (FStar_Pervasives_Native.Some "Action"))
                                      in
-                                  FStar_SMTEncoding_Term.DeclFun uu____13066
+                                  FStar_SMTEncoding_Term.DeclFun uu____13106
                                    in
-                                [uu____13065;
+                                [uu____13105;
                                 FStar_SMTEncoding_Term.DeclFun
                                   (atok, [],
                                     FStar_SMTEncoding_Term.Term_sort,
                                     (FStar_Pervasives_Native.Some
                                        "Action token"))]
                                  in
-                              let uu____13115 =
-                                let aux uu____13161 uu____13162 =
-                                  match (uu____13161, uu____13162) with
-                                  | ((bv,uu____13206),(env3,acc_sorts,acc))
+                              let uu____13155 =
+                                let aux uu____13201 uu____13202 =
+                                  match (uu____13201, uu____13202) with
+                                  | ((bv,uu____13246),(env3,acc_sorts,acc))
                                       ->
-                                      let uu____13238 =
+                                      let uu____13278 =
                                         FStar_SMTEncoding_Env.gen_term_var
                                           env3 bv
                                          in
-                                      (match uu____13238 with
+                                      (match uu____13278 with
                                        | (xxsym,xx,env4) ->
-                                           let uu____13261 =
-                                             let uu____13264 =
+                                           let uu____13301 =
+                                             let uu____13304 =
                                                FStar_SMTEncoding_Term.mk_fv
                                                  (xxsym,
                                                    FStar_SMTEncoding_Term.Term_sort)
                                                 in
-                                             uu____13264 :: acc_sorts  in
-                                           (env4, uu____13261, (xx :: acc)))
+                                             uu____13304 :: acc_sorts  in
+                                           (env4, uu____13301, (xx :: acc)))
                                    in
                                 FStar_List.fold_right aux formals
                                   (env2, [], [])
                                  in
-                              (match uu____13115 with
-                               | (uu____13296,xs_sorts,xs) ->
+                              (match uu____13155 with
+                               | (uu____13336,xs_sorts,xs) ->
                                    let app =
                                      FStar_SMTEncoding_Util.mkApp (aname, xs)
                                       in
                                    let a_eq =
-                                     let uu____13312 =
-                                       let uu____13320 =
-                                         let uu____13321 =
+                                     let uu____13352 =
+                                       let uu____13360 =
+                                         let uu____13361 =
                                            FStar_Ident.range_of_lid
                                              a.FStar_Syntax_Syntax.action_name
                                             in
-                                         let uu____13322 =
-                                           let uu____13333 =
-                                             let uu____13334 =
-                                               let uu____13339 =
+                                         let uu____13362 =
+                                           let uu____13373 =
+                                             let uu____13374 =
+                                               let uu____13379 =
                                                  FStar_SMTEncoding_EncodeTerm.mk_Apply
                                                    tm xs_sorts
                                                   in
-                                               (app, uu____13339)  in
+                                               (app, uu____13379)  in
                                              FStar_SMTEncoding_Util.mkEq
-                                               uu____13334
+                                               uu____13374
                                               in
-                                           ([[app]], xs_sorts, uu____13333)
+                                           ([[app]], xs_sorts, uu____13373)
                                             in
                                          FStar_SMTEncoding_Term.mkForall
-                                           uu____13321 uu____13322
+                                           uu____13361 uu____13362
                                           in
-                                       (uu____13320,
+                                       (uu____13360,
                                          (FStar_Pervasives_Native.Some
                                             "Action equality"),
                                          (Prims.op_Hat aname "_equality"))
                                         in
                                      FStar_SMTEncoding_Util.mkAssume
-                                       uu____13312
+                                       uu____13352
                                       in
                                    let tok_correspondence =
                                      let tok_term =
-                                       let uu____13354 =
+                                       let uu____13394 =
                                          FStar_SMTEncoding_Term.mk_fv
                                            (atok,
                                              FStar_SMTEncoding_Term.Term_sort)
                                           in
                                        FStar_All.pipe_left
                                          FStar_SMTEncoding_Util.mkFreeV
-                                         uu____13354
+                                         uu____13394
                                         in
                                      let tok_app =
                                        FStar_SMTEncoding_EncodeTerm.mk_Apply
                                          tok_term xs_sorts
                                         in
-                                     let uu____13357 =
-                                       let uu____13365 =
-                                         let uu____13366 =
+                                     let uu____13397 =
+                                       let uu____13405 =
+                                         let uu____13406 =
                                            FStar_Ident.range_of_lid
                                              a.FStar_Syntax_Syntax.action_name
                                             in
-                                         let uu____13367 =
-                                           let uu____13378 =
+                                         let uu____13407 =
+                                           let uu____13418 =
                                              FStar_SMTEncoding_Util.mkEq
                                                (tok_app, app)
                                               in
                                            ([[tok_app]], xs_sorts,
-                                             uu____13378)
+                                             uu____13418)
                                             in
                                          FStar_SMTEncoding_Term.mkForall
-                                           uu____13366 uu____13367
+                                           uu____13406 uu____13407
                                           in
-                                       (uu____13365,
+                                       (uu____13405,
                                          (FStar_Pervasives_Native.Some
                                             "Action token correspondence"),
                                          (Prims.op_Hat aname
                                             "_token_correspondence"))
                                         in
                                      FStar_SMTEncoding_Util.mkAssume
-                                       uu____13357
+                                       uu____13397
                                       in
-                                   let uu____13391 =
-                                     let uu____13394 =
+                                   let uu____13431 =
+                                     let uu____13434 =
                                        FStar_All.pipe_right
                                          (FStar_List.append a_decls
                                             [a_eq; tok_correspondence])
                                          FStar_SMTEncoding_Term.mk_decls_trivial
                                         in
-                                     FStar_List.append decls uu____13394  in
-                                   (env2, uu____13391))))
+                                     FStar_List.append decls uu____13434  in
+                                   (env2, uu____13431))))
                  in
-              let uu____13403 =
+              let uu____13443 =
                 FStar_Util.fold_map encode_action env
                   ed.FStar_Syntax_Syntax.actions
                  in
-              match uu____13403 with
+              match uu____13443 with
               | (env1,decls2) -> ((FStar_List.flatten decls2), env1))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____13429,uu____13430)
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____13469,uu____13470)
            when FStar_Ident.lid_equals lid FStar_Parser_Const.precedes_lid ->
-           let uu____13431 =
+           let uu____13471 =
              FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid env lid
                (Prims.of_int (4))
               in
-           (match uu____13431 with | (tname,ttok,env1) -> ([], env1))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____13453,t) ->
+           (match uu____13471 with | (tname,ttok,env1) -> ([], env1))
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____13493,t) ->
            let quals = se.FStar_Syntax_Syntax.sigquals  in
            let will_encode_definition =
-             let uu____13460 =
+             let uu____13500 =
                FStar_All.pipe_right quals
                  (FStar_Util.for_some
-                    (fun uu___3_13466  ->
-                       match uu___3_13466 with
+                    (fun uu___3_13506  ->
+                       match uu___3_13506 with
                        | FStar_Syntax_Syntax.Assumption  -> true
-                       | FStar_Syntax_Syntax.Projector uu____13469 -> true
-                       | FStar_Syntax_Syntax.Discriminator uu____13475 ->
+                       | FStar_Syntax_Syntax.Projector uu____13509 -> true
+                       | FStar_Syntax_Syntax.Discriminator uu____13515 ->
                            true
                        | FStar_Syntax_Syntax.Irreducible  -> true
-                       | uu____13478 -> false))
+                       | uu____13518 -> false))
                 in
-             Prims.op_Negation uu____13460  in
+             Prims.op_Negation uu____13500  in
            if will_encode_definition
            then ([], env)
            else
@@ -4779,93 +4816,96 @@ and (encode_sigelt' :
                   FStar_Syntax_Syntax.delta_constant
                   FStar_Pervasives_Native.None
                  in
-              let uu____13488 =
-                let uu____13493 =
+              let uu____13528 =
+                let uu____13533 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigattrs
                     (FStar_Util.for_some is_uninterpreted_by_smt)
                    in
-                encode_top_level_val uu____13493 env fv t quals  in
-              match uu____13488 with
+                encode_top_level_val uu____13533 env fv t quals  in
+              match uu____13528 with
               | (decls,env1) ->
-                  let tname = lid.FStar_Ident.str  in
+                  let tname = FStar_Ident.string_of_lid lid  in
                   let tsym =
-                    let uu____13507 =
+                    let uu____13547 =
                       FStar_SMTEncoding_Env.try_lookup_free_var env1 lid  in
-                    FStar_Option.get uu____13507  in
-                  let uu____13510 =
-                    let uu____13511 =
-                      let uu____13514 =
+                    FStar_Option.get uu____13547  in
+                  let uu____13550 =
+                    let uu____13551 =
+                      let uu____13554 =
                         primitive_type_axioms
                           env1.FStar_SMTEncoding_Env.tcenv lid tname tsym
                          in
-                      FStar_All.pipe_right uu____13514
+                      FStar_All.pipe_right uu____13554
                         FStar_SMTEncoding_Term.mk_decls_trivial
                        in
-                    FStar_List.append decls uu____13511  in
-                  (uu____13510, env1))
+                    FStar_List.append decls uu____13551  in
+                  (uu____13550, env1))
        | FStar_Syntax_Syntax.Sig_assume (l,us,f) ->
-           let uu____13524 = FStar_Syntax_Subst.open_univ_vars us f  in
-           (match uu____13524 with
+           let uu____13564 = FStar_Syntax_Subst.open_univ_vars us f  in
+           (match uu____13564 with
             | (uvs,f1) ->
                 let env1 =
-                  let uu___1008_13536 = env  in
-                  let uu____13537 =
+                  let uu___1008_13576 = env  in
+                  let uu____13577 =
                     FStar_TypeChecker_Env.push_univ_vars
                       env.FStar_SMTEncoding_Env.tcenv uvs
                      in
                   {
                     FStar_SMTEncoding_Env.bvar_bindings =
-                      (uu___1008_13536.FStar_SMTEncoding_Env.bvar_bindings);
+                      (uu___1008_13576.FStar_SMTEncoding_Env.bvar_bindings);
                     FStar_SMTEncoding_Env.fvar_bindings =
-                      (uu___1008_13536.FStar_SMTEncoding_Env.fvar_bindings);
+                      (uu___1008_13576.FStar_SMTEncoding_Env.fvar_bindings);
                     FStar_SMTEncoding_Env.depth =
-                      (uu___1008_13536.FStar_SMTEncoding_Env.depth);
-                    FStar_SMTEncoding_Env.tcenv = uu____13537;
+                      (uu___1008_13576.FStar_SMTEncoding_Env.depth);
+                    FStar_SMTEncoding_Env.tcenv = uu____13577;
                     FStar_SMTEncoding_Env.warn =
-                      (uu___1008_13536.FStar_SMTEncoding_Env.warn);
+                      (uu___1008_13576.FStar_SMTEncoding_Env.warn);
                     FStar_SMTEncoding_Env.nolabels =
-                      (uu___1008_13536.FStar_SMTEncoding_Env.nolabels);
+                      (uu___1008_13576.FStar_SMTEncoding_Env.nolabels);
                     FStar_SMTEncoding_Env.use_zfuel_name =
-                      (uu___1008_13536.FStar_SMTEncoding_Env.use_zfuel_name);
+                      (uu___1008_13576.FStar_SMTEncoding_Env.use_zfuel_name);
                     FStar_SMTEncoding_Env.encode_non_total_function_typ =
-                      (uu___1008_13536.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                      (uu___1008_13576.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                     FStar_SMTEncoding_Env.current_module_name =
-                      (uu___1008_13536.FStar_SMTEncoding_Env.current_module_name);
+                      (uu___1008_13576.FStar_SMTEncoding_Env.current_module_name);
                     FStar_SMTEncoding_Env.encoding_quantifier =
-                      (uu___1008_13536.FStar_SMTEncoding_Env.encoding_quantifier);
+                      (uu___1008_13576.FStar_SMTEncoding_Env.encoding_quantifier);
                     FStar_SMTEncoding_Env.global_cache =
-                      (uu___1008_13536.FStar_SMTEncoding_Env.global_cache)
+                      (uu___1008_13576.FStar_SMTEncoding_Env.global_cache)
                   }  in
                 let f2 = norm_before_encoding env1 f1  in
-                let uu____13539 =
+                let uu____13579 =
                   FStar_SMTEncoding_EncodeTerm.encode_formula f2 env1  in
-                (match uu____13539 with
+                (match uu____13579 with
                  | (f3,decls) ->
                      let g =
-                       let uu____13553 =
-                         let uu____13556 =
-                           let uu____13557 =
-                             let uu____13565 =
-                               let uu____13566 =
-                                 let uu____13568 =
+                       let uu____13593 =
+                         let uu____13596 =
+                           let uu____13597 =
+                             let uu____13605 =
+                               let uu____13606 =
+                                 let uu____13608 =
                                    FStar_Syntax_Print.lid_to_string l  in
                                  FStar_Util.format1 "Assumption: %s"
-                                   uu____13568
+                                   uu____13608
                                   in
-                               FStar_Pervasives_Native.Some uu____13566  in
-                             let uu____13572 =
+                               FStar_Pervasives_Native.Some uu____13606  in
+                             let uu____13612 =
+                               let uu____13614 =
+                                 let uu____13616 =
+                                   FStar_Ident.string_of_lid l  in
+                                 Prims.op_Hat "assumption_" uu____13616  in
                                FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
-                                 (Prims.op_Hat "assumption_"
-                                    l.FStar_Ident.str)
+                                 uu____13614
                                 in
-                             (f3, uu____13565, uu____13572)  in
-                           FStar_SMTEncoding_Util.mkAssume uu____13557  in
-                         [uu____13556]  in
-                       FStar_All.pipe_right uu____13553
+                             (f3, uu____13605, uu____13612)  in
+                           FStar_SMTEncoding_Util.mkAssume uu____13597  in
+                         [uu____13596]  in
+                       FStar_All.pipe_right uu____13593
                          FStar_SMTEncoding_Term.mk_decls_trivial
                         in
                      ((FStar_List.append decls g), env1)))
-       | FStar_Syntax_Syntax.Sig_let (lbs,uu____13581) when
+       | FStar_Syntax_Syntax.Sig_let (lbs,uu____13625) when
            (FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
               (FStar_List.contains FStar_Syntax_Syntax.Irreducible))
              ||
@@ -4873,65 +4913,65 @@ and (encode_sigelt' :
                 (FStar_Util.for_some is_opaque_to_smt))
            ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs  in
-           let uu____13595 =
+           let uu____13639 =
              FStar_Util.fold_map
                (fun env1  ->
                   fun lb  ->
                     let lid =
-                      let uu____13617 =
-                        let uu____13620 =
+                      let uu____13661 =
+                        let uu____13664 =
                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-                        uu____13620.FStar_Syntax_Syntax.fv_name  in
-                      uu____13617.FStar_Syntax_Syntax.v  in
-                    let uu____13621 =
-                      let uu____13623 =
+                        uu____13664.FStar_Syntax_Syntax.fv_name  in
+                      uu____13661.FStar_Syntax_Syntax.v  in
+                    let uu____13665 =
+                      let uu____13667 =
                         FStar_TypeChecker_Env.try_lookup_val_decl
                           env1.FStar_SMTEncoding_Env.tcenv lid
                          in
-                      FStar_All.pipe_left FStar_Option.isNone uu____13623  in
-                    if uu____13621
+                      FStar_All.pipe_left FStar_Option.isNone uu____13667  in
+                    if uu____13665
                     then
                       let val_decl =
-                        let uu___1025_13655 = se  in
+                        let uu___1025_13699 = se  in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_declare_typ
                                (lid, (lb.FStar_Syntax_Syntax.lbunivs),
                                  (lb.FStar_Syntax_Syntax.lbtyp)));
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___1025_13655.FStar_Syntax_Syntax.sigrng);
+                            (uu___1025_13699.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
                             (FStar_Syntax_Syntax.Irreducible ::
                             (se.FStar_Syntax_Syntax.sigquals));
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___1025_13655.FStar_Syntax_Syntax.sigmeta);
+                            (uu___1025_13699.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___1025_13655.FStar_Syntax_Syntax.sigattrs);
+                            (uu___1025_13699.FStar_Syntax_Syntax.sigattrs);
                           FStar_Syntax_Syntax.sigopts =
-                            (uu___1025_13655.FStar_Syntax_Syntax.sigopts)
+                            (uu___1025_13699.FStar_Syntax_Syntax.sigopts)
                         }  in
-                      let uu____13656 = encode_sigelt' env1 val_decl  in
-                      match uu____13656 with | (decls,env2) -> (env2, decls)
+                      let uu____13700 = encode_sigelt' env1 val_decl  in
+                      match uu____13700 with | (decls,env2) -> (env2, decls)
                     else (env1, [])) env (FStar_Pervasives_Native.snd lbs)
               in
-           (match uu____13595 with
+           (match uu____13639 with
             | (env1,decls) -> ((FStar_List.flatten decls), env1))
        | FStar_Syntax_Syntax.Sig_let
-           ((uu____13692,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr b2t;
-                           FStar_Syntax_Syntax.lbunivs = uu____13694;
-                           FStar_Syntax_Syntax.lbtyp = uu____13695;
-                           FStar_Syntax_Syntax.lbeff = uu____13696;
-                           FStar_Syntax_Syntax.lbdef = uu____13697;
-                           FStar_Syntax_Syntax.lbattrs = uu____13698;
-                           FStar_Syntax_Syntax.lbpos = uu____13699;_}::[]),uu____13700)
+           ((uu____13736,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr b2t;
+                           FStar_Syntax_Syntax.lbunivs = uu____13738;
+                           FStar_Syntax_Syntax.lbtyp = uu____13739;
+                           FStar_Syntax_Syntax.lbeff = uu____13740;
+                           FStar_Syntax_Syntax.lbdef = uu____13741;
+                           FStar_Syntax_Syntax.lbattrs = uu____13742;
+                           FStar_Syntax_Syntax.lbpos = uu____13743;_}::[]),uu____13744)
            when FStar_Syntax_Syntax.fv_eq_lid b2t FStar_Parser_Const.b2t_lid
            ->
-           let uu____13719 =
+           let uu____13763 =
              FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid env
                (b2t.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                Prims.int_one
               in
-           (match uu____13719 with
+           (match uu____13763 with
             | (tname,ttok,env1) ->
                 let xx =
                   FStar_SMTEncoding_Term.mk_fv
@@ -4943,104 +4983,106 @@ and (encode_sigelt' :
                 let valid_b2t_x =
                   FStar_SMTEncoding_Util.mkApp ("Valid", [b2t_x])  in
                 let decls =
-                  let uu____13757 =
-                    let uu____13760 =
-                      let uu____13761 =
-                        let uu____13769 =
-                          let uu____13770 =
+                  let uu____13801 =
+                    let uu____13804 =
+                      let uu____13805 =
+                        let uu____13813 =
+                          let uu____13814 =
                             FStar_Syntax_Syntax.range_of_fv b2t  in
-                          let uu____13771 =
-                            let uu____13782 =
-                              let uu____13783 =
-                                let uu____13788 =
+                          let uu____13815 =
+                            let uu____13826 =
+                              let uu____13827 =
+                                let uu____13832 =
                                   FStar_SMTEncoding_Util.mkApp
                                     ((FStar_Pervasives_Native.snd
                                         FStar_SMTEncoding_Term.boxBoolFun),
                                       [x])
                                    in
-                                (valid_b2t_x, uu____13788)  in
-                              FStar_SMTEncoding_Util.mkEq uu____13783  in
-                            ([[b2t_x]], [xx], uu____13782)  in
-                          FStar_SMTEncoding_Term.mkForall uu____13770
-                            uu____13771
+                                (valid_b2t_x, uu____13832)  in
+                              FStar_SMTEncoding_Util.mkEq uu____13827  in
+                            ([[b2t_x]], [xx], uu____13826)  in
+                          FStar_SMTEncoding_Term.mkForall uu____13814
+                            uu____13815
                            in
-                        (uu____13769,
+                        (uu____13813,
                           (FStar_Pervasives_Native.Some "b2t def"),
                           "b2t_def")
                          in
-                      FStar_SMTEncoding_Util.mkAssume uu____13761  in
-                    [uu____13760]  in
+                      FStar_SMTEncoding_Util.mkAssume uu____13805  in
+                    [uu____13804]  in
                   (FStar_SMTEncoding_Term.DeclFun
                      (tname, [FStar_SMTEncoding_Term.Term_sort],
                        FStar_SMTEncoding_Term.Term_sort,
                        FStar_Pervasives_Native.None))
-                    :: uu____13757
+                    :: uu____13801
                    in
-                let uu____13826 =
+                let uu____13870 =
                   FStar_All.pipe_right decls
                     FStar_SMTEncoding_Term.mk_decls_trivial
                    in
-                (uu____13826, env1))
-       | FStar_Syntax_Syntax.Sig_let (uu____13829,uu____13830) when
+                (uu____13870, env1))
+       | FStar_Syntax_Syntax.Sig_let (uu____13873,uu____13874) when
            FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
              (FStar_Util.for_some
-                (fun uu___4_13840  ->
-                   match uu___4_13840 with
-                   | FStar_Syntax_Syntax.Discriminator uu____13842 -> true
-                   | uu____13844 -> false))
+                (fun uu___4_13884  ->
+                   match uu___4_13884 with
+                   | FStar_Syntax_Syntax.Discriminator uu____13886 -> true
+                   | uu____13888 -> false))
            -> ([], env)
-       | FStar_Syntax_Syntax.Sig_let (uu____13846,lids) when
+       | FStar_Syntax_Syntax.Sig_let (uu____13890,lids) when
            (FStar_All.pipe_right lids
               (FStar_Util.for_some
                  (fun l  ->
-                    let uu____13858 =
-                      let uu____13860 = FStar_List.hd l.FStar_Ident.ns  in
-                      uu____13860.FStar_Ident.idText  in
-                    uu____13858 = "Prims")))
+                    let uu____13902 =
+                      let uu____13904 =
+                        let uu____13905 = FStar_Ident.ns_of_lid l  in
+                        FStar_List.hd uu____13905  in
+                      FStar_Ident.text_of_id uu____13904  in
+                    uu____13902 = "Prims")))
              &&
              (FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                 (FStar_Util.for_some
-                   (fun uu___5_13867  ->
-                      match uu___5_13867 with
+                   (fun uu___5_13914  ->
+                      match uu___5_13914 with
                       | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen 
                           -> true
-                      | uu____13870 -> false)))
+                      | uu____13917 -> false)))
            -> ([], env)
-       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____13873) when
+       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____13920) when
            FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
              (FStar_Util.for_some
-                (fun uu___6_13887  ->
-                   match uu___6_13887 with
-                   | FStar_Syntax_Syntax.Projector uu____13889 -> true
-                   | uu____13895 -> false))
+                (fun uu___6_13934  ->
+                   match uu___6_13934 with
+                   | FStar_Syntax_Syntax.Projector uu____13936 -> true
+                   | uu____13942 -> false))
            ->
            let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
            let l = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-           let uu____13899 = FStar_SMTEncoding_Env.try_lookup_free_var env l
+           let uu____13946 = FStar_SMTEncoding_Env.try_lookup_free_var env l
               in
-           (match uu____13899 with
-            | FStar_Pervasives_Native.Some uu____13906 -> ([], env)
+           (match uu____13946 with
+            | FStar_Pervasives_Native.Some uu____13953 -> ([], env)
             | FStar_Pervasives_Native.None  ->
                 let se1 =
-                  let uu___1090_13908 = se  in
-                  let uu____13909 = FStar_Ident.range_of_lid l  in
+                  let uu___1090_13955 = se  in
+                  let uu____13956 = FStar_Ident.range_of_lid l  in
                   {
                     FStar_Syntax_Syntax.sigel =
                       (FStar_Syntax_Syntax.Sig_declare_typ
                          (l, (lb.FStar_Syntax_Syntax.lbunivs),
                            (lb.FStar_Syntax_Syntax.lbtyp)));
-                    FStar_Syntax_Syntax.sigrng = uu____13909;
+                    FStar_Syntax_Syntax.sigrng = uu____13956;
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___1090_13908.FStar_Syntax_Syntax.sigquals);
+                      (uu___1090_13955.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___1090_13908.FStar_Syntax_Syntax.sigmeta);
+                      (uu___1090_13955.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___1090_13908.FStar_Syntax_Syntax.sigattrs);
+                      (uu___1090_13955.FStar_Syntax_Syntax.sigattrs);
                     FStar_Syntax_Syntax.sigopts =
-                      (uu___1090_13908.FStar_Syntax_Syntax.sigopts)
+                      (uu___1090_13955.FStar_Syntax_Syntax.sigopts)
                   }  in
                 encode_sigelt env se1)
-       | FStar_Syntax_Syntax.Sig_let ((is_rec,bindings),uu____13912) ->
+       | FStar_Syntax_Syntax.Sig_let ((is_rec,bindings),uu____13959) ->
            let bindings1 =
              FStar_List.map
                (fun lb  ->
@@ -5048,213 +5090,213 @@ and (encode_sigelt' :
                     norm_before_encoding env lb.FStar_Syntax_Syntax.lbdef  in
                   let typ =
                     norm_before_encoding env lb.FStar_Syntax_Syntax.lbtyp  in
-                  let uu___1102_13933 = lb  in
+                  let uu___1102_13980 = lb  in
                   {
                     FStar_Syntax_Syntax.lbname =
-                      (uu___1102_13933.FStar_Syntax_Syntax.lbname);
+                      (uu___1102_13980.FStar_Syntax_Syntax.lbname);
                     FStar_Syntax_Syntax.lbunivs =
-                      (uu___1102_13933.FStar_Syntax_Syntax.lbunivs);
+                      (uu___1102_13980.FStar_Syntax_Syntax.lbunivs);
                     FStar_Syntax_Syntax.lbtyp = typ;
                     FStar_Syntax_Syntax.lbeff =
-                      (uu___1102_13933.FStar_Syntax_Syntax.lbeff);
+                      (uu___1102_13980.FStar_Syntax_Syntax.lbeff);
                     FStar_Syntax_Syntax.lbdef = def;
                     FStar_Syntax_Syntax.lbattrs =
-                      (uu___1102_13933.FStar_Syntax_Syntax.lbattrs);
+                      (uu___1102_13980.FStar_Syntax_Syntax.lbattrs);
                     FStar_Syntax_Syntax.lbpos =
-                      (uu___1102_13933.FStar_Syntax_Syntax.lbpos)
+                      (uu___1102_13980.FStar_Syntax_Syntax.lbpos)
                   }) bindings
               in
            encode_top_level_let env (is_rec, bindings1)
              se.FStar_Syntax_Syntax.sigquals
-       | FStar_Syntax_Syntax.Sig_bundle (ses,uu____13938) ->
-           let uu____13947 = encode_sigelts env ses  in
-           (match uu____13947 with
+       | FStar_Syntax_Syntax.Sig_bundle (ses,uu____13985) ->
+           let uu____13994 = encode_sigelts env ses  in
+           (match uu____13994 with
             | (g,env1) ->
-                let uu____13958 =
+                let uu____14005 =
                   FStar_List.fold_left
-                    (fun uu____13982  ->
+                    (fun uu____14029  ->
                        fun elt  ->
-                         match uu____13982 with
+                         match uu____14029 with
                          | (g',inversions) ->
-                             let uu____14010 =
+                             let uu____14057 =
                                FStar_All.pipe_right
                                  elt.FStar_SMTEncoding_Term.decls
                                  (FStar_List.partition
-                                    (fun uu___7_14033  ->
-                                       match uu___7_14033 with
+                                    (fun uu___7_14080  ->
+                                       match uu___7_14080 with
                                        | FStar_SMTEncoding_Term.Assume
                                            {
                                              FStar_SMTEncoding_Term.assumption_term
-                                               = uu____14035;
+                                               = uu____14082;
                                              FStar_SMTEncoding_Term.assumption_caption
                                                = FStar_Pervasives_Native.Some
                                                "inversion axiom";
                                              FStar_SMTEncoding_Term.assumption_name
-                                               = uu____14036;
+                                               = uu____14083;
                                              FStar_SMTEncoding_Term.assumption_fact_ids
-                                               = uu____14037;_}
+                                               = uu____14084;_}
                                            -> false
-                                       | uu____14044 -> true))
+                                       | uu____14091 -> true))
                                 in
-                             (match uu____14010 with
+                             (match uu____14057 with
                               | (elt_g',elt_inversions) ->
                                   ((FStar_List.append g'
-                                      [(let uu___1128_14069 = elt  in
+                                      [(let uu___1128_14116 = elt  in
                                         {
                                           FStar_SMTEncoding_Term.sym_name =
-                                            (uu___1128_14069.FStar_SMTEncoding_Term.sym_name);
+                                            (uu___1128_14116.FStar_SMTEncoding_Term.sym_name);
                                           FStar_SMTEncoding_Term.key =
-                                            (uu___1128_14069.FStar_SMTEncoding_Term.key);
+                                            (uu___1128_14116.FStar_SMTEncoding_Term.key);
                                           FStar_SMTEncoding_Term.decls =
                                             elt_g';
                                           FStar_SMTEncoding_Term.a_names =
-                                            (uu___1128_14069.FStar_SMTEncoding_Term.a_names)
+                                            (uu___1128_14116.FStar_SMTEncoding_Term.a_names)
                                         })]),
                                     (FStar_List.append inversions
                                        elt_inversions)))) ([], []) g
                    in
-                (match uu____13958 with
+                (match uu____14005 with
                  | (g',inversions) ->
-                     let uu____14088 =
+                     let uu____14135 =
                        FStar_List.fold_left
-                         (fun uu____14119  ->
+                         (fun uu____14166  ->
                             fun elt  ->
-                              match uu____14119 with
+                              match uu____14166 with
                               | (decls,elts,rest) ->
-                                  let uu____14160 =
+                                  let uu____14207 =
                                     (FStar_All.pipe_right
                                        elt.FStar_SMTEncoding_Term.key
                                        FStar_Util.is_some)
                                       &&
                                       (FStar_List.existsb
-                                         (fun uu___8_14169  ->
-                                            match uu___8_14169 with
+                                         (fun uu___8_14216  ->
+                                            match uu___8_14216 with
                                             | FStar_SMTEncoding_Term.DeclFun
-                                                uu____14171 -> true
-                                            | uu____14184 -> false)
+                                                uu____14218 -> true
+                                            | uu____14231 -> false)
                                          elt.FStar_SMTEncoding_Term.decls)
                                      in
-                                  if uu____14160
+                                  if uu____14207
                                   then
                                     (decls, (FStar_List.append elts [elt]),
                                       rest)
                                   else
-                                    (let uu____14207 =
+                                    (let uu____14254 =
                                        FStar_All.pipe_right
                                          elt.FStar_SMTEncoding_Term.decls
                                          (FStar_List.partition
-                                            (fun uu___9_14228  ->
-                                               match uu___9_14228 with
+                                            (fun uu___9_14275  ->
+                                               match uu___9_14275 with
                                                | FStar_SMTEncoding_Term.DeclFun
-                                                   uu____14230 -> true
-                                               | uu____14243 -> false))
+                                                   uu____14277 -> true
+                                               | uu____14290 -> false))
                                         in
-                                     match uu____14207 with
+                                     match uu____14254 with
                                      | (elt_decls,elt_rest) ->
                                          ((FStar_List.append decls elt_decls),
                                            elts,
                                            (FStar_List.append rest
-                                              [(let uu___1150_14274 = elt  in
+                                              [(let uu___1150_14321 = elt  in
                                                 {
                                                   FStar_SMTEncoding_Term.sym_name
                                                     =
-                                                    (uu___1150_14274.FStar_SMTEncoding_Term.sym_name);
+                                                    (uu___1150_14321.FStar_SMTEncoding_Term.sym_name);
                                                   FStar_SMTEncoding_Term.key
                                                     =
-                                                    (uu___1150_14274.FStar_SMTEncoding_Term.key);
+                                                    (uu___1150_14321.FStar_SMTEncoding_Term.key);
                                                   FStar_SMTEncoding_Term.decls
                                                     = elt_rest;
                                                   FStar_SMTEncoding_Term.a_names
                                                     =
-                                                    (uu___1150_14274.FStar_SMTEncoding_Term.a_names)
+                                                    (uu___1150_14321.FStar_SMTEncoding_Term.a_names)
                                                 })])))) ([], [], []) g'
                         in
-                     (match uu____14088 with
+                     (match uu____14135 with
                       | (decls,elts,rest) ->
-                          let uu____14300 =
-                            let uu____14301 =
+                          let uu____14347 =
+                            let uu____14348 =
                               FStar_All.pipe_right decls
                                 FStar_SMTEncoding_Term.mk_decls_trivial
                                in
-                            let uu____14308 =
-                              let uu____14311 =
-                                let uu____14314 =
+                            let uu____14355 =
+                              let uu____14358 =
+                                let uu____14361 =
                                   FStar_All.pipe_right inversions
                                     FStar_SMTEncoding_Term.mk_decls_trivial
                                    in
-                                FStar_List.append rest uu____14314  in
-                              FStar_List.append elts uu____14311  in
-                            FStar_List.append uu____14301 uu____14308  in
-                          (uu____14300, env1))))
+                                FStar_List.append rest uu____14361  in
+                              FStar_List.append elts uu____14358  in
+                            FStar_List.append uu____14348 uu____14355  in
+                          (uu____14347, env1))))
        | FStar_Syntax_Syntax.Sig_inductive_typ
-           (t,universe_names,tps,k,uu____14325,datas) ->
+           (t,universe_names,tps,k,uu____14372,datas) ->
            let tcenv = env.FStar_SMTEncoding_Env.tcenv  in
            let is_injective =
-             let uu____14338 =
+             let uu____14385 =
                FStar_Syntax_Subst.univ_var_opening universe_names  in
-             match uu____14338 with
+             match uu____14385 with
              | (usubst,uvs) ->
-                 let uu____14358 =
-                   let uu____14365 =
+                 let uu____14405 =
+                   let uu____14412 =
                      FStar_TypeChecker_Env.push_univ_vars tcenv uvs  in
-                   let uu____14366 =
+                   let uu____14413 =
                      FStar_Syntax_Subst.subst_binders usubst tps  in
-                   let uu____14367 =
-                     let uu____14368 =
+                   let uu____14414 =
+                     let uu____14415 =
                        FStar_Syntax_Subst.shift_subst (FStar_List.length tps)
                          usubst
                         in
-                     FStar_Syntax_Subst.subst uu____14368 k  in
-                   (uu____14365, uu____14366, uu____14367)  in
-                 (match uu____14358 with
+                     FStar_Syntax_Subst.subst uu____14415 k  in
+                   (uu____14412, uu____14413, uu____14414)  in
+                 (match uu____14405 with
                   | (env1,tps1,k1) ->
-                      let uu____14381 = FStar_Syntax_Subst.open_term tps1 k1
+                      let uu____14428 = FStar_Syntax_Subst.open_term tps1 k1
                          in
-                      (match uu____14381 with
+                      (match uu____14428 with
                        | (tps2,k2) ->
-                           let uu____14389 =
+                           let uu____14436 =
                              FStar_Syntax_Util.arrow_formals k2  in
-                           (match uu____14389 with
-                            | (uu____14397,k3) ->
-                                let uu____14403 =
+                           (match uu____14436 with
+                            | (uu____14444,k3) ->
+                                let uu____14450 =
                                   FStar_TypeChecker_TcTerm.tc_binders env1
                                     tps2
                                    in
-                                (match uu____14403 with
-                                 | (tps3,env_tps,uu____14415,us) ->
+                                (match uu____14450 with
+                                 | (tps3,env_tps,uu____14462,us) ->
                                      let u_k =
-                                       let uu____14418 =
-                                         let uu____14419 =
+                                       let uu____14465 =
+                                         let uu____14466 =
                                            FStar_Ident.range_of_lid t  in
-                                         let uu____14420 =
-                                           let uu____14425 =
+                                         let uu____14467 =
+                                           let uu____14472 =
                                              FStar_Syntax_Syntax.fvar t
                                                (FStar_Syntax_Syntax.Delta_constant_at_level
                                                   Prims.int_zero)
                                                FStar_Pervasives_Native.None
                                               in
-                                           let uu____14427 =
-                                             let uu____14428 =
+                                           let uu____14474 =
+                                             let uu____14475 =
                                                FStar_Syntax_Util.args_of_binders
                                                  tps3
                                                 in
                                              FStar_Pervasives_Native.snd
-                                               uu____14428
+                                               uu____14475
                                               in
                                            FStar_Syntax_Syntax.mk_Tm_app
-                                             uu____14425 uu____14427
+                                             uu____14472 uu____14474
                                             in
-                                         uu____14420
+                                         uu____14467
                                            FStar_Pervasives_Native.None
-                                           uu____14419
+                                           uu____14466
                                           in
                                        FStar_TypeChecker_TcTerm.level_of_type
-                                         env_tps uu____14418 k3
+                                         env_tps uu____14465 k3
                                         in
                                      let rec universe_leq u v =
                                        match (u, v) with
                                        | (FStar_Syntax_Syntax.U_zero
-                                          ,uu____14446) -> true
+                                          ,uu____14493) -> true
                                        | (FStar_Syntax_Syntax.U_succ
                                           u0,FStar_Syntax_Syntax.U_succ v0)
                                            -> universe_leq u0 v0
@@ -5262,89 +5304,89 @@ and (encode_sigelt' :
                                           u0,FStar_Syntax_Syntax.U_name v0)
                                            -> FStar_Ident.ident_equals u0 v0
                                        | (FStar_Syntax_Syntax.U_name
-                                          uu____14452,FStar_Syntax_Syntax.U_succ
+                                          uu____14499,FStar_Syntax_Syntax.U_succ
                                           v0) -> universe_leq u v0
                                        | (FStar_Syntax_Syntax.U_max
-                                          us1,uu____14455) ->
+                                          us1,uu____14502) ->
                                            FStar_All.pipe_right us1
                                              (FStar_Util.for_all
                                                 (fun u1  -> universe_leq u1 v))
-                                       | (uu____14463,FStar_Syntax_Syntax.U_max
+                                       | (uu____14510,FStar_Syntax_Syntax.U_max
                                           vs) ->
                                            FStar_All.pipe_right vs
                                              (FStar_Util.for_some
                                                 (universe_leq u))
                                        | (FStar_Syntax_Syntax.U_unknown
-                                          ,uu____14470) ->
-                                           let uu____14471 =
-                                             let uu____14473 =
+                                          ,uu____14517) ->
+                                           let uu____14518 =
+                                             let uu____14520 =
                                                FStar_Ident.string_of_lid t
                                                 in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____14473
+                                               uu____14520
                                               in
-                                           failwith uu____14471
-                                       | (uu____14477,FStar_Syntax_Syntax.U_unknown
+                                           failwith uu____14518
+                                       | (uu____14524,FStar_Syntax_Syntax.U_unknown
                                           ) ->
-                                           let uu____14478 =
-                                             let uu____14480 =
+                                           let uu____14525 =
+                                             let uu____14527 =
                                                FStar_Ident.string_of_lid t
                                                 in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____14480
+                                               uu____14527
                                               in
-                                           failwith uu____14478
+                                           failwith uu____14525
                                        | (FStar_Syntax_Syntax.U_unif
-                                          uu____14484,uu____14485) ->
-                                           let uu____14494 =
-                                             let uu____14496 =
+                                          uu____14531,uu____14532) ->
+                                           let uu____14541 =
+                                             let uu____14543 =
                                                FStar_Ident.string_of_lid t
                                                 in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____14496
+                                               uu____14543
                                               in
-                                           failwith uu____14494
-                                       | (uu____14500,FStar_Syntax_Syntax.U_unif
-                                          uu____14501) ->
-                                           let uu____14510 =
-                                             let uu____14512 =
+                                           failwith uu____14541
+                                       | (uu____14547,FStar_Syntax_Syntax.U_unif
+                                          uu____14548) ->
+                                           let uu____14557 =
+                                             let uu____14559 =
                                                FStar_Ident.string_of_lid t
                                                 in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____14512
+                                               uu____14559
                                               in
-                                           failwith uu____14510
-                                       | uu____14516 -> false  in
+                                           failwith uu____14557
+                                       | uu____14563 -> false  in
                                      let u_leq_u_k u =
-                                       let uu____14529 =
+                                       let uu____14576 =
                                          FStar_TypeChecker_Normalize.normalize_universe
                                            env_tps u
                                           in
-                                       universe_leq uu____14529 u_k  in
+                                       universe_leq uu____14576 u_k  in
                                      let tp_ok tp u_tp =
                                        let t_tp =
                                          (FStar_Pervasives_Native.fst tp).FStar_Syntax_Syntax.sort
                                           in
-                                       let uu____14547 = u_leq_u_k u_tp  in
-                                       if uu____14547
+                                       let uu____14594 = u_leq_u_k u_tp  in
+                                       if uu____14594
                                        then true
                                        else
-                                         (let uu____14554 =
+                                         (let uu____14601 =
                                             FStar_Syntax_Util.arrow_formals
                                               t_tp
                                              in
-                                          match uu____14554 with
-                                          | (formals,uu____14563) ->
-                                              let uu____14568 =
+                                          match uu____14601 with
+                                          | (formals,uu____14610) ->
+                                              let uu____14615 =
                                                 FStar_TypeChecker_TcTerm.tc_binders
                                                   env_tps formals
                                                  in
-                                              (match uu____14568 with
-                                               | (uu____14578,uu____14579,uu____14580,u_formals)
+                                              (match uu____14615 with
+                                               | (uu____14625,uu____14626,uu____14627,u_formals)
                                                    ->
                                                    FStar_Util.for_all
                                                      (fun u_formal  ->
@@ -5353,137 +5395,137 @@ and (encode_sigelt' :
                                         in
                                      FStar_List.forall2 tp_ok tps3 us))))
               in
-           ((let uu____14591 =
+           ((let uu____14638 =
                FStar_All.pipe_left
                  (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
                  (FStar_Options.Other "SMTEncoding")
                 in
-             if uu____14591
+             if uu____14638
              then
-               let uu____14596 = FStar_Ident.string_of_lid t  in
+               let uu____14643 = FStar_Ident.string_of_lid t  in
                FStar_Util.print2 "%s injectivity for %s\n"
-                 (if is_injective then "YES" else "NO") uu____14596
+                 (if is_injective then "YES" else "NO") uu____14643
              else ());
             (let quals = se.FStar_Syntax_Syntax.sigquals  in
              let is_logical =
                FStar_All.pipe_right quals
                  (FStar_Util.for_some
-                    (fun uu___10_14616  ->
-                       match uu___10_14616 with
+                    (fun uu___10_14663  ->
+                       match uu___10_14663 with
                        | FStar_Syntax_Syntax.Logic  -> true
                        | FStar_Syntax_Syntax.Assumption  -> true
-                       | uu____14620 -> false))
+                       | uu____14667 -> false))
                 in
              let constructor_or_logic_type_decl c =
                if is_logical
                then
-                 let uu____14633 = c  in
-                 match uu____14633 with
-                 | (name,args,uu____14638,uu____14639,uu____14640) ->
-                     let uu____14651 =
-                       let uu____14652 =
-                         let uu____14664 =
+                 let uu____14680 = c  in
+                 match uu____14680 with
+                 | (name,args,uu____14685,uu____14686,uu____14687) ->
+                     let uu____14698 =
+                       let uu____14699 =
+                         let uu____14711 =
                            FStar_All.pipe_right args
                              (FStar_List.map
-                                (fun uu____14691  ->
-                                   match uu____14691 with
-                                   | (uu____14700,sort,uu____14702) -> sort))
+                                (fun uu____14738  ->
+                                   match uu____14738 with
+                                   | (uu____14747,sort,uu____14749) -> sort))
                             in
-                         (name, uu____14664,
+                         (name, uu____14711,
                            FStar_SMTEncoding_Term.Term_sort,
                            FStar_Pervasives_Native.None)
                           in
-                       FStar_SMTEncoding_Term.DeclFun uu____14652  in
-                     [uu____14651]
+                       FStar_SMTEncoding_Term.DeclFun uu____14699  in
+                     [uu____14698]
                else
-                 (let uu____14713 = FStar_Ident.range_of_lid t  in
-                  FStar_SMTEncoding_Term.constructor_to_decl uu____14713 c)
+                 (let uu____14760 = FStar_Ident.range_of_lid t  in
+                  FStar_SMTEncoding_Term.constructor_to_decl uu____14760 c)
                 in
              let inversion_axioms tapp vars =
-               let uu____14731 =
+               let uu____14778 =
                  FStar_All.pipe_right datas
                    (FStar_Util.for_some
                       (fun l  ->
-                         let uu____14739 =
+                         let uu____14786 =
                            FStar_TypeChecker_Env.try_lookup_lid
                              env.FStar_SMTEncoding_Env.tcenv l
                             in
-                         FStar_All.pipe_right uu____14739 FStar_Option.isNone))
+                         FStar_All.pipe_right uu____14786 FStar_Option.isNone))
                   in
-               if uu____14731
+               if uu____14778
                then []
                else
-                 (let uu____14774 =
+                 (let uu____14821 =
                     FStar_SMTEncoding_Env.fresh_fvar
                       env.FStar_SMTEncoding_Env.current_module_name "x"
                       FStar_SMTEncoding_Term.Term_sort
                      in
-                  match uu____14774 with
+                  match uu____14821 with
                   | (xxsym,xx) ->
-                      let uu____14787 =
+                      let uu____14834 =
                         FStar_All.pipe_right datas
                           (FStar_List.fold_left
-                             (fun uu____14826  ->
+                             (fun uu____14873  ->
                                 fun l  ->
-                                  match uu____14826 with
+                                  match uu____14873 with
                                   | (out,decls) ->
-                                      let uu____14846 =
+                                      let uu____14893 =
                                         FStar_TypeChecker_Env.lookup_datacon
                                           env.FStar_SMTEncoding_Env.tcenv l
                                          in
-                                      (match uu____14846 with
-                                       | (uu____14857,data_t) ->
-                                           let uu____14859 =
+                                      (match uu____14893 with
+                                       | (uu____14904,data_t) ->
+                                           let uu____14906 =
                                              FStar_Syntax_Util.arrow_formals
                                                data_t
                                               in
-                                           (match uu____14859 with
+                                           (match uu____14906 with
                                             | (args,res) ->
                                                 let indices =
-                                                  let uu____14879 =
-                                                    let uu____14880 =
+                                                  let uu____14926 =
+                                                    let uu____14927 =
                                                       FStar_Syntax_Subst.compress
                                                         res
                                                        in
-                                                    uu____14880.FStar_Syntax_Syntax.n
+                                                    uu____14927.FStar_Syntax_Syntax.n
                                                      in
-                                                  match uu____14879 with
+                                                  match uu____14926 with
                                                   | FStar_Syntax_Syntax.Tm_app
-                                                      (uu____14883,indices)
+                                                      (uu____14930,indices)
                                                       -> indices
-                                                  | uu____14909 -> []  in
+                                                  | uu____14956 -> []  in
                                                 let env1 =
                                                   FStar_All.pipe_right args
                                                     (FStar_List.fold_left
                                                        (fun env1  ->
-                                                          fun uu____14939  ->
-                                                            match uu____14939
+                                                          fun uu____14986  ->
+                                                            match uu____14986
                                                             with
-                                                            | (x,uu____14947)
+                                                            | (x,uu____14994)
                                                                 ->
-                                                                let uu____14952
+                                                                let uu____14999
                                                                   =
-                                                                  let uu____14953
+                                                                  let uu____15000
                                                                     =
-                                                                    let uu____14961
+                                                                    let uu____15008
                                                                     =
                                                                     FStar_SMTEncoding_Env.mk_term_projector_name
                                                                     l x  in
-                                                                    (uu____14961,
+                                                                    (uu____15008,
                                                                     [xx])  in
                                                                   FStar_SMTEncoding_Util.mkApp
-                                                                    uu____14953
+                                                                    uu____15000
                                                                    in
                                                                 FStar_SMTEncoding_Env.push_term_var
                                                                   env1 x
-                                                                  uu____14952)
+                                                                  uu____14999)
                                                        env)
                                                    in
-                                                let uu____14966 =
+                                                let uu____15013 =
                                                   FStar_SMTEncoding_EncodeTerm.encode_args
                                                     indices env1
                                                    in
-                                                (match uu____14966 with
+                                                (match uu____15013 with
                                                  | (indices1,decls') ->
                                                      (if
                                                         (FStar_List.length
@@ -5500,58 +5542,58 @@ and (encode_sigelt' :
                                                            FStar_List.map2
                                                              (fun v  ->
                                                                 fun a  ->
-                                                                  let uu____15001
+                                                                  let uu____15048
                                                                     =
-                                                                    let uu____15006
+                                                                    let uu____15053
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v  in
-                                                                    (uu____15006,
+                                                                    (uu____15053,
                                                                     a)  in
                                                                   FStar_SMTEncoding_Util.mkEq
-                                                                    uu____15001)
+                                                                    uu____15048)
                                                              vars indices1
                                                          else []  in
-                                                       let uu____15009 =
-                                                         let uu____15010 =
-                                                           let uu____15015 =
-                                                             let uu____15016
+                                                       let uu____15056 =
+                                                         let uu____15057 =
+                                                           let uu____15062 =
+                                                             let uu____15063
                                                                =
-                                                               let uu____15021
+                                                               let uu____15068
                                                                  =
                                                                  FStar_SMTEncoding_Env.mk_data_tester
                                                                    env1 l xx
                                                                   in
-                                                               let uu____15022
+                                                               let uu____15069
                                                                  =
                                                                  FStar_All.pipe_right
                                                                    eqs
                                                                    FStar_SMTEncoding_Util.mk_and_l
                                                                   in
-                                                               (uu____15021,
-                                                                 uu____15022)
+                                                               (uu____15068,
+                                                                 uu____15069)
                                                                 in
                                                              FStar_SMTEncoding_Util.mkAnd
-                                                               uu____15016
+                                                               uu____15063
                                                               in
-                                                           (out, uu____15015)
+                                                           (out, uu____15062)
                                                             in
                                                          FStar_SMTEncoding_Util.mkOr
-                                                           uu____15010
+                                                           uu____15057
                                                           in
-                                                       (uu____15009,
+                                                       (uu____15056,
                                                          (FStar_List.append
                                                             decls decls'))))))))
                              (FStar_SMTEncoding_Util.mkFalse, []))
                          in
-                      (match uu____14787 with
+                      (match uu____14834 with
                        | (data_ax,decls) ->
-                           let uu____15037 =
+                           let uu____15084 =
                              FStar_SMTEncoding_Env.fresh_fvar
                                env.FStar_SMTEncoding_Env.current_module_name
                                "f" FStar_SMTEncoding_Term.Fuel_sort
                               in
-                           (match uu____15037 with
+                           (match uu____15084 with
                             | (ffsym,ff) ->
                                 let fuel_guarded_inversion =
                                   let xx_has_type_sfuel =
@@ -5559,159 +5601,164 @@ and (encode_sigelt' :
                                       (FStar_List.length datas) >
                                         Prims.int_one
                                     then
-                                      let uu____15054 =
+                                      let uu____15101 =
                                         FStar_SMTEncoding_Util.mkApp
                                           ("SFuel", [ff])
                                          in
                                       FStar_SMTEncoding_Term.mk_HasTypeFuel
-                                        uu____15054 xx tapp
+                                        uu____15101 xx tapp
                                     else
                                       FStar_SMTEncoding_Term.mk_HasTypeFuel
                                         ff xx tapp
                                      in
-                                  let uu____15061 =
-                                    let uu____15069 =
-                                      let uu____15070 =
+                                  let uu____15108 =
+                                    let uu____15116 =
+                                      let uu____15117 =
                                         FStar_Ident.range_of_lid t  in
-                                      let uu____15071 =
-                                        let uu____15082 =
-                                          let uu____15083 =
+                                      let uu____15118 =
+                                        let uu____15129 =
+                                          let uu____15130 =
                                             FStar_SMTEncoding_Term.mk_fv
                                               (ffsym,
                                                 FStar_SMTEncoding_Term.Fuel_sort)
                                              in
-                                          let uu____15085 =
-                                            let uu____15088 =
+                                          let uu____15132 =
+                                            let uu____15135 =
                                               FStar_SMTEncoding_Term.mk_fv
                                                 (xxsym,
                                                   FStar_SMTEncoding_Term.Term_sort)
                                                in
-                                            uu____15088 :: vars  in
+                                            uu____15135 :: vars  in
                                           FStar_SMTEncoding_Env.add_fuel
-                                            uu____15083 uu____15085
+                                            uu____15130 uu____15132
                                            in
-                                        let uu____15090 =
+                                        let uu____15137 =
                                           FStar_SMTEncoding_Util.mkImp
                                             (xx_has_type_sfuel, data_ax)
                                            in
-                                        ([[xx_has_type_sfuel]], uu____15082,
-                                          uu____15090)
+                                        ([[xx_has_type_sfuel]], uu____15129,
+                                          uu____15137)
                                          in
                                       FStar_SMTEncoding_Term.mkForall
-                                        uu____15070 uu____15071
+                                        uu____15117 uu____15118
                                        in
-                                    let uu____15099 =
+                                    let uu____15146 =
+                                      let uu____15148 =
+                                        let uu____15150 =
+                                          FStar_Ident.string_of_lid t  in
+                                        Prims.op_Hat
+                                          "fuel_guarded_inversion_"
+                                          uu____15150
+                                         in
                                       FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
-                                        (Prims.op_Hat
-                                           "fuel_guarded_inversion_"
-                                           t.FStar_Ident.str)
+                                        uu____15148
                                        in
-                                    (uu____15069,
+                                    (uu____15116,
                                       (FStar_Pervasives_Native.Some
-                                         "inversion axiom"), uu____15099)
+                                         "inversion axiom"), uu____15146)
                                      in
-                                  FStar_SMTEncoding_Util.mkAssume uu____15061
+                                  FStar_SMTEncoding_Util.mkAssume uu____15108
                                    in
-                                let uu____15105 =
+                                let uu____15156 =
                                   FStar_All.pipe_right
                                     [fuel_guarded_inversion]
                                     FStar_SMTEncoding_Term.mk_decls_trivial
                                    in
-                                FStar_List.append decls uu____15105)))
+                                FStar_List.append decls uu____15156)))
                 in
-             let uu____15112 =
+             let uu____15163 =
                let k1 =
                  match tps with
                  | [] -> k
-                 | uu____15126 ->
-                     let uu____15127 =
-                       let uu____15134 =
-                         let uu____15135 =
-                           let uu____15150 = FStar_Syntax_Syntax.mk_Total k
+                 | uu____15177 ->
+                     let uu____15178 =
+                       let uu____15185 =
+                         let uu____15186 =
+                           let uu____15201 = FStar_Syntax_Syntax.mk_Total k
                               in
-                           (tps, uu____15150)  in
-                         FStar_Syntax_Syntax.Tm_arrow uu____15135  in
-                       FStar_Syntax_Syntax.mk uu____15134  in
-                     uu____15127 FStar_Pervasives_Native.None
+                           (tps, uu____15201)  in
+                         FStar_Syntax_Syntax.Tm_arrow uu____15186  in
+                       FStar_Syntax_Syntax.mk uu____15185  in
+                     uu____15178 FStar_Pervasives_Native.None
                        k.FStar_Syntax_Syntax.pos
                   in
                let k2 = norm_before_encoding env k1  in
                FStar_Syntax_Util.arrow_formals k2  in
-             match uu____15112 with
+             match uu____15163 with
              | (formals,res) ->
-                 let uu____15174 =
+                 let uu____15225 =
                    FStar_SMTEncoding_EncodeTerm.encode_binders
                      FStar_Pervasives_Native.None formals env
                     in
-                 (match uu____15174 with
-                  | (vars,guards,env',binder_decls,uu____15199) ->
+                 (match uu____15225 with
+                  | (vars,guards,env',binder_decls,uu____15250) ->
                       let arity = FStar_List.length vars  in
-                      let uu____15213 =
+                      let uu____15264 =
                         FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                           env t arity
                          in
-                      (match uu____15213 with
+                      (match uu____15264 with
                        | (tname,ttok,env1) ->
                            let ttok_tm =
                              FStar_SMTEncoding_Util.mkApp (ttok, [])  in
                            let guard = FStar_SMTEncoding_Util.mk_and_l guards
                               in
                            let tapp =
-                             let uu____15239 =
-                               let uu____15247 =
+                             let uu____15290 =
+                               let uu____15298 =
                                  FStar_List.map
                                    FStar_SMTEncoding_Util.mkFreeV vars
                                   in
-                               (tname, uu____15247)  in
-                             FStar_SMTEncoding_Util.mkApp uu____15239  in
-                           let uu____15253 =
+                               (tname, uu____15298)  in
+                             FStar_SMTEncoding_Util.mkApp uu____15290  in
+                           let uu____15304 =
                              let tname_decl =
-                               let uu____15263 =
-                                 let uu____15264 =
+                               let uu____15314 =
+                                 let uu____15315 =
                                    FStar_All.pipe_right vars
                                      (FStar_List.map
                                         (fun fv  ->
-                                           let uu____15283 =
-                                             let uu____15285 =
+                                           let uu____15334 =
+                                             let uu____15336 =
                                                FStar_SMTEncoding_Term.fv_name
                                                  fv
                                                 in
-                                             Prims.op_Hat tname uu____15285
+                                             Prims.op_Hat tname uu____15336
                                               in
-                                           let uu____15287 =
+                                           let uu____15338 =
                                              FStar_SMTEncoding_Term.fv_sort
                                                fv
                                               in
-                                           (uu____15283, uu____15287, false)))
+                                           (uu____15334, uu____15338, false)))
                                     in
-                                 let uu____15291 =
+                                 let uu____15342 =
                                    FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                      ()
                                     in
-                                 (tname, uu____15264,
+                                 (tname, uu____15315,
                                    FStar_SMTEncoding_Term.Term_sort,
-                                   uu____15291, false)
+                                   uu____15342, false)
                                   in
-                               constructor_or_logic_type_decl uu____15263  in
-                             let uu____15299 =
+                               constructor_or_logic_type_decl uu____15314  in
+                             let uu____15350 =
                                match vars with
                                | [] ->
-                                   let uu____15312 =
-                                     let uu____15313 =
-                                       let uu____15316 =
+                                   let uu____15363 =
+                                     let uu____15364 =
+                                       let uu____15367 =
                                          FStar_SMTEncoding_Util.mkApp
                                            (tname, [])
                                           in
                                        FStar_All.pipe_left
-                                         (fun uu____15322  ->
+                                         (fun uu____15373  ->
                                             FStar_Pervasives_Native.Some
-                                              uu____15322) uu____15316
+                                              uu____15373) uu____15367
                                         in
                                      FStar_SMTEncoding_Env.push_free_var env1
-                                       t arity tname uu____15313
+                                       t arity tname uu____15364
                                       in
-                                   ([], uu____15312)
-                               | uu____15325 ->
+                                   ([], uu____15363)
+                               | uu____15376 ->
                                    let ttok_decl =
                                      FStar_SMTEncoding_Term.DeclFun
                                        (ttok, [],
@@ -5720,14 +5767,14 @@ and (encode_sigelt' :
                                             "token"))
                                       in
                                    let ttok_fresh =
-                                     let uu____15335 =
+                                     let uu____15386 =
                                        FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                          ()
                                         in
                                      FStar_SMTEncoding_Term.fresh_token
                                        (ttok,
                                          FStar_SMTEncoding_Term.Term_sort)
-                                       uu____15335
+                                       uu____15386
                                       in
                                    let ttok_app =
                                      FStar_SMTEncoding_EncodeTerm.mk_Apply
@@ -5735,199 +5782,199 @@ and (encode_sigelt' :
                                       in
                                    let pats = [[ttok_app]; [tapp]]  in
                                    let name_tok_corr =
-                                     let uu____15351 =
-                                       let uu____15359 =
-                                         let uu____15360 =
+                                     let uu____15402 =
+                                       let uu____15410 =
+                                         let uu____15411 =
                                            FStar_Ident.range_of_lid t  in
-                                         let uu____15361 =
-                                           let uu____15377 =
+                                         let uu____15412 =
+                                           let uu____15428 =
                                              FStar_SMTEncoding_Util.mkEq
                                                (ttok_app, tapp)
                                               in
                                            (pats,
                                              FStar_Pervasives_Native.None,
-                                             vars, uu____15377)
+                                             vars, uu____15428)
                                             in
                                          FStar_SMTEncoding_Term.mkForall'
-                                           uu____15360 uu____15361
+                                           uu____15411 uu____15412
                                           in
-                                       (uu____15359,
+                                       (uu____15410,
                                          (FStar_Pervasives_Native.Some
                                             "name-token correspondence"),
                                          (Prims.op_Hat
                                             "token_correspondence_" ttok))
                                         in
                                      FStar_SMTEncoding_Util.mkAssume
-                                       uu____15351
+                                       uu____15402
                                       in
                                    ([ttok_decl; ttok_fresh; name_tok_corr],
                                      env1)
                                 in
-                             match uu____15299 with
+                             match uu____15350 with
                              | (tok_decls,env2) ->
-                                 let uu____15404 =
+                                 let uu____15455 =
                                    FStar_Ident.lid_equals t
                                      FStar_Parser_Const.lex_t_lid
                                     in
-                                 if uu____15404
+                                 if uu____15455
                                  then (tok_decls, env2)
                                  else
                                    ((FStar_List.append tname_decl tok_decls),
                                      env2)
                               in
-                           (match uu____15253 with
+                           (match uu____15304 with
                             | (decls,env2) ->
                                 let kindingAx =
-                                  let uu____15432 =
+                                  let uu____15483 =
                                     FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                       FStar_Pervasives_Native.None res env'
                                       tapp
                                      in
-                                  match uu____15432 with
+                                  match uu____15483 with
                                   | (k1,decls1) ->
                                       let karr =
                                         if
                                           (FStar_List.length formals) >
                                             Prims.int_zero
                                         then
-                                          let uu____15454 =
-                                            let uu____15455 =
-                                              let uu____15463 =
-                                                let uu____15464 =
+                                          let uu____15505 =
+                                            let uu____15506 =
+                                              let uu____15514 =
+                                                let uu____15515 =
                                                   FStar_SMTEncoding_Term.mk_PreType
                                                     ttok_tm
                                                    in
                                                 FStar_SMTEncoding_Term.mk_tester
-                                                  "Tm_arrow" uu____15464
+                                                  "Tm_arrow" uu____15515
                                                  in
-                                              (uu____15463,
+                                              (uu____15514,
                                                 (FStar_Pervasives_Native.Some
                                                    "kinding"),
                                                 (Prims.op_Hat "pre_kinding_"
                                                    ttok))
                                                in
                                             FStar_SMTEncoding_Util.mkAssume
-                                              uu____15455
+                                              uu____15506
                                              in
-                                          [uu____15454]
+                                          [uu____15505]
                                         else []  in
                                       let rng = FStar_Ident.range_of_lid t
                                          in
                                       let tot_fun_axioms =
-                                        let uu____15474 =
+                                        let uu____15525 =
                                           FStar_List.map
-                                            (fun uu____15478  ->
+                                            (fun uu____15529  ->
                                                FStar_SMTEncoding_Util.mkTrue)
                                             vars
                                            in
                                         FStar_SMTEncoding_EncodeTerm.isTotFun_axioms
-                                          rng ttok_tm vars uu____15474 true
+                                          rng ttok_tm vars uu____15525 true
                                          in
-                                      let uu____15480 =
-                                        let uu____15483 =
-                                          let uu____15486 =
-                                            let uu____15489 =
-                                              let uu____15490 =
-                                                let uu____15498 =
-                                                  let uu____15499 =
-                                                    let uu____15504 =
-                                                      let uu____15505 =
-                                                        let uu____15516 =
+                                      let uu____15531 =
+                                        let uu____15534 =
+                                          let uu____15537 =
+                                            let uu____15540 =
+                                              let uu____15541 =
+                                                let uu____15549 =
+                                                  let uu____15550 =
+                                                    let uu____15555 =
+                                                      let uu____15556 =
+                                                        let uu____15567 =
                                                           FStar_SMTEncoding_Util.mkImp
                                                             (guard, k1)
                                                            in
                                                         ([[tapp]], vars,
-                                                          uu____15516)
+                                                          uu____15567)
                                                          in
                                                       FStar_SMTEncoding_Term.mkForall
-                                                        rng uu____15505
+                                                        rng uu____15556
                                                        in
                                                     (tot_fun_axioms,
-                                                      uu____15504)
+                                                      uu____15555)
                                                      in
                                                   FStar_SMTEncoding_Util.mkAnd
-                                                    uu____15499
+                                                    uu____15550
                                                    in
-                                                (uu____15498,
+                                                (uu____15549,
                                                   FStar_Pervasives_Native.None,
                                                   (Prims.op_Hat "kinding_"
                                                      ttok))
                                                  in
                                               FStar_SMTEncoding_Util.mkAssume
-                                                uu____15490
+                                                uu____15541
                                                in
-                                            [uu____15489]  in
-                                          FStar_List.append karr uu____15486
+                                            [uu____15540]  in
+                                          FStar_List.append karr uu____15537
                                            in
-                                        FStar_All.pipe_right uu____15483
+                                        FStar_All.pipe_right uu____15534
                                           FStar_SMTEncoding_Term.mk_decls_trivial
                                          in
-                                      FStar_List.append decls1 uu____15480
+                                      FStar_List.append decls1 uu____15531
                                    in
                                 let aux =
-                                  let uu____15535 =
-                                    let uu____15538 =
+                                  let uu____15586 =
+                                    let uu____15589 =
                                       inversion_axioms tapp vars  in
-                                    let uu____15541 =
-                                      let uu____15544 =
-                                        let uu____15547 =
-                                          let uu____15548 =
+                                    let uu____15592 =
+                                      let uu____15595 =
+                                        let uu____15598 =
+                                          let uu____15599 =
                                             FStar_Ident.range_of_lid t  in
-                                          pretype_axiom uu____15548 env2 tapp
+                                          pretype_axiom uu____15599 env2 tapp
                                             vars
                                            in
-                                        [uu____15547]  in
-                                      FStar_All.pipe_right uu____15544
+                                        [uu____15598]  in
+                                      FStar_All.pipe_right uu____15595
                                         FStar_SMTEncoding_Term.mk_decls_trivial
                                        in
-                                    FStar_List.append uu____15538 uu____15541
+                                    FStar_List.append uu____15589 uu____15592
                                      in
-                                  FStar_List.append kindingAx uu____15535  in
+                                  FStar_List.append kindingAx uu____15586  in
                                 let g =
-                                  let uu____15556 =
+                                  let uu____15607 =
                                     FStar_All.pipe_right decls
                                       FStar_SMTEncoding_Term.mk_decls_trivial
                                      in
-                                  FStar_List.append uu____15556
+                                  FStar_List.append uu____15607
                                     (FStar_List.append binder_decls aux)
                                    in
                                 (g, env2))))))
        | FStar_Syntax_Syntax.Sig_datacon
-           (d,uu____15564,uu____15565,uu____15566,uu____15567,uu____15568)
+           (d,uu____15615,uu____15616,uu____15617,uu____15618,uu____15619)
            when FStar_Ident.lid_equals d FStar_Parser_Const.lexcons_lid ->
            ([], env)
        | FStar_Syntax_Syntax.Sig_datacon
-           (d,uu____15576,t,uu____15578,n_tps,uu____15580) ->
+           (d,uu____15627,t,uu____15629,n_tps,uu____15631) ->
            let quals = se.FStar_Syntax_Syntax.sigquals  in
            let t1 = norm_before_encoding env t  in
-           let uu____15591 = FStar_Syntax_Util.arrow_formals t1  in
-           (match uu____15591 with
+           let uu____15642 = FStar_Syntax_Util.arrow_formals t1  in
+           (match uu____15642 with
             | (formals,t_res) ->
                 let arity = FStar_List.length formals  in
-                let uu____15615 =
+                let uu____15666 =
                   FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                     env d arity
                    in
-                (match uu____15615 with
+                (match uu____15666 with
                  | (ddconstrsym,ddtok,env1) ->
                      let ddtok_tm = FStar_SMTEncoding_Util.mkApp (ddtok, [])
                         in
-                     let uu____15639 =
+                     let uu____15690 =
                        FStar_SMTEncoding_Env.fresh_fvar
                          env1.FStar_SMTEncoding_Env.current_module_name "f"
                          FStar_SMTEncoding_Term.Fuel_sort
                         in
-                     (match uu____15639 with
+                     (match uu____15690 with
                       | (fuel_var,fuel_tm) ->
                           let s_fuel_tm =
                             FStar_SMTEncoding_Util.mkApp ("SFuel", [fuel_tm])
                              in
-                          let uu____15659 =
+                          let uu____15710 =
                             FStar_SMTEncoding_EncodeTerm.encode_binders
                               (FStar_Pervasives_Native.Some fuel_tm) formals
                               env1
                              in
-                          (match uu____15659 with
+                          (match uu____15710 with
                            | (vars,guards,env',binder_decls,names) ->
                                let fields =
                                  FStar_All.pipe_right names
@@ -5935,31 +5982,31 @@ and (encode_sigelt' :
                                       (fun n  ->
                                          fun x  ->
                                            let projectible = true  in
-                                           let uu____15738 =
+                                           let uu____15789 =
                                              FStar_SMTEncoding_Env.mk_term_projector_name
                                                d x
                                               in
-                                           (uu____15738,
+                                           (uu____15789,
                                              FStar_SMTEncoding_Term.Term_sort,
                                              projectible)))
                                   in
                                let datacons =
-                                 let uu____15745 =
-                                   let uu____15746 =
+                                 let uu____15796 =
+                                   let uu____15797 =
                                      FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                        ()
                                       in
                                    (ddconstrsym, fields,
                                      FStar_SMTEncoding_Term.Term_sort,
-                                     uu____15746, true)
+                                     uu____15797, true)
                                     in
-                                 let uu____15754 =
-                                   let uu____15761 =
+                                 let uu____15805 =
+                                   let uu____15812 =
                                      FStar_Ident.range_of_lid d  in
                                    FStar_SMTEncoding_Term.constructor_to_decl
-                                     uu____15761
+                                     uu____15812
                                     in
-                                 FStar_All.pipe_right uu____15745 uu____15754
+                                 FStar_All.pipe_right uu____15796 uu____15805
                                   in
                                let app =
                                  FStar_SMTEncoding_EncodeTerm.mk_Apply
@@ -5975,16 +6022,16 @@ and (encode_sigelt' :
                                  FStar_SMTEncoding_Util.mkApp
                                    (ddconstrsym, xvars)
                                   in
-                               let uu____15773 =
+                               let uu____15824 =
                                  FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                    FStar_Pervasives_Native.None t1 env1
                                    ddtok_tm
                                   in
-                               (match uu____15773 with
+                               (match uu____15824 with
                                 | (tok_typing,decls3) ->
                                     let tok_typing1 =
                                       match fields with
-                                      | uu____15785::uu____15786 ->
+                                      | uu____15836::uu____15837 ->
                                           let ff =
                                             FStar_SMTEncoding_Term.mk_fv
                                               ("ty",
@@ -5998,38 +6045,38 @@ and (encode_sigelt' :
                                               ddtok_tm [ff]
                                              in
                                           let vtok_app_r =
-                                            let uu____15835 =
-                                              let uu____15836 =
+                                            let uu____15886 =
+                                              let uu____15887 =
                                                 FStar_SMTEncoding_Term.mk_fv
                                                   (ddtok,
                                                     FStar_SMTEncoding_Term.Term_sort)
                                                  in
-                                              [uu____15836]  in
+                                              [uu____15887]  in
                                             FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                              f uu____15835
+                                              f uu____15886
                                              in
-                                          let uu____15862 =
+                                          let uu____15913 =
                                             FStar_Ident.range_of_lid d  in
-                                          let uu____15863 =
-                                            let uu____15874 =
+                                          let uu____15914 =
+                                            let uu____15925 =
                                               FStar_SMTEncoding_Term.mk_NoHoist
                                                 f tok_typing
                                                in
                                             ([[vtok_app_l]; [vtok_app_r]],
-                                              [ff], uu____15874)
+                                              [ff], uu____15925)
                                              in
                                           FStar_SMTEncoding_Term.mkForall
-                                            uu____15862 uu____15863
-                                      | uu____15901 -> tok_typing  in
-                                    let uu____15912 =
+                                            uu____15913 uu____15914
+                                      | uu____15952 -> tok_typing  in
+                                    let uu____15963 =
                                       FStar_SMTEncoding_EncodeTerm.encode_binders
                                         (FStar_Pervasives_Native.Some fuel_tm)
                                         formals env1
                                        in
-                                    (match uu____15912 with
-                                     | (vars',guards',env'',decls_formals,uu____15937)
+                                    (match uu____15963 with
+                                     | (vars',guards',env'',decls_formals,uu____15988)
                                          ->
-                                         let uu____15950 =
+                                         let uu____16001 =
                                            let xvars1 =
                                              FStar_List.map
                                                FStar_SMTEncoding_Util.mkFreeV
@@ -6043,7 +6090,7 @@ and (encode_sigelt' :
                                              (FStar_Pervasives_Native.Some
                                                 fuel_tm) t_res env'' dapp1
                                             in
-                                         (match uu____15950 with
+                                         (match uu____16001 with
                                           | (ty_pred',decls_pred) ->
                                               let guard' =
                                                 FStar_SMTEncoding_Util.mk_and_l
@@ -6052,34 +6099,34 @@ and (encode_sigelt' :
                                               let proxy_fresh =
                                                 match formals with
                                                 | [] -> []
-                                                | uu____15980 ->
-                                                    let uu____15981 =
-                                                      let uu____15982 =
+                                                | uu____16031 ->
+                                                    let uu____16032 =
+                                                      let uu____16033 =
                                                         FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                                           ()
                                                          in
                                                       FStar_SMTEncoding_Term.fresh_token
                                                         (ddtok,
                                                           FStar_SMTEncoding_Term.Term_sort)
-                                                        uu____15982
+                                                        uu____16033
                                                        in
-                                                    [uu____15981]
+                                                    [uu____16032]
                                                  in
-                                              let encode_elim uu____15998 =
-                                                let uu____15999 =
+                                              let encode_elim uu____16049 =
+                                                let uu____16050 =
                                                   FStar_Syntax_Util.head_and_args
                                                     t_res
                                                    in
-                                                match uu____15999 with
+                                                match uu____16050 with
                                                 | (head,args) ->
-                                                    let uu____16050 =
-                                                      let uu____16051 =
+                                                    let uu____16101 =
+                                                      let uu____16102 =
                                                         FStar_Syntax_Subst.compress
                                                           head
                                                          in
-                                                      uu____16051.FStar_Syntax_Syntax.n
+                                                      uu____16102.FStar_Syntax_Syntax.n
                                                        in
-                                                    (match uu____16050 with
+                                                    (match uu____16101 with
                                                      | FStar_Syntax_Syntax.Tm_uinst
                                                          ({
                                                             FStar_Syntax_Syntax.n
@@ -6087,9 +6134,9 @@ and (encode_sigelt' :
                                                               FStar_Syntax_Syntax.Tm_fvar
                                                               fv;
                                                             FStar_Syntax_Syntax.pos
-                                                              = uu____16063;
+                                                              = uu____16114;
                                                             FStar_Syntax_Syntax.vars
-                                                              = uu____16064;_},uu____16065)
+                                                              = uu____16115;_},uu____16116)
                                                          ->
                                                          let encoded_head_fvb
                                                            =
@@ -6097,11 +6144,11 @@ and (encode_sigelt' :
                                                              env'
                                                              fv.FStar_Syntax_Syntax.fv_name
                                                             in
-                                                         let uu____16071 =
+                                                         let uu____16122 =
                                                            FStar_SMTEncoding_EncodeTerm.encode_args
                                                              args env'
                                                             in
-                                                         (match uu____16071
+                                                         (match uu____16122
                                                           with
                                                           | (encoded_args,arg_decls)
                                                               ->
@@ -6115,26 +6162,26 @@ and (encode_sigelt' :
                                                                   | FStar_SMTEncoding_Term.FreeV
                                                                     fv1 ->
                                                                     fv1
-                                                                  | uu____16134
+                                                                  | uu____16185
                                                                     ->
-                                                                    let uu____16135
+                                                                    let uu____16186
                                                                     =
-                                                                    let uu____16141
+                                                                    let uu____16192
                                                                     =
-                                                                    let uu____16143
+                                                                    let uu____16194
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     orig_arg
                                                                      in
                                                                     FStar_Util.format1
                                                                     "Inductive type parameter %s must be a variable ; You may want to change it to an index."
-                                                                    uu____16143
+                                                                    uu____16194
                                                                      in
                                                                     (FStar_Errors.Fatal_NonVariableInductiveTypeParameter,
-                                                                    uu____16141)
+                                                                    uu____16192)
                                                                      in
                                                                     FStar_Errors.raise_error
-                                                                    uu____16135
+                                                                    uu____16186
                                                                     orig_arg.FStar_Syntax_Syntax.pos
                                                                    in
                                                                 let guards1 =
@@ -6144,33 +6191,33 @@ and (encode_sigelt' :
                                                                     FStar_List.collect
                                                                     (fun g 
                                                                     ->
-                                                                    let uu____16166
+                                                                    let uu____16217
                                                                     =
-                                                                    let uu____16168
+                                                                    let uu____16219
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     g  in
                                                                     FStar_List.contains
                                                                     fv1
-                                                                    uu____16168
+                                                                    uu____16219
                                                                      in
                                                                     if
-                                                                    uu____16166
+                                                                    uu____16217
                                                                     then
-                                                                    let uu____16190
+                                                                    let uu____16241
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
                                                                     g fv1 xv
                                                                      in
-                                                                    [uu____16190]
+                                                                    [uu____16241]
                                                                     else []))
                                                                    in
                                                                 FStar_SMTEncoding_Util.mk_and_l
                                                                   guards1
                                                                  in
-                                                              let uu____16193
+                                                              let uu____16244
                                                                 =
-                                                                let uu____16207
+                                                                let uu____16258
                                                                   =
                                                                   FStar_List.zip
                                                                     args
@@ -6178,22 +6225,22 @@ and (encode_sigelt' :
                                                                    in
                                                                 FStar_List.fold_left
                                                                   (fun
-                                                                    uu____16264
+                                                                    uu____16315
                                                                      ->
                                                                     fun
-                                                                    uu____16265
+                                                                    uu____16316
                                                                      ->
                                                                     match 
-                                                                    (uu____16264,
-                                                                    uu____16265)
+                                                                    (uu____16315,
+                                                                    uu____16316)
                                                                     with
                                                                     | 
                                                                     ((env2,arg_vars,eqns_or_guards,i),
                                                                     (orig_arg,arg))
                                                                     ->
-                                                                    let uu____16376
+                                                                    let uu____16427
                                                                     =
-                                                                    let uu____16384
+                                                                    let uu____16435
                                                                     =
                                                                     FStar_Syntax_Syntax.new_bv
                                                                     FStar_Pervasives_Native.None
@@ -6201,35 +6248,35 @@ and (encode_sigelt' :
                                                                      in
                                                                     FStar_SMTEncoding_Env.gen_term_var
                                                                     env2
-                                                                    uu____16384
+                                                                    uu____16435
                                                                      in
-                                                                    (match uu____16376
+                                                                    (match uu____16427
                                                                     with
                                                                     | 
-                                                                    (uu____16398,xv,env3)
+                                                                    (uu____16449,xv,env3)
                                                                     ->
                                                                     let eqns
                                                                     =
                                                                     if
                                                                     i < n_tps
                                                                     then
-                                                                    let uu____16409
+                                                                    let uu____16460
                                                                     =
                                                                     guards_for_parameter
                                                                     (FStar_Pervasives_Native.fst
                                                                     orig_arg)
                                                                     arg xv
                                                                      in
-                                                                    uu____16409
+                                                                    uu____16460
                                                                     ::
                                                                     eqns_or_guards
                                                                     else
-                                                                    (let uu____16414
+                                                                    (let uu____16465
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (arg, xv)
                                                                      in
-                                                                    uu____16414
+                                                                    uu____16465
                                                                     ::
                                                                     eqns_or_guards)
                                                                      in
@@ -6242,11 +6289,11 @@ and (encode_sigelt' :
                                                                   (env', [],
                                                                     [],
                                                                     Prims.int_zero)
-                                                                  uu____16207
+                                                                  uu____16258
                                                                  in
-                                                              (match uu____16193
+                                                              (match uu____16244
                                                                with
-                                                               | (uu____16435,arg_vars,elim_eqns_or_guards,uu____16438)
+                                                               | (uu____16486,arg_vars,elim_eqns_or_guards,uu____16489)
                                                                    ->
                                                                    let arg_vars1
                                                                     =
@@ -6285,35 +6332,35 @@ and (encode_sigelt' :
                                                                      in
                                                                    let typing_inversion
                                                                     =
-                                                                    let uu____16465
+                                                                    let uu____16516
                                                                     =
-                                                                    let uu____16473
+                                                                    let uu____16524
                                                                     =
-                                                                    let uu____16474
+                                                                    let uu____16525
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____16475
+                                                                    let uu____16526
                                                                     =
-                                                                    let uu____16486
+                                                                    let uu____16537
                                                                     =
-                                                                    let uu____16487
+                                                                    let uu____16538
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____16487
+                                                                    uu____16538
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders)
                                                                      in
-                                                                    let uu____16489
+                                                                    let uu____16540
                                                                     =
-                                                                    let uu____16490
+                                                                    let uu____16541
                                                                     =
-                                                                    let uu____16495
+                                                                    let uu____16546
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
@@ -6321,21 +6368,21 @@ and (encode_sigelt' :
                                                                     guards)
                                                                      in
                                                                     (ty_pred,
-                                                                    uu____16495)
+                                                                    uu____16546)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____16490
+                                                                    uu____16541
                                                                      in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____16486,
-                                                                    uu____16489)
+                                                                    uu____16537,
+                                                                    uu____16540)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____16474
-                                                                    uu____16475
+                                                                    uu____16525
+                                                                    uu____16526
                                                                      in
-                                                                    (uu____16473,
+                                                                    (uu____16524,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing elim"),
                                                                     (Prims.op_Hat
@@ -6343,34 +6390,34 @@ and (encode_sigelt' :
                                                                     ddconstrsym))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____16465
+                                                                    uu____16516
                                                                      in
                                                                    let subterm_ordering
                                                                     =
                                                                     let lex_t
                                                                     =
-                                                                    let uu____16510
+                                                                    let uu____16561
                                                                     =
-                                                                    let uu____16511
+                                                                    let uu____16562
                                                                     =
-                                                                    let uu____16517
+                                                                    let uu____16568
                                                                     =
-                                                                    FStar_Ident.text_of_lid
+                                                                    FStar_Ident.string_of_lid
                                                                     FStar_Parser_Const.lex_t_lid
                                                                      in
-                                                                    (uu____16517,
+                                                                    (uu____16568,
                                                                     FStar_SMTEncoding_Term.Term_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mk_fv
-                                                                    uu____16511
+                                                                    uu____16562
                                                                      in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____16510
+                                                                    uu____16561
                                                                      in
                                                                     let prec
                                                                     =
-                                                                    let uu____16523
+                                                                    let uu____16574
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     vars
@@ -6382,71 +6429,71 @@ and (encode_sigelt' :
                                                                     i < n_tps
                                                                     then []
                                                                     else
-                                                                    (let uu____16546
+                                                                    (let uu____16597
                                                                     =
-                                                                    let uu____16547
+                                                                    let uu____16598
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v  in
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     lex_t
                                                                     lex_t
-                                                                    uu____16547
+                                                                    uu____16598
                                                                     dapp1  in
-                                                                    [uu____16546])))
+                                                                    [uu____16597])))
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____16523
+                                                                    uu____16574
                                                                     FStar_List.flatten
                                                                      in
-                                                                    let uu____16554
+                                                                    let uu____16605
                                                                     =
-                                                                    let uu____16562
+                                                                    let uu____16613
                                                                     =
-                                                                    let uu____16563
+                                                                    let uu____16614
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____16564
+                                                                    let uu____16615
                                                                     =
-                                                                    let uu____16575
+                                                                    let uu____16626
                                                                     =
-                                                                    let uu____16576
+                                                                    let uu____16627
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____16576
+                                                                    uu____16627
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders)
                                                                      in
-                                                                    let uu____16578
+                                                                    let uu____16629
                                                                     =
-                                                                    let uu____16579
+                                                                    let uu____16630
                                                                     =
-                                                                    let uu____16584
+                                                                    let uu____16635
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     prec  in
                                                                     (ty_pred,
-                                                                    uu____16584)
+                                                                    uu____16635)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____16579
+                                                                    uu____16630
                                                                      in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____16575,
-                                                                    uu____16578)
+                                                                    uu____16626,
+                                                                    uu____16629)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____16563
-                                                                    uu____16564
+                                                                    uu____16614
+                                                                    uu____16615
                                                                      in
-                                                                    (uu____16562,
+                                                                    (uu____16613,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "subterm ordering"),
                                                                     (Prims.op_Hat
@@ -6454,7 +6501,7 @@ and (encode_sigelt' :
                                                                     ddconstrsym))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____16554
+                                                                    uu____16605
                                                                      in
                                                                    (arg_decls,
                                                                     [typing_inversion;
@@ -6467,11 +6514,11 @@ and (encode_sigelt' :
                                                              env'
                                                              fv.FStar_Syntax_Syntax.fv_name
                                                             in
-                                                         let uu____16603 =
+                                                         let uu____16654 =
                                                            FStar_SMTEncoding_EncodeTerm.encode_args
                                                              args env'
                                                             in
-                                                         (match uu____16603
+                                                         (match uu____16654
                                                           with
                                                           | (encoded_args,arg_decls)
                                                               ->
@@ -6485,26 +6532,26 @@ and (encode_sigelt' :
                                                                   | FStar_SMTEncoding_Term.FreeV
                                                                     fv1 ->
                                                                     fv1
-                                                                  | uu____16666
+                                                                  | uu____16717
                                                                     ->
-                                                                    let uu____16667
+                                                                    let uu____16718
                                                                     =
-                                                                    let uu____16673
+                                                                    let uu____16724
                                                                     =
-                                                                    let uu____16675
+                                                                    let uu____16726
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     orig_arg
                                                                      in
                                                                     FStar_Util.format1
                                                                     "Inductive type parameter %s must be a variable ; You may want to change it to an index."
-                                                                    uu____16675
+                                                                    uu____16726
                                                                      in
                                                                     (FStar_Errors.Fatal_NonVariableInductiveTypeParameter,
-                                                                    uu____16673)
+                                                                    uu____16724)
                                                                      in
                                                                     FStar_Errors.raise_error
-                                                                    uu____16667
+                                                                    uu____16718
                                                                     orig_arg.FStar_Syntax_Syntax.pos
                                                                    in
                                                                 let guards1 =
@@ -6514,33 +6561,33 @@ and (encode_sigelt' :
                                                                     FStar_List.collect
                                                                     (fun g 
                                                                     ->
-                                                                    let uu____16698
+                                                                    let uu____16749
                                                                     =
-                                                                    let uu____16700
+                                                                    let uu____16751
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     g  in
                                                                     FStar_List.contains
                                                                     fv1
-                                                                    uu____16700
+                                                                    uu____16751
                                                                      in
                                                                     if
-                                                                    uu____16698
+                                                                    uu____16749
                                                                     then
-                                                                    let uu____16722
+                                                                    let uu____16773
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
                                                                     g fv1 xv
                                                                      in
-                                                                    [uu____16722]
+                                                                    [uu____16773]
                                                                     else []))
                                                                    in
                                                                 FStar_SMTEncoding_Util.mk_and_l
                                                                   guards1
                                                                  in
-                                                              let uu____16725
+                                                              let uu____16776
                                                                 =
-                                                                let uu____16739
+                                                                let uu____16790
                                                                   =
                                                                   FStar_List.zip
                                                                     args
@@ -6548,22 +6595,22 @@ and (encode_sigelt' :
                                                                    in
                                                                 FStar_List.fold_left
                                                                   (fun
-                                                                    uu____16796
+                                                                    uu____16847
                                                                      ->
                                                                     fun
-                                                                    uu____16797
+                                                                    uu____16848
                                                                      ->
                                                                     match 
-                                                                    (uu____16796,
-                                                                    uu____16797)
+                                                                    (uu____16847,
+                                                                    uu____16848)
                                                                     with
                                                                     | 
                                                                     ((env2,arg_vars,eqns_or_guards,i),
                                                                     (orig_arg,arg))
                                                                     ->
-                                                                    let uu____16908
+                                                                    let uu____16959
                                                                     =
-                                                                    let uu____16916
+                                                                    let uu____16967
                                                                     =
                                                                     FStar_Syntax_Syntax.new_bv
                                                                     FStar_Pervasives_Native.None
@@ -6571,35 +6618,35 @@ and (encode_sigelt' :
                                                                      in
                                                                     FStar_SMTEncoding_Env.gen_term_var
                                                                     env2
-                                                                    uu____16916
+                                                                    uu____16967
                                                                      in
-                                                                    (match uu____16908
+                                                                    (match uu____16959
                                                                     with
                                                                     | 
-                                                                    (uu____16930,xv,env3)
+                                                                    (uu____16981,xv,env3)
                                                                     ->
                                                                     let eqns
                                                                     =
                                                                     if
                                                                     i < n_tps
                                                                     then
-                                                                    let uu____16941
+                                                                    let uu____16992
                                                                     =
                                                                     guards_for_parameter
                                                                     (FStar_Pervasives_Native.fst
                                                                     orig_arg)
                                                                     arg xv
                                                                      in
-                                                                    uu____16941
+                                                                    uu____16992
                                                                     ::
                                                                     eqns_or_guards
                                                                     else
-                                                                    (let uu____16946
+                                                                    (let uu____16997
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (arg, xv)
                                                                      in
-                                                                    uu____16946
+                                                                    uu____16997
                                                                     ::
                                                                     eqns_or_guards)
                                                                      in
@@ -6612,11 +6659,11 @@ and (encode_sigelt' :
                                                                   (env', [],
                                                                     [],
                                                                     Prims.int_zero)
-                                                                  uu____16739
+                                                                  uu____16790
                                                                  in
-                                                              (match uu____16725
+                                                              (match uu____16776
                                                                with
-                                                               | (uu____16967,arg_vars,elim_eqns_or_guards,uu____16970)
+                                                               | (uu____17018,arg_vars,elim_eqns_or_guards,uu____17021)
                                                                    ->
                                                                    let arg_vars1
                                                                     =
@@ -6655,35 +6702,35 @@ and (encode_sigelt' :
                                                                      in
                                                                    let typing_inversion
                                                                     =
-                                                                    let uu____16997
+                                                                    let uu____17048
                                                                     =
-                                                                    let uu____17005
+                                                                    let uu____17056
                                                                     =
-                                                                    let uu____17006
+                                                                    let uu____17057
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____17007
+                                                                    let uu____17058
                                                                     =
-                                                                    let uu____17018
+                                                                    let uu____17069
                                                                     =
-                                                                    let uu____17019
+                                                                    let uu____17070
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____17019
+                                                                    uu____17070
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders)
                                                                      in
-                                                                    let uu____17021
+                                                                    let uu____17072
                                                                     =
-                                                                    let uu____17022
+                                                                    let uu____17073
                                                                     =
-                                                                    let uu____17027
+                                                                    let uu____17078
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
@@ -6691,21 +6738,21 @@ and (encode_sigelt' :
                                                                     guards)
                                                                      in
                                                                     (ty_pred,
-                                                                    uu____17027)
+                                                                    uu____17078)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____17022
+                                                                    uu____17073
                                                                      in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____17018,
-                                                                    uu____17021)
+                                                                    uu____17069,
+                                                                    uu____17072)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____17006
-                                                                    uu____17007
+                                                                    uu____17057
+                                                                    uu____17058
                                                                      in
-                                                                    (uu____17005,
+                                                                    (uu____17056,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing elim"),
                                                                     (Prims.op_Hat
@@ -6713,34 +6760,34 @@ and (encode_sigelt' :
                                                                     ddconstrsym))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____16997
+                                                                    uu____17048
                                                                      in
                                                                    let subterm_ordering
                                                                     =
                                                                     let lex_t
                                                                     =
-                                                                    let uu____17042
+                                                                    let uu____17093
                                                                     =
-                                                                    let uu____17043
+                                                                    let uu____17094
                                                                     =
-                                                                    let uu____17049
+                                                                    let uu____17100
                                                                     =
-                                                                    FStar_Ident.text_of_lid
+                                                                    FStar_Ident.string_of_lid
                                                                     FStar_Parser_Const.lex_t_lid
                                                                      in
-                                                                    (uu____17049,
+                                                                    (uu____17100,
                                                                     FStar_SMTEncoding_Term.Term_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mk_fv
-                                                                    uu____17043
+                                                                    uu____17094
                                                                      in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____17042
+                                                                    uu____17093
                                                                      in
                                                                     let prec
                                                                     =
-                                                                    let uu____17055
+                                                                    let uu____17106
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     vars
@@ -6752,71 +6799,71 @@ and (encode_sigelt' :
                                                                     i < n_tps
                                                                     then []
                                                                     else
-                                                                    (let uu____17078
+                                                                    (let uu____17129
                                                                     =
-                                                                    let uu____17079
+                                                                    let uu____17130
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v  in
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     lex_t
                                                                     lex_t
-                                                                    uu____17079
+                                                                    uu____17130
                                                                     dapp1  in
-                                                                    [uu____17078])))
+                                                                    [uu____17129])))
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____17055
+                                                                    uu____17106
                                                                     FStar_List.flatten
                                                                      in
-                                                                    let uu____17086
+                                                                    let uu____17137
                                                                     =
-                                                                    let uu____17094
+                                                                    let uu____17145
                                                                     =
-                                                                    let uu____17095
+                                                                    let uu____17146
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____17096
+                                                                    let uu____17147
                                                                     =
-                                                                    let uu____17107
+                                                                    let uu____17158
                                                                     =
-                                                                    let uu____17108
+                                                                    let uu____17159
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____17108
+                                                                    uu____17159
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders)
                                                                      in
-                                                                    let uu____17110
+                                                                    let uu____17161
                                                                     =
-                                                                    let uu____17111
+                                                                    let uu____17162
                                                                     =
-                                                                    let uu____17116
+                                                                    let uu____17167
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     prec  in
                                                                     (ty_pred,
-                                                                    uu____17116)
+                                                                    uu____17167)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____17111
+                                                                    uu____17162
                                                                      in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____17107,
-                                                                    uu____17110)
+                                                                    uu____17158,
+                                                                    uu____17161)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____17095
-                                                                    uu____17096
+                                                                    uu____17146
+                                                                    uu____17147
                                                                      in
-                                                                    (uu____17094,
+                                                                    (uu____17145,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "subterm ordering"),
                                                                     (Prims.op_Hat
@@ -6824,98 +6871,98 @@ and (encode_sigelt' :
                                                                     ddconstrsym))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____17086
+                                                                    uu____17137
                                                                      in
                                                                    (arg_decls,
                                                                     [typing_inversion;
                                                                     subterm_ordering])))
-                                                     | uu____17133 ->
-                                                         ((let uu____17135 =
-                                                             let uu____17141
+                                                     | uu____17184 ->
+                                                         ((let uu____17186 =
+                                                             let uu____17192
                                                                =
-                                                               let uu____17143
+                                                               let uu____17194
                                                                  =
                                                                  FStar_Syntax_Print.lid_to_string
                                                                    d
                                                                   in
-                                                               let uu____17145
+                                                               let uu____17196
                                                                  =
                                                                  FStar_Syntax_Print.term_to_string
                                                                    head
                                                                   in
                                                                FStar_Util.format2
                                                                  "Constructor %s builds an unexpected type %s\n"
-                                                                 uu____17143
-                                                                 uu____17145
+                                                                 uu____17194
+                                                                 uu____17196
                                                                 in
                                                              (FStar_Errors.Warning_ConstructorBuildsUnexpectedType,
-                                                               uu____17141)
+                                                               uu____17192)
                                                               in
                                                            FStar_Errors.log_issue
                                                              se.FStar_Syntax_Syntax.sigrng
-                                                             uu____17135);
+                                                             uu____17186);
                                                           ([], [])))
                                                  in
-                                              let uu____17153 =
+                                              let uu____17204 =
                                                 encode_elim ()  in
-                                              (match uu____17153 with
+                                              (match uu____17204 with
                                                | (decls2,elim) ->
                                                    let g =
-                                                     let uu____17179 =
-                                                       let uu____17182 =
-                                                         let uu____17185 =
-                                                           let uu____17188 =
-                                                             let uu____17191
+                                                     let uu____17230 =
+                                                       let uu____17233 =
+                                                         let uu____17236 =
+                                                           let uu____17239 =
+                                                             let uu____17242
                                                                =
-                                                               let uu____17194
+                                                               let uu____17245
                                                                  =
-                                                                 let uu____17197
+                                                                 let uu____17248
                                                                    =
-                                                                   let uu____17198
+                                                                   let uu____17249
                                                                     =
-                                                                    let uu____17210
+                                                                    let uu____17261
                                                                     =
-                                                                    let uu____17211
+                                                                    let uu____17262
                                                                     =
-                                                                    let uu____17213
+                                                                    let uu____17264
                                                                     =
                                                                     FStar_Syntax_Print.lid_to_string
                                                                     d  in
                                                                     FStar_Util.format1
                                                                     "data constructor proxy: %s"
-                                                                    uu____17213
+                                                                    uu____17264
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____17211
+                                                                    uu____17262
                                                                      in
                                                                     (ddtok,
                                                                     [],
                                                                     FStar_SMTEncoding_Term.Term_sort,
-                                                                    uu____17210)
+                                                                    uu____17261)
                                                                      in
                                                                    FStar_SMTEncoding_Term.DeclFun
-                                                                    uu____17198
+                                                                    uu____17249
                                                                     in
-                                                                 [uu____17197]
+                                                                 [uu____17248]
                                                                   in
                                                                FStar_List.append
-                                                                 uu____17194
+                                                                 uu____17245
                                                                  proxy_fresh
                                                                 in
                                                              FStar_All.pipe_right
-                                                               uu____17191
+                                                               uu____17242
                                                                FStar_SMTEncoding_Term.mk_decls_trivial
                                                               in
-                                                           let uu____17224 =
-                                                             let uu____17227
+                                                           let uu____17275 =
+                                                             let uu____17278
                                                                =
-                                                               let uu____17230
+                                                               let uu____17281
                                                                  =
-                                                                 let uu____17233
+                                                                 let uu____17284
                                                                    =
-                                                                   let uu____17236
+                                                                   let uu____17287
                                                                     =
-                                                                    let uu____17239
+                                                                    let uu____17290
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkAssume
                                                                     (tok_typing1,
@@ -6925,34 +6972,34 @@ and (encode_sigelt' :
                                                                     "typing_tok_"
                                                                     ddtok))
                                                                      in
-                                                                    let uu____17244
+                                                                    let uu____17295
                                                                     =
-                                                                    let uu____17247
+                                                                    let uu____17298
                                                                     =
-                                                                    let uu____17248
+                                                                    let uu____17299
                                                                     =
-                                                                    let uu____17256
+                                                                    let uu____17307
                                                                     =
-                                                                    let uu____17257
+                                                                    let uu____17308
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____17258
+                                                                    let uu____17309
                                                                     =
-                                                                    let uu____17269
+                                                                    let uu____17320
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (app,
                                                                     dapp)  in
                                                                     ([[app]],
                                                                     vars,
-                                                                    uu____17269)
+                                                                    uu____17320)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____17257
-                                                                    uu____17258
+                                                                    uu____17308
+                                                                    uu____17309
                                                                      in
-                                                                    (uu____17256,
+                                                                    (uu____17307,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "equality for proxy"),
                                                                     (Prims.op_Hat
@@ -6960,34 +7007,34 @@ and (encode_sigelt' :
                                                                     ddtok))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____17248
+                                                                    uu____17299
                                                                      in
-                                                                    let uu____17282
+                                                                    let uu____17333
                                                                     =
-                                                                    let uu____17285
+                                                                    let uu____17336
                                                                     =
-                                                                    let uu____17286
+                                                                    let uu____17337
                                                                     =
-                                                                    let uu____17294
+                                                                    let uu____17345
                                                                     =
-                                                                    let uu____17295
+                                                                    let uu____17346
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____17296
+                                                                    let uu____17347
                                                                     =
-                                                                    let uu____17307
+                                                                    let uu____17358
                                                                     =
-                                                                    let uu____17308
+                                                                    let uu____17359
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____17308
+                                                                    uu____17359
                                                                     vars'  in
-                                                                    let uu____17310
+                                                                    let uu____17361
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkImp
                                                                     (guard',
@@ -6995,14 +7042,14 @@ and (encode_sigelt' :
                                                                      in
                                                                     ([
                                                                     [ty_pred']],
-                                                                    uu____17307,
-                                                                    uu____17310)
+                                                                    uu____17358,
+                                                                    uu____17361)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____17295
-                                                                    uu____17296
+                                                                    uu____17346
+                                                                    uu____17347
                                                                      in
-                                                                    (uu____17294,
+                                                                    (uu____17345,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing intro"),
                                                                     (Prims.op_Hat
@@ -7010,58 +7057,58 @@ and (encode_sigelt' :
                                                                     ddtok))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____17286
+                                                                    uu____17337
                                                                      in
-                                                                    [uu____17285]
+                                                                    [uu____17336]
                                                                      in
-                                                                    uu____17247
+                                                                    uu____17298
                                                                     ::
-                                                                    uu____17282
+                                                                    uu____17333
                                                                      in
-                                                                    uu____17239
+                                                                    uu____17290
                                                                     ::
-                                                                    uu____17244
+                                                                    uu____17295
                                                                      in
                                                                    FStar_List.append
-                                                                    uu____17236
+                                                                    uu____17287
                                                                     elim
                                                                     in
                                                                  FStar_All.pipe_right
-                                                                   uu____17233
+                                                                   uu____17284
                                                                    FStar_SMTEncoding_Term.mk_decls_trivial
                                                                   in
                                                                FStar_List.append
                                                                  decls_pred
-                                                                 uu____17230
+                                                                 uu____17281
                                                                 in
                                                              FStar_List.append
                                                                decls_formals
-                                                               uu____17227
+                                                               uu____17278
                                                               in
                                                            FStar_List.append
-                                                             uu____17188
-                                                             uu____17224
+                                                             uu____17239
+                                                             uu____17275
                                                             in
                                                          FStar_List.append
-                                                           decls3 uu____17185
+                                                           decls3 uu____17236
                                                           in
                                                        FStar_List.append
-                                                         decls2 uu____17182
+                                                         decls2 uu____17233
                                                         in
                                                      FStar_List.append
                                                        binder_decls
-                                                       uu____17179
+                                                       uu____17230
                                                       in
-                                                   let uu____17327 =
-                                                     let uu____17328 =
+                                                   let uu____17378 =
+                                                     let uu____17379 =
                                                        FStar_All.pipe_right
                                                          datacons
                                                          FStar_SMTEncoding_Term.mk_decls_trivial
                                                         in
                                                      FStar_List.append
-                                                       uu____17328 g
+                                                       uu____17379 g
                                                       in
-                                                   (uu____17327, env1))))))))))
+                                                   (uu____17378, env1))))))))))
 
 and (encode_sigelts :
   FStar_SMTEncoding_Env.env_t ->
@@ -7072,12 +7119,12 @@ and (encode_sigelts :
     fun ses  ->
       FStar_All.pipe_right ses
         (FStar_List.fold_left
-           (fun uu____17362  ->
+           (fun uu____17413  ->
               fun se  ->
-                match uu____17362 with
+                match uu____17413 with
                 | (g,env1) ->
-                    let uu____17382 = encode_sigelt env1 se  in
-                    (match uu____17382 with
+                    let uu____17433 = encode_sigelt env1 se  in
+                    (match uu____17433 with
                      | (g',env2) -> ((FStar_List.append g g'), env2)))
            ([], env))
 
@@ -7088,74 +7135,74 @@ let (encode_env_bindings :
   =
   fun env  ->
     fun bindings  ->
-      let encode_binding b uu____17450 =
-        match uu____17450 with
+      let encode_binding b uu____17501 =
+        match uu____17501 with
         | (i,decls,env1) ->
             (match b with
-             | FStar_Syntax_Syntax.Binding_univ uu____17487 ->
+             | FStar_Syntax_Syntax.Binding_univ uu____17538 ->
                  ((i + Prims.int_one), decls, env1)
              | FStar_Syntax_Syntax.Binding_var x ->
                  let t1 =
                    norm_before_encoding env1 x.FStar_Syntax_Syntax.sort  in
-                 ((let uu____17495 =
+                 ((let uu____17546 =
                      FStar_All.pipe_left
                        (FStar_TypeChecker_Env.debug
                           env1.FStar_SMTEncoding_Env.tcenv)
                        (FStar_Options.Other "SMTEncoding")
                       in
-                   if uu____17495
+                   if uu____17546
                    then
-                     let uu____17500 = FStar_Syntax_Print.bv_to_string x  in
-                     let uu____17502 =
+                     let uu____17551 = FStar_Syntax_Print.bv_to_string x  in
+                     let uu____17553 =
                        FStar_Syntax_Print.term_to_string
                          x.FStar_Syntax_Syntax.sort
                         in
-                     let uu____17504 = FStar_Syntax_Print.term_to_string t1
+                     let uu____17555 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print3 "Normalized %s : %s to %s\n"
-                       uu____17500 uu____17502 uu____17504
+                       uu____17551 uu____17553 uu____17555
                    else ());
-                  (let uu____17509 =
+                  (let uu____17560 =
                      FStar_SMTEncoding_EncodeTerm.encode_term t1 env1  in
-                   match uu____17509 with
+                   match uu____17560 with
                    | (t,decls') ->
                        let t_hash = FStar_SMTEncoding_Term.hash_of_term t  in
-                       let uu____17527 =
-                         let uu____17535 =
-                           let uu____17537 =
-                             let uu____17539 =
+                       let uu____17578 =
+                         let uu____17586 =
+                           let uu____17588 =
+                             let uu____17590 =
                                FStar_Util.digest_of_string t_hash  in
-                             Prims.op_Hat uu____17539
+                             Prims.op_Hat uu____17590
                                (Prims.op_Hat "_" (Prims.string_of_int i))
                               in
-                           Prims.op_Hat "x_" uu____17537  in
+                           Prims.op_Hat "x_" uu____17588  in
                          FStar_SMTEncoding_Env.new_term_constant_from_string
-                           env1 x uu____17535
+                           env1 x uu____17586
                           in
-                       (match uu____17527 with
+                       (match uu____17578 with
                         | (xxsym,xx,env') ->
                             let t2 =
                               FStar_SMTEncoding_Term.mk_HasTypeWithFuel
                                 FStar_Pervasives_Native.None xx t
                                in
                             let caption =
-                              let uu____17559 = FStar_Options.log_queries ()
+                              let uu____17610 = FStar_Options.log_queries ()
                                  in
-                              if uu____17559
+                              if uu____17610
                               then
-                                let uu____17562 =
-                                  let uu____17564 =
+                                let uu____17613 =
+                                  let uu____17615 =
                                     FStar_Syntax_Print.bv_to_string x  in
-                                  let uu____17566 =
+                                  let uu____17617 =
                                     FStar_Syntax_Print.term_to_string
                                       x.FStar_Syntax_Syntax.sort
                                      in
-                                  let uu____17568 =
+                                  let uu____17619 =
                                     FStar_Syntax_Print.term_to_string t1  in
                                   FStar_Util.format3 "%s : %s (%s)"
-                                    uu____17564 uu____17566 uu____17568
+                                    uu____17615 uu____17617 uu____17619
                                    in
-                                FStar_Pervasives_Native.Some uu____17562
+                                FStar_Pervasives_Native.Some uu____17613
                               else FStar_Pervasives_Native.None  in
                             let ax =
                               let a_name = Prims.op_Hat "binder_" xxsym  in
@@ -7164,7 +7211,7 @@ let (encode_env_bindings :
                                   a_name)
                                in
                             let g =
-                              let uu____17584 =
+                              let uu____17635 =
                                 FStar_All.pipe_right
                                   [FStar_SMTEncoding_Term.DeclFun
                                      (xxsym, [],
@@ -7172,34 +7219,34 @@ let (encode_env_bindings :
                                        caption)]
                                   FStar_SMTEncoding_Term.mk_decls_trivial
                                  in
-                              let uu____17594 =
-                                let uu____17597 =
+                              let uu____17645 =
+                                let uu____17648 =
                                   FStar_All.pipe_right [ax]
                                     FStar_SMTEncoding_Term.mk_decls_trivial
                                    in
-                                FStar_List.append decls' uu____17597  in
-                              FStar_List.append uu____17584 uu____17594  in
+                                FStar_List.append decls' uu____17648  in
+                              FStar_List.append uu____17635 uu____17645  in
                             ((i + Prims.int_one),
                               (FStar_List.append decls g), env'))))
-             | FStar_Syntax_Syntax.Binding_lid (x,(uu____17609,t)) ->
+             | FStar_Syntax_Syntax.Binding_lid (x,(uu____17660,t)) ->
                  let t_norm = norm_before_encoding env1 t  in
                  let fv =
                    FStar_Syntax_Syntax.lid_as_fv x
                      FStar_Syntax_Syntax.delta_constant
                      FStar_Pervasives_Native.None
                     in
-                 let uu____17629 = encode_free_var false env1 fv t t_norm []
+                 let uu____17680 = encode_free_var false env1 fv t t_norm []
                     in
-                 (match uu____17629 with
+                 (match uu____17680 with
                   | (g,env') ->
                       ((i + Prims.int_one), (FStar_List.append decls g),
                         env')))
          in
-      let uu____17650 =
+      let uu____17701 =
         FStar_List.fold_right encode_binding bindings
           (Prims.int_zero, [], env)
          in
-      match uu____17650 with | (uu____17677,decls,env1) -> (decls, env1)
+      match uu____17701 with | (uu____17728,decls,env1) -> (decls, env1)
   
 let (encode_labels :
   FStar_SMTEncoding_Term.error_label Prims.list ->
@@ -7210,34 +7257,34 @@ let (encode_labels :
     let prefix =
       FStar_All.pipe_right labs
         (FStar_List.map
-           (fun uu____17730  ->
-              match uu____17730 with
-              | (l,uu____17739,uu____17740) ->
-                  let uu____17743 =
-                    let uu____17755 = FStar_SMTEncoding_Term.fv_name l  in
-                    (uu____17755, [], FStar_SMTEncoding_Term.Bool_sort,
+           (fun uu____17781  ->
+              match uu____17781 with
+              | (l,uu____17790,uu____17791) ->
+                  let uu____17794 =
+                    let uu____17806 = FStar_SMTEncoding_Term.fv_name l  in
+                    (uu____17806, [], FStar_SMTEncoding_Term.Bool_sort,
                       FStar_Pervasives_Native.None)
                      in
-                  FStar_SMTEncoding_Term.DeclFun uu____17743))
+                  FStar_SMTEncoding_Term.DeclFun uu____17794))
        in
     let suffix =
       FStar_All.pipe_right labs
         (FStar_List.collect
-           (fun uu____17788  ->
-              match uu____17788 with
-              | (l,uu____17799,uu____17800) ->
-                  let uu____17803 =
-                    let uu____17804 = FStar_SMTEncoding_Term.fv_name l  in
+           (fun uu____17839  ->
+              match uu____17839 with
+              | (l,uu____17850,uu____17851) ->
+                  let uu____17854 =
+                    let uu____17855 = FStar_SMTEncoding_Term.fv_name l  in
                     FStar_All.pipe_left
-                      (fun uu____17807  ->
-                         FStar_SMTEncoding_Term.Echo uu____17807) uu____17804
+                      (fun uu____17858  ->
+                         FStar_SMTEncoding_Term.Echo uu____17858) uu____17855
                      in
-                  let uu____17808 =
-                    let uu____17811 =
-                      let uu____17812 = FStar_SMTEncoding_Util.mkFreeV l  in
-                      FStar_SMTEncoding_Term.Eval uu____17812  in
-                    [uu____17811]  in
-                  uu____17803 :: uu____17808))
+                  let uu____17859 =
+                    let uu____17862 =
+                      let uu____17863 = FStar_SMTEncoding_Util.mkFreeV l  in
+                      FStar_SMTEncoding_Term.Eval uu____17863  in
+                    [uu____17862]  in
+                  uu____17854 :: uu____17859))
        in
     (prefix, suffix)
   
@@ -7245,31 +7292,31 @@ let (last_env : FStar_SMTEncoding_Env.env_t Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref [] 
 let (init_env : FStar_TypeChecker_Env.env -> unit) =
   fun tcenv  ->
-    let uu____17830 =
-      let uu____17833 =
-        let uu____17834 = FStar_Util.psmap_empty ()  in
-        let uu____17849 =
-          let uu____17858 = FStar_Util.psmap_empty ()  in (uu____17858, [])
+    let uu____17881 =
+      let uu____17884 =
+        let uu____17885 = FStar_Util.psmap_empty ()  in
+        let uu____17900 =
+          let uu____17909 = FStar_Util.psmap_empty ()  in (uu____17909, [])
            in
-        let uu____17865 =
-          let uu____17867 = FStar_TypeChecker_Env.current_module tcenv  in
-          FStar_All.pipe_right uu____17867 FStar_Ident.string_of_lid  in
-        let uu____17869 = FStar_Util.smap_create (Prims.of_int (100))  in
+        let uu____17916 =
+          let uu____17918 = FStar_TypeChecker_Env.current_module tcenv  in
+          FStar_All.pipe_right uu____17918 FStar_Ident.string_of_lid  in
+        let uu____17920 = FStar_Util.smap_create (Prims.of_int (100))  in
         {
-          FStar_SMTEncoding_Env.bvar_bindings = uu____17834;
-          FStar_SMTEncoding_Env.fvar_bindings = uu____17849;
+          FStar_SMTEncoding_Env.bvar_bindings = uu____17885;
+          FStar_SMTEncoding_Env.fvar_bindings = uu____17900;
           FStar_SMTEncoding_Env.depth = Prims.int_zero;
           FStar_SMTEncoding_Env.tcenv = tcenv;
           FStar_SMTEncoding_Env.warn = true;
           FStar_SMTEncoding_Env.nolabels = false;
           FStar_SMTEncoding_Env.use_zfuel_name = false;
           FStar_SMTEncoding_Env.encode_non_total_function_typ = true;
-          FStar_SMTEncoding_Env.current_module_name = uu____17865;
+          FStar_SMTEncoding_Env.current_module_name = uu____17916;
           FStar_SMTEncoding_Env.encoding_quantifier = false;
-          FStar_SMTEncoding_Env.global_cache = uu____17869
+          FStar_SMTEncoding_Env.global_cache = uu____17920
         }  in
-      [uu____17833]  in
-    FStar_ST.op_Colon_Equals last_env uu____17830
+      [uu____17884]  in
+    FStar_ST.op_Colon_Equals last_env uu____17881
   
 let (get_env :
   FStar_Ident.lident ->
@@ -7277,60 +7324,60 @@ let (get_env :
   =
   fun cmn  ->
     fun tcenv  ->
-      let uu____17913 = FStar_ST.op_Bang last_env  in
-      match uu____17913 with
+      let uu____17964 = FStar_ST.op_Bang last_env  in
+      match uu____17964 with
       | [] -> failwith "No env; call init first!"
-      | e::uu____17941 ->
-          let uu___1574_17944 = e  in
-          let uu____17945 = FStar_Ident.string_of_lid cmn  in
+      | e::uu____17992 ->
+          let uu___1574_17995 = e  in
+          let uu____17996 = FStar_Ident.string_of_lid cmn  in
           {
             FStar_SMTEncoding_Env.bvar_bindings =
-              (uu___1574_17944.FStar_SMTEncoding_Env.bvar_bindings);
+              (uu___1574_17995.FStar_SMTEncoding_Env.bvar_bindings);
             FStar_SMTEncoding_Env.fvar_bindings =
-              (uu___1574_17944.FStar_SMTEncoding_Env.fvar_bindings);
+              (uu___1574_17995.FStar_SMTEncoding_Env.fvar_bindings);
             FStar_SMTEncoding_Env.depth =
-              (uu___1574_17944.FStar_SMTEncoding_Env.depth);
+              (uu___1574_17995.FStar_SMTEncoding_Env.depth);
             FStar_SMTEncoding_Env.tcenv = tcenv;
             FStar_SMTEncoding_Env.warn =
-              (uu___1574_17944.FStar_SMTEncoding_Env.warn);
+              (uu___1574_17995.FStar_SMTEncoding_Env.warn);
             FStar_SMTEncoding_Env.nolabels =
-              (uu___1574_17944.FStar_SMTEncoding_Env.nolabels);
+              (uu___1574_17995.FStar_SMTEncoding_Env.nolabels);
             FStar_SMTEncoding_Env.use_zfuel_name =
-              (uu___1574_17944.FStar_SMTEncoding_Env.use_zfuel_name);
+              (uu___1574_17995.FStar_SMTEncoding_Env.use_zfuel_name);
             FStar_SMTEncoding_Env.encode_non_total_function_typ =
-              (uu___1574_17944.FStar_SMTEncoding_Env.encode_non_total_function_typ);
-            FStar_SMTEncoding_Env.current_module_name = uu____17945;
+              (uu___1574_17995.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+            FStar_SMTEncoding_Env.current_module_name = uu____17996;
             FStar_SMTEncoding_Env.encoding_quantifier =
-              (uu___1574_17944.FStar_SMTEncoding_Env.encoding_quantifier);
+              (uu___1574_17995.FStar_SMTEncoding_Env.encoding_quantifier);
             FStar_SMTEncoding_Env.global_cache =
-              (uu___1574_17944.FStar_SMTEncoding_Env.global_cache)
+              (uu___1574_17995.FStar_SMTEncoding_Env.global_cache)
           }
   
 let (set_env : FStar_SMTEncoding_Env.env_t -> unit) =
   fun env  ->
-    let uu____17953 = FStar_ST.op_Bang last_env  in
-    match uu____17953 with
+    let uu____18004 = FStar_ST.op_Bang last_env  in
+    match uu____18004 with
     | [] -> failwith "Empty env stack"
-    | uu____17980::tl -> FStar_ST.op_Colon_Equals last_env (env :: tl)
+    | uu____18031::tl -> FStar_ST.op_Colon_Equals last_env (env :: tl)
   
 let (push_env : unit -> unit) =
-  fun uu____18012  ->
-    let uu____18013 = FStar_ST.op_Bang last_env  in
-    match uu____18013 with
+  fun uu____18063  ->
+    let uu____18064 = FStar_ST.op_Bang last_env  in
+    match uu____18064 with
     | [] -> failwith "Empty env stack"
     | hd::tl ->
         let top = copy_env hd  in
         FStar_ST.op_Colon_Equals last_env (top :: hd :: tl)
   
 let (pop_env : unit -> unit) =
-  fun uu____18073  ->
-    let uu____18074 = FStar_ST.op_Bang last_env  in
-    match uu____18074 with
+  fun uu____18124  ->
+    let uu____18125 = FStar_ST.op_Bang last_env  in
+    match uu____18125 with
     | [] -> failwith "Popping an empty stack"
-    | uu____18101::tl -> FStar_ST.op_Colon_Equals last_env tl
+    | uu____18152::tl -> FStar_ST.op_Colon_Equals last_env tl
   
 let (snapshot_env : unit -> (Prims.int * unit)) =
-  fun uu____18138  -> FStar_Common.snapshot push_env last_env () 
+  fun uu____18189  -> FStar_Common.snapshot push_env last_env () 
 let (rollback_env : Prims.int FStar_Pervasives_Native.option -> unit) =
   fun depth  -> FStar_Common.rollback pop_env last_env depth 
 let (init : FStar_TypeChecker_Env.env -> unit) =
@@ -7343,17 +7390,17 @@ let (snapshot :
   Prims.string -> (FStar_TypeChecker_Env.solver_depth_t * unit)) =
   fun msg  ->
     FStar_Util.atomically
-      (fun uu____18191  ->
-         let uu____18192 = snapshot_env ()  in
-         match uu____18192 with
+      (fun uu____18242  ->
+         let uu____18243 = snapshot_env ()  in
+         match uu____18243 with
          | (env_depth,()) ->
-             let uu____18214 =
+             let uu____18265 =
                FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.snapshot ()
                 in
-             (match uu____18214 with
+             (match uu____18265 with
               | (varops_depth,()) ->
-                  let uu____18236 = FStar_SMTEncoding_Z3.snapshot msg  in
-                  (match uu____18236 with
+                  let uu____18287 = FStar_SMTEncoding_Z3.snapshot msg  in
+                  (match uu____18287 with
                    | (z3_depth,()) ->
                        ((env_depth, varops_depth, z3_depth), ()))))
   
@@ -7365,8 +7412,8 @@ let (rollback :
   fun msg  ->
     fun depth  ->
       FStar_Util.atomically
-        (fun uu____18294  ->
-           let uu____18295 =
+        (fun uu____18345  ->
+           let uu____18346 =
              match depth with
              | FStar_Pervasives_Native.Some (s1,s2,s3) ->
                  ((FStar_Pervasives_Native.Some s1),
@@ -7376,7 +7423,7 @@ let (rollback :
                  (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None,
                    FStar_Pervasives_Native.None)
               in
-           match uu____18295 with
+           match uu____18346 with
            | (env_depth,varops_depth,z3_depth) ->
                (rollback_env env_depth;
                 FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.rollback
@@ -7384,7 +7431,7 @@ let (rollback :
                 FStar_SMTEncoding_Z3.rollback msg z3_depth))
   
 let (push : Prims.string -> unit) =
-  fun msg  -> let uu____18390 = snapshot msg  in () 
+  fun msg  -> let uu____18441 = snapshot msg  in () 
 let (pop : Prims.string -> unit) =
   fun msg  -> rollback msg FStar_Pervasives_Native.None 
 let (open_fact_db_tags :
@@ -7399,19 +7446,19 @@ let (place_decl_in_fact_dbs :
     fun fact_db_ids  ->
       fun d  ->
         match (fact_db_ids, d) with
-        | (uu____18436::uu____18437,FStar_SMTEncoding_Term.Assume a) ->
+        | (uu____18487::uu____18488,FStar_SMTEncoding_Term.Assume a) ->
             FStar_SMTEncoding_Term.Assume
-              (let uu___1635_18445 = a  in
+              (let uu___1635_18496 = a  in
                {
                  FStar_SMTEncoding_Term.assumption_term =
-                   (uu___1635_18445.FStar_SMTEncoding_Term.assumption_term);
+                   (uu___1635_18496.FStar_SMTEncoding_Term.assumption_term);
                  FStar_SMTEncoding_Term.assumption_caption =
-                   (uu___1635_18445.FStar_SMTEncoding_Term.assumption_caption);
+                   (uu___1635_18496.FStar_SMTEncoding_Term.assumption_caption);
                  FStar_SMTEncoding_Term.assumption_name =
-                   (uu___1635_18445.FStar_SMTEncoding_Term.assumption_name);
+                   (uu___1635_18496.FStar_SMTEncoding_Term.assumption_name);
                  FStar_SMTEncoding_Term.assumption_fact_ids = fact_db_ids
                })
-        | uu____18446 -> d
+        | uu____18497 -> d
   
 let (place_decl_elt_in_fact_dbs :
   FStar_SMTEncoding_Env.env_t ->
@@ -7421,19 +7468,19 @@ let (place_decl_elt_in_fact_dbs :
   fun env  ->
     fun fact_db_ids  ->
       fun elt  ->
-        let uu___1641_18473 = elt  in
-        let uu____18474 =
+        let uu___1641_18524 = elt  in
+        let uu____18525 =
           FStar_All.pipe_right elt.FStar_SMTEncoding_Term.decls
             (FStar_List.map (place_decl_in_fact_dbs env fact_db_ids))
            in
         {
           FStar_SMTEncoding_Term.sym_name =
-            (uu___1641_18473.FStar_SMTEncoding_Term.sym_name);
+            (uu___1641_18524.FStar_SMTEncoding_Term.sym_name);
           FStar_SMTEncoding_Term.key =
-            (uu___1641_18473.FStar_SMTEncoding_Term.key);
-          FStar_SMTEncoding_Term.decls = uu____18474;
+            (uu___1641_18524.FStar_SMTEncoding_Term.key);
+          FStar_SMTEncoding_Term.decls = uu____18525;
           FStar_SMTEncoding_Term.a_names =
-            (uu___1641_18473.FStar_SMTEncoding_Term.a_names)
+            (uu___1641_18524.FStar_SMTEncoding_Term.a_names)
         }
   
 let (fact_dbs_for_lid :
@@ -7442,14 +7489,16 @@ let (fact_dbs_for_lid :
   =
   fun env  ->
     fun lid  ->
-      let uu____18494 =
-        let uu____18497 =
-          let uu____18498 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
-          FStar_SMTEncoding_Term.Namespace uu____18498  in
-        let uu____18499 = open_fact_db_tags env  in uu____18497 ::
-          uu____18499
+      let uu____18545 =
+        let uu____18548 =
+          let uu____18549 =
+            let uu____18550 = FStar_Ident.ns_of_lid lid  in
+            FStar_Ident.lid_of_ids uu____18550  in
+          FStar_SMTEncoding_Term.Namespace uu____18549  in
+        let uu____18551 = open_fact_db_tags env  in uu____18548 ::
+          uu____18551
          in
-      (FStar_SMTEncoding_Term.Name lid) :: uu____18494
+      (FStar_SMTEncoding_Term.Name lid) :: uu____18545
   
 let (encode_top_level_facts :
   FStar_SMTEncoding_Env.env_t ->
@@ -7463,8 +7512,8 @@ let (encode_top_level_facts :
         FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
           (FStar_List.collect (fact_dbs_for_lid env))
          in
-      let uu____18526 = encode_sigelt env se  in
-      match uu____18526 with
+      let uu____18578 = encode_sigelt env se  in
+      match uu____18578 with
       | (g,env1) ->
           let g1 =
             FStar_All.pipe_right g
@@ -7485,27 +7534,27 @@ let (recover_caching_and_update_env :
                 elt.FStar_SMTEncoding_Term.key = FStar_Pervasives_Native.None
               then [elt]
               else
-                (let uu____18572 =
-                   let uu____18575 =
+                (let uu____18624 =
+                   let uu____18627 =
                      FStar_All.pipe_right elt.FStar_SMTEncoding_Term.key
                        FStar_Util.must
                       in
                    FStar_Util.smap_try_find
-                     env.FStar_SMTEncoding_Env.global_cache uu____18575
+                     env.FStar_SMTEncoding_Env.global_cache uu____18627
                     in
-                 match uu____18572 with
+                 match uu____18624 with
                  | FStar_Pervasives_Native.Some cache_elt ->
                      FStar_All.pipe_right
                        [FStar_SMTEncoding_Term.RetainAssumptions
                           (cache_elt.FStar_SMTEncoding_Term.a_names)]
                        FStar_SMTEncoding_Term.mk_decls_trivial
                  | FStar_Pervasives_Native.None  ->
-                     ((let uu____18590 =
+                     ((let uu____18642 =
                          FStar_All.pipe_right elt.FStar_SMTEncoding_Term.key
                            FStar_Util.must
                           in
                        FStar_Util.smap_add
-                         env.FStar_SMTEncoding_Env.global_cache uu____18590
+                         env.FStar_SMTEncoding_Env.global_cache uu____18642
                          elt);
                       [elt]))))
   
@@ -7514,47 +7563,47 @@ let (encode_sig :
   fun tcenv  ->
     fun se  ->
       let caption decls =
-        let uu____18620 = FStar_Options.log_queries ()  in
-        if uu____18620
+        let uu____18672 = FStar_Options.log_queries ()  in
+        if uu____18672
         then
-          let uu____18625 =
-            let uu____18626 =
-              let uu____18628 =
-                let uu____18630 =
+          let uu____18677 =
+            let uu____18678 =
+              let uu____18680 =
+                let uu____18682 =
                   FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
                     (FStar_List.map FStar_Syntax_Print.lid_to_string)
                    in
-                FStar_All.pipe_right uu____18630 (FStar_String.concat ", ")
+                FStar_All.pipe_right uu____18682 (FStar_String.concat ", ")
                  in
-              Prims.op_Hat "encoding sigelt " uu____18628  in
-            FStar_SMTEncoding_Term.Caption uu____18626  in
-          uu____18625 :: decls
+              Prims.op_Hat "encoding sigelt " uu____18680  in
+            FStar_SMTEncoding_Term.Caption uu____18678  in
+          uu____18677 :: decls
         else decls  in
-      (let uu____18649 =
+      (let uu____18701 =
          FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium  in
-       if uu____18649
+       if uu____18701
        then
-         let uu____18652 = FStar_Syntax_Print.sigelt_to_string se  in
-         FStar_Util.print1 "+++++++++++Encoding sigelt %s\n" uu____18652
+         let uu____18704 = FStar_Syntax_Print.sigelt_to_string se  in
+         FStar_Util.print1 "+++++++++++Encoding sigelt %s\n" uu____18704
        else ());
       (let env =
-         let uu____18658 = FStar_TypeChecker_Env.current_module tcenv  in
-         get_env uu____18658 tcenv  in
-       let uu____18659 = encode_top_level_facts env se  in
-       match uu____18659 with
+         let uu____18710 = FStar_TypeChecker_Env.current_module tcenv  in
+         get_env uu____18710 tcenv  in
+       let uu____18711 = encode_top_level_facts env se  in
+       match uu____18711 with
        | (decls,env1) ->
            (set_env env1;
-            (let uu____18673 =
-               let uu____18676 =
-                 let uu____18679 =
+            (let uu____18725 =
+               let uu____18728 =
+                 let uu____18731 =
                    FStar_All.pipe_right decls
                      (recover_caching_and_update_env env1)
                     in
-                 FStar_All.pipe_right uu____18679
+                 FStar_All.pipe_right uu____18731
                    FStar_SMTEncoding_Term.decls_list_of
                   in
-               caption uu____18676  in
-             FStar_SMTEncoding_Z3.giveZ3 uu____18673)))
+               caption uu____18728  in
+             FStar_SMTEncoding_Z3.giveZ3 uu____18725)))
   
 let (give_decls_to_z3_and_set_env :
   FStar_SMTEncoding_Env.env_t ->
@@ -7564,8 +7613,8 @@ let (give_decls_to_z3_and_set_env :
     fun name  ->
       fun decls  ->
         let caption decls1 =
-          let uu____18712 = FStar_Options.log_queries ()  in
-          if uu____18712
+          let uu____18764 = FStar_Options.log_queries ()  in
+          if uu____18764
           then
             let msg = Prims.op_Hat "Externals for " name  in
             [FStar_SMTEncoding_Term.Module
@@ -7575,40 +7624,40 @@ let (give_decls_to_z3_and_set_env :
                     [FStar_SMTEncoding_Term.Caption (Prims.op_Hat "End " msg)]))]
           else [FStar_SMTEncoding_Term.Module (name, decls1)]  in
         set_env
-          (let uu___1679_18732 = env  in
+          (let uu___1679_18784 = env  in
            {
              FStar_SMTEncoding_Env.bvar_bindings =
-               (uu___1679_18732.FStar_SMTEncoding_Env.bvar_bindings);
+               (uu___1679_18784.FStar_SMTEncoding_Env.bvar_bindings);
              FStar_SMTEncoding_Env.fvar_bindings =
-               (uu___1679_18732.FStar_SMTEncoding_Env.fvar_bindings);
+               (uu___1679_18784.FStar_SMTEncoding_Env.fvar_bindings);
              FStar_SMTEncoding_Env.depth =
-               (uu___1679_18732.FStar_SMTEncoding_Env.depth);
+               (uu___1679_18784.FStar_SMTEncoding_Env.depth);
              FStar_SMTEncoding_Env.tcenv =
-               (uu___1679_18732.FStar_SMTEncoding_Env.tcenv);
+               (uu___1679_18784.FStar_SMTEncoding_Env.tcenv);
              FStar_SMTEncoding_Env.warn = true;
              FStar_SMTEncoding_Env.nolabels =
-               (uu___1679_18732.FStar_SMTEncoding_Env.nolabels);
+               (uu___1679_18784.FStar_SMTEncoding_Env.nolabels);
              FStar_SMTEncoding_Env.use_zfuel_name =
-               (uu___1679_18732.FStar_SMTEncoding_Env.use_zfuel_name);
+               (uu___1679_18784.FStar_SMTEncoding_Env.use_zfuel_name);
              FStar_SMTEncoding_Env.encode_non_total_function_typ =
-               (uu___1679_18732.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+               (uu___1679_18784.FStar_SMTEncoding_Env.encode_non_total_function_typ);
              FStar_SMTEncoding_Env.current_module_name =
-               (uu___1679_18732.FStar_SMTEncoding_Env.current_module_name);
+               (uu___1679_18784.FStar_SMTEncoding_Env.current_module_name);
              FStar_SMTEncoding_Env.encoding_quantifier =
-               (uu___1679_18732.FStar_SMTEncoding_Env.encoding_quantifier);
+               (uu___1679_18784.FStar_SMTEncoding_Env.encoding_quantifier);
              FStar_SMTEncoding_Env.global_cache =
-               (uu___1679_18732.FStar_SMTEncoding_Env.global_cache)
+               (uu___1679_18784.FStar_SMTEncoding_Env.global_cache)
            });
         (let z3_decls =
-           let uu____18737 =
-             let uu____18740 =
+           let uu____18789 =
+             let uu____18792 =
                FStar_All.pipe_right decls
                  (recover_caching_and_update_env env)
                 in
-             FStar_All.pipe_right uu____18740
+             FStar_All.pipe_right uu____18792
                FStar_SMTEncoding_Term.decls_list_of
               in
-           caption uu____18737  in
+           caption uu____18789  in
          FStar_SMTEncoding_Z3.giveZ3 z3_decls)
   
 let (encode_modul :
@@ -7619,92 +7668,93 @@ let (encode_modul :
   =
   fun tcenv  ->
     fun modul  ->
-      let uu____18760 = (FStar_Options.lax ()) && (FStar_Options.ml_ish ())
+      let uu____18812 = (FStar_Options.lax ()) && (FStar_Options.ml_ish ())
          in
-      if uu____18760
+      if uu____18812
       then ([], [])
       else
         (FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.reset_fresh ();
          (let name =
+            let uu____18828 =
+              FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name  in
             FStar_Util.format2 "%s %s"
               (if modul.FStar_Syntax_Syntax.is_interface
                then "interface"
-               else "module")
-              (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
+               else "module") uu____18828
              in
-          (let uu____18784 =
+          (let uu____18838 =
              FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium  in
-           if uu____18784
+           if uu____18838
            then
-             let uu____18787 =
+             let uu____18841 =
                FStar_All.pipe_right
                  (FStar_List.length modul.FStar_Syntax_Syntax.exports)
                  Prims.string_of_int
                 in
              FStar_Util.print2
                "+++++++++++Encoding externals for %s ... %s exports\n" name
-               uu____18787
+               uu____18841
            else ());
           (let env =
-             let uu____18795 = get_env modul.FStar_Syntax_Syntax.name tcenv
+             let uu____18849 = get_env modul.FStar_Syntax_Syntax.name tcenv
                 in
-             FStar_All.pipe_right uu____18795
+             FStar_All.pipe_right uu____18849
                FStar_SMTEncoding_Env.reset_current_module_fvbs
               in
            let encode_signature env1 ses =
              FStar_All.pipe_right ses
                (FStar_List.fold_left
-                  (fun uu____18834  ->
+                  (fun uu____18888  ->
                      fun se  ->
-                       match uu____18834 with
+                       match uu____18888 with
                        | (g,env2) ->
-                           let uu____18854 = encode_top_level_facts env2 se
+                           let uu____18908 = encode_top_level_facts env2 se
                               in
-                           (match uu____18854 with
+                           (match uu____18908 with
                             | (g',env3) -> ((FStar_List.append g g'), env3)))
                   ([], env1))
               in
-           let uu____18877 =
+           let uu____18931 =
              encode_signature
-               (let uu___1702_18886 = env  in
+               (let uu___1702_18940 = env  in
                 {
                   FStar_SMTEncoding_Env.bvar_bindings =
-                    (uu___1702_18886.FStar_SMTEncoding_Env.bvar_bindings);
+                    (uu___1702_18940.FStar_SMTEncoding_Env.bvar_bindings);
                   FStar_SMTEncoding_Env.fvar_bindings =
-                    (uu___1702_18886.FStar_SMTEncoding_Env.fvar_bindings);
+                    (uu___1702_18940.FStar_SMTEncoding_Env.fvar_bindings);
                   FStar_SMTEncoding_Env.depth =
-                    (uu___1702_18886.FStar_SMTEncoding_Env.depth);
+                    (uu___1702_18940.FStar_SMTEncoding_Env.depth);
                   FStar_SMTEncoding_Env.tcenv =
-                    (uu___1702_18886.FStar_SMTEncoding_Env.tcenv);
+                    (uu___1702_18940.FStar_SMTEncoding_Env.tcenv);
                   FStar_SMTEncoding_Env.warn = false;
                   FStar_SMTEncoding_Env.nolabels =
-                    (uu___1702_18886.FStar_SMTEncoding_Env.nolabels);
+                    (uu___1702_18940.FStar_SMTEncoding_Env.nolabels);
                   FStar_SMTEncoding_Env.use_zfuel_name =
-                    (uu___1702_18886.FStar_SMTEncoding_Env.use_zfuel_name);
+                    (uu___1702_18940.FStar_SMTEncoding_Env.use_zfuel_name);
                   FStar_SMTEncoding_Env.encode_non_total_function_typ =
-                    (uu___1702_18886.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                    (uu___1702_18940.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                   FStar_SMTEncoding_Env.current_module_name =
-                    (uu___1702_18886.FStar_SMTEncoding_Env.current_module_name);
+                    (uu___1702_18940.FStar_SMTEncoding_Env.current_module_name);
                   FStar_SMTEncoding_Env.encoding_quantifier =
-                    (uu___1702_18886.FStar_SMTEncoding_Env.encoding_quantifier);
+                    (uu___1702_18940.FStar_SMTEncoding_Env.encoding_quantifier);
                   FStar_SMTEncoding_Env.global_cache =
-                    (uu___1702_18886.FStar_SMTEncoding_Env.global_cache)
+                    (uu___1702_18940.FStar_SMTEncoding_Env.global_cache)
                 }) modul.FStar_Syntax_Syntax.exports
               in
-           match uu____18877 with
+           match uu____18931 with
            | (decls,env1) ->
                (give_decls_to_z3_and_set_env env1 name decls;
-                (let uu____18902 =
+                (let uu____18956 =
                    FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium  in
-                 if uu____18902
+                 if uu____18956
                  then
                    FStar_Util.print1 "Done encoding externals for %s\n" name
                  else ());
-                (let uu____18908 =
+                (let uu____18962 =
                    FStar_All.pipe_right env1
                      FStar_SMTEncoding_Env.get_current_module_fvbs
                     in
-                 (decls, uu____18908))))))
+                 (decls, uu____18962))))))
   
 let (encode_modul_from_cache :
   FStar_TypeChecker_Env.env ->
@@ -7714,43 +7764,45 @@ let (encode_modul_from_cache :
   =
   fun tcenv  ->
     fun tcmod  ->
-      fun uu____18936  ->
-        match uu____18936 with
+      fun uu____18990  ->
+        match uu____18990 with
         | (decls,fvbs) ->
-            let uu____18949 =
+            let uu____19003 =
               (FStar_Options.lax ()) && (FStar_Options.ml_ish ())  in
-            if uu____18949
+            if uu____19003
             then ()
             else
               (let name =
+                 let uu____19010 =
+                   FStar_Ident.string_of_lid tcmod.FStar_Syntax_Syntax.name
+                    in
                  FStar_Util.format2 "%s %s"
                    (if tcmod.FStar_Syntax_Syntax.is_interface
                     then "interface"
-                    else "module")
-                   (tcmod.FStar_Syntax_Syntax.name).FStar_Ident.str
+                    else "module") uu____19010
                   in
-               (let uu____18964 =
+               (let uu____19020 =
                   FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium  in
-                if uu____18964
+                if uu____19020
                 then
-                  let uu____18967 =
+                  let uu____19023 =
                     FStar_All.pipe_right (FStar_List.length decls)
                       Prims.string_of_int
                      in
                   FStar_Util.print2
                     "+++++++++++Encoding externals from cache for %s ... %s decls\n"
-                    name uu____18967
+                    name uu____19023
                 else ());
                (let env =
-                  let uu____18975 =
+                  let uu____19031 =
                     get_env tcmod.FStar_Syntax_Syntax.name tcenv  in
-                  FStar_All.pipe_right uu____18975
+                  FStar_All.pipe_right uu____19031
                     FStar_SMTEncoding_Env.reset_current_module_fvbs
                    in
                 let env1 =
-                  let uu____18977 = FStar_All.pipe_right fvbs FStar_List.rev
+                  let uu____19033 = FStar_All.pipe_right fvbs FStar_List.rev
                      in
-                  FStar_All.pipe_right uu____18977
+                  FStar_All.pipe_right uu____19033
                     (FStar_List.fold_left
                        (fun env1  ->
                           fun fvb  ->
@@ -7758,9 +7810,9 @@ let (encode_modul_from_cache :
                               env1) env)
                    in
                 give_decls_to_z3_and_set_env env1 name decls;
-                (let uu____18991 =
+                (let uu____19047 =
                    FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium  in
-                 if uu____18991
+                 if uu____19047
                  then
                    FStar_Util.print1
                      "Done encoding externals from cache for %s\n" name
@@ -7778,36 +7830,36 @@ let (encode_query :
   fun use_env_msg  ->
     fun tcenv  ->
       fun q  ->
-        (let uu____19053 =
-           let uu____19055 = FStar_TypeChecker_Env.current_module tcenv  in
-           uu____19055.FStar_Ident.str  in
+        (let uu____19109 =
+           let uu____19111 = FStar_TypeChecker_Env.current_module tcenv  in
+           FStar_Ident.string_of_lid uu____19111  in
          FStar_SMTEncoding_Z3.query_logging.FStar_SMTEncoding_Z3.set_module_name
-           uu____19053);
+           uu____19109);
         (let env =
-           let uu____19057 = FStar_TypeChecker_Env.current_module tcenv  in
-           get_env uu____19057 tcenv  in
-         let uu____19058 =
+           let uu____19113 = FStar_TypeChecker_Env.current_module tcenv  in
+           get_env uu____19113 tcenv  in
+         let uu____19114 =
            let rec aux bindings =
              match bindings with
              | (FStar_Syntax_Syntax.Binding_var x)::rest ->
-                 let uu____19095 = aux rest  in
-                 (match uu____19095 with
+                 let uu____19151 = aux rest  in
+                 (match uu____19151 with
                   | (out,rest1) ->
                       let t =
-                        let uu____19123 =
+                        let uu____19179 =
                           FStar_Syntax_Util.destruct_typ_as_formula
                             x.FStar_Syntax_Syntax.sort
                            in
-                        match uu____19123 with
-                        | FStar_Pervasives_Native.Some uu____19126 ->
-                            let uu____19127 =
+                        match uu____19179 with
+                        | FStar_Pervasives_Native.Some uu____19182 ->
+                            let uu____19183 =
                               FStar_Syntax_Syntax.new_bv
                                 FStar_Pervasives_Native.None
                                 FStar_Syntax_Syntax.t_unit
                                in
-                            FStar_Syntax_Util.refine uu____19127
+                            FStar_Syntax_Util.refine uu____19183
                               x.FStar_Syntax_Syntax.sort
-                        | uu____19128 -> x.FStar_Syntax_Syntax.sort  in
+                        | uu____19184 -> x.FStar_Syntax_Syntax.sort  in
                       let t1 =
                         norm_with_steps
                           [FStar_TypeChecker_Env.Eager_unfolding;
@@ -7817,36 +7869,36 @@ let (encode_query :
                           FStar_TypeChecker_Env.EraseUniverses]
                           env.FStar_SMTEncoding_Env.tcenv t
                          in
-                      let uu____19132 =
-                        let uu____19135 =
+                      let uu____19188 =
+                        let uu____19191 =
                           FStar_Syntax_Syntax.mk_binder
-                            (let uu___1745_19138 = x  in
+                            (let uu___1745_19194 = x  in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___1745_19138.FStar_Syntax_Syntax.ppname);
+                                 (uu___1745_19194.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___1745_19138.FStar_Syntax_Syntax.index);
+                                 (uu___1745_19194.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort = t1
                              })
                            in
-                        uu____19135 :: out  in
-                      (uu____19132, rest1))
-             | uu____19143 -> ([], bindings)  in
-           let uu____19150 = aux tcenv.FStar_TypeChecker_Env.gamma  in
-           match uu____19150 with
+                        uu____19191 :: out  in
+                      (uu____19188, rest1))
+             | uu____19199 -> ([], bindings)  in
+           let uu____19206 = aux tcenv.FStar_TypeChecker_Env.gamma  in
+           match uu____19206 with
            | (closing,bindings) ->
-               let uu____19175 =
+               let uu____19231 =
                  FStar_Syntax_Util.close_forall_no_univs
                    (FStar_List.rev closing) q
                   in
-               (uu____19175, bindings)
+               (uu____19231, bindings)
             in
-         match uu____19058 with
+         match uu____19114 with
          | (q1,bindings) ->
-             let uu____19198 = encode_env_bindings env bindings  in
-             (match uu____19198 with
+             let uu____19254 = encode_env_bindings env bindings  in
+             (match uu____19254 with
               | (env_decls,env1) ->
-                  ((let uu____19220 =
+                  ((let uu____19276 =
                       ((FStar_TypeChecker_Env.debug tcenv
                           FStar_Options.Medium)
                          ||
@@ -7858,94 +7910,94 @@ let (encode_query :
                            (FStar_TypeChecker_Env.debug tcenv)
                            (FStar_Options.Other "SMTQuery"))
                        in
-                    if uu____19220
+                    if uu____19276
                     then
-                      let uu____19227 = FStar_Syntax_Print.term_to_string q1
+                      let uu____19283 = FStar_Syntax_Print.term_to_string q1
                          in
                       FStar_Util.print1 "Encoding query formula {: %s\n"
-                        uu____19227
+                        uu____19283
                     else ());
-                   (let uu____19232 =
+                   (let uu____19288 =
                       FStar_Util.record_time
-                        (fun uu____19247  ->
+                        (fun uu____19303  ->
                            FStar_SMTEncoding_EncodeTerm.encode_formula q1
                              env1)
                        in
-                    match uu____19232 with
+                    match uu____19288 with
                     | ((phi,qdecls),ms) ->
-                        let uu____19271 =
-                          let uu____19276 =
+                        let uu____19327 =
+                          let uu____19332 =
                             FStar_TypeChecker_Env.get_range tcenv  in
                           FStar_SMTEncoding_ErrorReporting.label_goals
-                            use_env_msg uu____19276 phi
+                            use_env_msg uu____19332 phi
                            in
-                        (match uu____19271 with
+                        (match uu____19327 with
                          | (labels,phi1) ->
-                             let uu____19293 = encode_labels labels  in
-                             (match uu____19293 with
+                             let uu____19349 = encode_labels labels  in
+                             (match uu____19349 with
                               | (label_prefix,label_suffix) ->
                                   let caption =
-                                    let uu____19329 =
+                                    let uu____19385 =
                                       FStar_Options.log_queries ()  in
-                                    if uu____19329
+                                    if uu____19385
                                     then
-                                      let uu____19334 =
-                                        let uu____19335 =
-                                          let uu____19337 =
+                                      let uu____19390 =
+                                        let uu____19391 =
+                                          let uu____19393 =
                                             FStar_Syntax_Print.term_to_string
                                               q1
                                              in
                                           Prims.op_Hat
                                             "Encoding query formula : "
-                                            uu____19337
+                                            uu____19393
                                            in
                                         FStar_SMTEncoding_Term.Caption
-                                          uu____19335
+                                          uu____19391
                                          in
-                                      [uu____19334]
+                                      [uu____19390]
                                     else []  in
                                   let query_prelude =
-                                    let uu____19345 =
-                                      let uu____19346 =
-                                        let uu____19347 =
-                                          let uu____19350 =
+                                    let uu____19401 =
+                                      let uu____19402 =
+                                        let uu____19403 =
+                                          let uu____19406 =
                                             FStar_All.pipe_right label_prefix
                                               FStar_SMTEncoding_Term.mk_decls_trivial
                                              in
-                                          let uu____19357 =
-                                            let uu____19360 =
+                                          let uu____19413 =
+                                            let uu____19416 =
                                               FStar_All.pipe_right caption
                                                 FStar_SMTEncoding_Term.mk_decls_trivial
                                                in
                                             FStar_List.append qdecls
-                                              uu____19360
+                                              uu____19416
                                              in
-                                          FStar_List.append uu____19350
-                                            uu____19357
+                                          FStar_List.append uu____19406
+                                            uu____19413
                                            in
                                         FStar_List.append env_decls
-                                          uu____19347
+                                          uu____19403
                                          in
-                                      FStar_All.pipe_right uu____19346
+                                      FStar_All.pipe_right uu____19402
                                         (recover_caching_and_update_env env1)
                                        in
-                                    FStar_All.pipe_right uu____19345
+                                    FStar_All.pipe_right uu____19401
                                       FStar_SMTEncoding_Term.decls_list_of
                                      in
                                   let qry =
-                                    let uu____19370 =
-                                      let uu____19378 =
+                                    let uu____19426 =
+                                      let uu____19434 =
                                         FStar_SMTEncoding_Util.mkNot phi1  in
-                                      let uu____19379 =
+                                      let uu____19435 =
                                         FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
                                           "@query"
                                          in
-                                      (uu____19378,
+                                      (uu____19434,
                                         (FStar_Pervasives_Native.Some "query"),
-                                        uu____19379)
+                                        uu____19435)
                                        in
                                     FStar_SMTEncoding_Util.mkAssume
-                                      uu____19370
+                                      uu____19426
                                      in
                                   let suffix =
                                     FStar_List.append
@@ -7955,7 +8007,7 @@ let (encode_query :
                                             "</labels>";
                                          FStar_SMTEncoding_Term.Echo "Done!"])
                                      in
-                                  ((let uu____19392 =
+                                  ((let uu____19448 =
                                       ((FStar_TypeChecker_Env.debug tcenv
                                           FStar_Options.Medium)
                                          ||
@@ -7969,12 +8021,12 @@ let (encode_query :
                                            (FStar_TypeChecker_Env.debug tcenv)
                                            (FStar_Options.Other "SMTQuery"))
                                        in
-                                    if uu____19392
+                                    if uu____19448
                                     then
                                       FStar_Util.print_string
                                         "} Done encoding\n"
                                     else ());
-                                   (let uu____19403 =
+                                   (let uu____19459 =
                                       (((FStar_TypeChecker_Env.debug tcenv
                                            FStar_Options.Medium)
                                           ||
@@ -7993,7 +8045,7 @@ let (encode_query :
                                            (FStar_TypeChecker_Env.debug tcenv)
                                            (FStar_Options.Other "Time"))
                                        in
-                                    if uu____19403
+                                    if uu____19459
                                     then
                                       FStar_Util.print1
                                         "Encoding took %sms\n"

--- a/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
@@ -4339,7 +4339,7 @@ and (encode_formula :
                              FStar_SMTEncoding_Term.rng = uu____13329;_}::[])::[]
                             when
                             let uu____13349 =
-                              FStar_Ident.text_of_lid
+                              FStar_Ident.string_of_lid
                                 FStar_Parser_Const.guard_free
                                in
                             uu____13349 = gf -> []

--- a/src/ocaml-output/FStar_SMTEncoding_Env.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Env.ml
@@ -38,9 +38,10 @@ let (mk_term_projector_name :
   fun lid  ->
     fun a  ->
       let uu____264 =
-        FStar_Util.format2 "%s_%s" lid.FStar_Ident.str
-          (a.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-         in
+        let uu____266 = FStar_Ident.string_of_lid lid  in
+        let uu____268 = FStar_Ident.text_of_id a.FStar_Syntax_Syntax.ppname
+           in
+        FStar_Util.format2 "%s_%s" uu____266 uu____268  in
       FStar_All.pipe_left escape uu____264
   
 let (primitive_projector_by_pos :
@@ -50,24 +51,25 @@ let (primitive_projector_by_pos :
   fun env  ->
     fun lid  ->
       fun i  ->
-        let fail uu____294 =
-          let uu____295 =
+        let fail uu____298 =
+          let uu____299 =
+            let uu____301 = FStar_Ident.string_of_lid lid  in
             FStar_Util.format2
               "Projector %s on data constructor %s not found"
-              (Prims.string_of_int i) lid.FStar_Ident.str
+              (Prims.string_of_int i) uu____301
              in
-          failwith uu____295  in
-        let uu____299 = FStar_TypeChecker_Env.lookup_datacon env lid  in
-        match uu____299 with
-        | (uu____305,t) ->
-            let uu____307 =
-              let uu____308 = FStar_Syntax_Subst.compress t  in
-              uu____308.FStar_Syntax_Syntax.n  in
-            (match uu____307 with
+          failwith uu____299  in
+        let uu____305 = FStar_TypeChecker_Env.lookup_datacon env lid  in
+        match uu____305 with
+        | (uu____311,t) ->
+            let uu____313 =
+              let uu____314 = FStar_Syntax_Subst.compress t  in
+              uu____314.FStar_Syntax_Syntax.n  in
+            (match uu____313 with
              | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                 let uu____334 = FStar_Syntax_Subst.open_comp bs c  in
-                 (match uu____334 with
-                  | (binders,uu____341) ->
+                 let uu____340 = FStar_Syntax_Subst.open_comp bs c  in
+                 (match uu____340 with
+                  | (binders,uu____347) ->
                       if
                         (i < Prims.int_zero) ||
                           (i >= (FStar_List.length binders))
@@ -76,58 +78,61 @@ let (primitive_projector_by_pos :
                         (let b = FStar_List.nth binders i  in
                          mk_term_projector_name lid
                            (FStar_Pervasives_Native.fst b)))
-             | uu____368 -> fail ())
+             | uu____374 -> fail ())
   
 let (mk_term_projector_name_by_pos :
   FStar_Ident.lident -> Prims.int -> Prims.string) =
   fun lid  ->
     fun i  ->
-      let uu____383 =
-        FStar_Util.format2 "%s_%s" lid.FStar_Ident.str
-          (Prims.string_of_int i)
-         in
-      FStar_All.pipe_left escape uu____383
+      let uu____389 =
+        let uu____391 = FStar_Ident.string_of_lid lid  in
+        FStar_Util.format2 "%s_%s" uu____391 (Prims.string_of_int i)  in
+      FStar_All.pipe_left escape uu____389
   
 let (mk_term_projector :
   FStar_Ident.lident -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term)
   =
   fun lid  ->
     fun a  ->
-      let uu____399 =
-        let uu____400 =
-          let uu____406 = mk_term_projector_name lid a  in
-          (uu____406,
+      let uu____407 =
+        let uu____408 =
+          let uu____414 = mk_term_projector_name lid a  in
+          (uu____414,
             (FStar_SMTEncoding_Term.Arrow
                (FStar_SMTEncoding_Term.Term_sort,
                  FStar_SMTEncoding_Term.Term_sort)))
            in
-        FStar_SMTEncoding_Term.mk_fv uu____400  in
-      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____399
+        FStar_SMTEncoding_Term.mk_fv uu____408  in
+      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____407
   
 let (mk_term_projector_by_pos :
   FStar_Ident.lident -> Prims.int -> FStar_SMTEncoding_Term.term) =
   fun lid  ->
     fun i  ->
-      let uu____422 =
-        let uu____423 =
-          let uu____429 = mk_term_projector_name_by_pos lid i  in
-          (uu____429,
+      let uu____430 =
+        let uu____431 =
+          let uu____437 = mk_term_projector_name_by_pos lid i  in
+          (uu____437,
             (FStar_SMTEncoding_Term.Arrow
                (FStar_SMTEncoding_Term.Term_sort,
                  FStar_SMTEncoding_Term.Term_sort)))
            in
-        FStar_SMTEncoding_Term.mk_fv uu____423  in
-      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____422
+        FStar_SMTEncoding_Term.mk_fv uu____431  in
+      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____430
   
 let mk_data_tester :
-  'uuuuuu441 .
-    'uuuuuu441 ->
+  'uuuuuu449 .
+    'uuuuuu449 ->
       FStar_Ident.lident ->
         FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term
   =
   fun env  ->
     fun l  ->
-      fun x  -> FStar_SMTEncoding_Term.mk_tester (escape l.FStar_Ident.str) x
+      fun x  ->
+        let uu____465 =
+          let uu____467 = FStar_Ident.string_of_lid l  in escape uu____467
+           in
+        FStar_SMTEncoding_Term.mk_tester uu____465 x
   
 type varops_t =
   {
@@ -218,87 +223,90 @@ let (__proj__Mkvarops_t__item__mk_unique :
 let (varops : varops_t) =
   let initial_ctr = (Prims.of_int (100))  in
   let ctr = FStar_Util.mk_ref initial_ctr  in
-  let new_scope uu____1559 =
-    let uu____1560 = FStar_Util.smap_create (Prims.of_int (100))  in
-    let uu____1566 = FStar_Util.smap_create (Prims.of_int (100))  in
-    (uu____1560, uu____1566)  in
+  let new_scope uu____1571 =
+    let uu____1572 = FStar_Util.smap_create (Prims.of_int (100))  in
+    let uu____1578 = FStar_Util.smap_create (Prims.of_int (100))  in
+    (uu____1572, uu____1578)  in
   let scopes =
-    let uu____1589 = let uu____1601 = new_scope ()  in [uu____1601]  in
-    FStar_Util.mk_ref uu____1589  in
+    let uu____1601 = let uu____1613 = new_scope ()  in [uu____1613]  in
+    FStar_Util.mk_ref uu____1601  in
   let mk_unique y =
     let y1 = escape y  in
     let y2 =
-      let uu____1653 =
-        let uu____1657 = FStar_ST.op_Bang scopes  in
-        FStar_Util.find_map uu____1657
-          (fun uu____1723  ->
-             match uu____1723 with
-             | (names,uu____1737) -> FStar_Util.smap_try_find names y1)
+      let uu____1665 =
+        let uu____1669 = FStar_ST.op_Bang scopes  in
+        FStar_Util.find_map uu____1669
+          (fun uu____1735  ->
+             match uu____1735 with
+             | (names,uu____1749) -> FStar_Util.smap_try_find names y1)
          in
-      match uu____1653 with
+      match uu____1665 with
       | FStar_Pervasives_Native.None  -> y1
-      | FStar_Pervasives_Native.Some uu____1751 ->
+      | FStar_Pervasives_Native.Some uu____1763 ->
           (FStar_Util.incr ctr;
-           (let uu____1755 =
-              let uu____1757 =
-                let uu____1759 = FStar_ST.op_Bang ctr  in
-                Prims.string_of_int uu____1759  in
-              Prims.op_Hat "__" uu____1757  in
-            Prims.op_Hat y1 uu____1755))
+           (let uu____1767 =
+              let uu____1769 =
+                let uu____1771 = FStar_ST.op_Bang ctr  in
+                Prims.string_of_int uu____1771  in
+              Prims.op_Hat "__" uu____1769  in
+            Prims.op_Hat y1 uu____1767))
        in
     let top_scope =
-      let uu____1787 =
-        let uu____1797 = FStar_ST.op_Bang scopes  in FStar_List.hd uu____1797
+      let uu____1799 =
+        let uu____1809 = FStar_ST.op_Bang scopes  in FStar_List.hd uu____1809
          in
-      FStar_All.pipe_left FStar_Pervasives_Native.fst uu____1787  in
+      FStar_All.pipe_left FStar_Pervasives_Native.fst uu____1799  in
     FStar_Util.smap_add top_scope y2 true; y2  in
   let new_var pp rn =
-    FStar_All.pipe_left mk_unique
-      (Prims.op_Hat pp.FStar_Ident.idText
-         (Prims.op_Hat "__" (Prims.string_of_int rn)))
-     in
-  let new_fvar lid = mk_unique lid.FStar_Ident.str  in
-  let next_id uu____1909 = FStar_Util.incr ctr; FStar_ST.op_Bang ctr  in
-  let fresh mname pfx =
-    let uu____1948 =
-      let uu____1950 = next_id ()  in
-      FStar_All.pipe_left Prims.string_of_int uu____1950  in
-    FStar_Util.format3 "%s_%s_%s" pfx mname uu____1948  in
-  let reset_fresh uu____1960 = FStar_ST.op_Colon_Equals ctr initial_ctr  in
-  let string_const s =
-    let uu____1990 =
-      let uu____1993 = FStar_ST.op_Bang scopes  in
-      FStar_Util.find_map uu____1993
-        (fun uu____2058  ->
-           match uu____2058 with
-           | (uu____2070,strings) -> FStar_Util.smap_try_find strings s)
+    let uu____1905 =
+      let uu____1907 = FStar_Ident.text_of_id pp  in
+      Prims.op_Hat uu____1907 (Prims.op_Hat "__" (Prims.string_of_int rn))
        in
-    match uu____1990 with
+    FStar_All.pipe_left mk_unique uu____1905  in
+  let new_fvar lid =
+    let uu____1919 = FStar_Ident.string_of_lid lid  in mk_unique uu____1919
+     in
+  let next_id uu____1927 = FStar_Util.incr ctr; FStar_ST.op_Bang ctr  in
+  let fresh mname pfx =
+    let uu____1966 =
+      let uu____1968 = next_id ()  in
+      FStar_All.pipe_left Prims.string_of_int uu____1968  in
+    FStar_Util.format3 "%s_%s_%s" pfx mname uu____1966  in
+  let reset_fresh uu____1978 = FStar_ST.op_Colon_Equals ctr initial_ctr  in
+  let string_const s =
+    let uu____2008 =
+      let uu____2011 = FStar_ST.op_Bang scopes  in
+      FStar_Util.find_map uu____2011
+        (fun uu____2076  ->
+           match uu____2076 with
+           | (uu____2088,strings) -> FStar_Util.smap_try_find strings s)
+       in
+    match uu____2008 with
     | FStar_Pervasives_Native.Some f -> f
     | FStar_Pervasives_Native.None  ->
         let id = next_id ()  in
         let f =
-          let uu____2086 = FStar_SMTEncoding_Util.mk_String_const id  in
-          FStar_All.pipe_left FStar_SMTEncoding_Term.boxString uu____2086  in
+          let uu____2104 = FStar_SMTEncoding_Util.mk_String_const id  in
+          FStar_All.pipe_left FStar_SMTEncoding_Term.boxString uu____2104  in
         let top_scope =
-          let uu____2090 =
-            let uu____2100 = FStar_ST.op_Bang scopes  in
-            FStar_List.hd uu____2100  in
-          FStar_All.pipe_left FStar_Pervasives_Native.snd uu____2090  in
+          let uu____2108 =
+            let uu____2118 = FStar_ST.op_Bang scopes  in
+            FStar_List.hd uu____2118  in
+          FStar_All.pipe_left FStar_Pervasives_Native.snd uu____2108  in
         (FStar_Util.smap_add top_scope s f; f)
      in
-  let push uu____2184 =
-    let uu____2185 =
-      let uu____2197 = new_scope ()  in
-      let uu____2207 = FStar_ST.op_Bang scopes  in uu____2197 :: uu____2207
+  let push uu____2202 =
+    let uu____2203 =
+      let uu____2215 = new_scope ()  in
+      let uu____2225 = FStar_ST.op_Bang scopes  in uu____2215 :: uu____2225
        in
-    FStar_ST.op_Colon_Equals scopes uu____2185  in
-  let pop uu____2315 =
-    let uu____2316 =
-      let uu____2328 = FStar_ST.op_Bang scopes  in FStar_List.tl uu____2328
+    FStar_ST.op_Colon_Equals scopes uu____2203  in
+  let pop uu____2333 =
+    let uu____2334 =
+      let uu____2346 = FStar_ST.op_Bang scopes  in FStar_List.tl uu____2346
        in
-    FStar_ST.op_Colon_Equals scopes uu____2316  in
-  let snapshot uu____2441 = FStar_Common.snapshot push scopes ()  in
+    FStar_ST.op_Colon_Equals scopes uu____2334  in
+  let snapshot uu____2459 = FStar_Common.snapshot push scopes ()  in
   let rollback depth = FStar_Common.rollback pop scopes depth  in
   {
     push;
@@ -366,19 +374,19 @@ let (__proj__Mkfvar_binding__item__fvb_thunked : fvar_binding -> Prims.bool)
   
 let (fvb_to_string : fvar_binding -> Prims.string) =
   fun fvb  ->
-    let term_opt_to_string uu___1_2652 =
-      match uu___1_2652 with
+    let term_opt_to_string uu___1_2670 =
+      match uu___1_2670 with
       | FStar_Pervasives_Native.None  -> "None"
       | FStar_Pervasives_Native.Some s ->
           FStar_SMTEncoding_Term.print_smt_term s
        in
-    let uu____2658 = FStar_Ident.string_of_lid fvb.fvar_lid  in
-    let uu____2660 = term_opt_to_string fvb.smt_token  in
-    let uu____2662 = term_opt_to_string fvb.smt_fuel_partial_app  in
-    let uu____2664 = FStar_Util.string_of_bool fvb.fvb_thunked  in
+    let uu____2676 = FStar_Ident.string_of_lid fvb.fvar_lid  in
+    let uu____2678 = term_opt_to_string fvb.smt_token  in
+    let uu____2680 = term_opt_to_string fvb.smt_fuel_partial_app  in
+    let uu____2682 = FStar_Util.string_of_bool fvb.fvb_thunked  in
     FStar_Util.format5
       "{ lid = %s;\n  smt_id = %s;\n  smt_token = %s;\n smt_fuel_partial_app = %s;\n fvb_thunked = %s }"
-      uu____2658 fvb.smt_id uu____2660 uu____2662 uu____2664
+      uu____2676 fvb.smt_id uu____2678 uu____2680 uu____2682
   
 let (check_valid_fvb : fvar_binding -> unit) =
   fun fvb  ->
@@ -387,38 +395,38 @@ let (check_valid_fvb : fvar_binding -> unit) =
          (FStar_Option.isSome fvb.smt_fuel_partial_app))
         && fvb.fvb_thunked
     then
-      (let uu____2675 =
-         let uu____2677 = FStar_Ident.string_of_lid fvb.fvar_lid  in
-         FStar_Util.format1 "Unexpected thunked SMT symbol: %s" uu____2677
+      (let uu____2693 =
+         let uu____2695 = FStar_Ident.string_of_lid fvb.fvar_lid  in
+         FStar_Util.format1 "Unexpected thunked SMT symbol: %s" uu____2695
           in
-       failwith uu____2675)
+       failwith uu____2693)
     else
       if fvb.fvb_thunked && (fvb.smt_arity <> Prims.int_zero)
       then
-        (let uu____2685 =
-           let uu____2687 = FStar_Ident.string_of_lid fvb.fvar_lid  in
+        (let uu____2703 =
+           let uu____2705 = FStar_Ident.string_of_lid fvb.fvar_lid  in
            FStar_Util.format1 "Unexpected arity of thunked SMT symbol: %s"
-             uu____2687
+             uu____2705
             in
-         failwith uu____2685)
+         failwith uu____2703)
       else ();
     (match fvb.smt_token with
      | FStar_Pervasives_Native.Some
          {
            FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.FreeV
-             uu____2692;
-           FStar_SMTEncoding_Term.freevars = uu____2693;
-           FStar_SMTEncoding_Term.rng = uu____2694;_}
+             uu____2710;
+           FStar_SMTEncoding_Term.freevars = uu____2711;
+           FStar_SMTEncoding_Term.rng = uu____2712;_}
          ->
-         let uu____2715 =
-           let uu____2717 = fvb_to_string fvb  in
-           FStar_Util.format1 "bad fvb\n%s" uu____2717  in
-         failwith uu____2715
-     | uu____2720 -> ())
+         let uu____2733 =
+           let uu____2735 = fvb_to_string fvb  in
+           FStar_Util.format1 "bad fvb\n%s" uu____2735  in
+         failwith uu____2733
+     | uu____2738 -> ())
   
 let binder_of_eithervar :
-  'uuuuuu2730 'uuuuuu2731 .
-    'uuuuuu2730 -> ('uuuuuu2730 * 'uuuuuu2731 FStar_Pervasives_Native.option)
+  'uuuuuu2748 'uuuuuu2749 .
+    'uuuuuu2748 -> ('uuuuuu2748 * 'uuuuuu2749 FStar_Pervasives_Native.option)
   = fun v  -> (v, FStar_Pervasives_Native.None) 
 type env_t =
   {
@@ -529,26 +537,26 @@ let (print_env : env_t -> Prims.string) =
              fun acc  ->
                FStar_Util.pimap_fold pi
                  (fun _i  ->
-                    fun uu____3387  ->
+                    fun uu____3405  ->
                       fun acc1  ->
-                        match uu____3387 with
+                        match uu____3405 with
                         | (x,_term) ->
-                            let uu____3402 =
+                            let uu____3420 =
                               FStar_Syntax_Print.bv_to_string x  in
-                            uu____3402 :: acc1) acc) []
+                            uu____3420 :: acc1) acc) []
        in
     let allvars =
-      let uu____3409 =
+      let uu____3427 =
         FStar_All.pipe_right e.fvar_bindings FStar_Pervasives_Native.fst  in
-      FStar_Util.psmap_fold uu____3409
+      FStar_Util.psmap_fold uu____3427
         (fun _k  -> fun fvb  -> fun acc  -> (fvb.fvar_lid) :: acc) []
        in
     let last_fvar =
       match FStar_List.rev allvars with
       | [] -> ""
-      | l::uu____3442 ->
-          let uu____3445 = FStar_Syntax_Print.lid_to_string l  in
-          Prims.op_Hat "...," uu____3445
+      | l::uu____3460 ->
+          let uu____3463 = FStar_Syntax_Print.lid_to_string l  in
+          Prims.op_Hat "...," uu____3463
        in
     FStar_String.concat ", " (last_fvar :: bvars)
   
@@ -560,11 +568,11 @@ let (lookup_bvar_binding :
   =
   fun env  ->
     fun bv  ->
-      let uu____3467 =
-        FStar_Util.psmap_try_find env.bvar_bindings
-          (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-         in
-      match uu____3467 with
+      let uu____3485 =
+        let uu____3494 = FStar_Ident.text_of_id bv.FStar_Syntax_Syntax.ppname
+           in
+        FStar_Util.psmap_try_find env.bvar_bindings uu____3494  in
+      match uu____3485 with
       | FStar_Pervasives_Native.Some bvs ->
           FStar_Util.pimap_try_find bvs bv.FStar_Syntax_Syntax.index
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
@@ -574,28 +582,32 @@ let (lookup_fvar_binding :
   =
   fun env  ->
     fun lid  ->
-      let uu____3528 =
+      let uu____3548 =
         FStar_All.pipe_right env.fvar_bindings FStar_Pervasives_Native.fst
          in
-      FStar_Util.psmap_try_find uu____3528 lid.FStar_Ident.str
+      let uu____3565 = FStar_Ident.string_of_lid lid  in
+      FStar_Util.psmap_try_find uu____3548 uu____3565
   
 let add_bvar_binding :
-  'uuuuuu3552 .
-    (FStar_Syntax_Syntax.bv * 'uuuuuu3552) ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu3552) FStar_Util.pimap
+  'uuuuuu3574 .
+    (FStar_Syntax_Syntax.bv * 'uuuuuu3574) ->
+      (FStar_Syntax_Syntax.bv * 'uuuuuu3574) FStar_Util.pimap
         FStar_Util.psmap ->
-        (FStar_Syntax_Syntax.bv * 'uuuuuu3552) FStar_Util.pimap
+        (FStar_Syntax_Syntax.bv * 'uuuuuu3574) FStar_Util.pimap
           FStar_Util.psmap
   =
   fun bvb  ->
     fun bvbs  ->
-      FStar_Util.psmap_modify bvbs
-        ((FStar_Pervasives_Native.fst bvb).FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+      let uu____3617 =
+        FStar_Ident.text_of_id
+          (FStar_Pervasives_Native.fst bvb).FStar_Syntax_Syntax.ppname
+         in
+      FStar_Util.psmap_modify bvbs uu____3617
         (fun pimap_opt  ->
-           let uu____3612 =
-             let uu____3619 = FStar_Util.pimap_empty ()  in
-             FStar_Util.dflt uu____3619 pimap_opt  in
-           FStar_Util.pimap_add uu____3612
+           let uu____3636 =
+             let uu____3643 = FStar_Util.pimap_empty ()  in
+             FStar_Util.dflt uu____3643 pimap_opt  in
+           FStar_Util.pimap_add uu____3636
              (FStar_Pervasives_Native.fst bvb).FStar_Syntax_Syntax.index bvb)
   
 let (add_fvar_binding :
@@ -604,13 +616,13 @@ let (add_fvar_binding :
       (fvar_binding FStar_Util.psmap * fvar_binding Prims.list))
   =
   fun fvb  ->
-    fun uu____3666  ->
-      match uu____3666 with
+    fun uu____3690  ->
+      match uu____3690 with
       | (fvb_map,fvb_list) ->
-          let uu____3693 =
-            FStar_Util.psmap_add fvb_map (fvb.fvar_lid).FStar_Ident.str fvb
-             in
-          (uu____3693, (fvb :: fvb_list))
+          let uu____3717 =
+            let uu____3720 = FStar_Ident.string_of_lid fvb.fvar_lid  in
+            FStar_Util.psmap_add fvb_map uu____3720 fvb  in
+          (uu____3717, (fvb :: fvb_list))
   
 let (fresh_fvar :
   Prims.string ->
@@ -622,10 +634,10 @@ let (fresh_fvar :
     fun x  ->
       fun s  ->
         let xsym = varops.fresh mname x  in
-        let uu____3727 =
-          let uu____3728 = FStar_SMTEncoding_Term.mk_fv (xsym, s)  in
-          FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____3728  in
-        (xsym, uu____3727)
+        let uu____3753 =
+          let uu____3754 = FStar_SMTEncoding_Term.mk_fv (xsym, s)  in
+          FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____3754  in
+        (xsym, uu____3753)
   
 let (gen_term_var :
   env_t ->
@@ -636,29 +648,29 @@ let (gen_term_var :
     fun x  ->
       let ysym = Prims.op_Hat "@x" (Prims.string_of_int env.depth)  in
       let y =
-        let uu____3753 =
+        let uu____3779 =
           FStar_SMTEncoding_Term.mk_fv
             (ysym, FStar_SMTEncoding_Term.Term_sort)
            in
-        FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____3753  in
-      let uu____3755 =
-        let uu___241_3756 = env  in
-        let uu____3757 = add_bvar_binding (x, y) env.bvar_bindings  in
+        FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____3779  in
+      let uu____3781 =
+        let uu___241_3782 = env  in
+        let uu____3783 = add_bvar_binding (x, y) env.bvar_bindings  in
         {
-          bvar_bindings = uu____3757;
-          fvar_bindings = (uu___241_3756.fvar_bindings);
+          bvar_bindings = uu____3783;
+          fvar_bindings = (uu___241_3782.fvar_bindings);
           depth = (env.depth + Prims.int_one);
-          tcenv = (uu___241_3756.tcenv);
-          warn = (uu___241_3756.warn);
-          nolabels = (uu___241_3756.nolabels);
-          use_zfuel_name = (uu___241_3756.use_zfuel_name);
+          tcenv = (uu___241_3782.tcenv);
+          warn = (uu___241_3782.warn);
+          nolabels = (uu___241_3782.nolabels);
+          use_zfuel_name = (uu___241_3782.use_zfuel_name);
           encode_non_total_function_typ =
-            (uu___241_3756.encode_non_total_function_typ);
-          current_module_name = (uu___241_3756.current_module_name);
-          encoding_quantifier = (uu___241_3756.encoding_quantifier);
-          global_cache = (uu___241_3756.global_cache)
+            (uu___241_3782.encode_non_total_function_typ);
+          current_module_name = (uu___241_3782.current_module_name);
+          encoding_quantifier = (uu___241_3782.encoding_quantifier);
+          global_cache = (uu___241_3782.global_cache)
         }  in
-      (ysym, y, uu____3755)
+      (ysym, y, uu____3781)
   
 let (new_term_constant :
   env_t ->
@@ -672,24 +684,24 @@ let (new_term_constant :
           x.FStar_Syntax_Syntax.index
          in
       let y = FStar_SMTEncoding_Util.mkApp (ysym, [])  in
-      let uu____3792 =
-        let uu___247_3793 = env  in
-        let uu____3794 = add_bvar_binding (x, y) env.bvar_bindings  in
+      let uu____3818 =
+        let uu___247_3819 = env  in
+        let uu____3820 = add_bvar_binding (x, y) env.bvar_bindings  in
         {
-          bvar_bindings = uu____3794;
-          fvar_bindings = (uu___247_3793.fvar_bindings);
-          depth = (uu___247_3793.depth);
-          tcenv = (uu___247_3793.tcenv);
-          warn = (uu___247_3793.warn);
-          nolabels = (uu___247_3793.nolabels);
-          use_zfuel_name = (uu___247_3793.use_zfuel_name);
+          bvar_bindings = uu____3820;
+          fvar_bindings = (uu___247_3819.fvar_bindings);
+          depth = (uu___247_3819.depth);
+          tcenv = (uu___247_3819.tcenv);
+          warn = (uu___247_3819.warn);
+          nolabels = (uu___247_3819.nolabels);
+          use_zfuel_name = (uu___247_3819.use_zfuel_name);
           encode_non_total_function_typ =
-            (uu___247_3793.encode_non_total_function_typ);
-          current_module_name = (uu___247_3793.current_module_name);
-          encoding_quantifier = (uu___247_3793.encoding_quantifier);
-          global_cache = (uu___247_3793.global_cache)
+            (uu___247_3819.encode_non_total_function_typ);
+          current_module_name = (uu___247_3819.current_module_name);
+          encoding_quantifier = (uu___247_3819.encoding_quantifier);
+          global_cache = (uu___247_3819.global_cache)
         }  in
-      (ysym, y, uu____3792)
+      (ysym, y, uu____3818)
   
 let (new_term_constant_from_string :
   env_t ->
@@ -701,65 +713,65 @@ let (new_term_constant_from_string :
       fun str  ->
         let ysym = varops.mk_unique str  in
         let y = FStar_SMTEncoding_Util.mkApp (ysym, [])  in
-        let uu____3835 =
-          let uu___254_3836 = env  in
-          let uu____3837 = add_bvar_binding (x, y) env.bvar_bindings  in
+        let uu____3861 =
+          let uu___254_3862 = env  in
+          let uu____3863 = add_bvar_binding (x, y) env.bvar_bindings  in
           {
-            bvar_bindings = uu____3837;
-            fvar_bindings = (uu___254_3836.fvar_bindings);
-            depth = (uu___254_3836.depth);
-            tcenv = (uu___254_3836.tcenv);
-            warn = (uu___254_3836.warn);
-            nolabels = (uu___254_3836.nolabels);
-            use_zfuel_name = (uu___254_3836.use_zfuel_name);
+            bvar_bindings = uu____3863;
+            fvar_bindings = (uu___254_3862.fvar_bindings);
+            depth = (uu___254_3862.depth);
+            tcenv = (uu___254_3862.tcenv);
+            warn = (uu___254_3862.warn);
+            nolabels = (uu___254_3862.nolabels);
+            use_zfuel_name = (uu___254_3862.use_zfuel_name);
             encode_non_total_function_typ =
-              (uu___254_3836.encode_non_total_function_typ);
-            current_module_name = (uu___254_3836.current_module_name);
-            encoding_quantifier = (uu___254_3836.encoding_quantifier);
-            global_cache = (uu___254_3836.global_cache)
+              (uu___254_3862.encode_non_total_function_typ);
+            current_module_name = (uu___254_3862.current_module_name);
+            encoding_quantifier = (uu___254_3862.encoding_quantifier);
+            global_cache = (uu___254_3862.global_cache)
           }  in
-        (ysym, y, uu____3835)
+        (ysym, y, uu____3861)
   
 let (push_term_var :
   env_t -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term -> env_t) =
   fun env  ->
     fun x  ->
       fun t  ->
-        let uu___259_3863 = env  in
-        let uu____3864 = add_bvar_binding (x, t) env.bvar_bindings  in
+        let uu___259_3889 = env  in
+        let uu____3890 = add_bvar_binding (x, t) env.bvar_bindings  in
         {
-          bvar_bindings = uu____3864;
-          fvar_bindings = (uu___259_3863.fvar_bindings);
-          depth = (uu___259_3863.depth);
-          tcenv = (uu___259_3863.tcenv);
-          warn = (uu___259_3863.warn);
-          nolabels = (uu___259_3863.nolabels);
-          use_zfuel_name = (uu___259_3863.use_zfuel_name);
+          bvar_bindings = uu____3890;
+          fvar_bindings = (uu___259_3889.fvar_bindings);
+          depth = (uu___259_3889.depth);
+          tcenv = (uu___259_3889.tcenv);
+          warn = (uu___259_3889.warn);
+          nolabels = (uu___259_3889.nolabels);
+          use_zfuel_name = (uu___259_3889.use_zfuel_name);
           encode_non_total_function_typ =
-            (uu___259_3863.encode_non_total_function_typ);
-          current_module_name = (uu___259_3863.current_module_name);
-          encoding_quantifier = (uu___259_3863.encoding_quantifier);
-          global_cache = (uu___259_3863.global_cache)
+            (uu___259_3889.encode_non_total_function_typ);
+          current_module_name = (uu___259_3889.current_module_name);
+          encoding_quantifier = (uu___259_3889.encoding_quantifier);
+          global_cache = (uu___259_3889.global_cache)
         }
   
 let (lookup_term_var :
   env_t -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term) =
   fun env  ->
     fun a  ->
-      let uu____3884 = lookup_bvar_binding env a  in
-      match uu____3884 with
+      let uu____3910 = lookup_bvar_binding env a  in
+      match uu____3910 with
       | FStar_Pervasives_Native.None  ->
-          let uu____3895 = lookup_bvar_binding env a  in
-          (match uu____3895 with
+          let uu____3921 = lookup_bvar_binding env a  in
+          (match uu____3921 with
            | FStar_Pervasives_Native.None  ->
-               let uu____3906 =
-                 let uu____3908 = FStar_Syntax_Print.bv_to_string a  in
-                 let uu____3910 = print_env env  in
+               let uu____3932 =
+                 let uu____3934 = FStar_Syntax_Print.bv_to_string a  in
+                 let uu____3936 = print_env env  in
                  FStar_Util.format2
                    "Bound term variable not found  %s in environment: %s"
-                   uu____3908 uu____3910
+                   uu____3934 uu____3936
                   in
-               failwith uu____3906
+               failwith uu____3932
            | FStar_Pervasives_Native.Some (b,t) -> t)
       | FStar_Pervasives_Native.Some (b,t) -> t
   
@@ -801,7 +813,7 @@ let (new_term_constant_and_tok_from_lid_aux :
       fun arity  ->
         fun thunked  ->
           let fname = varops.new_fvar x  in
-          let uu____4009 =
+          let uu____4035 =
             if thunked
             then (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
             else
@@ -810,30 +822,30 @@ let (new_term_constant_and_tok_from_lid_aux :
                ((FStar_Pervasives_Native.Some ftok_name),
                  (FStar_Pervasives_Native.Some ftok)))
              in
-          match uu____4009 with
+          match uu____4035 with
           | (ftok_name,ftok) ->
               let fvb =
                 mk_fvb x fname arity ftok FStar_Pervasives_Native.None
                   thunked
                  in
-              let uu____4073 =
-                let uu___293_4074 = env  in
-                let uu____4075 = add_fvar_binding fvb env.fvar_bindings  in
+              let uu____4099 =
+                let uu___293_4100 = env  in
+                let uu____4101 = add_fvar_binding fvb env.fvar_bindings  in
                 {
-                  bvar_bindings = (uu___293_4074.bvar_bindings);
-                  fvar_bindings = uu____4075;
-                  depth = (uu___293_4074.depth);
-                  tcenv = (uu___293_4074.tcenv);
-                  warn = (uu___293_4074.warn);
-                  nolabels = (uu___293_4074.nolabels);
-                  use_zfuel_name = (uu___293_4074.use_zfuel_name);
+                  bvar_bindings = (uu___293_4100.bvar_bindings);
+                  fvar_bindings = uu____4101;
+                  depth = (uu___293_4100.depth);
+                  tcenv = (uu___293_4100.tcenv);
+                  warn = (uu___293_4100.warn);
+                  nolabels = (uu___293_4100.nolabels);
+                  use_zfuel_name = (uu___293_4100.use_zfuel_name);
                   encode_non_total_function_typ =
-                    (uu___293_4074.encode_non_total_function_typ);
-                  current_module_name = (uu___293_4074.current_module_name);
-                  encoding_quantifier = (uu___293_4074.encoding_quantifier);
-                  global_cache = (uu___293_4074.global_cache)
+                    (uu___293_4100.encode_non_total_function_typ);
+                  current_module_name = (uu___293_4100.current_module_name);
+                  encoding_quantifier = (uu___293_4100.encoding_quantifier);
+                  global_cache = (uu___293_4100.global_cache)
                 }  in
-              (fname, ftok_name, uu____4073)
+              (fname, ftok_name, uu____4099)
   
 let (new_term_constant_and_tok_from_lid :
   env_t ->
@@ -842,12 +854,12 @@ let (new_term_constant_and_tok_from_lid :
   fun env  ->
     fun x  ->
       fun arity  ->
-        let uu____4114 =
+        let uu____4140 =
           new_term_constant_and_tok_from_lid_aux env x arity false  in
-        match uu____4114 with
+        match uu____4140 with
         | (fname,ftok_name_opt,env1) ->
-            let uu____4145 = FStar_Option.get ftok_name_opt  in
-            (fname, uu____4145, env1)
+            let uu____4171 = FStar_Option.get ftok_name_opt  in
+            (fname, uu____4171, env1)
   
 let (new_term_constant_and_tok_from_lid_maybe_thunked :
   env_t ->
@@ -865,13 +877,13 @@ let (new_term_constant_and_tok_from_lid_maybe_thunked :
 let (lookup_lid : env_t -> FStar_Ident.lident -> fvar_binding) =
   fun env  ->
     fun a  ->
-      let uu____4196 = lookup_fvar_binding env a  in
-      match uu____4196 with
+      let uu____4222 = lookup_fvar_binding env a  in
+      match uu____4222 with
       | FStar_Pervasives_Native.None  ->
-          let uu____4199 =
-            let uu____4201 = FStar_Syntax_Print.lid_to_string a  in
-            FStar_Util.format1 "Name not found: %s" uu____4201  in
-          failwith uu____4199
+          let uu____4225 =
+            let uu____4227 = FStar_Syntax_Print.lid_to_string a  in
+            FStar_Util.format1 "Name not found: %s" uu____4227  in
+          failwith uu____4225
       | FStar_Pervasives_Native.Some s -> (check_valid_fvb s; s)
   
 let (push_free_var_maybe_thunked :
@@ -892,21 +904,21 @@ let (push_free_var_maybe_thunked :
                 mk_fvb x fname arity ftok FStar_Pervasives_Native.None
                   thunked
                  in
-              let uu___319_4248 = env  in
-              let uu____4249 = add_fvar_binding fvb env.fvar_bindings  in
+              let uu___319_4274 = env  in
+              let uu____4275 = add_fvar_binding fvb env.fvar_bindings  in
               {
-                bvar_bindings = (uu___319_4248.bvar_bindings);
-                fvar_bindings = uu____4249;
-                depth = (uu___319_4248.depth);
-                tcenv = (uu___319_4248.tcenv);
-                warn = (uu___319_4248.warn);
-                nolabels = (uu___319_4248.nolabels);
-                use_zfuel_name = (uu___319_4248.use_zfuel_name);
+                bvar_bindings = (uu___319_4274.bvar_bindings);
+                fvar_bindings = uu____4275;
+                depth = (uu___319_4274.depth);
+                tcenv = (uu___319_4274.tcenv);
+                warn = (uu___319_4274.warn);
+                nolabels = (uu___319_4274.nolabels);
+                use_zfuel_name = (uu___319_4274.use_zfuel_name);
                 encode_non_total_function_typ =
-                  (uu___319_4248.encode_non_total_function_typ);
-                current_module_name = (uu___319_4248.current_module_name);
-                encoding_quantifier = (uu___319_4248.encoding_quantifier);
-                global_cache = (uu___319_4248.global_cache)
+                  (uu___319_4274.encode_non_total_function_typ);
+                current_module_name = (uu___319_4274.current_module_name);
+                encoding_quantifier = (uu___319_4274.encoding_quantifier);
+                global_cache = (uu___319_4274.global_cache)
               }
   
 let (push_free_var :
@@ -945,31 +957,31 @@ let (push_zfuel_name : env_t -> FStar_Ident.lident -> Prims.string -> env_t)
       fun f  ->
         let fvb = lookup_lid env x  in
         let t3 =
-          let uu____4349 =
-            let uu____4357 =
-              let uu____4360 = FStar_SMTEncoding_Util.mkApp ("ZFuel", [])  in
-              [uu____4360]  in
-            (f, uu____4357)  in
-          FStar_SMTEncoding_Util.mkApp uu____4349  in
+          let uu____4375 =
+            let uu____4383 =
+              let uu____4386 = FStar_SMTEncoding_Util.mkApp ("ZFuel", [])  in
+              [uu____4386]  in
+            (f, uu____4383)  in
+          FStar_SMTEncoding_Util.mkApp uu____4375  in
         let fvb1 =
           mk_fvb x fvb.smt_id fvb.smt_arity fvb.smt_token
             (FStar_Pervasives_Native.Some t3) false
            in
-        let uu___337_4370 = env  in
-        let uu____4371 = add_fvar_binding fvb1 env.fvar_bindings  in
+        let uu___337_4396 = env  in
+        let uu____4397 = add_fvar_binding fvb1 env.fvar_bindings  in
         {
-          bvar_bindings = (uu___337_4370.bvar_bindings);
-          fvar_bindings = uu____4371;
-          depth = (uu___337_4370.depth);
-          tcenv = (uu___337_4370.tcenv);
-          warn = (uu___337_4370.warn);
-          nolabels = (uu___337_4370.nolabels);
-          use_zfuel_name = (uu___337_4370.use_zfuel_name);
+          bvar_bindings = (uu___337_4396.bvar_bindings);
+          fvar_bindings = uu____4397;
+          depth = (uu___337_4396.depth);
+          tcenv = (uu___337_4396.tcenv);
+          warn = (uu___337_4396.warn);
+          nolabels = (uu___337_4396.nolabels);
+          use_zfuel_name = (uu___337_4396.use_zfuel_name);
           encode_non_total_function_typ =
-            (uu___337_4370.encode_non_total_function_typ);
-          current_module_name = (uu___337_4370.current_module_name);
-          encoding_quantifier = (uu___337_4370.encoding_quantifier);
-          global_cache = (uu___337_4370.global_cache)
+            (uu___337_4396.encode_non_total_function_typ);
+          current_module_name = (uu___337_4396.current_module_name);
+          encoding_quantifier = (uu___337_4396.encoding_quantifier);
+          global_cache = (uu___337_4396.global_cache)
         }
   
 let (force_thunk : fvar_binding -> FStar_SMTEncoding_Term.term) =
@@ -989,64 +1001,64 @@ let (try_lookup_free_var :
   =
   fun env  ->
     fun l  ->
-      let uu____4409 = lookup_fvar_binding env l  in
-      match uu____4409 with
+      let uu____4435 = lookup_fvar_binding env l  in
+      match uu____4435 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some fvb ->
-          ((let uu____4416 =
+          ((let uu____4442 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv)
                 (FStar_Options.Other "PartialApp")
                in
-            if uu____4416
+            if uu____4442
             then
-              let uu____4421 = FStar_Ident.string_of_lid l  in
-              let uu____4423 = fvb_to_string fvb  in
-              FStar_Util.print2 "Looked up %s found\n%s\n" uu____4421
-                uu____4423
+              let uu____4447 = FStar_Ident.string_of_lid l  in
+              let uu____4449 = fvb_to_string fvb  in
+              FStar_Util.print2 "Looked up %s found\n%s\n" uu____4447
+                uu____4449
             else ());
            if fvb.fvb_thunked
            then
-             (let uu____4431 = force_thunk fvb  in
-              FStar_Pervasives_Native.Some uu____4431)
+             (let uu____4457 = force_thunk fvb  in
+              FStar_Pervasives_Native.Some uu____4457)
            else
              (match fvb.smt_fuel_partial_app with
               | FStar_Pervasives_Native.Some f when env.use_zfuel_name ->
                   FStar_Pervasives_Native.Some f
-              | uu____4437 ->
+              | uu____4463 ->
                   (match fvb.smt_token with
                    | FStar_Pervasives_Native.Some t ->
                        (match t.FStar_SMTEncoding_Term.tm with
-                        | FStar_SMTEncoding_Term.App (uu____4445,fuel::[]) ->
-                            let uu____4449 =
-                              let uu____4451 =
-                                let uu____4453 =
+                        | FStar_SMTEncoding_Term.App (uu____4471,fuel::[]) ->
+                            let uu____4475 =
+                              let uu____4477 =
+                                let uu____4479 =
                                   FStar_SMTEncoding_Term.fv_of_term fuel  in
-                                FStar_All.pipe_right uu____4453
+                                FStar_All.pipe_right uu____4479
                                   FStar_SMTEncoding_Term.fv_name
                                  in
-                              FStar_Util.starts_with uu____4451 "fuel"  in
-                            if uu____4449
+                              FStar_Util.starts_with uu____4477 "fuel"  in
+                            if uu____4475
                             then
-                              let uu____4459 =
-                                let uu____4460 =
-                                  let uu____4461 =
+                              let uu____4485 =
+                                let uu____4486 =
+                                  let uu____4487 =
                                     FStar_SMTEncoding_Term.mk_fv
                                       ((fvb.smt_id),
                                         FStar_SMTEncoding_Term.Term_sort)
                                      in
                                   FStar_All.pipe_left
-                                    FStar_SMTEncoding_Util.mkFreeV uu____4461
+                                    FStar_SMTEncoding_Util.mkFreeV uu____4487
                                    in
-                                FStar_SMTEncoding_Term.mk_ApplyTF uu____4460
+                                FStar_SMTEncoding_Term.mk_ApplyTF uu____4486
                                   fuel
                                  in
                               FStar_All.pipe_left
-                                (fun uu____4465  ->
-                                   FStar_Pervasives_Native.Some uu____4465)
-                                uu____4459
+                                (fun uu____4491  ->
+                                   FStar_Pervasives_Native.Some uu____4491)
+                                uu____4485
                             else FStar_Pervasives_Native.Some t
-                        | uu____4468 -> FStar_Pervasives_Native.Some t)
-                   | uu____4469 -> FStar_Pervasives_Native.None)))
+                        | uu____4494 -> FStar_Pervasives_Native.Some t)
+                   | uu____4495 -> FStar_Pervasives_Native.None)))
   
 let (lookup_free_var :
   env_t ->
@@ -1055,15 +1067,15 @@ let (lookup_free_var :
   =
   fun env  ->
     fun a  ->
-      let uu____4487 = try_lookup_free_var env a.FStar_Syntax_Syntax.v  in
-      match uu____4487 with
+      let uu____4513 = try_lookup_free_var env a.FStar_Syntax_Syntax.v  in
+      match uu____4513 with
       | FStar_Pervasives_Native.Some t -> t
       | FStar_Pervasives_Native.None  ->
-          let uu____4491 =
-            let uu____4493 =
+          let uu____4517 =
+            let uu____4519 =
               FStar_Syntax_Print.lid_to_string a.FStar_Syntax_Syntax.v  in
-            FStar_Util.format1 "Name not found: %s" uu____4493  in
-          failwith uu____4491
+            FStar_Util.format1 "Name not found: %s" uu____4519  in
+          failwith uu____4517
   
 let (lookup_free_var_name :
   env_t -> FStar_Ident.lident FStar_Syntax_Syntax.withinfo_t -> fvar_binding)
@@ -1081,17 +1093,17 @@ let (lookup_free_var_sym :
       match fvb.smt_fuel_partial_app with
       | FStar_Pervasives_Native.Some
           { FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (g,zf);
-            FStar_SMTEncoding_Term.freevars = uu____4555;
-            FStar_SMTEncoding_Term.rng = uu____4556;_}
+            FStar_SMTEncoding_Term.freevars = uu____4581;
+            FStar_SMTEncoding_Term.rng = uu____4582;_}
           when env.use_zfuel_name ->
           ((FStar_Util.Inl g), zf, (fvb.smt_arity + Prims.int_one))
-      | uu____4581 ->
+      | uu____4607 ->
           (match fvb.smt_token with
            | FStar_Pervasives_Native.None  when fvb.fvb_thunked ->
-               let uu____4597 =
-                 let uu____4602 = force_thunk fvb  in
-                 FStar_Util.Inr uu____4602  in
-               (uu____4597, [], (fvb.smt_arity))
+               let uu____4623 =
+                 let uu____4628 = force_thunk fvb  in
+                 FStar_Util.Inr uu____4628  in
+               (uu____4623, [], (fvb.smt_arity))
            | FStar_Pervasives_Native.None  ->
                ((FStar_Util.Inl (FStar_SMTEncoding_Term.Var (fvb.smt_id))),
                  [], (fvb.smt_arity))
@@ -1100,7 +1112,7 @@ let (lookup_free_var_sym :
                 | FStar_SMTEncoding_Term.App (g,fuel::[]) ->
                     ((FStar_Util.Inl g), [fuel],
                       (fvb.smt_arity + Prims.int_one))
-                | uu____4643 ->
+                | uu____4669 ->
                     ((FStar_Util.Inl
                         (FStar_SMTEncoding_Term.Var (fvb.smt_id))), [],
                       (fvb.smt_arity))))
@@ -1112,68 +1124,68 @@ let (tok_of_name :
   =
   fun env  ->
     fun nm  ->
-      let uu____4666 =
-        let uu____4669 =
+      let uu____4692 =
+        let uu____4695 =
           FStar_All.pipe_right env.fvar_bindings FStar_Pervasives_Native.fst
            in
-        FStar_Util.psmap_find_map uu____4669
-          (fun uu____4689  ->
+        FStar_Util.psmap_find_map uu____4695
+          (fun uu____4715  ->
              fun fvb  ->
                check_valid_fvb fvb;
                if fvb.smt_id = nm
                then fvb.smt_token
                else FStar_Pervasives_Native.None)
          in
-      match uu____4666 with
+      match uu____4692 with
       | FStar_Pervasives_Native.Some b -> FStar_Pervasives_Native.Some b
       | FStar_Pervasives_Native.None  ->
           FStar_Util.psmap_find_map env.bvar_bindings
-            (fun uu____4710  ->
+            (fun uu____4736  ->
                fun pi  ->
                  FStar_Util.pimap_fold pi
-                   (fun uu____4730  ->
+                   (fun uu____4756  ->
                       fun y  ->
                         fun res  ->
                           match (res, y) with
                           | (FStar_Pervasives_Native.Some
-                             uu____4748,uu____4749) -> res
+                             uu____4774,uu____4775) -> res
                           | (FStar_Pervasives_Native.None
-                             ,(uu____4760,{
+                             ,(uu____4786,{
                                             FStar_SMTEncoding_Term.tm =
                                               FStar_SMTEncoding_Term.App
                                               (FStar_SMTEncoding_Term.Var
                                                sym,[]);
                                             FStar_SMTEncoding_Term.freevars =
-                                              uu____4762;
+                                              uu____4788;
                                             FStar_SMTEncoding_Term.rng =
-                                              uu____4763;_}))
+                                              uu____4789;_}))
                               when sym = nm ->
                               FStar_Pervasives_Native.Some
                                 (FStar_Pervasives_Native.snd y)
-                          | uu____4786 -> FStar_Pervasives_Native.None)
+                          | uu____4812 -> FStar_Pervasives_Native.None)
                    FStar_Pervasives_Native.None)
   
 let (reset_current_module_fvbs : env_t -> env_t) =
   fun env  ->
-    let uu___424_4803 = env  in
-    let uu____4804 =
-      let uu____4813 =
+    let uu___424_4829 = env  in
+    let uu____4830 =
+      let uu____4839 =
         FStar_All.pipe_right env.fvar_bindings FStar_Pervasives_Native.fst
          in
-      (uu____4813, [])  in
+      (uu____4839, [])  in
     {
-      bvar_bindings = (uu___424_4803.bvar_bindings);
-      fvar_bindings = uu____4804;
-      depth = (uu___424_4803.depth);
-      tcenv = (uu___424_4803.tcenv);
-      warn = (uu___424_4803.warn);
-      nolabels = (uu___424_4803.nolabels);
-      use_zfuel_name = (uu___424_4803.use_zfuel_name);
+      bvar_bindings = (uu___424_4829.bvar_bindings);
+      fvar_bindings = uu____4830;
+      depth = (uu___424_4829.depth);
+      tcenv = (uu___424_4829.tcenv);
+      warn = (uu___424_4829.warn);
+      nolabels = (uu___424_4829.nolabels);
+      use_zfuel_name = (uu___424_4829.use_zfuel_name);
       encode_non_total_function_typ =
-        (uu___424_4803.encode_non_total_function_typ);
-      current_module_name = (uu___424_4803.current_module_name);
-      encoding_quantifier = (uu___424_4803.encoding_quantifier);
-      global_cache = (uu___424_4803.global_cache)
+        (uu___424_4829.encode_non_total_function_typ);
+      current_module_name = (uu___424_4829.current_module_name);
+      encoding_quantifier = (uu___424_4829.encoding_quantifier);
+      global_cache = (uu___424_4829.global_cache)
     }
   
 let (get_current_module_fvbs : env_t -> fvar_binding Prims.list) =
@@ -1183,20 +1195,20 @@ let (get_current_module_fvbs : env_t -> fvar_binding Prims.list) =
 let (add_fvar_binding_to_env : fvar_binding -> env_t -> env_t) =
   fun fvb  ->
     fun env  ->
-      let uu___429_4867 = env  in
-      let uu____4868 = add_fvar_binding fvb env.fvar_bindings  in
+      let uu___429_4893 = env  in
+      let uu____4894 = add_fvar_binding fvb env.fvar_bindings  in
       {
-        bvar_bindings = (uu___429_4867.bvar_bindings);
-        fvar_bindings = uu____4868;
-        depth = (uu___429_4867.depth);
-        tcenv = (uu___429_4867.tcenv);
-        warn = (uu___429_4867.warn);
-        nolabels = (uu___429_4867.nolabels);
-        use_zfuel_name = (uu___429_4867.use_zfuel_name);
+        bvar_bindings = (uu___429_4893.bvar_bindings);
+        fvar_bindings = uu____4894;
+        depth = (uu___429_4893.depth);
+        tcenv = (uu___429_4893.tcenv);
+        warn = (uu___429_4893.warn);
+        nolabels = (uu___429_4893.nolabels);
+        use_zfuel_name = (uu___429_4893.use_zfuel_name);
         encode_non_total_function_typ =
-          (uu___429_4867.encode_non_total_function_typ);
-        current_module_name = (uu___429_4867.current_module_name);
-        encoding_quantifier = (uu___429_4867.encoding_quantifier);
-        global_cache = (uu___429_4867.global_cache)
+          (uu___429_4893.encode_non_total_function_typ);
+        current_module_name = (uu___429_4893.current_module_name);
+        encoding_quantifier = (uu___429_4893.encoding_quantifier);
+        global_cache = (uu___429_4893.global_cache)
       }
   

--- a/src/ocaml-output/FStar_SMTEncoding_Solver.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Solver.ml
@@ -1053,7 +1053,7 @@ let (ask_and_report_errors :
                  | (uu____3578,FStar_Pervasives_Native.None ) ->
                      failwith "No query name set!"
                  | (uu____3604,FStar_Pervasives_Native.Some (q,n)) ->
-                     let uu____3627 = FStar_Ident.text_of_lid q  in
+                     let uu____3627 = FStar_Ident.string_of_lid q  in
                      (uu____3627, n)
                   in
                match uu____3565 with

--- a/src/ocaml-output/FStar_SMTEncoding_Term.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Term.ml
@@ -1987,10 +1987,10 @@ let rec (declToSmt' : Prims.bool -> Prims.string -> decl -> Prims.string) =
                    (fun uu___7_8122  ->
                       match uu___7_8122 with
                       | Name n ->
-                          let uu____8125 = FStar_Ident.text_of_lid n  in
+                          let uu____8125 = FStar_Ident.string_of_lid n  in
                           Prims.op_Hat "Name " uu____8125
                       | Namespace ns ->
-                          let uu____8129 = FStar_Ident.text_of_lid ns  in
+                          let uu____8129 = FStar_Ident.string_of_lid ns  in
                           Prims.op_Hat "Namespace " uu____8129
                       | Tag t -> Prims.op_Hat "Tag " t))
                in

--- a/src/ocaml-output/FStar_Syntax_DsEnv.ml
+++ b/src/ocaml-output/FStar_Syntax_DsEnv.ml
@@ -522,7 +522,7 @@ let (set_iface_decls :
             }
   
 let (qual : FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident) =
-  FStar_Syntax_Util.qual_id 
+  FStar_Ident.qual_id 
 let (qualify : env -> FStar_Ident.ident -> FStar_Ident.lident) =
   fun env1  ->
     fun id  ->
@@ -650,22 +650,21 @@ let (set_bv_range :
   FStar_Syntax_Syntax.bv -> FStar_Range.range -> FStar_Syntax_Syntax.bv) =
   fun bv  ->
     fun r  ->
-      let id =
-        let uu___211_2775 = bv.FStar_Syntax_Syntax.ppname  in
-        {
-          FStar_Ident.idText = (uu___211_2775.FStar_Ident.idText);
-          FStar_Ident.idRange = r
-        }  in
-      let uu___214_2776 = bv  in
+      let id = FStar_Ident.set_id_range r bv.FStar_Syntax_Syntax.ppname  in
+      let uu___212_2775 = bv  in
       {
         FStar_Syntax_Syntax.ppname = id;
-        FStar_Syntax_Syntax.index = (uu___214_2776.FStar_Syntax_Syntax.index);
-        FStar_Syntax_Syntax.sort = (uu___214_2776.FStar_Syntax_Syntax.sort)
+        FStar_Syntax_Syntax.index = (uu___212_2775.FStar_Syntax_Syntax.index);
+        FStar_Syntax_Syntax.sort = (uu___212_2775.FStar_Syntax_Syntax.sort)
       }
   
 let (bv_to_name :
   FStar_Syntax_Syntax.bv -> FStar_Range.range -> FStar_Syntax_Syntax.term) =
-  fun bv  -> fun r  -> FStar_Syntax_Syntax.bv_to_name (set_bv_range bv r) 
+  fun bv  ->
+    fun r  ->
+      let uu____2787 = set_bv_range bv r  in
+      FStar_Syntax_Syntax.bv_to_name uu____2787
+  
 let (unmangleMap :
   (Prims.string * Prims.string * FStar_Syntax_Syntax.delta_depth *
     FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option) Prims.list)
@@ -681,18 +680,20 @@ let (unmangleOpName :
   =
   fun id  ->
     FStar_Util.find_map unmangleMap
-      (fun uu____2879  ->
-         match uu____2879 with
+      (fun uu____2880  ->
+         match uu____2880 with
          | (x,y,dd,dq) ->
-             if id.FStar_Ident.idText = x
+             let uu____2907 =
+               let uu____2909 = FStar_Ident.text_of_id id  in uu____2909 = x
+                in
+             if uu____2907
              then
-               let uu____2910 =
-                 let uu____2911 =
-                   FStar_Ident.lid_of_path ["Prims"; y]
-                     id.FStar_Ident.idRange
-                    in
-                 FStar_Syntax_Syntax.fvar uu____2911 dd dq  in
-               FStar_Pervasives_Native.Some uu____2910
+               let uu____2915 =
+                 let uu____2916 =
+                   let uu____2917 = FStar_Ident.range_of_id id  in
+                   FStar_Ident.lid_of_path ["Prims"; y] uu____2917  in
+                 FStar_Syntax_Syntax.fvar uu____2916 dd dq  in
+               FStar_Pervasives_Native.Some uu____2915
              else FStar_Pervasives_Native.None)
   
 type 'a cont_t =
@@ -701,17 +702,17 @@ type 'a cont_t =
   | Cont_ignore 
 let uu___is_Cont_ok : 'a . 'a cont_t -> Prims.bool =
   fun projectee  ->
-    match projectee with | Cont_ok _0 -> true | uu____2951 -> false
+    match projectee with | Cont_ok _0 -> true | uu____2957 -> false
   
 let __proj__Cont_ok__item___0 : 'a . 'a cont_t -> 'a =
   fun projectee  -> match projectee with | Cont_ok _0 -> _0 
 let uu___is_Cont_fail : 'a . 'a cont_t -> Prims.bool =
   fun projectee  ->
-    match projectee with | Cont_fail  -> true | uu____2988 -> false
+    match projectee with | Cont_fail  -> true | uu____2994 -> false
   
 let uu___is_Cont_ignore : 'a . 'a cont_t -> Prims.bool =
   fun projectee  ->
-    match projectee with | Cont_ignore  -> true | uu____3009 -> false
+    match projectee with | Cont_ignore  -> true | uu____3015 -> false
   
 let option_of_cont :
   'a .
@@ -719,41 +720,49 @@ let option_of_cont :
       'a cont_t -> 'a FStar_Pervasives_Native.option
   =
   fun k_ignore  ->
-    fun uu___1_3039  ->
-      match uu___1_3039 with
+    fun uu___1_3045  ->
+      match uu___1_3045 with
       | Cont_ok a1 -> FStar_Pervasives_Native.Some a1
       | Cont_fail  -> FStar_Pervasives_Native.None
       | Cont_ignore  -> k_ignore ()
   
 let find_in_record :
-  'uuuuuu3058 .
+  'uuuuuu3064 .
     FStar_Ident.ident Prims.list ->
       FStar_Ident.ident ->
         record_or_dc ->
-          (record_or_dc -> 'uuuuuu3058 cont_t) -> 'uuuuuu3058 cont_t
+          (record_or_dc -> 'uuuuuu3064 cont_t) -> 'uuuuuu3064 cont_t
   =
   fun ns  ->
     fun id  ->
       fun record  ->
         fun cont  ->
           let typename' =
-            FStar_Ident.lid_of_ids
-              (FStar_List.append ns [(record.typename).FStar_Ident.ident])
+            let uu____3101 =
+              let uu____3102 =
+                let uu____3105 = FStar_Ident.ident_of_lid record.typename  in
+                [uu____3105]  in
+              FStar_List.append ns uu____3102  in
+            FStar_Ident.lid_of_ids uu____3101  in
+          let uu____3106 = FStar_Ident.lid_equals typename' record.typename
              in
-          let uu____3095 = FStar_Ident.lid_equals typename' record.typename
-             in
-          if uu____3095
+          if uu____3106
           then
             let fname =
-              FStar_Ident.lid_of_ids
-                (FStar_List.append (record.typename).FStar_Ident.ns [id])
-               in
+              let uu____3112 =
+                let uu____3113 = FStar_Ident.ns_of_lid record.typename  in
+                FStar_List.append uu____3113 [id]  in
+              FStar_Ident.lid_of_ids uu____3112  in
             let find =
               FStar_Util.find_map record.fields
-                (fun uu____3111  ->
-                   match uu____3111 with
-                   | (f,uu____3119) ->
-                       if id.FStar_Ident.idText = f.FStar_Ident.idText
+                (fun uu____3127  ->
+                   match uu____3127 with
+                   | (f,uu____3135) ->
+                       let uu____3136 =
+                         let uu____3138 = FStar_Ident.text_of_id id  in
+                         let uu____3140 = FStar_Ident.text_of_id f  in
+                         uu____3138 = uu____3140  in
+                       if uu____3136
                        then FStar_Pervasives_Native.Some record
                        else FStar_Pervasives_Native.None)
                in
@@ -776,8 +785,8 @@ let (get_trans_exported_id_set :
   =
   fun e  -> fun mname  -> FStar_Util.smap_try_find e.trans_exported_ids mname 
 let (string_of_exported_id_kind : exported_id_kind -> Prims.string) =
-  fun uu___2_3193  ->
-    match uu___2_3193 with
+  fun uu___2_3215  ->
+    match uu___2_3215 with
     | Exported_id_field  -> "field"
     | Exported_id_term_type  -> "term/type"
   
@@ -794,26 +803,26 @@ let find_in_module_with_includes :
         fun env1  ->
           fun ns  ->
             fun id  ->
-              let idstr = id.FStar_Ident.idText  in
-              let rec aux uu___3_3269 =
-                match uu___3_3269 with
+              let idstr = FStar_Ident.text_of_id id  in
+              let rec aux uu___3_3291 =
+                match uu___3_3291 with
                 | [] -> find_in_module_default
                 | modul::q ->
-                    let mname = modul.FStar_Ident.str  in
+                    let mname = FStar_Ident.string_of_lid modul  in
                     let not_shadowed =
-                      let uu____3282 = get_exported_id_set env1 mname  in
-                      match uu____3282 with
+                      let uu____3304 = get_exported_id_set env1 mname  in
+                      match uu____3304 with
                       | FStar_Pervasives_Native.None  -> true
                       | FStar_Pervasives_Native.Some mex ->
                           let mexports =
-                            let uu____3309 = mex eikind  in
-                            FStar_ST.op_Bang uu____3309  in
+                            let uu____3331 = mex eikind  in
+                            FStar_ST.op_Bang uu____3331  in
                           FStar_Util.set_mem idstr mexports
                        in
                     let mincludes =
-                      let uu____3371 =
+                      let uu____3393 =
                         FStar_Util.smap_try_find env1.includes mname  in
-                      match uu____3371 with
+                      match uu____3393 with
                       | FStar_Pervasives_Native.None  -> []
                       | FStar_Pervasives_Native.Some minc ->
                           FStar_ST.op_Bang minc
@@ -821,18 +830,18 @@ let find_in_module_with_includes :
                     let look_into =
                       if not_shadowed
                       then
-                        let uu____3426 = qual modul id  in
-                        find_in_module uu____3426
+                        let uu____3448 = qual modul id  in
+                        find_in_module uu____3448
                       else Cont_ignore  in
                     (match look_into with
                      | Cont_ignore  -> aux (FStar_List.append mincludes q)
-                     | uu____3431 -> look_into)
+                     | uu____3453 -> look_into)
                  in
               aux [ns]
   
 let (is_exported_id_field : exported_id_kind -> Prims.bool) =
-  fun uu___4_3440  ->
-    match uu___4_3440 with | Exported_id_field  -> true | uu____3443 -> false
+  fun uu___4_3462  ->
+    match uu___4_3462 with | Exported_id_field  -> true | uu____3465 -> false
   
 let try_lookup_id'' :
   'a .
@@ -854,85 +863,93 @@ let try_lookup_id'' :
             fun k_record  ->
               fun find_in_module  ->
                 fun lookup_default_id  ->
-                  let check_local_binding_id uu___5_3567 =
-                    match uu___5_3567 with
-                    | (id',uu____3570,uu____3571) ->
-                        id'.FStar_Ident.idText = id.FStar_Ident.idText
+                  let check_local_binding_id uu___5_3589 =
+                    match uu___5_3589 with
+                    | (id',uu____3592,uu____3593) ->
+                        let uu____3594 = FStar_Ident.text_of_id id'  in
+                        let uu____3596 = FStar_Ident.text_of_id id  in
+                        uu____3594 = uu____3596
                      in
-                  let check_rec_binding_id uu___6_3579 =
-                    match uu___6_3579 with
-                    | (id',uu____3582,uu____3583,uu____3584) ->
-                        id'.FStar_Ident.idText = id.FStar_Ident.idText
+                  let check_rec_binding_id uu___6_3605 =
+                    match uu___6_3605 with
+                    | (id',uu____3608,uu____3609,uu____3610) ->
+                        let uu____3611 = FStar_Ident.text_of_id id'  in
+                        let uu____3613 = FStar_Ident.text_of_id id  in
+                        uu____3611 = uu____3613
                      in
                   let curmod_ns =
-                    let uu____3589 = current_module env1  in
-                    FStar_Ident.ids_of_lid uu____3589  in
-                  let proc uu___7_3597 =
-                    match uu___7_3597 with
+                    let uu____3617 = current_module env1  in
+                    FStar_Ident.ids_of_lid uu____3617  in
+                  let proc uu___7_3625 =
+                    match uu___7_3625 with
                     | Local_binding l when check_local_binding_id l ->
-                        let uu____3601 = l  in
-                        (match uu____3601 with
-                         | (uu____3604,uu____3605,used_marker1) ->
+                        let uu____3629 = l  in
+                        (match uu____3629 with
+                         | (uu____3632,uu____3633,used_marker1) ->
                              (FStar_ST.op_Colon_Equals used_marker1 true;
                               k_local_binding l))
                     | Rec_binding r when check_rec_binding_id r ->
-                        let uu____3631 = r  in
-                        (match uu____3631 with
-                         | (uu____3634,uu____3635,uu____3636,used_marker1) ->
+                        let uu____3659 = r  in
+                        (match uu____3659 with
+                         | (uu____3662,uu____3663,uu____3664,used_marker1) ->
                              (FStar_ST.op_Colon_Equals used_marker1 true;
                               k_rec_binding r))
                     | Open_module_or_namespace (ns,Open_module ) ->
                         find_in_module_with_includes eikind find_in_module
                           Cont_ignore env1 ns id
                     | Top_level_def id' when
-                        id'.FStar_Ident.idText = id.FStar_Ident.idText ->
+                        let uu____3691 = FStar_Ident.text_of_id id'  in
+                        let uu____3693 = FStar_Ident.text_of_id id  in
+                        uu____3691 = uu____3693 ->
                         lookup_default_id Cont_ignore id
                     | Record_or_dc r when is_exported_id_field eikind ->
-                        let uu____3665 = FStar_Ident.lid_of_ids curmod_ns  in
+                        let uu____3697 = FStar_Ident.lid_of_ids curmod_ns  in
                         find_in_module_with_includes Exported_id_field
                           (fun lid  ->
-                             let id1 = lid.FStar_Ident.ident  in
-                             find_in_record lid.FStar_Ident.ns id1 r k_record)
-                          Cont_ignore env1 uu____3665 id
-                    | uu____3670 -> Cont_ignore  in
-                  let rec aux uu___8_3680 =
-                    match uu___8_3680 with
+                             let id1 = FStar_Ident.ident_of_lid lid  in
+                             let uu____3703 = FStar_Ident.ns_of_lid lid  in
+                             find_in_record uu____3703 id1 r k_record)
+                          Cont_ignore env1 uu____3697 id
+                    | uu____3706 -> Cont_ignore  in
+                  let rec aux uu___8_3716 =
+                    match uu___8_3716 with
                     | a1::q ->
-                        let uu____3689 = proc a1  in
-                        option_of_cont (fun uu____3693  -> aux q) uu____3689
+                        let uu____3725 = proc a1  in
+                        option_of_cont (fun uu____3729  -> aux q) uu____3725
                     | [] ->
-                        let uu____3694 = lookup_default_id Cont_fail id  in
+                        let uu____3730 = lookup_default_id Cont_fail id  in
                         option_of_cont
-                          (fun uu____3698  -> FStar_Pervasives_Native.None)
-                          uu____3694
+                          (fun uu____3734  -> FStar_Pervasives_Native.None)
+                          uu____3730
                      in
                   aux env1.scope_mods
   
 let found_local_binding :
-  'uuuuuu3708 'uuuuuu3709 .
+  'uuuuuu3744 'uuuuuu3745 .
     FStar_Range.range ->
-      ('uuuuuu3708 * FStar_Syntax_Syntax.bv * 'uuuuuu3709) ->
+      ('uuuuuu3744 * FStar_Syntax_Syntax.bv * 'uuuuuu3745) ->
         FStar_Syntax_Syntax.term
   =
   fun r  ->
-    fun uu____3725  ->
-      match uu____3725 with | (id',x,uu____3734) -> bv_to_name x r
+    fun uu____3761  ->
+      match uu____3761 with | (id',x,uu____3770) -> bv_to_name x r
   
 let find_in_module :
-  'uuuuuu3746 .
+  'uuuuuu3782 .
     env ->
       FStar_Ident.lident ->
         (FStar_Ident.lident ->
-           (FStar_Syntax_Syntax.sigelt * Prims.bool) -> 'uuuuuu3746)
-          -> 'uuuuuu3746 -> 'uuuuuu3746
+           (FStar_Syntax_Syntax.sigelt * Prims.bool) -> 'uuuuuu3782)
+          -> 'uuuuuu3782 -> 'uuuuuu3782
   =
   fun env1  ->
     fun lid  ->
       fun k_global_def  ->
         fun k_not_found  ->
-          let uu____3787 =
-            FStar_Util.smap_try_find (sigmap env1) lid.FStar_Ident.str  in
-          match uu____3787 with
+          let uu____3823 =
+            let uu____3831 = FStar_Ident.string_of_lid lid  in
+            FStar_Util.smap_try_find (sigmap env1) uu____3831  in
+          match uu____3823 with
           | FStar_Pervasives_Native.Some sb -> k_global_def lid sb
           | FStar_Pervasives_Native.None  -> k_not_found
   
@@ -943,21 +960,22 @@ let (try_lookup_id :
   =
   fun env1  ->
     fun id  ->
-      let uu____3831 = unmangleOpName id  in
-      match uu____3831 with
+      let uu____3869 = unmangleOpName id  in
+      match uu____3869 with
       | FStar_Pervasives_Native.Some f -> FStar_Pervasives_Native.Some f
-      | uu____3837 ->
+      | uu____3875 ->
           try_lookup_id'' env1 id Exported_id_term_type
             (fun r  ->
-               let uu____3843 = found_local_binding id.FStar_Ident.idRange r
-                  in
-               Cont_ok uu____3843) (fun uu____3845  -> Cont_fail)
-            (fun uu____3847  -> Cont_ignore)
+               let uu____3881 =
+                 let uu____3882 = FStar_Ident.range_of_id id  in
+                 found_local_binding uu____3882 r  in
+               Cont_ok uu____3881) (fun uu____3884  -> Cont_fail)
+            (fun uu____3886  -> Cont_ignore)
             (fun i  ->
                find_in_module env1 i
-                 (fun uu____3854  -> fun uu____3855  -> Cont_fail)
+                 (fun uu____3893  -> fun uu____3894  -> Cont_fail)
                  Cont_ignore)
-            (fun uu____3863  -> fun uu____3864  -> Cont_fail)
+            (fun uu____3902  -> fun uu____3903  -> Cont_fail)
   
 let lookup_default_id :
   'a .
@@ -973,15 +991,15 @@ let lookup_default_id :
         fun k_not_found  ->
           let find_in_monad =
             match env1.curmonad with
-            | FStar_Pervasives_Native.Some uu____3938 ->
+            | FStar_Pervasives_Native.Some uu____3977 ->
                 let lid = qualify env1 id  in
-                let uu____3940 =
-                  FStar_Util.smap_try_find (sigmap env1) lid.FStar_Ident.str
-                   in
-                (match uu____3940 with
+                let uu____3979 =
+                  let uu____3987 = FStar_Ident.string_of_lid lid  in
+                  FStar_Util.smap_try_find (sigmap env1) uu____3987  in
+                (match uu____3979 with
                  | FStar_Pervasives_Native.Some r ->
-                     let uu____3968 = k_global_def lid r  in
-                     FStar_Pervasives_Native.Some uu____3968
+                     let uu____4009 = k_global_def lid r  in
+                     FStar_Pervasives_Native.Some uu____4009
                  | FStar_Pervasives_Native.None  ->
                      FStar_Pervasives_Native.None)
             | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
@@ -990,7 +1008,7 @@ let lookup_default_id :
           | FStar_Pervasives_Native.Some v -> v
           | FStar_Pervasives_Native.None  ->
               let lid =
-                let uu____3992 = current_module env1  in qual uu____3992 id
+                let uu____4033 = current_module env1  in qual uu____4033 id
                  in
               find_in_module env1 lid k_global_def k_not_found
   
@@ -1018,33 +1036,38 @@ let (resolve_module_name :
   fun env1  ->
     fun lid  ->
       fun honor_ns  ->
-        let nslen = FStar_List.length lid.FStar_Ident.ns  in
-        let rec aux uu___9_4064 =
-          match uu___9_4064 with
+        let nslen =
+          let uu____4096 = FStar_Ident.ns_of_lid lid  in
+          FStar_List.length uu____4096  in
+        let rec aux uu___9_4108 =
+          match uu___9_4108 with
           | [] ->
-              let uu____4069 = module_is_defined env1 lid  in
-              if uu____4069
+              let uu____4113 = module_is_defined env1 lid  in
+              if uu____4113
               then FStar_Pervasives_Native.Some lid
               else FStar_Pervasives_Native.None
           | (Open_module_or_namespace (ns,Open_namespace ))::q when honor_ns
               ->
               let new_lid =
-                let uu____4081 =
-                  let uu____4082 = FStar_Ident.path_of_lid ns  in
-                  let uu____4086 = FStar_Ident.path_of_lid lid  in
-                  FStar_List.append uu____4082 uu____4086  in
-                let uu____4091 = FStar_Ident.range_of_lid lid  in
-                FStar_Ident.lid_of_path uu____4081 uu____4091  in
-              let uu____4092 = module_is_defined env1 new_lid  in
-              if uu____4092
+                let uu____4125 =
+                  let uu____4126 = FStar_Ident.path_of_lid ns  in
+                  let uu____4130 = FStar_Ident.path_of_lid lid  in
+                  FStar_List.append uu____4126 uu____4130  in
+                let uu____4135 = FStar_Ident.range_of_lid lid  in
+                FStar_Ident.lid_of_path uu____4125 uu____4135  in
+              let uu____4136 = module_is_defined env1 new_lid  in
+              if uu____4136
               then FStar_Pervasives_Native.Some new_lid
               else aux q
-          | (Module_abbrev (name,modul))::uu____4101 when
+          | (Module_abbrev (name,modul))::uu____4145 when
               (nslen = Prims.int_zero) &&
-                (name.FStar_Ident.idText =
-                   (lid.FStar_Ident.ident).FStar_Ident.idText)
+                (let uu____4152 = FStar_Ident.text_of_id name  in
+                 let uu____4154 =
+                   let uu____4156 = FStar_Ident.ident_of_lid lid  in
+                   FStar_Ident.text_of_id uu____4156  in
+                 uu____4152 = uu____4154)
               -> FStar_Pervasives_Native.Some modul
-          | uu____4107::q -> aux q  in
+          | uu____4158::q -> aux q  in
         aux env1.scope_mods
   
 let (is_open : env -> FStar_Ident.lident -> open_kind -> Prims.bool) =
@@ -1052,11 +1075,11 @@ let (is_open : env -> FStar_Ident.lident -> open_kind -> Prims.bool) =
     fun lid  ->
       fun open_kind1  ->
         FStar_List.existsb
-          (fun uu___10_4131  ->
-             match uu___10_4131 with
+          (fun uu___10_4182  ->
+             match uu___10_4182 with
              | Open_module_or_namespace (ns,k) ->
                  (k = open_kind1) && (FStar_Ident.lid_equals lid ns)
-             | uu____4135 -> false) env1.scope_mods
+             | uu____4186 -> false) env1.scope_mods
   
 let (namespace_is_open : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  -> fun lid  -> is_open env1 lid Open_namespace 
@@ -1083,11 +1106,11 @@ let (shorten_module_path :
             (match revns with
              | [] -> FStar_Pervasives_Native.None
              | ns_last_id::rev_ns_prefix ->
-                 let uu____4264 = aux rev_ns_prefix ns_last_id  in
-                 FStar_All.pipe_right uu____4264
+                 let uu____4315 = aux rev_ns_prefix ns_last_id  in
+                 FStar_All.pipe_right uu____4315
                    (FStar_Util.map_option
-                      (fun uu____4314  ->
-                         match uu____4314 with
+                      (fun uu____4365  ->
+                         match uu____4365 with
                          | (stripped_ids,rev_kept_ids) ->
                              (stripped_ids, (id :: rev_kept_ids)))))
            in
@@ -1095,21 +1118,21 @@ let (shorten_module_path :
           match FStar_List.rev ids1 with
           | [] -> ([], [])
           | ns_last_id::ns_rev_prefix ->
-              let uu____4384 = aux ns_rev_prefix ns_last_id  in
-              (match uu____4384 with
+              let uu____4435 = aux ns_rev_prefix ns_last_id  in
+              (match uu____4435 with
                | FStar_Pervasives_Native.None  -> ([], ids1)
                | FStar_Pervasives_Native.Some (stripped_ids,rev_kept_ids) ->
                    (stripped_ids, (FStar_List.rev rev_kept_ids)))
            in
         if is_full_path && ((FStar_List.length ids) > Prims.int_zero)
         then
-          let uu____4447 =
-            let uu____4450 = FStar_Ident.lid_of_ids ids  in
-            resolve_module_name env1 uu____4450 true  in
-          match uu____4447 with
+          let uu____4498 =
+            let uu____4501 = FStar_Ident.lid_of_ids ids  in
+            resolve_module_name env1 uu____4501 true  in
+          match uu____4498 with
           | FStar_Pervasives_Native.Some m when module_is_open env1 m ->
               (ids, [])
-          | uu____4465 -> do_shorten env1 ids
+          | uu____4516 -> do_shorten env1 ids
         else do_shorten env1 ids
   
 let resolve_in_open_namespaces'' :
@@ -1132,36 +1155,40 @@ let resolve_in_open_namespaces'' :
             fun k_record  ->
               fun f_module  ->
                 fun l_default  ->
-                  match lid.FStar_Ident.ns with
-                  | uu____4586::uu____4587 ->
-                      let uu____4590 =
-                        let uu____4593 =
-                          let uu____4594 =
-                            FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
-                          let uu____4595 = FStar_Ident.range_of_lid lid  in
-                          FStar_Ident.set_lid_range uu____4594 uu____4595  in
-                        resolve_module_name env1 uu____4593 true  in
-                      (match uu____4590 with
+                  let uu____4637 = FStar_Ident.ns_of_lid lid  in
+                  match uu____4637 with
+                  | uu____4640::uu____4641 ->
+                      let uu____4644 =
+                        let uu____4647 =
+                          let uu____4648 =
+                            let uu____4649 = FStar_Ident.ns_of_lid lid  in
+                            FStar_Ident.lid_of_ids uu____4649  in
+                          let uu____4650 = FStar_Ident.range_of_lid lid  in
+                          FStar_Ident.set_lid_range uu____4648 uu____4650  in
+                        resolve_module_name env1 uu____4647 true  in
+                      (match uu____4644 with
                        | FStar_Pervasives_Native.None  ->
                            FStar_Pervasives_Native.None
                        | FStar_Pervasives_Native.Some modul ->
-                           let uu____4600 =
+                           let uu____4655 =
+                             let uu____4658 = FStar_Ident.ident_of_lid lid
+                                in
                              find_in_module_with_includes eikind f_module
-                               Cont_fail env1 modul lid.FStar_Ident.ident
+                               Cont_fail env1 modul uu____4658
                               in
                            option_of_cont
-                             (fun uu____4604  -> FStar_Pervasives_Native.None)
-                             uu____4600)
+                             (fun uu____4660  -> FStar_Pervasives_Native.None)
+                             uu____4655)
                   | [] ->
-                      try_lookup_id'' env1 lid.FStar_Ident.ident eikind
-                        k_local_binding k_rec_binding k_record f_module
-                        l_default
+                      let uu____4661 = FStar_Ident.ident_of_lid lid  in
+                      try_lookup_id'' env1 uu____4661 eikind k_local_binding
+                        k_rec_binding k_record f_module l_default
   
 let cont_of_option :
   'a . 'a cont_t -> 'a FStar_Pervasives_Native.option -> 'a cont_t =
   fun k_none  ->
-    fun uu___11_4628  ->
-      match uu___11_4628 with
+    fun uu___11_4685  ->
+      match uu___11_4685 with
       | FStar_Pervasives_Native.Some v -> Cont_ok v
       | FStar_Pervasives_Native.None  -> k_none
   
@@ -1182,8 +1209,8 @@ let resolve_in_open_namespaces' :
         fun k_rec_binding  ->
           fun k_global_def  ->
             let k_global_def' k lid1 def =
-              let uu____4749 = k_global_def lid1 def  in
-              cont_of_option k uu____4749  in
+              let uu____4806 = k_global_def lid1 def  in
+              cont_of_option k uu____4806  in
             let f_module lid' =
               let k = Cont_ignore  in
               find_in_module env1 lid' (k_global_def' k) k  in
@@ -1191,12 +1218,12 @@ let resolve_in_open_namespaces' :
                in
             resolve_in_open_namespaces'' env1 lid Exported_id_term_type
               (fun l  ->
-                 let uu____4785 = k_local_binding l  in
-                 cont_of_option Cont_fail uu____4785)
+                 let uu____4842 = k_local_binding l  in
+                 cont_of_option Cont_fail uu____4842)
               (fun r  ->
-                 let uu____4791 = k_rec_binding r  in
-                 cont_of_option Cont_fail uu____4791)
-              (fun uu____4795  -> Cont_ignore) f_module l_default
+                 let uu____4848 = k_rec_binding r  in
+                 cont_of_option Cont_fail uu____4848)
+              (fun uu____4852  -> Cont_ignore) f_module l_default
   
 let (fv_qual_of_se :
   FStar_Syntax_Syntax.sigelt ->
@@ -1205,23 +1232,23 @@ let (fv_qual_of_se :
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_datacon
-        (uu____4806,uu____4807,uu____4808,l,uu____4810,uu____4811) ->
+        (uu____4863,uu____4864,uu____4865,l,uu____4867,uu____4868) ->
         let qopt =
           FStar_Util.find_map se.FStar_Syntax_Syntax.sigquals
-            (fun uu___12_4824  ->
-               match uu___12_4824 with
-               | FStar_Syntax_Syntax.RecordConstructor (uu____4827,fs) ->
+            (fun uu___12_4881  ->
+               match uu___12_4881 with
+               | FStar_Syntax_Syntax.RecordConstructor (uu____4884,fs) ->
                    FStar_Pervasives_Native.Some
                      (FStar_Syntax_Syntax.Record_ctor (l, fs))
-               | uu____4839 -> FStar_Pervasives_Native.None)
+               | uu____4896 -> FStar_Pervasives_Native.None)
            in
         (match qopt with
          | FStar_Pervasives_Native.None  ->
              FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor
          | x -> x)
-    | FStar_Syntax_Syntax.Sig_declare_typ (uu____4845,uu____4846,uu____4847)
+    | FStar_Syntax_Syntax.Sig_declare_typ (uu____4902,uu____4903,uu____4904)
         -> FStar_Pervasives_Native.None
-    | uu____4848 -> FStar_Pervasives_Native.None
+    | uu____4905 -> FStar_Pervasives_Native.None
   
 let (lb_fv :
   FStar_Syntax_Syntax.letbinding Prims.list ->
@@ -1229,27 +1256,32 @@ let (lb_fv :
   =
   fun lbs  ->
     fun lid  ->
-      let uu____4864 =
+      let uu____4921 =
         FStar_Util.find_map lbs
           (fun lb  ->
              let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-             let uu____4872 = FStar_Syntax_Syntax.fv_eq_lid fv lid  in
-             if uu____4872
+             let uu____4929 = FStar_Syntax_Syntax.fv_eq_lid fv lid  in
+             if uu____4929
              then FStar_Pervasives_Native.Some fv
              else FStar_Pervasives_Native.None)
          in
-      FStar_All.pipe_right uu____4864 FStar_Util.must
+      FStar_All.pipe_right uu____4921 FStar_Util.must
   
 let (ns_of_lid_equals :
   FStar_Ident.lident -> FStar_Ident.lident -> Prims.bool) =
   fun lid  ->
     fun ns  ->
-      (let uu____4895 =
-         let uu____4896 = FStar_Ident.ids_of_lid ns  in
-         FStar_List.length uu____4896  in
-       (FStar_List.length lid.FStar_Ident.ns) = uu____4895) &&
-        (let uu____4900 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
-         FStar_Ident.lid_equals uu____4900 ns)
+      (let uu____4954 =
+         let uu____4955 = FStar_Ident.ns_of_lid lid  in
+         FStar_List.length uu____4955  in
+       let uu____4958 =
+         let uu____4959 = FStar_Ident.ids_of_lid ns  in
+         FStar_List.length uu____4959  in
+       uu____4954 = uu____4958) &&
+        (let uu____4963 =
+           let uu____4964 = FStar_Ident.ns_of_lid lid  in
+           FStar_Ident.lid_of_ids uu____4964  in
+         FStar_Ident.lid_equals uu____4963 ns)
   
 let (delta_depth_of_declaration :
   FStar_Ident.lident ->
@@ -1259,45 +1291,45 @@ let (delta_depth_of_declaration :
   fun lid  ->
     fun quals  ->
       let dd =
-        let uu____4917 =
+        let uu____4981 =
           (FStar_Syntax_Util.is_primop_lid lid) ||
             (FStar_All.pipe_right quals
                (FStar_Util.for_some
-                  (fun uu___13_4924  ->
-                     match uu___13_4924 with
-                     | FStar_Syntax_Syntax.Projector uu____4926 -> true
-                     | FStar_Syntax_Syntax.Discriminator uu____4932 -> true
-                     | uu____4934 -> false)))
+                  (fun uu___13_4988  ->
+                     match uu___13_4988 with
+                     | FStar_Syntax_Syntax.Projector uu____4990 -> true
+                     | FStar_Syntax_Syntax.Discriminator uu____4996 -> true
+                     | uu____4998 -> false)))
            in
-        if uu____4917
+        if uu____4981
         then FStar_Syntax_Syntax.delta_equational
         else FStar_Syntax_Syntax.delta_constant  in
-      let uu____4939 =
+      let uu____5003 =
         (FStar_All.pipe_right quals
            (FStar_Util.for_some
-              (fun uu___14_4945  ->
-                 match uu___14_4945 with
+              (fun uu___14_5009  ->
+                 match uu___14_5009 with
                  | FStar_Syntax_Syntax.Abstract  -> true
-                 | uu____4948 -> false)))
+                 | uu____5012 -> false)))
           ||
           ((FStar_All.pipe_right quals
               (FStar_Util.for_some
-                 (fun uu___15_4954  ->
-                    match uu___15_4954 with
+                 (fun uu___15_5018  ->
+                    match uu___15_5018 with
                     | FStar_Syntax_Syntax.Assumption  -> true
-                    | uu____4957 -> false)))
+                    | uu____5021 -> false)))
              &&
-             (let uu____4960 =
+             (let uu____5024 =
                 FStar_All.pipe_right quals
                   (FStar_Util.for_some
-                     (fun uu___16_4966  ->
-                        match uu___16_4966 with
+                     (fun uu___16_5030  ->
+                        match uu___16_5030 with
                         | FStar_Syntax_Syntax.New  -> true
-                        | uu____4969 -> false))
+                        | uu____5033 -> false))
                  in
-              Prims.op_Negation uu____4960))
+              Prims.op_Negation uu____5024))
          in
-      if uu____4939 then FStar_Syntax_Syntax.Delta_abstract dd else dd
+      if uu____5003 then FStar_Syntax_Syntax.Delta_abstract dd else dd
   
 let (try_lookup_name :
   Prims.bool ->
@@ -1309,75 +1341,75 @@ let (try_lookup_name :
       fun env1  ->
         fun lid  ->
           let occurrence_range = FStar_Ident.range_of_lid lid  in
-          let k_global_def source_lid uu___19_5021 =
-            match uu___19_5021 with
-            | (uu____5029,true ) when exclude_interf ->
+          let k_global_def source_lid uu___19_5085 =
+            match uu___19_5085 with
+            | (uu____5093,true ) when exclude_interf ->
                 FStar_Pervasives_Native.None
-            | (se,uu____5033) ->
+            | (se,uu____5097) ->
                 (match se.FStar_Syntax_Syntax.sigel with
-                 | FStar_Syntax_Syntax.Sig_inductive_typ uu____5038 ->
-                     let uu____5055 =
-                       let uu____5056 =
-                         let uu____5063 =
+                 | FStar_Syntax_Syntax.Sig_inductive_typ uu____5102 ->
+                     let uu____5119 =
+                       let uu____5120 =
+                         let uu____5127 =
                            FStar_Syntax_Syntax.fvar source_lid
                              FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None
                             in
-                         (uu____5063, (se.FStar_Syntax_Syntax.sigattrs))  in
-                       Term_name uu____5056  in
-                     FStar_Pervasives_Native.Some uu____5055
-                 | FStar_Syntax_Syntax.Sig_datacon uu____5066 ->
-                     let uu____5082 =
-                       let uu____5083 =
-                         let uu____5090 =
-                           let uu____5091 = fv_qual_of_se se  in
+                         (uu____5127, (se.FStar_Syntax_Syntax.sigattrs))  in
+                       Term_name uu____5120  in
+                     FStar_Pervasives_Native.Some uu____5119
+                 | FStar_Syntax_Syntax.Sig_datacon uu____5130 ->
+                     let uu____5146 =
+                       let uu____5147 =
+                         let uu____5154 =
+                           let uu____5155 = fv_qual_of_se se  in
                            FStar_Syntax_Syntax.fvar source_lid
-                             FStar_Syntax_Syntax.delta_constant uu____5091
+                             FStar_Syntax_Syntax.delta_constant uu____5155
                             in
-                         (uu____5090, (se.FStar_Syntax_Syntax.sigattrs))  in
-                       Term_name uu____5083  in
-                     FStar_Pervasives_Native.Some uu____5082
-                 | FStar_Syntax_Syntax.Sig_let ((uu____5096,lbs),uu____5098)
+                         (uu____5154, (se.FStar_Syntax_Syntax.sigattrs))  in
+                       Term_name uu____5147  in
+                     FStar_Pervasives_Native.Some uu____5146
+                 | FStar_Syntax_Syntax.Sig_let ((uu____5160,lbs),uu____5162)
                      ->
                      let fv = lb_fv lbs source_lid  in
-                     let uu____5110 =
-                       let uu____5111 =
-                         let uu____5118 =
+                     let uu____5174 =
+                       let uu____5175 =
+                         let uu____5182 =
                            FStar_Syntax_Syntax.fvar source_lid
                              fv.FStar_Syntax_Syntax.fv_delta
                              fv.FStar_Syntax_Syntax.fv_qual
                             in
-                         (uu____5118, (se.FStar_Syntax_Syntax.sigattrs))  in
-                       Term_name uu____5111  in
-                     FStar_Pervasives_Native.Some uu____5110
+                         (uu____5182, (se.FStar_Syntax_Syntax.sigattrs))  in
+                       Term_name uu____5175  in
+                     FStar_Pervasives_Native.Some uu____5174
                  | FStar_Syntax_Syntax.Sig_declare_typ
-                     (lid1,uu____5122,uu____5123) ->
+                     (lid1,uu____5186,uu____5187) ->
                      let quals = se.FStar_Syntax_Syntax.sigquals  in
-                     let uu____5127 =
+                     let uu____5191 =
                        any_val ||
                          (FStar_All.pipe_right quals
                             (FStar_Util.for_some
-                               (fun uu___17_5133  ->
-                                  match uu___17_5133 with
+                               (fun uu___17_5197  ->
+                                  match uu___17_5197 with
                                   | FStar_Syntax_Syntax.Assumption  -> true
-                                  | uu____5136 -> false)))
+                                  | uu____5200 -> false)))
                         in
-                     if uu____5127
+                     if uu____5191
                      then
                        let lid2 =
-                         let uu____5142 = FStar_Ident.range_of_lid source_lid
+                         let uu____5206 = FStar_Ident.range_of_lid source_lid
                             in
-                         FStar_Ident.set_lid_range lid1 uu____5142  in
+                         FStar_Ident.set_lid_range lid1 uu____5206  in
                        let dd = delta_depth_of_declaration lid2 quals  in
-                       let uu____5144 =
+                       let uu____5208 =
                          FStar_Util.find_map quals
-                           (fun uu___18_5149  ->
-                              match uu___18_5149 with
+                           (fun uu___18_5213  ->
+                              match uu___18_5213 with
                               | FStar_Syntax_Syntax.Reflectable refl_monad ->
                                   FStar_Pervasives_Native.Some refl_monad
-                              | uu____5153 -> FStar_Pervasives_Native.None)
+                              | uu____5217 -> FStar_Pervasives_Native.None)
                           in
-                       (match uu____5144 with
+                       (match uu____5208 with
                         | FStar_Pervasives_Native.Some refl_monad ->
                             let refl_const =
                               FStar_Syntax_Syntax.mk
@@ -1389,77 +1421,80 @@ let (try_lookup_name :
                               (Term_name
                                  (refl_const,
                                    (se.FStar_Syntax_Syntax.sigattrs)))
-                        | uu____5162 ->
-                            let uu____5165 =
-                              let uu____5166 =
-                                let uu____5173 =
-                                  let uu____5174 = fv_qual_of_se se  in
-                                  FStar_Syntax_Syntax.fvar lid2 dd uu____5174
+                        | uu____5226 ->
+                            let uu____5229 =
+                              let uu____5230 =
+                                let uu____5237 =
+                                  let uu____5238 = fv_qual_of_se se  in
+                                  FStar_Syntax_Syntax.fvar lid2 dd uu____5238
                                    in
-                                (uu____5173,
+                                (uu____5237,
                                   (se.FStar_Syntax_Syntax.sigattrs))
                                  in
-                              Term_name uu____5166  in
-                            FStar_Pervasives_Native.Some uu____5165)
+                              Term_name uu____5230  in
+                            FStar_Pervasives_Native.Some uu____5229)
                      else FStar_Pervasives_Native.None
                  | FStar_Syntax_Syntax.Sig_new_effect ne ->
-                     let uu____5182 =
-                       let uu____5183 =
-                         let uu____5188 =
-                           let uu____5189 =
+                     let uu____5246 =
+                       let uu____5247 =
+                         let uu____5252 =
+                           let uu____5253 =
                              FStar_Ident.range_of_lid source_lid  in
                            FStar_Ident.set_lid_range
-                             ne.FStar_Syntax_Syntax.mname uu____5189
+                             ne.FStar_Syntax_Syntax.mname uu____5253
                             in
-                         (se, uu____5188)  in
-                       Eff_name uu____5183  in
-                     FStar_Pervasives_Native.Some uu____5182
-                 | FStar_Syntax_Syntax.Sig_effect_abbrev uu____5190 ->
+                         (se, uu____5252)  in
+                       Eff_name uu____5247  in
+                     FStar_Pervasives_Native.Some uu____5246
+                 | FStar_Syntax_Syntax.Sig_effect_abbrev uu____5254 ->
                      FStar_Pervasives_Native.Some (Eff_name (se, source_lid))
                  | FStar_Syntax_Syntax.Sig_splice (lids,t) ->
-                     let uu____5209 =
-                       let uu____5210 =
-                         let uu____5217 =
+                     let uu____5273 =
+                       let uu____5274 =
+                         let uu____5281 =
                            FStar_Syntax_Syntax.fvar source_lid
                              (FStar_Syntax_Syntax.Delta_constant_at_level
                                 Prims.int_one) FStar_Pervasives_Native.None
                             in
-                         (uu____5217, [])  in
-                       Term_name uu____5210  in
-                     FStar_Pervasives_Native.Some uu____5209
-                 | uu____5221 -> FStar_Pervasives_Native.None)
+                         (uu____5281, [])  in
+                       Term_name uu____5274  in
+                     FStar_Pervasives_Native.Some uu____5273
+                 | uu____5285 -> FStar_Pervasives_Native.None)
              in
           let k_local_binding r =
             let t =
-              let uu____5243 = FStar_Ident.range_of_lid lid  in
-              found_local_binding uu____5243 r  in
+              let uu____5307 = FStar_Ident.range_of_lid lid  in
+              found_local_binding uu____5307 r  in
             FStar_Pervasives_Native.Some (Term_name (t, []))  in
-          let k_rec_binding uu____5301 =
-            match uu____5301 with
+          let k_rec_binding uu____5365 =
+            match uu____5365 with
             | (id,l,dd,used_marker1) ->
                 (FStar_ST.op_Colon_Equals used_marker1 true;
-                 (let uu____5459 =
-                    let uu____5460 =
-                      let uu____5467 =
-                        let uu____5468 =
-                          let uu____5469 = FStar_Ident.range_of_lid lid  in
-                          FStar_Ident.set_lid_range l uu____5469  in
-                        FStar_Syntax_Syntax.fvar uu____5468 dd
+                 (let uu____5523 =
+                    let uu____5524 =
+                      let uu____5531 =
+                        let uu____5532 =
+                          let uu____5533 = FStar_Ident.range_of_lid lid  in
+                          FStar_Ident.set_lid_range l uu____5533  in
+                        FStar_Syntax_Syntax.fvar uu____5532 dd
                           FStar_Pervasives_Native.None
                          in
-                      (uu____5467, [])  in
-                    Term_name uu____5460  in
-                  FStar_Pervasives_Native.Some uu____5459))
+                      (uu____5531, [])  in
+                    Term_name uu____5524  in
+                  FStar_Pervasives_Native.Some uu____5523))
              in
           let found_unmangled =
-            match lid.FStar_Ident.ns with
+            let uu____5539 = FStar_Ident.ns_of_lid lid  in
+            match uu____5539 with
             | [] ->
-                let uu____5477 = unmangleOpName lid.FStar_Ident.ident  in
-                (match uu____5477 with
+                let uu____5542 =
+                  let uu____5545 = FStar_Ident.ident_of_lid lid  in
+                  unmangleOpName uu____5545  in
+                (match uu____5542 with
                  | FStar_Pervasives_Native.Some t ->
                      FStar_Pervasives_Native.Some (Term_name (t, []))
-                 | uu____5485 -> FStar_Pervasives_Native.None)
-            | uu____5488 -> FStar_Pervasives_Native.None  in
+                 | uu____5551 -> FStar_Pervasives_Native.None)
+            | uu____5554 -> FStar_Pervasives_Native.None  in
           match found_unmangled with
           | FStar_Pervasives_Native.None  ->
               resolve_in_open_namespaces' env1 lid k_local_binding
@@ -1476,11 +1511,11 @@ let (try_lookup_effect_name' :
   fun exclude_interf  ->
     fun env1  ->
       fun lid  ->
-        let uu____5526 = try_lookup_name true exclude_interf env1 lid  in
-        match uu____5526 with
+        let uu____5590 = try_lookup_name true exclude_interf env1 lid  in
+        match uu____5590 with
         | FStar_Pervasives_Native.Some (Eff_name (o,l)) ->
             FStar_Pervasives_Native.Some (o, l)
-        | uu____5542 -> FStar_Pervasives_Native.None
+        | uu____5606 -> FStar_Pervasives_Native.None
   
 let (try_lookup_effect_name :
   env ->
@@ -1488,12 +1523,12 @@ let (try_lookup_effect_name :
   =
   fun env1  ->
     fun l  ->
-      let uu____5562 =
+      let uu____5626 =
         try_lookup_effect_name' (Prims.op_Negation env1.iface) env1 l  in
-      match uu____5562 with
+      match uu____5626 with
       | FStar_Pervasives_Native.Some (o,l1) ->
           FStar_Pervasives_Native.Some l1
-      | uu____5577 -> FStar_Pervasives_Native.None
+      | uu____5641 -> FStar_Pervasives_Native.None
   
 let (try_lookup_effect_name_and_attributes :
   env ->
@@ -1503,18 +1538,18 @@ let (try_lookup_effect_name_and_attributes :
   =
   fun env1  ->
     fun l  ->
-      let uu____5603 =
+      let uu____5667 =
         try_lookup_effect_name' (Prims.op_Negation env1.iface) env1 l  in
-      match uu____5603 with
+      match uu____5667 with
       | FStar_Pervasives_Native.Some
           ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect
                ne;
-             FStar_Syntax_Syntax.sigrng = uu____5619;
-             FStar_Syntax_Syntax.sigquals = uu____5620;
-             FStar_Syntax_Syntax.sigmeta = uu____5621;
-             FStar_Syntax_Syntax.sigattrs = uu____5622;
-             FStar_Syntax_Syntax.sigopts = uu____5623;_},l1)
+             FStar_Syntax_Syntax.sigrng = uu____5683;
+             FStar_Syntax_Syntax.sigquals = uu____5684;
+             FStar_Syntax_Syntax.sigmeta = uu____5685;
+             FStar_Syntax_Syntax.sigattrs = uu____5686;
+             FStar_Syntax_Syntax.sigopts = uu____5687;_},l1)
           ->
           FStar_Pervasives_Native.Some
             (l1, (ne.FStar_Syntax_Syntax.cattributes))
@@ -1522,14 +1557,14 @@ let (try_lookup_effect_name_and_attributes :
           ({
              FStar_Syntax_Syntax.sigel =
                FStar_Syntax_Syntax.Sig_effect_abbrev
-               (uu____5643,uu____5644,uu____5645,uu____5646,cattributes);
-             FStar_Syntax_Syntax.sigrng = uu____5648;
-             FStar_Syntax_Syntax.sigquals = uu____5649;
-             FStar_Syntax_Syntax.sigmeta = uu____5650;
-             FStar_Syntax_Syntax.sigattrs = uu____5651;
-             FStar_Syntax_Syntax.sigopts = uu____5652;_},l1)
+               (uu____5707,uu____5708,uu____5709,uu____5710,cattributes);
+             FStar_Syntax_Syntax.sigrng = uu____5712;
+             FStar_Syntax_Syntax.sigquals = uu____5713;
+             FStar_Syntax_Syntax.sigmeta = uu____5714;
+             FStar_Syntax_Syntax.sigattrs = uu____5715;
+             FStar_Syntax_Syntax.sigopts = uu____5716;_},l1)
           -> FStar_Pervasives_Native.Some (l1, cattributes)
-      | uu____5676 -> FStar_Pervasives_Native.None
+      | uu____5740 -> FStar_Pervasives_Native.None
   
 let (try_lookup_effect_defn :
   env ->
@@ -1538,28 +1573,28 @@ let (try_lookup_effect_defn :
   =
   fun env1  ->
     fun l  ->
-      let uu____5702 =
+      let uu____5766 =
         try_lookup_effect_name' (Prims.op_Negation env1.iface) env1 l  in
-      match uu____5702 with
+      match uu____5766 with
       | FStar_Pervasives_Native.Some
           ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect
                ne;
-             FStar_Syntax_Syntax.sigrng = uu____5712;
-             FStar_Syntax_Syntax.sigquals = uu____5713;
-             FStar_Syntax_Syntax.sigmeta = uu____5714;
-             FStar_Syntax_Syntax.sigattrs = uu____5715;
-             FStar_Syntax_Syntax.sigopts = uu____5716;_},uu____5717)
+             FStar_Syntax_Syntax.sigrng = uu____5776;
+             FStar_Syntax_Syntax.sigquals = uu____5777;
+             FStar_Syntax_Syntax.sigmeta = uu____5778;
+             FStar_Syntax_Syntax.sigattrs = uu____5779;
+             FStar_Syntax_Syntax.sigopts = uu____5780;_},uu____5781)
           -> FStar_Pervasives_Native.Some ne
-      | uu____5728 -> FStar_Pervasives_Native.None
+      | uu____5792 -> FStar_Pervasives_Native.None
   
 let (is_effect_name : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
     fun lid  ->
-      let uu____5747 = try_lookup_effect_name env1 lid  in
-      match uu____5747 with
+      let uu____5811 = try_lookup_effect_name env1 lid  in
+      match uu____5811 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some uu____5752 -> true
+      | FStar_Pervasives_Native.Some uu____5816 -> true
   
 let (try_lookup_root_effect_name :
   env ->
@@ -1567,45 +1602,45 @@ let (try_lookup_root_effect_name :
   =
   fun env1  ->
     fun l  ->
-      let uu____5767 =
+      let uu____5831 =
         try_lookup_effect_name' (Prims.op_Negation env1.iface) env1 l  in
-      match uu____5767 with
+      match uu____5831 with
       | FStar_Pervasives_Native.Some
           ({
              FStar_Syntax_Syntax.sigel =
                FStar_Syntax_Syntax.Sig_effect_abbrev
-               (l',uu____5777,uu____5778,uu____5779,uu____5780);
-             FStar_Syntax_Syntax.sigrng = uu____5781;
-             FStar_Syntax_Syntax.sigquals = uu____5782;
-             FStar_Syntax_Syntax.sigmeta = uu____5783;
-             FStar_Syntax_Syntax.sigattrs = uu____5784;
-             FStar_Syntax_Syntax.sigopts = uu____5785;_},uu____5786)
+               (l',uu____5841,uu____5842,uu____5843,uu____5844);
+             FStar_Syntax_Syntax.sigrng = uu____5845;
+             FStar_Syntax_Syntax.sigquals = uu____5846;
+             FStar_Syntax_Syntax.sigmeta = uu____5847;
+             FStar_Syntax_Syntax.sigattrs = uu____5848;
+             FStar_Syntax_Syntax.sigopts = uu____5849;_},uu____5850)
           ->
           let rec aux new_name =
-            let uu____5809 =
-              FStar_Util.smap_try_find (sigmap env1) new_name.FStar_Ident.str
-               in
-            match uu____5809 with
+            let uu____5873 =
+              let uu____5881 = FStar_Ident.string_of_lid new_name  in
+              FStar_Util.smap_try_find (sigmap env1) uu____5881  in
+            match uu____5873 with
             | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-            | FStar_Pervasives_Native.Some (s,uu____5830) ->
+            | FStar_Pervasives_Native.Some (s,uu____5896) ->
                 (match s.FStar_Syntax_Syntax.sigel with
                  | FStar_Syntax_Syntax.Sig_new_effect ne ->
-                     let uu____5841 =
-                       let uu____5842 = FStar_Ident.range_of_lid l  in
+                     let uu____5907 =
+                       let uu____5908 = FStar_Ident.range_of_lid l  in
                        FStar_Ident.set_lid_range ne.FStar_Syntax_Syntax.mname
-                         uu____5842
+                         uu____5908
                         in
-                     FStar_Pervasives_Native.Some uu____5841
+                     FStar_Pervasives_Native.Some uu____5907
                  | FStar_Syntax_Syntax.Sig_effect_abbrev
-                     (uu____5843,uu____5844,uu____5845,cmp,uu____5847) ->
+                     (uu____5909,uu____5910,uu____5911,cmp,uu____5913) ->
                      let l'' = FStar_Syntax_Util.comp_effect_name cmp  in
                      aux l''
-                 | uu____5853 -> FStar_Pervasives_Native.None)
+                 | uu____5919 -> FStar_Pervasives_Native.None)
              in
           aux l'
-      | FStar_Pervasives_Native.Some (uu____5854,l') ->
+      | FStar_Pervasives_Native.Some (uu____5920,l') ->
           FStar_Pervasives_Native.Some l'
-      | uu____5860 -> FStar_Pervasives_Native.None
+      | uu____5926 -> FStar_Pervasives_Native.None
   
 let (lookup_letbinding_quals_and_attrs :
   env ->
@@ -1615,26 +1650,26 @@ let (lookup_letbinding_quals_and_attrs :
   =
   fun env1  ->
     fun lid  ->
-      let k_global_def lid1 uu___20_5911 =
-        match uu___20_5911 with
+      let k_global_def lid1 uu___20_5977 =
+        match uu___20_5977 with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-               (uu____5927,uu____5928,uu____5929);
-             FStar_Syntax_Syntax.sigrng = uu____5930;
+               (uu____5993,uu____5994,uu____5995);
+             FStar_Syntax_Syntax.sigrng = uu____5996;
              FStar_Syntax_Syntax.sigquals = quals;
-             FStar_Syntax_Syntax.sigmeta = uu____5932;
+             FStar_Syntax_Syntax.sigmeta = uu____5998;
              FStar_Syntax_Syntax.sigattrs = attrs;
-             FStar_Syntax_Syntax.sigopts = uu____5934;_},uu____5935)
+             FStar_Syntax_Syntax.sigopts = uu____6000;_},uu____6001)
             -> FStar_Pervasives_Native.Some (quals, attrs)
-        | uu____5956 -> FStar_Pervasives_Native.None  in
-      let uu____5970 =
+        | uu____6022 -> FStar_Pervasives_Native.None  in
+      let uu____6036 =
         resolve_in_open_namespaces' env1 lid
-          (fun uu____5990  -> FStar_Pervasives_Native.None)
-          (fun uu____6000  -> FStar_Pervasives_Native.None) k_global_def
+          (fun uu____6056  -> FStar_Pervasives_Native.None)
+          (fun uu____6066  -> FStar_Pervasives_Native.None) k_global_def
          in
-      match uu____5970 with
+      match uu____6036 with
       | FStar_Pervasives_Native.Some qa -> qa
-      | uu____6034 -> ([], [])
+      | uu____6100 -> ([], [])
   
 let (try_lookup_module :
   env ->
@@ -1643,16 +1678,16 @@ let (try_lookup_module :
   =
   fun env1  ->
     fun path  ->
-      let uu____6062 =
+      let uu____6128 =
         FStar_List.tryFind
-          (fun uu____6077  ->
-             match uu____6077 with
+          (fun uu____6143  ->
+             match uu____6143 with
              | (mlid,modul) ->
-                 let uu____6085 = FStar_Ident.path_of_lid mlid  in
-                 uu____6085 = path) env1.modules
+                 let uu____6151 = FStar_Ident.path_of_lid mlid  in
+                 uu____6151 = path) env1.modules
          in
-      match uu____6062 with
-      | FStar_Pervasives_Native.Some (uu____6088,modul) ->
+      match uu____6128 with
+      | FStar_Pervasives_Native.Some (uu____6154,modul) ->
           FStar_Pervasives_Native.Some modul
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
   
@@ -1663,27 +1698,27 @@ let (try_lookup_let :
   =
   fun env1  ->
     fun lid  ->
-      let k_global_def lid1 uu___21_6128 =
-        match uu___21_6128 with
+      let k_global_def lid1 uu___21_6194 =
+        match uu___21_6194 with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-               ((uu____6136,lbs),uu____6138);
-             FStar_Syntax_Syntax.sigrng = uu____6139;
-             FStar_Syntax_Syntax.sigquals = uu____6140;
-             FStar_Syntax_Syntax.sigmeta = uu____6141;
-             FStar_Syntax_Syntax.sigattrs = uu____6142;
-             FStar_Syntax_Syntax.sigopts = uu____6143;_},uu____6144)
+               ((uu____6202,lbs),uu____6204);
+             FStar_Syntax_Syntax.sigrng = uu____6205;
+             FStar_Syntax_Syntax.sigquals = uu____6206;
+             FStar_Syntax_Syntax.sigmeta = uu____6207;
+             FStar_Syntax_Syntax.sigattrs = uu____6208;
+             FStar_Syntax_Syntax.sigopts = uu____6209;_},uu____6210)
             ->
             let fv = lb_fv lbs lid1  in
-            let uu____6164 =
+            let uu____6230 =
               FStar_Syntax_Syntax.fvar lid1 fv.FStar_Syntax_Syntax.fv_delta
                 fv.FStar_Syntax_Syntax.fv_qual
                in
-            FStar_Pervasives_Native.Some uu____6164
-        | uu____6165 -> FStar_Pervasives_Native.None  in
+            FStar_Pervasives_Native.Some uu____6230
+        | uu____6231 -> FStar_Pervasives_Native.None  in
       resolve_in_open_namespaces' env1 lid
-        (fun uu____6172  -> FStar_Pervasives_Native.None)
-        (fun uu____6174  -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu____6238  -> FStar_Pervasives_Native.None)
+        (fun uu____6240  -> FStar_Pervasives_Native.None) k_global_def
   
 let (try_lookup_definition :
   env ->
@@ -1692,16 +1727,16 @@ let (try_lookup_definition :
   =
   fun env1  ->
     fun lid  ->
-      let k_global_def lid1 uu___22_6207 =
-        match uu___22_6207 with
+      let k_global_def lid1 uu___22_6273 =
+        match uu___22_6273 with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-               (lbs,uu____6218);
-             FStar_Syntax_Syntax.sigrng = uu____6219;
-             FStar_Syntax_Syntax.sigquals = uu____6220;
-             FStar_Syntax_Syntax.sigmeta = uu____6221;
-             FStar_Syntax_Syntax.sigattrs = uu____6222;
-             FStar_Syntax_Syntax.sigopts = uu____6223;_},uu____6224)
+               (lbs,uu____6284);
+             FStar_Syntax_Syntax.sigrng = uu____6285;
+             FStar_Syntax_Syntax.sigquals = uu____6286;
+             FStar_Syntax_Syntax.sigmeta = uu____6287;
+             FStar_Syntax_Syntax.sigattrs = uu____6288;
+             FStar_Syntax_Syntax.sigopts = uu____6289;_},uu____6290)
             ->
             FStar_Util.find_map (FStar_Pervasives_Native.snd lbs)
               (fun lb  ->
@@ -1710,11 +1745,11 @@ let (try_lookup_definition :
                      FStar_Syntax_Syntax.fv_eq_lid fv lid1 ->
                      FStar_Pervasives_Native.Some
                        (lb.FStar_Syntax_Syntax.lbdef)
-                 | uu____6252 -> FStar_Pervasives_Native.None)
-        | uu____6259 -> FStar_Pervasives_Native.None  in
+                 | uu____6318 -> FStar_Pervasives_Native.None)
+        | uu____6325 -> FStar_Pervasives_Native.None  in
       resolve_in_open_namespaces' env1 lid
-        (fun uu____6270  -> FStar_Pervasives_Native.None)
-        (fun uu____6274  -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu____6336  -> FStar_Pervasives_Native.None)
+        (fun uu____6340  -> FStar_Pervasives_Native.None) k_global_def
   
 let (empty_include_smap :
   FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap) = new_sigmap () 
@@ -1732,12 +1767,12 @@ let (try_lookup_lid' :
     fun exclude_interface  ->
       fun env1  ->
         fun lid  ->
-          let uu____6334 = try_lookup_name any_val exclude_interface env1 lid
+          let uu____6400 = try_lookup_name any_val exclude_interface env1 lid
              in
-          match uu____6334 with
+          match uu____6400 with
           | FStar_Pervasives_Native.Some (Term_name (e,attrs)) ->
               FStar_Pervasives_Native.Some (e, attrs)
-          | uu____6359 -> FStar_Pervasives_Native.None
+          | uu____6425 -> FStar_Pervasives_Native.None
   
 let (drop_attributes :
   (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.attribute Prims.list)
@@ -1746,7 +1781,7 @@ let (drop_attributes :
   =
   fun x  ->
     match x with
-    | FStar_Pervasives_Native.Some (t,uu____6397) ->
+    | FStar_Pervasives_Native.Some (t,uu____6463) ->
         FStar_Pervasives_Native.Some t
     | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
   
@@ -1763,8 +1798,8 @@ let (try_lookup_lid :
   =
   fun env1  ->
     fun l  ->
-      let uu____6455 = try_lookup_lid_with_attributes env1 l  in
-      FStar_All.pipe_right uu____6455 drop_attributes
+      let uu____6521 = try_lookup_lid_with_attributes env1 l  in
+      FStar_All.pipe_right uu____6521 drop_attributes
   
 let (resolve_to_fully_qualified_name :
   env ->
@@ -1772,41 +1807,47 @@ let (resolve_to_fully_qualified_name :
   =
   fun env1  ->
     fun l  ->
-      let uu____6487 = try_lookup_lid env1 l  in
-      match uu____6487 with
+      let uu____6553 = try_lookup_lid env1 l  in
+      match uu____6553 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some e ->
-          let uu____6493 =
-            let uu____6494 = FStar_Syntax_Subst.compress e  in
-            uu____6494.FStar_Syntax_Syntax.n  in
-          (match uu____6493 with
+          let uu____6559 =
+            let uu____6560 = FStar_Syntax_Subst.compress e  in
+            uu____6560.FStar_Syntax_Syntax.n  in
+          (match uu____6559 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                FStar_Pervasives_Native.Some
                  ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-           | uu____6500 -> FStar_Pervasives_Native.None)
+           | uu____6566 -> FStar_Pervasives_Native.None)
   
 let (shorten_lid' : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env1  ->
     fun lid  ->
-      let uu____6512 = shorten_module_path env1 lid.FStar_Ident.ns true  in
-      match uu____6512 with
-      | (uu____6522,short) ->
-          FStar_Ident.lid_of_ns_and_id short lid.FStar_Ident.ident
+      let uu____6578 =
+        let uu____6587 = FStar_Ident.ns_of_lid lid  in
+        shorten_module_path env1 uu____6587 true  in
+      match uu____6578 with
+      | (uu____6591,short) ->
+          let uu____6601 = FStar_Ident.ident_of_lid lid  in
+          FStar_Ident.lid_of_ns_and_id short uu____6601
   
 let (shorten_lid : env -> FStar_Ident.lid -> FStar_Ident.lid) =
   fun env1  ->
     fun lid  ->
       match env1.curmodule with
       | FStar_Pervasives_Native.None  -> shorten_lid' env1 lid
-      | uu____6543 ->
+      | uu____6613 ->
           let lid_without_ns =
-            FStar_Ident.lid_of_ns_and_id [] lid.FStar_Ident.ident  in
-          let uu____6547 =
+            let uu____6617 = FStar_Ident.ident_of_lid lid  in
+            FStar_Ident.lid_of_ns_and_id [] uu____6617  in
+          let uu____6618 =
             resolve_to_fully_qualified_name env1 lid_without_ns  in
-          (match uu____6547 with
+          (match uu____6618 with
            | FStar_Pervasives_Native.Some lid' when
-               lid'.FStar_Ident.str = lid.FStar_Ident.str -> lid_without_ns
-           | uu____6552 -> shorten_lid' env1 lid)
+               let uu____6622 = FStar_Ident.string_of_lid lid'  in
+               let uu____6624 = FStar_Ident.string_of_lid lid  in
+               uu____6622 = uu____6624 -> lid_without_ns
+           | uu____6627 -> shorten_lid' env1 lid)
   
 let (try_lookup_lid_with_attributes_no_resolve :
   env ->
@@ -1817,24 +1858,24 @@ let (try_lookup_lid_with_attributes_no_resolve :
   fun env1  ->
     fun l  ->
       let env' =
-        let uu___869_6583 = env1  in
+        let uu___867_6658 = env1  in
         {
-          curmodule = (uu___869_6583.curmodule);
-          curmonad = (uu___869_6583.curmonad);
-          modules = (uu___869_6583.modules);
+          curmodule = (uu___867_6658.curmodule);
+          curmonad = (uu___867_6658.curmonad);
+          modules = (uu___867_6658.modules);
           scope_mods = [];
           exported_ids = empty_exported_id_smap;
-          trans_exported_ids = (uu___869_6583.trans_exported_ids);
+          trans_exported_ids = (uu___867_6658.trans_exported_ids);
           includes = empty_include_smap;
-          sigaccum = (uu___869_6583.sigaccum);
-          sigmap = (uu___869_6583.sigmap);
-          iface = (uu___869_6583.iface);
-          admitted_iface = (uu___869_6583.admitted_iface);
-          expect_typ = (uu___869_6583.expect_typ);
-          remaining_iface_decls = (uu___869_6583.remaining_iface_decls);
-          syntax_only = (uu___869_6583.syntax_only);
-          ds_hooks = (uu___869_6583.ds_hooks);
-          dep_graph = (uu___869_6583.dep_graph)
+          sigaccum = (uu___867_6658.sigaccum);
+          sigmap = (uu___867_6658.sigmap);
+          iface = (uu___867_6658.iface);
+          admitted_iface = (uu___867_6658.admitted_iface);
+          expect_typ = (uu___867_6658.expect_typ);
+          remaining_iface_decls = (uu___867_6658.remaining_iface_decls);
+          syntax_only = (uu___867_6658.syntax_only);
+          ds_hooks = (uu___867_6658.ds_hooks);
+          dep_graph = (uu___867_6658.dep_graph)
         }  in
       try_lookup_lid_with_attributes env' l
   
@@ -1845,8 +1886,8 @@ let (try_lookup_lid_no_resolve :
   =
   fun env1  ->
     fun l  ->
-      let uu____6599 = try_lookup_lid_with_attributes_no_resolve env1 l  in
-      FStar_All.pipe_right uu____6599 drop_attributes
+      let uu____6674 = try_lookup_lid_with_attributes_no_resolve env1 l  in
+      FStar_All.pipe_right uu____6674 drop_attributes
   
 let (try_lookup_datacon :
   env ->
@@ -1859,49 +1900,49 @@ let (try_lookup_datacon :
         match se with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-               (uu____6656,uu____6657,uu____6658);
-             FStar_Syntax_Syntax.sigrng = uu____6659;
+               (uu____6731,uu____6732,uu____6733);
+             FStar_Syntax_Syntax.sigrng = uu____6734;
              FStar_Syntax_Syntax.sigquals = quals;
-             FStar_Syntax_Syntax.sigmeta = uu____6661;
-             FStar_Syntax_Syntax.sigattrs = uu____6662;
-             FStar_Syntax_Syntax.sigopts = uu____6663;_},uu____6664)
+             FStar_Syntax_Syntax.sigmeta = uu____6736;
+             FStar_Syntax_Syntax.sigattrs = uu____6737;
+             FStar_Syntax_Syntax.sigopts = uu____6738;_},uu____6739)
             ->
-            let uu____6673 =
+            let uu____6748 =
               FStar_All.pipe_right quals
                 (FStar_Util.for_some
-                   (fun uu___23_6679  ->
-                      match uu___23_6679 with
+                   (fun uu___23_6754  ->
+                      match uu___23_6754 with
                       | FStar_Syntax_Syntax.Assumption  -> true
-                      | uu____6682 -> false))
+                      | uu____6757 -> false))
                in
-            if uu____6673
+            if uu____6748
             then
-              let uu____6687 =
+              let uu____6762 =
                 FStar_Syntax_Syntax.lid_as_fv lid1
                   FStar_Syntax_Syntax.delta_constant
                   FStar_Pervasives_Native.None
                  in
-              FStar_Pervasives_Native.Some uu____6687
+              FStar_Pervasives_Native.Some uu____6762
             else FStar_Pervasives_Native.None
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-               uu____6690;
-             FStar_Syntax_Syntax.sigrng = uu____6691;
-             FStar_Syntax_Syntax.sigquals = uu____6692;
-             FStar_Syntax_Syntax.sigmeta = uu____6693;
-             FStar_Syntax_Syntax.sigattrs = uu____6694;
-             FStar_Syntax_Syntax.sigopts = uu____6695;_},uu____6696)
+               uu____6765;
+             FStar_Syntax_Syntax.sigrng = uu____6766;
+             FStar_Syntax_Syntax.sigquals = uu____6767;
+             FStar_Syntax_Syntax.sigmeta = uu____6768;
+             FStar_Syntax_Syntax.sigattrs = uu____6769;
+             FStar_Syntax_Syntax.sigopts = uu____6770;_},uu____6771)
             ->
             let qual1 = fv_qual_of_se (FStar_Pervasives_Native.fst se)  in
-            let uu____6724 =
+            let uu____6799 =
               FStar_Syntax_Syntax.lid_as_fv lid1
                 FStar_Syntax_Syntax.delta_constant qual1
                in
-            FStar_Pervasives_Native.Some uu____6724
-        | uu____6725 -> FStar_Pervasives_Native.None  in
+            FStar_Pervasives_Native.Some uu____6799
+        | uu____6800 -> FStar_Pervasives_Native.None  in
       resolve_in_open_namespaces' env1 lid
-        (fun uu____6732  -> FStar_Pervasives_Native.None)
-        (fun uu____6734  -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu____6807  -> FStar_Pervasives_Native.None)
+        (fun uu____6809  -> FStar_Pervasives_Native.None) k_global_def
   
 let (find_all_datacons :
   env ->
@@ -1910,22 +1951,22 @@ let (find_all_datacons :
   =
   fun env1  ->
     fun lid  ->
-      let k_global_def lid1 uu___24_6769 =
-        match uu___24_6769 with
+      let k_global_def lid1 uu___24_6844 =
+        match uu___24_6844 with
         | ({
              FStar_Syntax_Syntax.sigel =
                FStar_Syntax_Syntax.Sig_inductive_typ
-               (uu____6779,uu____6780,uu____6781,uu____6782,datas,uu____6784);
-             FStar_Syntax_Syntax.sigrng = uu____6785;
-             FStar_Syntax_Syntax.sigquals = uu____6786;
-             FStar_Syntax_Syntax.sigmeta = uu____6787;
-             FStar_Syntax_Syntax.sigattrs = uu____6788;
-             FStar_Syntax_Syntax.sigopts = uu____6789;_},uu____6790)
+               (uu____6854,uu____6855,uu____6856,uu____6857,datas,uu____6859);
+             FStar_Syntax_Syntax.sigrng = uu____6860;
+             FStar_Syntax_Syntax.sigquals = uu____6861;
+             FStar_Syntax_Syntax.sigmeta = uu____6862;
+             FStar_Syntax_Syntax.sigattrs = uu____6863;
+             FStar_Syntax_Syntax.sigopts = uu____6864;_},uu____6865)
             -> FStar_Pervasives_Native.Some datas
-        | uu____6809 -> FStar_Pervasives_Native.None  in
+        | uu____6884 -> FStar_Pervasives_Native.None  in
       resolve_in_open_namespaces' env1 lid
-        (fun uu____6820  -> FStar_Pervasives_Native.None)
-        (fun uu____6824  -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu____6895  -> FStar_Pervasives_Native.None)
+        (fun uu____6899  -> FStar_Pervasives_Native.None) k_global_def
   
 let (record_cache_aux_with_filter :
   ((((unit -> unit) * (unit -> unit)) * (((unit -> (Prims.int * unit)) *
@@ -1934,45 +1975,45 @@ let (record_cache_aux_with_filter :
     (unit -> unit)))
   =
   let record_cache = FStar_Util.mk_ref [[]]  in
-  let push uu____6903 =
-    let uu____6904 =
-      let uu____6909 =
-        let uu____6912 = FStar_ST.op_Bang record_cache  in
-        FStar_List.hd uu____6912  in
-      let uu____6946 = FStar_ST.op_Bang record_cache  in uu____6909 ::
-        uu____6946
+  let push uu____6978 =
+    let uu____6979 =
+      let uu____6984 =
+        let uu____6987 = FStar_ST.op_Bang record_cache  in
+        FStar_List.hd uu____6987  in
+      let uu____7021 = FStar_ST.op_Bang record_cache  in uu____6984 ::
+        uu____7021
        in
-    FStar_ST.op_Colon_Equals record_cache uu____6904  in
-  let pop uu____7012 =
-    let uu____7013 =
-      let uu____7018 = FStar_ST.op_Bang record_cache  in
-      FStar_List.tl uu____7018  in
-    FStar_ST.op_Colon_Equals record_cache uu____7013  in
-  let snapshot uu____7089 = FStar_Common.snapshot push record_cache ()  in
+    FStar_ST.op_Colon_Equals record_cache uu____6979  in
+  let pop uu____7087 =
+    let uu____7088 =
+      let uu____7093 = FStar_ST.op_Bang record_cache  in
+      FStar_List.tl uu____7093  in
+    FStar_ST.op_Colon_Equals record_cache uu____7088  in
+  let snapshot uu____7164 = FStar_Common.snapshot push record_cache ()  in
   let rollback depth = FStar_Common.rollback pop record_cache depth  in
-  let peek uu____7113 =
-    let uu____7114 = FStar_ST.op_Bang record_cache  in
-    FStar_List.hd uu____7114  in
+  let peek uu____7188 =
+    let uu____7189 = FStar_ST.op_Bang record_cache  in
+    FStar_List.hd uu____7189  in
   let insert r =
-    let uu____7154 =
-      let uu____7159 = let uu____7162 = peek ()  in r :: uu____7162  in
-      let uu____7165 =
-        let uu____7170 = FStar_ST.op_Bang record_cache  in
-        FStar_List.tl uu____7170  in
-      uu____7159 :: uu____7165  in
-    FStar_ST.op_Colon_Equals record_cache uu____7154  in
-  let filter uu____7238 =
+    let uu____7229 =
+      let uu____7234 = let uu____7237 = peek ()  in r :: uu____7237  in
+      let uu____7240 =
+        let uu____7245 = FStar_ST.op_Bang record_cache  in
+        FStar_List.tl uu____7245  in
+      uu____7234 :: uu____7240  in
+    FStar_ST.op_Colon_Equals record_cache uu____7229  in
+  let filter uu____7313 =
     let rc = peek ()  in
     let filtered =
       FStar_List.filter
         (fun r  -> Prims.op_Negation r.is_private_or_abstract) rc
        in
-    let uu____7247 =
-      let uu____7252 =
-        let uu____7257 = FStar_ST.op_Bang record_cache  in
-        FStar_List.tl uu____7257  in
-      filtered :: uu____7252  in
-    FStar_ST.op_Colon_Equals record_cache uu____7247  in
+    let uu____7322 =
+      let uu____7327 =
+        let uu____7332 = FStar_ST.op_Bang record_cache  in
+        FStar_List.tl uu____7332  in
+      filtered :: uu____7327  in
+    FStar_ST.op_Colon_Equals record_cache uu____7322  in
   let aux = ((push, pop), ((snapshot, rollback), (peek, insert)))  in
   (aux, filter) 
 let (record_cache_aux :
@@ -2015,75 +2056,75 @@ let (extract_record :
     fun new_globs  ->
       fun se  ->
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_bundle (sigs,uu____8183) ->
+        | FStar_Syntax_Syntax.Sig_bundle (sigs,uu____8258) ->
             let is_record =
               FStar_Util.for_some
-                (fun uu___25_8202  ->
-                   match uu___25_8202 with
-                   | FStar_Syntax_Syntax.RecordType uu____8204 -> true
-                   | FStar_Syntax_Syntax.RecordConstructor uu____8214 -> true
-                   | uu____8224 -> false)
+                (fun uu___25_8277  ->
+                   match uu___25_8277 with
+                   | FStar_Syntax_Syntax.RecordType uu____8279 -> true
+                   | FStar_Syntax_Syntax.RecordConstructor uu____8289 -> true
+                   | uu____8299 -> false)
                in
             let find_dc dc =
               FStar_All.pipe_right sigs
                 (FStar_Util.find_opt
-                   (fun uu___26_8250  ->
-                      match uu___26_8250 with
+                   (fun uu___26_8325  ->
+                      match uu___26_8325 with
                       | {
                           FStar_Syntax_Syntax.sigel =
                             FStar_Syntax_Syntax.Sig_datacon
-                            (lid,uu____8253,uu____8254,uu____8255,uu____8256,uu____8257);
-                          FStar_Syntax_Syntax.sigrng = uu____8258;
-                          FStar_Syntax_Syntax.sigquals = uu____8259;
-                          FStar_Syntax_Syntax.sigmeta = uu____8260;
-                          FStar_Syntax_Syntax.sigattrs = uu____8261;
-                          FStar_Syntax_Syntax.sigopts = uu____8262;_} ->
+                            (lid,uu____8328,uu____8329,uu____8330,uu____8331,uu____8332);
+                          FStar_Syntax_Syntax.sigrng = uu____8333;
+                          FStar_Syntax_Syntax.sigquals = uu____8334;
+                          FStar_Syntax_Syntax.sigmeta = uu____8335;
+                          FStar_Syntax_Syntax.sigattrs = uu____8336;
+                          FStar_Syntax_Syntax.sigopts = uu____8337;_} ->
                           FStar_Ident.lid_equals dc lid
-                      | uu____8275 -> false))
+                      | uu____8350 -> false))
                in
             FStar_All.pipe_right sigs
               (FStar_List.iter
-                 (fun uu___27_8316  ->
-                    match uu___27_8316 with
+                 (fun uu___27_8391  ->
+                    match uu___27_8391 with
                     | {
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_inductive_typ
-                          (typename,univs,parms,uu____8320,uu____8321,dc::[]);
-                        FStar_Syntax_Syntax.sigrng = uu____8323;
+                          (typename,univs,parms,uu____8395,uu____8396,dc::[]);
+                        FStar_Syntax_Syntax.sigrng = uu____8398;
                         FStar_Syntax_Syntax.sigquals = typename_quals;
-                        FStar_Syntax_Syntax.sigmeta = uu____8325;
-                        FStar_Syntax_Syntax.sigattrs = uu____8326;
-                        FStar_Syntax_Syntax.sigopts = uu____8327;_} ->
-                        let uu____8340 =
-                          let uu____8341 = find_dc dc  in
-                          FStar_All.pipe_left FStar_Util.must uu____8341  in
-                        (match uu____8340 with
+                        FStar_Syntax_Syntax.sigmeta = uu____8400;
+                        FStar_Syntax_Syntax.sigattrs = uu____8401;
+                        FStar_Syntax_Syntax.sigopts = uu____8402;_} ->
+                        let uu____8415 =
+                          let uu____8416 = find_dc dc  in
+                          FStar_All.pipe_left FStar_Util.must uu____8416  in
+                        (match uu____8415 with
                          | {
                              FStar_Syntax_Syntax.sigel =
                                FStar_Syntax_Syntax.Sig_datacon
-                               (constrname,uu____8347,t,uu____8349,n,uu____8351);
-                             FStar_Syntax_Syntax.sigrng = uu____8352;
-                             FStar_Syntax_Syntax.sigquals = uu____8353;
-                             FStar_Syntax_Syntax.sigmeta = uu____8354;
-                             FStar_Syntax_Syntax.sigattrs = uu____8355;
-                             FStar_Syntax_Syntax.sigopts = uu____8356;_} ->
-                             let uu____8369 =
+                               (constrname,uu____8422,t,uu____8424,n,uu____8426);
+                             FStar_Syntax_Syntax.sigrng = uu____8427;
+                             FStar_Syntax_Syntax.sigquals = uu____8428;
+                             FStar_Syntax_Syntax.sigmeta = uu____8429;
+                             FStar_Syntax_Syntax.sigattrs = uu____8430;
+                             FStar_Syntax_Syntax.sigopts = uu____8431;_} ->
+                             let uu____8444 =
                                FStar_Syntax_Util.arrow_formals t  in
-                             (match uu____8369 with
-                              | (all_formals,uu____8377) ->
-                                  let uu____8382 =
+                             (match uu____8444 with
+                              | (all_formals,uu____8452) ->
+                                  let uu____8457 =
                                     FStar_Util.first_N n all_formals  in
-                                  (match uu____8382 with
+                                  (match uu____8457 with
                                    | (_params,formals) ->
                                        let is_rec = is_record typename_quals
                                           in
                                        let formals' =
                                          FStar_All.pipe_right formals
                                            (FStar_List.collect
-                                              (fun uu____8476  ->
-                                                 match uu____8476 with
+                                              (fun uu____8551  ->
+                                                 match uu____8551 with
                                                  | (x,q) ->
-                                                     let uu____8489 =
+                                                     let uu____8564 =
                                                        (FStar_Syntax_Syntax.is_null_bv
                                                           x)
                                                          ||
@@ -2091,25 +2132,28 @@ let (extract_record :
                                                             (FStar_Syntax_Syntax.is_implicit
                                                                q))
                                                         in
-                                                     if uu____8489
+                                                     if uu____8564
                                                      then []
                                                      else [(x, q)]))
                                           in
                                        let fields' =
                                          FStar_All.pipe_right formals'
                                            (FStar_List.map
-                                              (fun uu____8544  ->
-                                                 match uu____8544 with
+                                              (fun uu____8619  ->
+                                                 match uu____8619 with
                                                  | (x,q) ->
                                                      ((x.FStar_Syntax_Syntax.ppname),
                                                        (x.FStar_Syntax_Syntax.sort))))
                                           in
                                        let fields = fields'  in
                                        let record =
+                                         let uu____8642 =
+                                           FStar_Ident.ident_of_lid
+                                             constrname
+                                            in
                                          {
                                            typename;
-                                           constrname =
-                                             (constrname.FStar_Ident.ident);
+                                           constrname = uu____8642;
                                            parms;
                                            fields;
                                            is_private_or_abstract =
@@ -2122,31 +2166,36 @@ let (extract_record :
                                                    typename_quals));
                                            is_record = is_rec
                                          }  in
-                                       ((let uu____8568 =
-                                           let uu____8571 =
+                                       ((let uu____8644 =
+                                           let uu____8647 =
                                              FStar_ST.op_Bang new_globs  in
                                            (Record_or_dc record) ::
-                                             uu____8571
+                                             uu____8647
                                             in
                                          FStar_ST.op_Colon_Equals new_globs
-                                           uu____8568);
+                                           uu____8644);
                                         (match () with
                                          | () ->
-                                             ((let add_field uu____8630 =
-                                                 match uu____8630 with
-                                                 | (id,uu____8636) ->
+                                             ((let add_field uu____8706 =
+                                                 match uu____8706 with
+                                                 | (id,uu____8712) ->
                                                      let modul =
-                                                       let uu____8639 =
+                                                       let uu____8715 =
+                                                         let uu____8716 =
+                                                           FStar_Ident.ns_of_lid
+                                                             constrname
+                                                            in
                                                          FStar_Ident.lid_of_ids
-                                                           constrname.FStar_Ident.ns
+                                                           uu____8716
                                                           in
-                                                       uu____8639.FStar_Ident.str
+                                                       FStar_Ident.string_of_lid
+                                                         uu____8715
                                                         in
-                                                     let uu____8640 =
+                                                     let uu____8717 =
                                                        get_exported_id_set e
                                                          modul
                                                         in
-                                                     (match uu____8640 with
+                                                     (match uu____8717 with
                                                       | FStar_Pervasives_Native.Some
                                                           my_ex ->
                                                           let my_exported_ids
@@ -2154,48 +2203,57 @@ let (extract_record :
                                                             my_ex
                                                               Exported_id_field
                                                              in
-                                                          ((let uu____8663 =
-                                                              let uu____8664
+                                                          ((let uu____8740 =
+                                                              let uu____8741
+                                                                =
+                                                                FStar_Ident.text_of_id
+                                                                  id
+                                                                 in
+                                                              let uu____8743
                                                                 =
                                                                 FStar_ST.op_Bang
                                                                   my_exported_ids
                                                                  in
                                                               FStar_Util.set_add
-                                                                id.FStar_Ident.idText
-                                                                uu____8664
+                                                                uu____8741
+                                                                uu____8743
                                                                in
                                                             FStar_ST.op_Colon_Equals
                                                               my_exported_ids
-                                                              uu____8663);
+                                                              uu____8740);
                                                            (match () with
                                                             | () ->
                                                                 let projname
                                                                   =
-                                                                  let uu____8709
+                                                                  let uu____8788
                                                                     =
-                                                                    let uu____8710
+                                                                    let uu____8789
                                                                     =
                                                                     FStar_Syntax_Util.mk_field_projector_name_from_ident
                                                                     constrname
                                                                     id  in
-                                                                    uu____8710.FStar_Ident.ident
+                                                                    FStar_All.pipe_right
+                                                                    uu____8789
+                                                                    FStar_Ident.ident_of_lid
                                                                      in
-                                                                  uu____8709.FStar_Ident.idText
+                                                                  FStar_All.pipe_right
+                                                                    uu____8788
+                                                                    FStar_Ident.text_of_id
                                                                    in
-                                                                let uu____8712
+                                                                let uu____8792
                                                                   =
-                                                                  let uu____8713
+                                                                  let uu____8793
                                                                     =
                                                                     FStar_ST.op_Bang
                                                                     my_exported_ids
                                                                      in
                                                                   FStar_Util.set_add
                                                                     projname
-                                                                    uu____8713
+                                                                    uu____8793
                                                                    in
                                                                 FStar_ST.op_Colon_Equals
                                                                   my_exported_ids
-                                                                  uu____8712))
+                                                                  uu____8792))
                                                       | FStar_Pervasives_Native.None
                                                            -> ())
                                                   in
@@ -2204,72 +2262,70 @@ let (extract_record :
                                               (match () with
                                                | () ->
                                                    insert_record_cache record))))))
-                         | uu____8765 -> ())
-                    | uu____8766 -> ()))
-        | uu____8767 -> ()
+                         | uu____8845 -> ())
+                    | uu____8846 -> ()))
+        | uu____8847 -> ()
   
 let (try_lookup_record_or_dc_by_field_name :
   env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option) =
   fun env1  ->
     fun fieldname  ->
       let find_in_cache fieldname1 =
-        let uu____8789 =
-          ((fieldname1.FStar_Ident.ns), (fieldname1.FStar_Ident.ident))  in
-        match uu____8789 with
+        let uu____8869 =
+          let uu____8876 = FStar_Ident.ns_of_lid fieldname1  in
+          let uu____8879 = FStar_Ident.ident_of_lid fieldname1  in
+          (uu____8876, uu____8879)  in
+        match uu____8869 with
         | (ns,id) ->
-            let uu____8806 = peek_record_cache ()  in
-            FStar_Util.find_map uu____8806
+            let uu____8890 = peek_record_cache ()  in
+            FStar_Util.find_map uu____8890
               (fun record  ->
-                 let uu____8812 =
+                 let uu____8896 =
                    find_in_record ns id record (fun r  -> Cont_ok r)  in
                  option_of_cont
-                   (fun uu____8818  -> FStar_Pervasives_Native.None)
-                   uu____8812)
+                   (fun uu____8902  -> FStar_Pervasives_Native.None)
+                   uu____8896)
          in
       resolve_in_open_namespaces'' env1 fieldname Exported_id_field
-        (fun uu____8820  -> Cont_ignore) (fun uu____8822  -> Cont_ignore)
+        (fun uu____8904  -> Cont_ignore) (fun uu____8906  -> Cont_ignore)
         (fun r  -> Cont_ok r)
         (fun fn  ->
-           let uu____8828 = find_in_cache fn  in
-           cont_of_option Cont_ignore uu____8828)
-        (fun k  -> fun uu____8834  -> k)
+           let uu____8912 = find_in_cache fn  in
+           cont_of_option Cont_ignore uu____8912)
+        (fun k  -> fun uu____8918  -> k)
   
 let (try_lookup_record_by_field_name :
   env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option) =
   fun env1  ->
     fun fieldname  ->
-      let uu____8850 = try_lookup_record_or_dc_by_field_name env1 fieldname
+      let uu____8934 = try_lookup_record_or_dc_by_field_name env1 fieldname
          in
-      match uu____8850 with
+      match uu____8934 with
       | FStar_Pervasives_Native.Some r when r.is_record ->
           FStar_Pervasives_Native.Some r
-      | uu____8856 -> FStar_Pervasives_Native.None
+      | uu____8940 -> FStar_Pervasives_Native.None
   
 let (belongs_to_record :
   env -> FStar_Ident.lident -> record_or_dc -> Prims.bool) =
   fun env1  ->
     fun lid  ->
       fun record  ->
-        let uu____8876 = try_lookup_record_by_field_name env1 lid  in
-        match uu____8876 with
+        let uu____8960 = try_lookup_record_by_field_name env1 lid  in
+        match uu____8960 with
         | FStar_Pervasives_Native.Some record' when
-            let uu____8881 =
-              let uu____8883 =
-                FStar_Ident.path_of_ns (record.typename).FStar_Ident.ns  in
-              FStar_Ident.text_of_path uu____8883  in
-            let uu____8884 =
-              let uu____8886 =
-                FStar_Ident.path_of_ns (record'.typename).FStar_Ident.ns  in
-              FStar_Ident.text_of_path uu____8886  in
-            uu____8881 = uu____8884 ->
-            let uu____8888 =
-              find_in_record (record.typename).FStar_Ident.ns
-                lid.FStar_Ident.ident record (fun uu____8892  -> Cont_ok ())
+            let uu____8965 = FStar_Ident.nsstr record.typename  in
+            let uu____8967 = FStar_Ident.nsstr record'.typename  in
+            uu____8965 = uu____8967 ->
+            let uu____8970 =
+              let uu____8973 = FStar_Ident.ns_of_lid record.typename  in
+              let uu____8976 = FStar_Ident.ident_of_lid lid  in
+              find_in_record uu____8973 uu____8976 record
+                (fun uu____8978  -> Cont_ok ())
                in
-            (match uu____8888 with
-             | Cont_ok uu____8894 -> true
-             | uu____8896 -> false)
-        | uu____8900 -> false
+            (match uu____8970 with
+             | Cont_ok uu____8980 -> true
+             | uu____8982 -> false)
+        | uu____8986 -> false
   
 let (try_lookup_dc_by_field_name :
   env ->
@@ -2278,35 +2334,35 @@ let (try_lookup_dc_by_field_name :
   =
   fun env1  ->
     fun fieldname  ->
-      let uu____8922 = try_lookup_record_or_dc_by_field_name env1 fieldname
+      let uu____9008 = try_lookup_record_or_dc_by_field_name env1 fieldname
          in
-      match uu____8922 with
+      match uu____9008 with
       | FStar_Pervasives_Native.Some r ->
-          let uu____8933 =
-            let uu____8939 =
-              let uu____8940 =
-                FStar_Ident.lid_of_ids
-                  (FStar_List.append (r.typename).FStar_Ident.ns
-                     [r.constrname])
-                 in
-              let uu____8941 = FStar_Ident.range_of_lid fieldname  in
-              FStar_Ident.set_lid_range uu____8940 uu____8941  in
-            (uu____8939, (r.is_record))  in
-          FStar_Pervasives_Native.Some uu____8933
-      | uu____8948 -> FStar_Pervasives_Native.None
+          let uu____9019 =
+            let uu____9025 =
+              let uu____9026 =
+                let uu____9027 =
+                  let uu____9028 = FStar_Ident.ns_of_lid r.typename  in
+                  FStar_List.append uu____9028 [r.constrname]  in
+                FStar_Ident.lid_of_ids uu____9027  in
+              let uu____9031 = FStar_Ident.range_of_lid fieldname  in
+              FStar_Ident.set_lid_range uu____9026 uu____9031  in
+            (uu____9025, (r.is_record))  in
+          FStar_Pervasives_Native.Some uu____9019
+      | uu____9038 -> FStar_Pervasives_Native.None
   
 let (string_set_ref_new : unit -> Prims.string FStar_Util.set FStar_ST.ref) =
-  fun uu____8966  ->
-    let uu____8967 = FStar_Util.new_set FStar_Util.compare  in
-    FStar_Util.mk_ref uu____8967
+  fun uu____9056  ->
+    let uu____9057 = FStar_Util.new_set FStar_Util.compare  in
+    FStar_Util.mk_ref uu____9057
   
 let (exported_id_set_new :
   unit -> exported_id_kind -> Prims.string FStar_Util.set FStar_ST.ref) =
-  fun uu____8988  ->
+  fun uu____9078  ->
     let term_type_set = string_set_ref_new ()  in
     let field_set = string_set_ref_new ()  in
-    fun uu___28_9001  ->
-      match uu___28_9001 with
+    fun uu___28_9091  ->
+      match uu___28_9091 with
       | Exported_id_term_type  -> term_type_set
       | Exported_id_field  -> field_set
   
@@ -2316,59 +2372,59 @@ let (unique :
     fun exclude_interface  ->
       fun env1  ->
         fun lid  ->
-          let filter_scope_mods uu___29_9039 =
-            match uu___29_9039 with
-            | Rec_binding uu____9041 -> true
-            | uu____9043 -> false  in
+          let filter_scope_mods uu___29_9129 =
+            match uu___29_9129 with
+            | Rec_binding uu____9131 -> true
+            | uu____9133 -> false  in
           let this_env =
-            let uu___1102_9046 = env1  in
-            let uu____9047 =
+            let uu___1100_9136 = env1  in
+            let uu____9137 =
               FStar_List.filter filter_scope_mods env1.scope_mods  in
             {
-              curmodule = (uu___1102_9046.curmodule);
-              curmonad = (uu___1102_9046.curmonad);
-              modules = (uu___1102_9046.modules);
-              scope_mods = uu____9047;
+              curmodule = (uu___1100_9136.curmodule);
+              curmonad = (uu___1100_9136.curmonad);
+              modules = (uu___1100_9136.modules);
+              scope_mods = uu____9137;
               exported_ids = empty_exported_id_smap;
-              trans_exported_ids = (uu___1102_9046.trans_exported_ids);
+              trans_exported_ids = (uu___1100_9136.trans_exported_ids);
               includes = empty_include_smap;
-              sigaccum = (uu___1102_9046.sigaccum);
-              sigmap = (uu___1102_9046.sigmap);
-              iface = (uu___1102_9046.iface);
-              admitted_iface = (uu___1102_9046.admitted_iface);
-              expect_typ = (uu___1102_9046.expect_typ);
-              remaining_iface_decls = (uu___1102_9046.remaining_iface_decls);
-              syntax_only = (uu___1102_9046.syntax_only);
-              ds_hooks = (uu___1102_9046.ds_hooks);
-              dep_graph = (uu___1102_9046.dep_graph)
+              sigaccum = (uu___1100_9136.sigaccum);
+              sigmap = (uu___1100_9136.sigmap);
+              iface = (uu___1100_9136.iface);
+              admitted_iface = (uu___1100_9136.admitted_iface);
+              expect_typ = (uu___1100_9136.expect_typ);
+              remaining_iface_decls = (uu___1100_9136.remaining_iface_decls);
+              syntax_only = (uu___1100_9136.syntax_only);
+              ds_hooks = (uu___1100_9136.ds_hooks);
+              dep_graph = (uu___1100_9136.dep_graph)
             }  in
-          let uu____9050 =
+          let uu____9140 =
             try_lookup_lid' any_val exclude_interface this_env lid  in
-          match uu____9050 with
+          match uu____9140 with
           | FStar_Pervasives_Native.None  -> true
-          | FStar_Pervasives_Native.Some uu____9067 -> false
+          | FStar_Pervasives_Native.Some uu____9157 -> false
   
 let (push_scope_mod : env -> scope_mod -> env) =
   fun env1  ->
     fun scope_mod1  ->
-      let uu___1110_9092 = env1  in
+      let uu___1108_9182 = env1  in
       {
-        curmodule = (uu___1110_9092.curmodule);
-        curmonad = (uu___1110_9092.curmonad);
-        modules = (uu___1110_9092.modules);
+        curmodule = (uu___1108_9182.curmodule);
+        curmonad = (uu___1108_9182.curmonad);
+        modules = (uu___1108_9182.modules);
         scope_mods = (scope_mod1 :: (env1.scope_mods));
-        exported_ids = (uu___1110_9092.exported_ids);
-        trans_exported_ids = (uu___1110_9092.trans_exported_ids);
-        includes = (uu___1110_9092.includes);
-        sigaccum = (uu___1110_9092.sigaccum);
-        sigmap = (uu___1110_9092.sigmap);
-        iface = (uu___1110_9092.iface);
-        admitted_iface = (uu___1110_9092.admitted_iface);
-        expect_typ = (uu___1110_9092.expect_typ);
-        remaining_iface_decls = (uu___1110_9092.remaining_iface_decls);
-        syntax_only = (uu___1110_9092.syntax_only);
-        ds_hooks = (uu___1110_9092.ds_hooks);
-        dep_graph = (uu___1110_9092.dep_graph)
+        exported_ids = (uu___1108_9182.exported_ids);
+        trans_exported_ids = (uu___1108_9182.trans_exported_ids);
+        includes = (uu___1108_9182.includes);
+        sigaccum = (uu___1108_9182.sigaccum);
+        sigmap = (uu___1108_9182.sigmap);
+        iface = (uu___1108_9182.iface);
+        admitted_iface = (uu___1108_9182.admitted_iface);
+        expect_typ = (uu___1108_9182.expect_typ);
+        remaining_iface_decls = (uu___1108_9182.remaining_iface_decls);
+        syntax_only = (uu___1108_9182.syntax_only);
+        ds_hooks = (uu___1108_9182.ds_hooks);
+        dep_graph = (uu___1108_9182.dep_graph)
       }
   
 let (push_bv' :
@@ -2376,8 +2432,11 @@ let (push_bv' :
   fun env1  ->
     fun x  ->
       let bv =
-        FStar_Syntax_Syntax.gen_bv x.FStar_Ident.idText
-          (FStar_Pervasives_Native.Some (x.FStar_Ident.idRange))
+        let uu____9201 = FStar_Ident.text_of_id x  in
+        let uu____9203 =
+          let uu____9206 = FStar_Ident.range_of_id x  in
+          FStar_Pervasives_Native.Some uu____9206  in
+        FStar_Syntax_Syntax.gen_bv uu____9201 uu____9203
           FStar_Syntax_Syntax.tun
          in
       let used_marker1 = FStar_Util.mk_ref false  in
@@ -2387,8 +2446,8 @@ let (push_bv' :
 let (push_bv : env -> FStar_Ident.ident -> (env * FStar_Syntax_Syntax.bv)) =
   fun env1  ->
     fun x  ->
-      let uu____9132 = push_bv' env1 x  in
-      match uu____9132 with | (env2,bv,uu____9145) -> (env2, bv)
+      let uu____9228 = push_bv' env1 x  in
+      match uu____9228 with | (env2,bv,uu____9241) -> (env2, bv)
   
 let (push_top_level_rec_binding :
   env ->
@@ -2399,172 +2458,186 @@ let (push_top_level_rec_binding :
     fun x  ->
       fun dd  ->
         let l = qualify env0 x  in
-        let uu____9177 =
+        let uu____9273 =
           (unique false true env0 l) || (FStar_Options.interactive ())  in
-        if uu____9177
+        if uu____9273
         then
           let used_marker1 = FStar_Util.mk_ref false  in
           ((push_scope_mod env0 (Rec_binding (x, l, dd, used_marker1))),
             used_marker1)
         else
-          (let uu____9200 = FStar_Ident.range_of_lid l  in
-           FStar_Errors.raise_error
-             (FStar_Errors.Fatal_DuplicateTopLevelNames,
-               (Prims.op_Hat "Duplicate top-level names " l.FStar_Ident.str))
-             uu____9200)
+          (let uu____9296 =
+             let uu____9302 =
+               let uu____9304 = FStar_Ident.string_of_lid l  in
+               Prims.op_Hat "Duplicate top-level names " uu____9304  in
+             (FStar_Errors.Fatal_DuplicateTopLevelNames, uu____9302)  in
+           let uu____9308 = FStar_Ident.range_of_lid l  in
+           FStar_Errors.raise_error uu____9296 uu____9308)
   
 let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
   fun fail_on_dup  ->
     fun env1  ->
       fun s  ->
         let err l =
-          let sopt = FStar_Util.smap_try_find (sigmap env1) l.FStar_Ident.str
-             in
+          let sopt =
+            let uu____9348 = FStar_Ident.string_of_lid l  in
+            FStar_Util.smap_try_find (sigmap env1) uu____9348  in
           let r =
             match sopt with
-            | FStar_Pervasives_Native.Some (se,uu____9251) ->
-                let uu____9259 =
+            | FStar_Pervasives_Native.Some (se,uu____9359) ->
+                let uu____9367 =
                   FStar_Util.find_opt (FStar_Ident.lid_equals l)
                     (FStar_Syntax_Util.lids_of_sigelt se)
                    in
-                (match uu____9259 with
+                (match uu____9367 with
                  | FStar_Pervasives_Native.Some l1 ->
-                     let uu____9264 = FStar_Ident.range_of_lid l1  in
+                     let uu____9372 = FStar_Ident.range_of_lid l1  in
                      FStar_All.pipe_left FStar_Range.string_of_range
-                       uu____9264
+                       uu____9372
                  | FStar_Pervasives_Native.None  -> "<unknown>")
             | FStar_Pervasives_Native.None  -> "<unknown>"  in
-          let uu____9273 =
-            let uu____9279 =
-              let uu____9281 = FStar_Ident.text_of_lid l  in
+          let uu____9381 =
+            let uu____9387 =
+              let uu____9389 = FStar_Ident.string_of_lid l  in
               FStar_Util.format2
                 "Duplicate top-level names [%s]; previously declared at %s"
-                uu____9281 r
+                uu____9389 r
                in
-            (FStar_Errors.Fatal_DuplicateTopLevelNames, uu____9279)  in
-          let uu____9285 = FStar_Ident.range_of_lid l  in
-          FStar_Errors.raise_error uu____9273 uu____9285  in
+            (FStar_Errors.Fatal_DuplicateTopLevelNames, uu____9387)  in
+          let uu____9393 = FStar_Ident.range_of_lid l  in
+          FStar_Errors.raise_error uu____9381 uu____9393  in
         let globals = FStar_Util.mk_ref env1.scope_mods  in
         let env2 =
-          let uu____9294 =
+          let uu____9402 =
             match s.FStar_Syntax_Syntax.sigel with
-            | FStar_Syntax_Syntax.Sig_let uu____9307 -> (false, true)
-            | FStar_Syntax_Syntax.Sig_bundle uu____9318 -> (false, true)
-            | uu____9331 -> (false, false)  in
-          match uu____9294 with
+            | FStar_Syntax_Syntax.Sig_let uu____9415 -> (false, true)
+            | FStar_Syntax_Syntax.Sig_bundle uu____9426 -> (false, true)
+            | uu____9439 -> (false, false)  in
+          match uu____9402 with
           | (any_val,exclude_interface) ->
               let lids = FStar_Syntax_Util.lids_of_sigelt s  in
-              let uu____9345 =
+              let uu____9453 =
                 FStar_Util.find_map lids
                   (fun l  ->
-                     let uu____9351 =
-                       let uu____9353 =
+                     let uu____9459 =
+                       let uu____9461 =
                          unique any_val exclude_interface env1 l  in
-                       Prims.op_Negation uu____9353  in
-                     if uu____9351
+                       Prims.op_Negation uu____9461  in
+                     if uu____9459
                      then FStar_Pervasives_Native.Some l
                      else FStar_Pervasives_Native.None)
                  in
-              (match uu____9345 with
+              (match uu____9453 with
                | FStar_Pervasives_Native.Some l when fail_on_dup -> err l
-               | uu____9361 ->
+               | uu____9469 ->
                    (extract_record env1 globals s;
-                    (let uu___1159_9365 = env1  in
+                    (let uu___1157_9473 = env1  in
                      {
-                       curmodule = (uu___1159_9365.curmodule);
-                       curmonad = (uu___1159_9365.curmonad);
-                       modules = (uu___1159_9365.modules);
-                       scope_mods = (uu___1159_9365.scope_mods);
-                       exported_ids = (uu___1159_9365.exported_ids);
+                       curmodule = (uu___1157_9473.curmodule);
+                       curmonad = (uu___1157_9473.curmonad);
+                       modules = (uu___1157_9473.modules);
+                       scope_mods = (uu___1157_9473.scope_mods);
+                       exported_ids = (uu___1157_9473.exported_ids);
                        trans_exported_ids =
-                         (uu___1159_9365.trans_exported_ids);
-                       includes = (uu___1159_9365.includes);
+                         (uu___1157_9473.trans_exported_ids);
+                       includes = (uu___1157_9473.includes);
                        sigaccum = (s :: (env1.sigaccum));
-                       sigmap = (uu___1159_9365.sigmap);
-                       iface = (uu___1159_9365.iface);
-                       admitted_iface = (uu___1159_9365.admitted_iface);
-                       expect_typ = (uu___1159_9365.expect_typ);
+                       sigmap = (uu___1157_9473.sigmap);
+                       iface = (uu___1157_9473.iface);
+                       admitted_iface = (uu___1157_9473.admitted_iface);
+                       expect_typ = (uu___1157_9473.expect_typ);
                        remaining_iface_decls =
-                         (uu___1159_9365.remaining_iface_decls);
-                       syntax_only = (uu___1159_9365.syntax_only);
-                       ds_hooks = (uu___1159_9365.ds_hooks);
-                       dep_graph = (uu___1159_9365.dep_graph)
+                         (uu___1157_9473.remaining_iface_decls);
+                       syntax_only = (uu___1157_9473.syntax_only);
+                       ds_hooks = (uu___1157_9473.ds_hooks);
+                       dep_graph = (uu___1157_9473.dep_graph)
                      })))
            in
         let env3 =
-          let uu___1162_9367 = env2  in
-          let uu____9368 = FStar_ST.op_Bang globals  in
+          let uu___1160_9475 = env2  in
+          let uu____9476 = FStar_ST.op_Bang globals  in
           {
-            curmodule = (uu___1162_9367.curmodule);
-            curmonad = (uu___1162_9367.curmonad);
-            modules = (uu___1162_9367.modules);
-            scope_mods = uu____9368;
-            exported_ids = (uu___1162_9367.exported_ids);
-            trans_exported_ids = (uu___1162_9367.trans_exported_ids);
-            includes = (uu___1162_9367.includes);
-            sigaccum = (uu___1162_9367.sigaccum);
-            sigmap = (uu___1162_9367.sigmap);
-            iface = (uu___1162_9367.iface);
-            admitted_iface = (uu___1162_9367.admitted_iface);
-            expect_typ = (uu___1162_9367.expect_typ);
-            remaining_iface_decls = (uu___1162_9367.remaining_iface_decls);
-            syntax_only = (uu___1162_9367.syntax_only);
-            ds_hooks = (uu___1162_9367.ds_hooks);
-            dep_graph = (uu___1162_9367.dep_graph)
+            curmodule = (uu___1160_9475.curmodule);
+            curmonad = (uu___1160_9475.curmonad);
+            modules = (uu___1160_9475.modules);
+            scope_mods = uu____9476;
+            exported_ids = (uu___1160_9475.exported_ids);
+            trans_exported_ids = (uu___1160_9475.trans_exported_ids);
+            includes = (uu___1160_9475.includes);
+            sigaccum = (uu___1160_9475.sigaccum);
+            sigmap = (uu___1160_9475.sigmap);
+            iface = (uu___1160_9475.iface);
+            admitted_iface = (uu___1160_9475.admitted_iface);
+            expect_typ = (uu___1160_9475.expect_typ);
+            remaining_iface_decls = (uu___1160_9475.remaining_iface_decls);
+            syntax_only = (uu___1160_9475.syntax_only);
+            ds_hooks = (uu___1160_9475.ds_hooks);
+            dep_graph = (uu___1160_9475.dep_graph)
           }  in
-        let uu____9394 =
+        let uu____9502 =
           match s.FStar_Syntax_Syntax.sigel with
-          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____9420) ->
-              let uu____9429 =
+          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____9528) ->
+              let uu____9537 =
                 FStar_List.map
                   (fun se  -> ((FStar_Syntax_Util.lids_of_sigelt se), se))
                   ses
                  in
-              (env3, uu____9429)
-          | uu____9456 -> (env3, [((FStar_Syntax_Util.lids_of_sigelt s), s)])
+              (env3, uu____9537)
+          | uu____9564 -> (env3, [((FStar_Syntax_Util.lids_of_sigelt s), s)])
            in
-        match uu____9394 with
+        match uu____9502 with
         | (env4,lss) ->
             (FStar_All.pipe_right lss
                (FStar_List.iter
-                  (fun uu____9515  ->
-                     match uu____9515 with
+                  (fun uu____9623  ->
+                     match uu____9623 with
                      | (lids,se) ->
                          FStar_All.pipe_right lids
                            (FStar_List.iter
                               (fun lid  ->
-                                 (let uu____9537 =
-                                    let uu____9540 = FStar_ST.op_Bang globals
+                                 (let uu____9646 =
+                                    let uu____9649 =
+                                      let uu____9650 =
+                                        FStar_Ident.ident_of_lid lid  in
+                                      Top_level_def uu____9650  in
+                                    let uu____9651 = FStar_ST.op_Bang globals
                                        in
-                                    (Top_level_def (lid.FStar_Ident.ident))
-                                      :: uu____9540
-                                     in
-                                  FStar_ST.op_Colon_Equals globals uu____9537);
+                                    uu____9649 :: uu____9651  in
+                                  FStar_ST.op_Colon_Equals globals uu____9646);
                                  (match () with
                                   | () ->
                                       let modul =
-                                        let uu____9591 =
-                                          FStar_Ident.lid_of_ids
-                                            lid.FStar_Ident.ns
+                                        let uu____9702 =
+                                          let uu____9703 =
+                                            FStar_Ident.ns_of_lid lid  in
+                                          FStar_Ident.lid_of_ids uu____9703
                                            in
-                                        uu____9591.FStar_Ident.str  in
-                                      ((let uu____9593 =
+                                        FStar_Ident.string_of_lid uu____9702
+                                         in
+                                      ((let uu____9705 =
                                           get_exported_id_set env4 modul  in
-                                        match uu____9593 with
+                                        match uu____9705 with
                                         | FStar_Pervasives_Native.Some f ->
                                             let my_exported_ids =
                                               f Exported_id_term_type  in
-                                            let uu____9615 =
-                                              let uu____9616 =
+                                            let uu____9727 =
+                                              let uu____9728 =
+                                                let uu____9730 =
+                                                  FStar_Ident.ident_of_lid
+                                                    lid
+                                                   in
+                                                FStar_Ident.text_of_id
+                                                  uu____9730
+                                                 in
+                                              let uu____9731 =
                                                 FStar_ST.op_Bang
                                                   my_exported_ids
                                                  in
-                                              FStar_Util.set_add
-                                                (lid.FStar_Ident.ident).FStar_Ident.idText
-                                                uu____9616
+                                              FStar_Util.set_add uu____9728
+                                                uu____9731
                                                in
                                             FStar_ST.op_Colon_Equals
-                                              my_exported_ids uu____9615
+                                              my_exported_ids uu____9727
                                         | FStar_Pervasives_Native.None  -> ());
                                        (match () with
                                         | () ->
@@ -2573,33 +2646,36 @@ let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
                                                 (Prims.op_Negation
                                                    env4.admitted_iface)
                                                in
+                                            let uu____9781 =
+                                              FStar_Ident.string_of_lid lid
+                                               in
                                             FStar_Util.smap_add (sigmap env4)
-                                              lid.FStar_Ident.str
+                                              uu____9781
                                               (se,
                                                 (env4.iface &&
                                                    (Prims.op_Negation
                                                       env4.admitted_iface))))))))));
              (let env5 =
-                let uu___1187_9673 = env4  in
-                let uu____9674 = FStar_ST.op_Bang globals  in
+                let uu___1185_9790 = env4  in
+                let uu____9791 = FStar_ST.op_Bang globals  in
                 {
-                  curmodule = (uu___1187_9673.curmodule);
-                  curmonad = (uu___1187_9673.curmonad);
-                  modules = (uu___1187_9673.modules);
-                  scope_mods = uu____9674;
-                  exported_ids = (uu___1187_9673.exported_ids);
-                  trans_exported_ids = (uu___1187_9673.trans_exported_ids);
-                  includes = (uu___1187_9673.includes);
-                  sigaccum = (uu___1187_9673.sigaccum);
-                  sigmap = (uu___1187_9673.sigmap);
-                  iface = (uu___1187_9673.iface);
-                  admitted_iface = (uu___1187_9673.admitted_iface);
-                  expect_typ = (uu___1187_9673.expect_typ);
+                  curmodule = (uu___1185_9790.curmodule);
+                  curmonad = (uu___1185_9790.curmonad);
+                  modules = (uu___1185_9790.modules);
+                  scope_mods = uu____9791;
+                  exported_ids = (uu___1185_9790.exported_ids);
+                  trans_exported_ids = (uu___1185_9790.trans_exported_ids);
+                  includes = (uu___1185_9790.includes);
+                  sigaccum = (uu___1185_9790.sigaccum);
+                  sigmap = (uu___1185_9790.sigmap);
+                  iface = (uu___1185_9790.iface);
+                  admitted_iface = (uu___1185_9790.admitted_iface);
+                  expect_typ = (uu___1185_9790.expect_typ);
                   remaining_iface_decls =
-                    (uu___1187_9673.remaining_iface_decls);
-                  syntax_only = (uu___1187_9673.syntax_only);
-                  ds_hooks = (uu___1187_9673.ds_hooks);
-                  dep_graph = (uu___1187_9673.dep_graph)
+                    (uu___1185_9790.remaining_iface_decls);
+                  syntax_only = (uu___1185_9790.syntax_only);
+                  ds_hooks = (uu___1185_9790.ds_hooks);
+                  dep_graph = (uu___1185_9790.dep_graph)
                 }  in
               env5))
   
@@ -2610,39 +2686,39 @@ let (push_sigelt_force : env -> FStar_Syntax_Syntax.sigelt -> env) =
 let (push_namespace : env -> FStar_Ident.lident -> env) =
   fun env1  ->
     fun ns  ->
-      let uu____9735 =
-        let uu____9740 = resolve_module_name env1 ns false  in
-        match uu____9740 with
+      let uu____9852 =
+        let uu____9857 = resolve_module_name env1 ns false  in
+        match uu____9857 with
         | FStar_Pervasives_Native.None  ->
             let modules = env1.modules  in
-            let uu____9755 =
+            let uu____9872 =
               FStar_All.pipe_right modules
                 (FStar_Util.for_some
-                   (fun uu____9773  ->
-                      match uu____9773 with
-                      | (m,uu____9780) ->
-                          let uu____9781 =
-                            let uu____9783 = FStar_Ident.text_of_lid m  in
-                            Prims.op_Hat uu____9783 "."  in
-                          let uu____9786 =
-                            let uu____9788 = FStar_Ident.text_of_lid ns  in
-                            Prims.op_Hat uu____9788 "."  in
-                          FStar_Util.starts_with uu____9781 uu____9786))
+                   (fun uu____9890  ->
+                      match uu____9890 with
+                      | (m,uu____9897) ->
+                          let uu____9898 =
+                            let uu____9900 = FStar_Ident.string_of_lid m  in
+                            Prims.op_Hat uu____9900 "."  in
+                          let uu____9903 =
+                            let uu____9905 = FStar_Ident.string_of_lid ns  in
+                            Prims.op_Hat uu____9905 "."  in
+                          FStar_Util.starts_with uu____9898 uu____9903))
                in
-            if uu____9755
+            if uu____9872
             then (ns, Open_namespace)
             else
-              (let uu____9798 =
-                 let uu____9804 =
-                   let uu____9806 = FStar_Ident.text_of_lid ns  in
+              (let uu____9915 =
+                 let uu____9921 =
+                   let uu____9923 = FStar_Ident.string_of_lid ns  in
                    FStar_Util.format1 "Namespace %s cannot be found"
-                     uu____9806
+                     uu____9923
                     in
-                 (FStar_Errors.Fatal_NameSpaceNotFound, uu____9804)  in
-               let uu____9810 = FStar_Ident.range_of_lid ns  in
-               FStar_Errors.raise_error uu____9798 uu____9810)
+                 (FStar_Errors.Fatal_NameSpaceNotFound, uu____9921)  in
+               let uu____9927 = FStar_Ident.range_of_lid ns  in
+               FStar_Errors.raise_error uu____9915 uu____9927)
         | FStar_Pervasives_Native.Some ns' -> (ns', Open_module)  in
-      match uu____9735 with
+      match uu____9852 with
       | (ns',kd) ->
           ((env1.ds_hooks).ds_push_open_hook env1 (ns', kd);
            push_scope_mod env1 (Open_module_or_namespace (ns', kd)))
@@ -2651,8 +2727,8 @@ let (push_include : env -> FStar_Ident.lident -> env) =
   fun env1  ->
     fun ns  ->
       let ns0 = ns  in
-      let uu____9831 = resolve_module_name env1 ns false  in
-      match uu____9831 with
+      let uu____9948 = resolve_module_name env1 ns false  in
+      match uu____9948 with
       | FStar_Pervasives_Native.Some ns1 ->
           ((env1.ds_hooks).ds_push_include_hook env1 ns1;
            (let env2 =
@@ -2660,99 +2736,101 @@ let (push_include : env -> FStar_Ident.lident -> env) =
                 (Open_module_or_namespace (ns1, Open_module))
                in
             let curmod =
-              let uu____9840 = current_module env2  in
-              uu____9840.FStar_Ident.str  in
-            (let uu____9842 = FStar_Util.smap_try_find env2.includes curmod
+              let uu____9957 = current_module env2  in
+              FStar_Ident.string_of_lid uu____9957  in
+            (let uu____9959 = FStar_Util.smap_try_find env2.includes curmod
                 in
-             match uu____9842 with
+             match uu____9959 with
              | FStar_Pervasives_Native.None  -> ()
              | FStar_Pervasives_Native.Some incl ->
-                 let uu____9866 =
-                   let uu____9869 = FStar_ST.op_Bang incl  in ns1 ::
-                     uu____9869
+                 let uu____9983 =
+                   let uu____9986 = FStar_ST.op_Bang incl  in ns1 ::
+                     uu____9986
                     in
-                 FStar_ST.op_Colon_Equals incl uu____9866);
+                 FStar_ST.op_Colon_Equals incl uu____9983);
             (match () with
              | () ->
-                 let uu____9918 =
-                   get_trans_exported_id_set env2 ns1.FStar_Ident.str  in
-                 (match uu____9918 with
+                 let uu____10035 =
+                   let uu____10043 = FStar_Ident.string_of_lid ns1  in
+                   get_trans_exported_id_set env2 uu____10043  in
+                 (match uu____10035 with
                   | FStar_Pervasives_Native.Some ns_trans_exports ->
-                      ((let uu____9938 =
-                          let uu____10035 = get_exported_id_set env2 curmod
+                      ((let uu____10057 =
+                          let uu____10154 = get_exported_id_set env2 curmod
                              in
-                          let uu____10082 =
+                          let uu____10201 =
                             get_trans_exported_id_set env2 curmod  in
-                          (uu____10035, uu____10082)  in
-                        match uu____9938 with
+                          (uu____10154, uu____10201)  in
+                        match uu____10057 with
                         | (FStar_Pervasives_Native.Some
                            cur_exports,FStar_Pervasives_Native.Some
                            cur_trans_exports) ->
                             let update_exports k =
                               let ns_ex =
-                                let uu____10498 = ns_trans_exports k  in
-                                FStar_ST.op_Bang uu____10498  in
+                                let uu____10617 = ns_trans_exports k  in
+                                FStar_ST.op_Bang uu____10617  in
                               let ex = cur_exports k  in
-                              (let uu____10599 =
-                                 let uu____10603 = FStar_ST.op_Bang ex  in
-                                 FStar_Util.set_difference uu____10603 ns_ex
+                              (let uu____10718 =
+                                 let uu____10722 = FStar_ST.op_Bang ex  in
+                                 FStar_Util.set_difference uu____10722 ns_ex
                                   in
-                               FStar_ST.op_Colon_Equals ex uu____10599);
+                               FStar_ST.op_Colon_Equals ex uu____10718);
                               (match () with
                                | () ->
                                    let trans_ex = cur_trans_exports k  in
-                                   let uu____10695 =
-                                     let uu____10699 =
+                                   let uu____10814 =
+                                     let uu____10818 =
                                        FStar_ST.op_Bang trans_ex  in
-                                     FStar_Util.set_union uu____10699 ns_ex
+                                     FStar_Util.set_union uu____10818 ns_ex
                                       in
                                    FStar_ST.op_Colon_Equals trans_ex
-                                     uu____10695)
+                                     uu____10814)
                                in
                             FStar_List.iter update_exports
                               all_exported_id_kinds
-                        | uu____10748 -> ());
+                        | uu____10867 -> ());
                        (match () with | () -> env2))
                   | FStar_Pervasives_Native.None  ->
-                      let uu____10850 =
-                        let uu____10856 =
+                      let uu____10969 =
+                        let uu____10975 =
+                          let uu____10977 = FStar_Ident.string_of_lid ns1  in
                           FStar_Util.format1
-                            "include: Module %s was not prepared"
-                            ns1.FStar_Ident.str
+                            "include: Module %s was not prepared" uu____10977
                            in
                         (FStar_Errors.Fatal_IncludeModuleNotPrepared,
-                          uu____10856)
+                          uu____10975)
                          in
-                      let uu____10860 = FStar_Ident.range_of_lid ns1  in
-                      FStar_Errors.raise_error uu____10850 uu____10860))))
-      | uu____10861 ->
-          let uu____10864 =
-            let uu____10870 =
+                      let uu____10981 = FStar_Ident.range_of_lid ns1  in
+                      FStar_Errors.raise_error uu____10969 uu____10981))))
+      | uu____10982 ->
+          let uu____10985 =
+            let uu____10991 =
+              let uu____10993 = FStar_Ident.string_of_lid ns  in
               FStar_Util.format1 "include: Module %s cannot be found"
-                ns.FStar_Ident.str
+                uu____10993
                in
-            (FStar_Errors.Fatal_ModuleNotFound, uu____10870)  in
-          let uu____10874 = FStar_Ident.range_of_lid ns  in
-          FStar_Errors.raise_error uu____10864 uu____10874
+            (FStar_Errors.Fatal_ModuleNotFound, uu____10991)  in
+          let uu____10997 = FStar_Ident.range_of_lid ns  in
+          FStar_Errors.raise_error uu____10985 uu____10997
   
 let (push_module_abbrev :
   env -> FStar_Ident.ident -> FStar_Ident.lident -> env) =
   fun env1  ->
     fun x  ->
       fun l  ->
-        let uu____10891 = module_is_defined env1 l  in
-        if uu____10891
+        let uu____11014 = module_is_defined env1 l  in
+        if uu____11014
         then
           ((env1.ds_hooks).ds_push_module_abbrev_hook env1 x l;
            push_scope_mod env1 (Module_abbrev (x, l)))
         else
-          (let uu____10897 =
-             let uu____10903 =
-               let uu____10905 = FStar_Ident.text_of_lid l  in
-               FStar_Util.format1 "Module %s cannot be found" uu____10905  in
-             (FStar_Errors.Fatal_ModuleNotFound, uu____10903)  in
-           let uu____10909 = FStar_Ident.range_of_lid l  in
-           FStar_Errors.raise_error uu____10897 uu____10909)
+          (let uu____11020 =
+             let uu____11026 =
+               let uu____11028 = FStar_Ident.string_of_lid l  in
+               FStar_Util.format1 "Module %s cannot be found" uu____11028  in
+             (FStar_Errors.Fatal_ModuleNotFound, uu____11026)  in
+           let uu____11032 = FStar_Ident.range_of_lid l  in
+           FStar_Errors.raise_error uu____11020 uu____11032)
   
 let (check_admits :
   env -> FStar_Syntax_Syntax.modul -> FStar_Syntax_Syntax.modul) =
@@ -2765,119 +2843,120 @@ let (check_admits :
                 fun se  ->
                   match se.FStar_Syntax_Syntax.sigel with
                   | FStar_Syntax_Syntax.Sig_declare_typ (l,u,t) when
-                      let uu____10952 =
+                      let uu____11075 =
                         FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                           (FStar_List.contains FStar_Syntax_Syntax.Assumption)
                          in
-                      Prims.op_Negation uu____10952 ->
-                      let uu____10957 =
-                        FStar_Util.smap_try_find (sigmap env1)
-                          l.FStar_Ident.str
+                      Prims.op_Negation uu____11075 ->
+                      let uu____11080 =
+                        let uu____11088 = FStar_Ident.string_of_lid l  in
+                        FStar_Util.smap_try_find (sigmap env1) uu____11088
                          in
-                      (match uu____10957 with
+                      (match uu____11080 with
                        | FStar_Pervasives_Native.Some
                            ({
                               FStar_Syntax_Syntax.sigel =
-                                FStar_Syntax_Syntax.Sig_let uu____10972;
-                              FStar_Syntax_Syntax.sigrng = uu____10973;
-                              FStar_Syntax_Syntax.sigquals = uu____10974;
-                              FStar_Syntax_Syntax.sigmeta = uu____10975;
-                              FStar_Syntax_Syntax.sigattrs = uu____10976;
-                              FStar_Syntax_Syntax.sigopts = uu____10977;_},uu____10978)
+                                FStar_Syntax_Syntax.Sig_let uu____11097;
+                              FStar_Syntax_Syntax.sigrng = uu____11098;
+                              FStar_Syntax_Syntax.sigquals = uu____11099;
+                              FStar_Syntax_Syntax.sigmeta = uu____11100;
+                              FStar_Syntax_Syntax.sigattrs = uu____11101;
+                              FStar_Syntax_Syntax.sigopts = uu____11102;_},uu____11103)
                            -> lids
                        | FStar_Pervasives_Native.Some
                            ({
                               FStar_Syntax_Syntax.sigel =
                                 FStar_Syntax_Syntax.Sig_inductive_typ
-                                uu____10998;
-                              FStar_Syntax_Syntax.sigrng = uu____10999;
-                              FStar_Syntax_Syntax.sigquals = uu____11000;
-                              FStar_Syntax_Syntax.sigmeta = uu____11001;
-                              FStar_Syntax_Syntax.sigattrs = uu____11002;
-                              FStar_Syntax_Syntax.sigopts = uu____11003;_},uu____11004)
+                                uu____11123;
+                              FStar_Syntax_Syntax.sigrng = uu____11124;
+                              FStar_Syntax_Syntax.sigquals = uu____11125;
+                              FStar_Syntax_Syntax.sigmeta = uu____11126;
+                              FStar_Syntax_Syntax.sigattrs = uu____11127;
+                              FStar_Syntax_Syntax.sigopts = uu____11128;_},uu____11129)
                            -> lids
-                       | uu____11034 ->
-                           ((let uu____11043 =
-                               let uu____11045 = FStar_Options.interactive ()
+                       | uu____11159 ->
+                           ((let uu____11168 =
+                               let uu____11170 = FStar_Options.interactive ()
                                   in
-                               Prims.op_Negation uu____11045  in
-                             if uu____11043
+                               Prims.op_Negation uu____11170  in
+                             if uu____11168
                              then
-                               let uu____11048 = FStar_Ident.range_of_lid l
+                               let uu____11173 = FStar_Ident.range_of_lid l
                                   in
-                               let uu____11049 =
-                                 let uu____11055 =
-                                   let uu____11057 =
+                               let uu____11174 =
+                                 let uu____11180 =
+                                   let uu____11182 =
                                      FStar_Ident.string_of_lid l  in
                                    FStar_Util.format1
                                      "Admitting %s without a definition"
-                                     uu____11057
+                                     uu____11182
                                     in
                                  (FStar_Errors.Warning_AdmitWithoutDefinition,
-                                   uu____11055)
+                                   uu____11180)
                                   in
-                               FStar_Errors.log_issue uu____11048 uu____11049
+                               FStar_Errors.log_issue uu____11173 uu____11174
                              else ());
                             (let quals = FStar_Syntax_Syntax.Assumption ::
                                (se.FStar_Syntax_Syntax.sigquals)  in
-                             FStar_Util.smap_add (sigmap env1)
-                               l.FStar_Ident.str
-                               ((let uu___1278_11074 = se  in
-                                 {
-                                   FStar_Syntax_Syntax.sigel =
-                                     (uu___1278_11074.FStar_Syntax_Syntax.sigel);
-                                   FStar_Syntax_Syntax.sigrng =
-                                     (uu___1278_11074.FStar_Syntax_Syntax.sigrng);
-                                   FStar_Syntax_Syntax.sigquals = quals;
-                                   FStar_Syntax_Syntax.sigmeta =
-                                     (uu___1278_11074.FStar_Syntax_Syntax.sigmeta);
-                                   FStar_Syntax_Syntax.sigattrs =
-                                     (uu___1278_11074.FStar_Syntax_Syntax.sigattrs);
-                                   FStar_Syntax_Syntax.sigopts =
-                                     (uu___1278_11074.FStar_Syntax_Syntax.sigopts)
-                                 }), false);
+                             (let uu____11192 = FStar_Ident.string_of_lid l
+                                 in
+                              FStar_Util.smap_add (sigmap env1) uu____11192
+                                ((let uu___1276_11201 = se  in
+                                  {
+                                    FStar_Syntax_Syntax.sigel =
+                                      (uu___1276_11201.FStar_Syntax_Syntax.sigel);
+                                    FStar_Syntax_Syntax.sigrng =
+                                      (uu___1276_11201.FStar_Syntax_Syntax.sigrng);
+                                    FStar_Syntax_Syntax.sigquals = quals;
+                                    FStar_Syntax_Syntax.sigmeta =
+                                      (uu___1276_11201.FStar_Syntax_Syntax.sigmeta);
+                                    FStar_Syntax_Syntax.sigattrs =
+                                      (uu___1276_11201.FStar_Syntax_Syntax.sigattrs);
+                                    FStar_Syntax_Syntax.sigopts =
+                                      (uu___1276_11201.FStar_Syntax_Syntax.sigopts)
+                                  }), false));
                              l
                              ::
                              lids)))
-                  | uu____11076 -> lids) [])
+                  | uu____11203 -> lids) [])
          in
-      let uu___1283_11077 = m  in
-      let uu____11078 =
+      let uu___1281_11204 = m  in
+      let uu____11205 =
         FStar_All.pipe_right m.FStar_Syntax_Syntax.declarations
           (FStar_List.map
              (fun s  ->
                 match s.FStar_Syntax_Syntax.sigel with
                 | FStar_Syntax_Syntax.Sig_declare_typ
-                    (lid,uu____11088,uu____11089) when
+                    (lid,uu____11215,uu____11216) when
                     FStar_List.existsb
                       (fun l  -> FStar_Ident.lid_equals l lid)
                       admitted_sig_lids
                     ->
-                    let uu___1292_11092 = s  in
+                    let uu___1290_11219 = s  in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___1292_11092.FStar_Syntax_Syntax.sigel);
+                        (uu___1290_11219.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___1292_11092.FStar_Syntax_Syntax.sigrng);
+                        (uu___1290_11219.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
                         (FStar_Syntax_Syntax.Assumption ::
                         (s.FStar_Syntax_Syntax.sigquals));
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___1292_11092.FStar_Syntax_Syntax.sigmeta);
+                        (uu___1290_11219.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___1292_11092.FStar_Syntax_Syntax.sigattrs);
+                        (uu___1290_11219.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___1292_11092.FStar_Syntax_Syntax.sigopts)
+                        (uu___1290_11219.FStar_Syntax_Syntax.sigopts)
                     }
-                | uu____11093 -> s))
+                | uu____11220 -> s))
          in
       {
-        FStar_Syntax_Syntax.name = (uu___1283_11077.FStar_Syntax_Syntax.name);
-        FStar_Syntax_Syntax.declarations = uu____11078;
+        FStar_Syntax_Syntax.name = (uu___1281_11204.FStar_Syntax_Syntax.name);
+        FStar_Syntax_Syntax.declarations = uu____11205;
         FStar_Syntax_Syntax.exports =
-          (uu___1283_11077.FStar_Syntax_Syntax.exports);
+          (uu___1281_11204.FStar_Syntax_Syntax.exports);
         FStar_Syntax_Syntax.is_interface =
-          (uu___1283_11077.FStar_Syntax_Syntax.is_interface)
+          (uu___1281_11204.FStar_Syntax_Syntax.is_interface)
       }
   
 let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
@@ -2888,7 +2967,7 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
            (fun se  ->
               let quals = se.FStar_Syntax_Syntax.sigquals  in
               match se.FStar_Syntax_Syntax.sigel with
-              | FStar_Syntax_Syntax.Sig_bundle (ses,uu____11117) ->
+              | FStar_Syntax_Syntax.Sig_bundle (ses,uu____11244) ->
                   if
                     (FStar_List.contains FStar_Syntax_Syntax.Private quals)
                       ||
@@ -2899,75 +2978,82 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                          (fun se1  ->
                             match se1.FStar_Syntax_Syntax.sigel with
                             | FStar_Syntax_Syntax.Sig_datacon
-                                (lid,uu____11138,uu____11139,uu____11140,uu____11141,uu____11142)
+                                (lid,uu____11266,uu____11267,uu____11268,uu____11269,uu____11270)
                                 ->
+                                let uu____11277 =
+                                  FStar_Ident.string_of_lid lid  in
                                 FStar_Util.smap_remove (sigmap env1)
-                                  lid.FStar_Ident.str
+                                  uu____11277
                             | FStar_Syntax_Syntax.Sig_inductive_typ
-                                (lid,univ_names,binders,typ,uu____11158,uu____11159)
+                                (lid,univ_names,binders,typ,uu____11288,uu____11289)
                                 ->
-                                (FStar_Util.smap_remove (sigmap env1)
-                                   lid.FStar_Ident.str;
+                                ((let uu____11299 =
+                                    FStar_Ident.string_of_lid lid  in
+                                  FStar_Util.smap_remove (sigmap env1)
+                                    uu____11299);
                                  if
                                    Prims.op_Negation
                                      (FStar_List.contains
                                         FStar_Syntax_Syntax.Private quals)
                                  then
                                    (let sigel =
-                                      let uu____11176 =
-                                        let uu____11183 =
-                                          let uu____11184 =
+                                      let uu____11308 =
+                                        let uu____11315 =
+                                          let uu____11316 =
                                             FStar_Ident.range_of_lid lid  in
-                                          let uu____11185 =
-                                            let uu____11192 =
-                                              let uu____11193 =
-                                                let uu____11208 =
+                                          let uu____11317 =
+                                            let uu____11324 =
+                                              let uu____11325 =
+                                                let uu____11340 =
                                                   FStar_Syntax_Syntax.mk_Total
                                                     typ
                                                    in
-                                                (binders, uu____11208)  in
+                                                (binders, uu____11340)  in
                                               FStar_Syntax_Syntax.Tm_arrow
-                                                uu____11193
+                                                uu____11325
                                                in
                                             FStar_Syntax_Syntax.mk
-                                              uu____11192
+                                              uu____11324
                                              in
-                                          uu____11185
+                                          uu____11317
                                             FStar_Pervasives_Native.None
-                                            uu____11184
+                                            uu____11316
                                            in
-                                        (lid, univ_names, uu____11183)  in
+                                        (lid, univ_names, uu____11315)  in
                                       FStar_Syntax_Syntax.Sig_declare_typ
-                                        uu____11176
+                                        uu____11308
                                        in
                                     let se2 =
-                                      let uu___1324_11222 = se1  in
+                                      let uu___1322_11354 = se1  in
                                       {
                                         FStar_Syntax_Syntax.sigel = sigel;
                                         FStar_Syntax_Syntax.sigrng =
-                                          (uu___1324_11222.FStar_Syntax_Syntax.sigrng);
+                                          (uu___1322_11354.FStar_Syntax_Syntax.sigrng);
                                         FStar_Syntax_Syntax.sigquals =
                                           (FStar_Syntax_Syntax.Assumption ::
                                           quals);
                                         FStar_Syntax_Syntax.sigmeta =
-                                          (uu___1324_11222.FStar_Syntax_Syntax.sigmeta);
+                                          (uu___1322_11354.FStar_Syntax_Syntax.sigmeta);
                                         FStar_Syntax_Syntax.sigattrs =
-                                          (uu___1324_11222.FStar_Syntax_Syntax.sigattrs);
+                                          (uu___1322_11354.FStar_Syntax_Syntax.sigattrs);
                                         FStar_Syntax_Syntax.sigopts =
-                                          (uu___1324_11222.FStar_Syntax_Syntax.sigopts)
+                                          (uu___1322_11354.FStar_Syntax_Syntax.sigopts)
                                       }  in
+                                    let uu____11355 =
+                                      FStar_Ident.string_of_lid lid  in
                                     FStar_Util.smap_add (sigmap env1)
-                                      lid.FStar_Ident.str (se2, false))
+                                      uu____11355 (se2, false))
                                  else ())
-                            | uu____11232 -> ()))
+                            | uu____11366 -> ()))
                   else ()
               | FStar_Syntax_Syntax.Sig_declare_typ
-                  (lid,uu____11236,uu____11237) ->
+                  (lid,uu____11370,uu____11371) ->
                   if FStar_List.contains FStar_Syntax_Syntax.Private quals
                   then
-                    FStar_Util.smap_remove (sigmap env1) lid.FStar_Ident.str
+                    let uu____11373 = FStar_Ident.string_of_lid lid  in
+                    FStar_Util.smap_remove (sigmap env1) uu____11373
                   else ()
-              | FStar_Syntax_Syntax.Sig_let ((uu____11246,lbs),uu____11248)
+              | FStar_Syntax_Syntax.Sig_let ((uu____11382,lbs),uu____11384)
                   ->
                   (if
                      (FStar_List.contains FStar_Syntax_Syntax.Private quals)
@@ -2978,18 +3064,18 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                      FStar_All.pipe_right lbs
                        (FStar_List.iter
                           (fun lb  ->
-                             let uu____11266 =
-                               let uu____11268 =
-                                 let uu____11269 =
-                                   let uu____11272 =
+                             let uu____11402 =
+                               let uu____11404 =
+                                 let uu____11405 =
+                                   let uu____11408 =
                                      FStar_Util.right
                                        lb.FStar_Syntax_Syntax.lbname
                                       in
-                                   uu____11272.FStar_Syntax_Syntax.fv_name
+                                   uu____11408.FStar_Syntax_Syntax.fv_name
                                     in
-                                 uu____11269.FStar_Syntax_Syntax.v  in
-                               uu____11268.FStar_Ident.str  in
-                             FStar_Util.smap_remove (sigmap env1) uu____11266))
+                                 uu____11405.FStar_Syntax_Syntax.v  in
+                               FStar_Ident.string_of_lid uu____11404  in
+                             FStar_Util.smap_remove (sigmap env1) uu____11402))
                    else ();
                    if
                      (FStar_List.contains FStar_Syntax_Syntax.Abstract quals)
@@ -3002,127 +3088,129 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                        (FStar_List.iter
                           (fun lb  ->
                              let lid =
-                               let uu____11289 =
-                                 let uu____11292 =
+                               let uu____11426 =
+                                 let uu____11429 =
                                    FStar_Util.right
                                      lb.FStar_Syntax_Syntax.lbname
                                     in
-                                 uu____11292.FStar_Syntax_Syntax.fv_name  in
-                               uu____11289.FStar_Syntax_Syntax.v  in
+                                 uu____11429.FStar_Syntax_Syntax.fv_name  in
+                               uu____11426.FStar_Syntax_Syntax.v  in
                              let quals1 = FStar_Syntax_Syntax.Assumption ::
                                quals  in
                              let decl =
-                               let uu___1347_11297 = se  in
+                               let uu___1345_11434 = se  in
                                {
                                  FStar_Syntax_Syntax.sigel =
                                    (FStar_Syntax_Syntax.Sig_declare_typ
                                       (lid, (lb.FStar_Syntax_Syntax.lbunivs),
                                         (lb.FStar_Syntax_Syntax.lbtyp)));
                                  FStar_Syntax_Syntax.sigrng =
-                                   (uu___1347_11297.FStar_Syntax_Syntax.sigrng);
+                                   (uu___1345_11434.FStar_Syntax_Syntax.sigrng);
                                  FStar_Syntax_Syntax.sigquals = quals1;
                                  FStar_Syntax_Syntax.sigmeta =
-                                   (uu___1347_11297.FStar_Syntax_Syntax.sigmeta);
+                                   (uu___1345_11434.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
-                                   (uu___1347_11297.FStar_Syntax_Syntax.sigattrs);
+                                   (uu___1345_11434.FStar_Syntax_Syntax.sigattrs);
                                  FStar_Syntax_Syntax.sigopts =
-                                   (uu___1347_11297.FStar_Syntax_Syntax.sigopts)
+                                   (uu___1345_11434.FStar_Syntax_Syntax.sigopts)
                                }  in
-                             FStar_Util.smap_add (sigmap env1)
-                               lid.FStar_Ident.str (decl, false)))
+                             let uu____11435 = FStar_Ident.string_of_lid lid
+                                in
+                             FStar_Util.smap_add (sigmap env1) uu____11435
+                               (decl, false)))
                    else ())
-              | uu____11307 -> ()));
+              | uu____11446 -> ()));
       (let curmod =
-         let uu____11310 = current_module env1  in
-         uu____11310.FStar_Ident.str  in
-       (let uu____11312 =
-          let uu____11409 = get_exported_id_set env1 curmod  in
-          let uu____11456 = get_trans_exported_id_set env1 curmod  in
-          (uu____11409, uu____11456)  in
-        match uu____11312 with
+         let uu____11449 = current_module env1  in
+         FStar_Ident.string_of_lid uu____11449  in
+       (let uu____11451 =
+          let uu____11548 = get_exported_id_set env1 curmod  in
+          let uu____11595 = get_trans_exported_id_set env1 curmod  in
+          (uu____11548, uu____11595)  in
+        match uu____11451 with
         | (FStar_Pervasives_Native.Some cur_ex,FStar_Pervasives_Native.Some
            cur_trans_ex) ->
             let update_exports eikind =
               let cur_ex_set =
-                let uu____11875 = cur_ex eikind  in
-                FStar_ST.op_Bang uu____11875  in
+                let uu____12014 = cur_ex eikind  in
+                FStar_ST.op_Bang uu____12014  in
               let cur_trans_ex_set_ref = cur_trans_ex eikind  in
-              let uu____11981 =
-                let uu____11985 = FStar_ST.op_Bang cur_trans_ex_set_ref  in
-                FStar_Util.set_union cur_ex_set uu____11985  in
-              FStar_ST.op_Colon_Equals cur_trans_ex_set_ref uu____11981  in
+              let uu____12120 =
+                let uu____12124 = FStar_ST.op_Bang cur_trans_ex_set_ref  in
+                FStar_Util.set_union cur_ex_set uu____12124  in
+              FStar_ST.op_Colon_Equals cur_trans_ex_set_ref uu____12120  in
             FStar_List.iter update_exports all_exported_id_kinds
-        | uu____12034 -> ());
+        | uu____12173 -> ());
        (match () with
         | () ->
             (filter_record_cache ();
              (match () with
               | () ->
-                  let uu___1365_12132 = env1  in
+                  let uu___1363_12271 = env1  in
                   {
                     curmodule = FStar_Pervasives_Native.None;
-                    curmonad = (uu___1365_12132.curmonad);
+                    curmonad = (uu___1363_12271.curmonad);
                     modules = (((modul.FStar_Syntax_Syntax.name), modul) ::
                       (env1.modules));
                     scope_mods = [];
-                    exported_ids = (uu___1365_12132.exported_ids);
-                    trans_exported_ids = (uu___1365_12132.trans_exported_ids);
-                    includes = (uu___1365_12132.includes);
+                    exported_ids = (uu___1363_12271.exported_ids);
+                    trans_exported_ids = (uu___1363_12271.trans_exported_ids);
+                    includes = (uu___1363_12271.includes);
                     sigaccum = [];
-                    sigmap = (uu___1365_12132.sigmap);
-                    iface = (uu___1365_12132.iface);
-                    admitted_iface = (uu___1365_12132.admitted_iface);
-                    expect_typ = (uu___1365_12132.expect_typ);
+                    sigmap = (uu___1363_12271.sigmap);
+                    iface = (uu___1363_12271.iface);
+                    admitted_iface = (uu___1363_12271.admitted_iface);
+                    expect_typ = (uu___1363_12271.expect_typ);
                     remaining_iface_decls =
-                      (uu___1365_12132.remaining_iface_decls);
-                    syntax_only = (uu___1365_12132.syntax_only);
-                    ds_hooks = (uu___1365_12132.ds_hooks);
-                    dep_graph = (uu___1365_12132.dep_graph)
+                      (uu___1363_12271.remaining_iface_decls);
+                    syntax_only = (uu___1363_12271.syntax_only);
+                    ds_hooks = (uu___1363_12271.ds_hooks);
+                    dep_graph = (uu___1363_12271.dep_graph)
                   }))))
   
 let (stack : env Prims.list FStar_ST.ref) = FStar_Util.mk_ref [] 
 let (push : env -> env) =
   fun env1  ->
     FStar_Util.atomically
-      (fun uu____12158  ->
+      (fun uu____12297  ->
          push_record_cache ();
-         (let uu____12161 =
-            let uu____12164 = FStar_ST.op_Bang stack  in env1 :: uu____12164
+         (let uu____12300 =
+            let uu____12303 = FStar_ST.op_Bang stack  in env1 :: uu____12303
              in
-          FStar_ST.op_Colon_Equals stack uu____12161);
-         (let uu___1371_12213 = env1  in
-          let uu____12214 = FStar_Util.smap_copy env1.exported_ids  in
-          let uu____12219 = FStar_Util.smap_copy env1.trans_exported_ids  in
-          let uu____12224 = FStar_Util.smap_copy env1.includes  in
-          let uu____12235 = FStar_Util.smap_copy env1.sigmap  in
+          FStar_ST.op_Colon_Equals stack uu____12300);
+         (let uu___1369_12352 = env1  in
+          let uu____12353 = FStar_Util.smap_copy env1.exported_ids  in
+          let uu____12358 = FStar_Util.smap_copy env1.trans_exported_ids  in
+          let uu____12363 = FStar_Util.smap_copy env1.includes  in
+          let uu____12374 = FStar_Util.smap_copy env1.sigmap  in
           {
-            curmodule = (uu___1371_12213.curmodule);
-            curmonad = (uu___1371_12213.curmonad);
-            modules = (uu___1371_12213.modules);
-            scope_mods = (uu___1371_12213.scope_mods);
-            exported_ids = uu____12214;
-            trans_exported_ids = uu____12219;
-            includes = uu____12224;
-            sigaccum = (uu___1371_12213.sigaccum);
-            sigmap = uu____12235;
-            iface = (uu___1371_12213.iface);
-            admitted_iface = (uu___1371_12213.admitted_iface);
-            expect_typ = (uu___1371_12213.expect_typ);
-            remaining_iface_decls = (uu___1371_12213.remaining_iface_decls);
-            syntax_only = (uu___1371_12213.syntax_only);
-            ds_hooks = (uu___1371_12213.ds_hooks);
-            dep_graph = (uu___1371_12213.dep_graph)
+            curmodule = (uu___1369_12352.curmodule);
+            curmonad = (uu___1369_12352.curmonad);
+            modules = (uu___1369_12352.modules);
+            scope_mods = (uu___1369_12352.scope_mods);
+            exported_ids = uu____12353;
+            trans_exported_ids = uu____12358;
+            includes = uu____12363;
+            sigaccum = (uu___1369_12352.sigaccum);
+            sigmap = uu____12374;
+            iface = (uu___1369_12352.iface);
+            admitted_iface = (uu___1369_12352.admitted_iface);
+            expect_typ = (uu___1369_12352.expect_typ);
+            remaining_iface_decls = (uu___1369_12352.remaining_iface_decls);
+            syntax_only = (uu___1369_12352.syntax_only);
+            ds_hooks = (uu___1369_12352.ds_hooks);
+            dep_graph = (uu___1369_12352.dep_graph)
           }))
   
 let (pop : unit -> env) =
-  fun uu____12253  ->
+  fun uu____12392  ->
     FStar_Util.atomically
-      (fun uu____12260  ->
-         let uu____12261 = FStar_ST.op_Bang stack  in
-         match uu____12261 with
+      (fun uu____12399  ->
+         let uu____12400 = FStar_ST.op_Bang stack  in
+         match uu____12400 with
          | env1::tl ->
              (pop_record_cache (); FStar_ST.op_Colon_Equals stack tl; env1)
-         | uu____12316 -> failwith "Impossible: Too many pops")
+         | uu____12455 -> failwith "Impossible: Too many pops")
   
 let (snapshot : env -> (Prims.int * env)) =
   fun env1  -> FStar_Common.snapshot push stack env1 
@@ -3133,8 +3221,11 @@ let (export_interface : FStar_Ident.lident -> env -> env) =
     fun env1  ->
       let sigelt_in_m se =
         match FStar_Syntax_Util.lids_of_sigelt se with
-        | l::uu____12363 -> l.FStar_Ident.nsstr = m.FStar_Ident.str
-        | uu____12367 -> false  in
+        | l::uu____12502 ->
+            let uu____12505 = FStar_Ident.nsstr l  in
+            let uu____12507 = FStar_Ident.string_of_lid m  in
+            uu____12505 = uu____12507
+        | uu____12510 -> false  in
       let sm = sigmap env1  in
       let env2 = pop ()  in
       let keys = FStar_Util.smap_keys sm  in
@@ -3142,33 +3233,33 @@ let (export_interface : FStar_Ident.lident -> env -> env) =
       FStar_All.pipe_right keys
         (FStar_List.iter
            (fun k  ->
-              let uu____12409 = FStar_Util.smap_try_find sm' k  in
-              match uu____12409 with
+              let uu____12552 = FStar_Util.smap_try_find sm' k  in
+              match uu____12552 with
               | FStar_Pervasives_Native.Some (se,true ) when sigelt_in_m se
                   ->
                   (FStar_Util.smap_remove sm' k;
                    (let se1 =
                       match se.FStar_Syntax_Syntax.sigel with
                       | FStar_Syntax_Syntax.Sig_declare_typ (l,u,t) ->
-                          let uu___1406_12440 = se  in
+                          let uu___1404_12583 = se  in
                           {
                             FStar_Syntax_Syntax.sigel =
-                              (uu___1406_12440.FStar_Syntax_Syntax.sigel);
+                              (uu___1404_12583.FStar_Syntax_Syntax.sigel);
                             FStar_Syntax_Syntax.sigrng =
-                              (uu___1406_12440.FStar_Syntax_Syntax.sigrng);
+                              (uu___1404_12583.FStar_Syntax_Syntax.sigrng);
                             FStar_Syntax_Syntax.sigquals =
                               (FStar_Syntax_Syntax.Assumption ::
                               (se.FStar_Syntax_Syntax.sigquals));
                             FStar_Syntax_Syntax.sigmeta =
-                              (uu___1406_12440.FStar_Syntax_Syntax.sigmeta);
+                              (uu___1404_12583.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___1406_12440.FStar_Syntax_Syntax.sigattrs);
+                              (uu___1404_12583.FStar_Syntax_Syntax.sigattrs);
                             FStar_Syntax_Syntax.sigopts =
-                              (uu___1406_12440.FStar_Syntax_Syntax.sigopts)
+                              (uu___1404_12583.FStar_Syntax_Syntax.sigopts)
                           }
-                      | uu____12441 -> se  in
+                      | uu____12584 -> se  in
                     FStar_Util.smap_add sm' k (se1, false)))
-              | uu____12449 -> ()));
+              | uu____12592 -> ()));
       env2
   
 let (finish_module_or_interface :
@@ -3179,7 +3270,7 @@ let (finish_module_or_interface :
         if Prims.op_Negation modul.FStar_Syntax_Syntax.is_interface
         then check_admits env1 modul
         else modul  in
-      let uu____12476 = finish env1 modul1  in (uu____12476, modul1)
+      let uu____12619 = finish env1 modul1  in (uu____12619, modul1)
   
 type exported_ids =
   {
@@ -3200,15 +3291,15 @@ let (__proj__Mkexported_ids__item__exported_id_fields :
 let (as_exported_ids : exported_id_set -> exported_ids) =
   fun e  ->
     let terms =
-      let uu____12545 =
-        let uu____12549 = e Exported_id_term_type  in
-        FStar_ST.op_Bang uu____12549  in
-      FStar_Util.set_elements uu____12545  in
+      let uu____12688 =
+        let uu____12692 = e Exported_id_term_type  in
+        FStar_ST.op_Bang uu____12692  in
+      FStar_Util.set_elements uu____12688  in
     let fields =
-      let uu____12612 =
-        let uu____12616 = e Exported_id_field  in
-        FStar_ST.op_Bang uu____12616  in
-      FStar_Util.set_elements uu____12612  in
+      let uu____12755 =
+        let uu____12759 = e Exported_id_field  in
+        FStar_ST.op_Bang uu____12759  in
+      FStar_Util.set_elements uu____12755  in
     { exported_id_terms = terms; exported_id_fields = fields }
   
 let (as_exported_id_set :
@@ -3220,15 +3311,15 @@ let (as_exported_id_set :
     | FStar_Pervasives_Native.None  -> exported_id_set_new ()
     | FStar_Pervasives_Native.Some e1 ->
         let terms =
-          let uu____12708 =
+          let uu____12851 =
             FStar_Util.as_set e1.exported_id_terms FStar_Util.compare  in
-          FStar_Util.mk_ref uu____12708  in
+          FStar_Util.mk_ref uu____12851  in
         let fields =
-          let uu____12722 =
+          let uu____12865 =
             FStar_Util.as_set e1.exported_id_fields FStar_Util.compare  in
-          FStar_Util.mk_ref uu____12722  in
-        (fun uu___30_12730  ->
-           match uu___30_12730 with
+          FStar_Util.mk_ref uu____12865  in
+        (fun uu___30_12873  ->
+           match uu___30_12873 with
            | Exported_id_term_type  -> terms
            | Exported_id_field  -> fields)
   
@@ -3267,12 +3358,12 @@ let (default_mii : module_inclusion_info) =
     mii_includes = FStar_Pervasives_Native.None
   } 
 let as_includes :
-  'uuuuuu12834 .
-    'uuuuuu12834 Prims.list FStar_Pervasives_Native.option ->
-      'uuuuuu12834 Prims.list FStar_ST.ref
+  'uuuuuu12977 .
+    'uuuuuu12977 Prims.list FStar_Pervasives_Native.option ->
+      'uuuuuu12977 Prims.list FStar_ST.ref
   =
-  fun uu___31_12847  ->
-    match uu___31_12847 with
+  fun uu___31_12990  ->
+    match uu___31_12990 with
     | FStar_Pervasives_Native.None  -> FStar_Util.mk_ref []
     | FStar_Pervasives_Native.Some l -> FStar_Util.mk_ref l
   
@@ -3281,17 +3372,17 @@ let (inclusion_info : env -> FStar_Ident.lident -> module_inclusion_info) =
     fun l  ->
       let mname = FStar_Ident.string_of_lid l  in
       let as_ids_opt m =
-        let uu____12890 = FStar_Util.smap_try_find m mname  in
-        FStar_Util.map_opt uu____12890 as_exported_ids  in
-      let uu____12896 = as_ids_opt env1.exported_ids  in
-      let uu____12899 = as_ids_opt env1.trans_exported_ids  in
-      let uu____12902 =
-        let uu____12907 = FStar_Util.smap_try_find env1.includes mname  in
-        FStar_Util.map_opt uu____12907 (fun r  -> FStar_ST.op_Bang r)  in
+        let uu____13033 = FStar_Util.smap_try_find m mname  in
+        FStar_Util.map_opt uu____13033 as_exported_ids  in
+      let uu____13039 = as_ids_opt env1.exported_ids  in
+      let uu____13042 = as_ids_opt env1.trans_exported_ids  in
+      let uu____13045 =
+        let uu____13050 = FStar_Util.smap_try_find env1.includes mname  in
+        FStar_Util.map_opt uu____13050 (fun r  -> FStar_ST.op_Bang r)  in
       {
-        mii_exported_ids = uu____12896;
-        mii_trans_exported_ids = uu____12899;
-        mii_includes = uu____12902
+        mii_exported_ids = uu____13039;
+        mii_trans_exported_ids = uu____13042;
+        mii_includes = uu____13045
       }
   
 let (prepare_module_or_interface :
@@ -3307,52 +3398,61 @@ let (prepare_module_or_interface :
           fun mii  ->
             let prep env2 =
               let filename =
-                let uu____12996 = FStar_Ident.text_of_lid mname  in
-                FStar_Util.strcat uu____12996 ".fst"  in
+                let uu____13139 = FStar_Ident.string_of_lid mname  in
+                FStar_Util.strcat uu____13139 ".fst"  in
               let auto_open =
                 FStar_Parser_Dep.hard_coded_dependencies filename  in
               let auto_open1 =
-                let convert_kind uu___32_13018 =
-                  match uu___32_13018 with
+                let convert_kind uu___32_13161 =
+                  match uu___32_13161 with
                   | FStar_Parser_Dep.Open_namespace  -> Open_namespace
                   | FStar_Parser_Dep.Open_module  -> Open_module  in
                 FStar_List.map
-                  (fun uu____13030  ->
-                     match uu____13030 with
+                  (fun uu____13173  ->
+                     match uu____13173 with
                      | (lid,kind) -> (lid, (convert_kind kind))) auto_open
                  in
               let namespace_of_module =
-                if (FStar_List.length mname.FStar_Ident.ns) > Prims.int_zero
+                let uu____13191 =
+                  let uu____13193 =
+                    let uu____13195 = FStar_Ident.ns_of_lid mname  in
+                    FStar_List.length uu____13195  in
+                  uu____13193 > Prims.int_zero  in
+                if uu____13191
                 then
-                  let uu____13056 =
-                    let uu____13061 =
-                      FStar_Ident.lid_of_ids mname.FStar_Ident.ns  in
-                    (uu____13061, Open_namespace)  in
-                  [uu____13056]
+                  let uu____13206 =
+                    let uu____13211 =
+                      let uu____13212 = FStar_Ident.ns_of_lid mname  in
+                      FStar_Ident.lid_of_ids uu____13212  in
+                    (uu____13211, Open_namespace)  in
+                  [uu____13206]
                 else []  in
               let auto_open2 =
                 FStar_List.append namespace_of_module
                   (FStar_List.rev auto_open1)
                  in
-              (let uu____13092 = as_exported_id_set mii.mii_exported_ids  in
-               FStar_Util.smap_add env2.exported_ids mname.FStar_Ident.str
-                 uu____13092);
+              (let uu____13243 = FStar_Ident.string_of_lid mname  in
+               let uu____13245 = as_exported_id_set mii.mii_exported_ids  in
+               FStar_Util.smap_add env2.exported_ids uu____13243 uu____13245);
               (match () with
                | () ->
-                   ((let uu____13097 =
+                   ((let uu____13250 = FStar_Ident.string_of_lid mname  in
+                     let uu____13252 =
                        as_exported_id_set mii.mii_trans_exported_ids  in
-                     FStar_Util.smap_add env2.trans_exported_ids
-                       mname.FStar_Ident.str uu____13097);
+                     FStar_Util.smap_add env2.trans_exported_ids uu____13250
+                       uu____13252);
                     (match () with
                      | () ->
-                         ((let uu____13102 = as_includes mii.mii_includes  in
-                           FStar_Util.smap_add env2.includes
-                             mname.FStar_Ident.str uu____13102);
+                         ((let uu____13257 = FStar_Ident.string_of_lid mname
+                              in
+                           let uu____13259 = as_includes mii.mii_includes  in
+                           FStar_Util.smap_add env2.includes uu____13257
+                             uu____13259);
                           (match () with
                            | () ->
                                let env' =
-                                 let uu___1476_13112 = env2  in
-                                 let uu____13113 =
+                                 let uu___1474_13269 = env2  in
+                                 let uu____13270 =
                                    FStar_List.map
                                      (fun x  -> Open_module_or_namespace x)
                                      auto_open2
@@ -3360,25 +3460,25 @@ let (prepare_module_or_interface :
                                  {
                                    curmodule =
                                      (FStar_Pervasives_Native.Some mname);
-                                   curmonad = (uu___1476_13112.curmonad);
-                                   modules = (uu___1476_13112.modules);
-                                   scope_mods = uu____13113;
+                                   curmonad = (uu___1474_13269.curmonad);
+                                   modules = (uu___1474_13269.modules);
+                                   scope_mods = uu____13270;
                                    exported_ids =
-                                     (uu___1476_13112.exported_ids);
+                                     (uu___1474_13269.exported_ids);
                                    trans_exported_ids =
-                                     (uu___1476_13112.trans_exported_ids);
-                                   includes = (uu___1476_13112.includes);
-                                   sigaccum = (uu___1476_13112.sigaccum);
+                                     (uu___1474_13269.trans_exported_ids);
+                                   includes = (uu___1474_13269.includes);
+                                   sigaccum = (uu___1474_13269.sigaccum);
                                    sigmap = (env2.sigmap);
                                    iface = intf;
                                    admitted_iface = admitted;
-                                   expect_typ = (uu___1476_13112.expect_typ);
+                                   expect_typ = (uu___1474_13269.expect_typ);
                                    remaining_iface_decls =
-                                     (uu___1476_13112.remaining_iface_decls);
+                                     (uu___1474_13269.remaining_iface_decls);
                                    syntax_only =
-                                     (uu___1476_13112.syntax_only);
-                                   ds_hooks = (uu___1476_13112.ds_hooks);
-                                   dep_graph = (uu___1476_13112.dep_graph)
+                                     (uu___1474_13269.syntax_only);
+                                   ds_hooks = (uu___1474_13269.ds_hooks);
+                                   dep_graph = (uu___1474_13269.dep_graph)
                                  }  in
                                (FStar_List.iter
                                   (fun op  ->
@@ -3386,72 +3486,79 @@ let (prepare_module_or_interface :
                                        op) (FStar_List.rev auto_open2);
                                 env'))))))
                in
-            let uu____13125 =
+            let uu____13282 =
               FStar_All.pipe_right env1.modules
                 (FStar_Util.find_opt
-                   (fun uu____13151  ->
-                      match uu____13151 with
-                      | (l,uu____13158) -> FStar_Ident.lid_equals l mname))
+                   (fun uu____13308  ->
+                      match uu____13308 with
+                      | (l,uu____13315) -> FStar_Ident.lid_equals l mname))
                in
-            match uu____13125 with
+            match uu____13282 with
             | FStar_Pervasives_Native.None  ->
-                let uu____13168 = prep env1  in (uu____13168, false)
-            | FStar_Pervasives_Native.Some (uu____13171,m) ->
-                ((let uu____13178 =
-                    (let uu____13182 = FStar_Options.interactive ()  in
-                     Prims.op_Negation uu____13182) &&
+                let uu____13325 = prep env1  in (uu____13325, false)
+            | FStar_Pervasives_Native.Some (uu____13328,m) ->
+                ((let uu____13335 =
+                    (let uu____13339 = FStar_Options.interactive ()  in
+                     Prims.op_Negation uu____13339) &&
                       ((Prims.op_Negation m.FStar_Syntax_Syntax.is_interface)
                          || intf)
                      in
-                  if uu____13178
+                  if uu____13335
                   then
-                    let uu____13185 =
-                      let uu____13191 =
+                    let uu____13342 =
+                      let uu____13348 =
+                        let uu____13350 = FStar_Ident.string_of_lid mname  in
                         FStar_Util.format1
                           "Duplicate module or interface name: %s"
-                          mname.FStar_Ident.str
+                          uu____13350
                          in
                       (FStar_Errors.Fatal_DuplicateModuleOrInterface,
-                        uu____13191)
+                        uu____13348)
                        in
-                    let uu____13195 = FStar_Ident.range_of_lid mname  in
-                    FStar_Errors.raise_error uu____13185 uu____13195
+                    let uu____13354 = FStar_Ident.range_of_lid mname  in
+                    FStar_Errors.raise_error uu____13342 uu____13354
                   else ());
-                 (let uu____13198 =
-                    let uu____13199 = push env1  in prep uu____13199  in
-                  (uu____13198, true)))
+                 (let uu____13357 =
+                    let uu____13358 = push env1  in prep uu____13358  in
+                  (uu____13357, true)))
   
 let (enter_monad_scope : env -> FStar_Ident.ident -> env) =
   fun env1  ->
     fun mname  ->
       match env1.curmonad with
       | FStar_Pervasives_Native.Some mname' ->
-          FStar_Errors.raise_error
-            (FStar_Errors.Fatal_MonadAlreadyDefined,
-              (Prims.op_Hat "Trying to define monad "
-                 (Prims.op_Hat mname.FStar_Ident.idText
-                    (Prims.op_Hat ", but already in monad scope "
-                       mname'.FStar_Ident.idText))))
-            mname.FStar_Ident.idRange
+          let uu____13373 =
+            let uu____13379 =
+              let uu____13381 =
+                let uu____13383 = FStar_Ident.text_of_id mname  in
+                let uu____13385 =
+                  let uu____13387 = FStar_Ident.text_of_id mname'  in
+                  Prims.op_Hat ", but already in monad scope " uu____13387
+                   in
+                Prims.op_Hat uu____13383 uu____13385  in
+              Prims.op_Hat "Trying to define monad " uu____13381  in
+            (FStar_Errors.Fatal_MonadAlreadyDefined, uu____13379)  in
+          let uu____13392 = FStar_Ident.range_of_id mname  in
+          FStar_Errors.raise_error uu____13373 uu____13392
       | FStar_Pervasives_Native.None  ->
-          let uu___1497_13217 = env1  in
+          let uu___1495_13393 = env1  in
           {
-            curmodule = (uu___1497_13217.curmodule);
+            curmodule = (uu___1495_13393.curmodule);
             curmonad = (FStar_Pervasives_Native.Some mname);
-            modules = (uu___1497_13217.modules);
-            scope_mods = (uu___1497_13217.scope_mods);
-            exported_ids = (uu___1497_13217.exported_ids);
-            trans_exported_ids = (uu___1497_13217.trans_exported_ids);
-            includes = (uu___1497_13217.includes);
-            sigaccum = (uu___1497_13217.sigaccum);
-            sigmap = (uu___1497_13217.sigmap);
-            iface = (uu___1497_13217.iface);
-            admitted_iface = (uu___1497_13217.admitted_iface);
-            expect_typ = (uu___1497_13217.expect_typ);
-            remaining_iface_decls = (uu___1497_13217.remaining_iface_decls);
-            syntax_only = (uu___1497_13217.syntax_only);
-            ds_hooks = (uu___1497_13217.ds_hooks);
-            dep_graph = (uu___1497_13217.dep_graph)
+            modules = (uu___1495_13393.modules);
+            scope_mods = (uu___1495_13393.scope_mods);
+            exported_ids = (uu___1495_13393.exported_ids);
+            trans_exported_ids = (uu___1495_13393.trans_exported_ids);
+            includes = (uu___1495_13393.includes);
+            sigaccum = (uu___1495_13393.sigaccum);
+            sigmap = (uu___1495_13393.sigmap);
+            iface = (uu___1495_13393.iface);
+            admitted_iface = (uu___1495_13393.admitted_iface);
+            expect_typ = (uu___1495_13393.expect_typ);
+            remaining_iface_decls = (uu___1495_13393.remaining_iface_decls);
+            syntax_only = (uu___1495_13393.syntax_only);
+            ds_hooks = (uu___1495_13393.ds_hooks);
+            dep_graph = (uu___1495_13393.dep_graph)
           }
   
 let fail_or :
@@ -3463,57 +3570,71 @@ let fail_or :
   fun env1  ->
     fun lookup  ->
       fun lid  ->
-        let uu____13252 = lookup lid  in
-        match uu____13252 with
+        let uu____13428 = lookup lid  in
+        match uu____13428 with
         | FStar_Pervasives_Native.None  ->
             let opened_modules =
               FStar_List.map
-                (fun uu____13267  ->
-                   match uu____13267 with
-                   | (lid1,uu____13274) -> FStar_Ident.text_of_lid lid1)
+                (fun uu____13443  ->
+                   match uu____13443 with
+                   | (lid1,uu____13450) -> FStar_Ident.string_of_lid lid1)
                 env1.modules
                in
             let msg =
-              let uu____13277 = FStar_Ident.text_of_lid lid  in
-              FStar_Util.format1 "Identifier not found: [%s]" uu____13277  in
+              let uu____13453 = FStar_Ident.string_of_lid lid  in
+              FStar_Util.format1 "Identifier not found: [%s]" uu____13453  in
             let msg1 =
-              if (FStar_List.length lid.FStar_Ident.ns) = Prims.int_zero
+              let uu____13458 =
+                let uu____13460 =
+                  let uu____13462 = FStar_Ident.ns_of_lid lid  in
+                  FStar_List.length uu____13462  in
+                uu____13460 = Prims.int_zero  in
+              if uu____13458
               then msg
               else
                 (let modul =
-                   let uu____13289 =
-                     FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
-                   let uu____13290 = FStar_Ident.range_of_lid lid  in
-                   FStar_Ident.set_lid_range uu____13289 uu____13290  in
-                 let uu____13291 = resolve_module_name env1 modul true  in
-                 match uu____13291 with
+                   let uu____13472 =
+                     let uu____13473 = FStar_Ident.ns_of_lid lid  in
+                     FStar_Ident.lid_of_ids uu____13473  in
+                   let uu____13474 = FStar_Ident.range_of_lid lid  in
+                   FStar_Ident.set_lid_range uu____13472 uu____13474  in
+                 let uu____13475 = resolve_module_name env1 modul true  in
+                 match uu____13475 with
                  | FStar_Pervasives_Native.None  ->
                      let opened_modules1 =
                        FStar_String.concat ", " opened_modules  in
+                     let uu____13483 = FStar_Ident.string_of_lid modul  in
                      FStar_Util.format3
                        "%s\nModule %s does not belong to the list of modules in scope, namely %s"
-                       msg modul.FStar_Ident.str opened_modules1
+                       msg uu____13483 opened_modules1
                  | FStar_Pervasives_Native.Some modul' when
                      Prims.op_Negation
                        (FStar_List.existsb
-                          (fun m  -> m = modul'.FStar_Ident.str)
-                          opened_modules)
+                          (fun m  ->
+                             let uu____13492 =
+                               FStar_Ident.string_of_lid modul'  in
+                             m = uu____13492) opened_modules)
                      ->
                      let opened_modules1 =
                        FStar_String.concat ", " opened_modules  in
+                     let uu____13498 = FStar_Ident.string_of_lid modul  in
+                     let uu____13500 = FStar_Ident.string_of_lid modul'  in
                      FStar_Util.format4
                        "%s\nModule %s resolved into %s, which does not belong to the list of modules in scope, namely %s"
-                       msg modul.FStar_Ident.str modul'.FStar_Ident.str
-                       opened_modules1
+                       msg uu____13498 uu____13500 opened_modules1
                  | FStar_Pervasives_Native.Some modul' ->
+                     let uu____13504 = FStar_Ident.string_of_lid modul  in
+                     let uu____13506 = FStar_Ident.string_of_lid modul'  in
+                     let uu____13508 =
+                       let uu____13510 = FStar_Ident.ident_of_lid lid  in
+                       FStar_Ident.text_of_id uu____13510  in
                      FStar_Util.format4
                        "%s\nModule %s resolved into %s, definition %s not found"
-                       msg modul.FStar_Ident.str modul'.FStar_Ident.str
-                       (lid.FStar_Ident.ident).FStar_Ident.idText)
+                       msg uu____13504 uu____13506 uu____13508)
                in
-            let uu____13312 = FStar_Ident.range_of_lid lid  in
+            let uu____13512 = FStar_Ident.range_of_lid lid  in
             FStar_Errors.raise_error
-              (FStar_Errors.Fatal_IdentifierNotFound, msg1) uu____13312
+              (FStar_Errors.Fatal_IdentifierNotFound, msg1) uu____13512
         | FStar_Pervasives_Native.Some r -> r
   
 let fail_or2 :
@@ -3523,13 +3644,17 @@ let fail_or2 :
   =
   fun lookup  ->
     fun id  ->
-      let uu____13342 = lookup id  in
-      match uu____13342 with
+      let uu____13542 = lookup id  in
+      match uu____13542 with
       | FStar_Pervasives_Native.None  ->
-          FStar_Errors.raise_error
-            (FStar_Errors.Fatal_IdentifierNotFound,
-              (Prims.op_Hat "Identifier not found ["
-                 (Prims.op_Hat id.FStar_Ident.idText "]")))
-            id.FStar_Ident.idRange
+          let uu____13545 =
+            let uu____13551 =
+              let uu____13553 =
+                let uu____13555 = FStar_Ident.text_of_id id  in
+                Prims.op_Hat uu____13555 "]"  in
+              Prims.op_Hat "Identifier not found [" uu____13553  in
+            (FStar_Errors.Fatal_IdentifierNotFound, uu____13551)  in
+          let uu____13560 = FStar_Ident.range_of_id id  in
+          FStar_Errors.raise_error uu____13545 uu____13560
       | FStar_Pervasives_Native.Some r -> r
   

--- a/src/ocaml-output/FStar_Syntax_MutRecTy.ml
+++ b/src/ocaml-output/FStar_Syntax_MutRecTy.ml
@@ -182,44 +182,48 @@ let (disentangle_abbrevs_from_bundle :
                            if uu____457
                            then
                              let msg =
+                               let uu____490 =
+                                 FStar_Ident.string_of_lid
+                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                                  in
                                FStar_Util.format1
                                  "Cycle on %s in mutually recursive type abbreviations"
-                                 ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
+                                 uu____490
                                 in
-                             let uu____491 =
+                             let uu____493 =
                                FStar_Ident.range_of_lid
                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                 in
                              FStar_Errors.raise_error
                                (FStar_Errors.Fatal_CycleInRecTypeAbbreviation,
-                                 msg) uu____491
+                                 msg) uu____493
                            else unfold_abbrev se
-                       | uu____495 -> t)
+                       | uu____497 -> t)
                 
                 and unfold_abbrev x =
                   match x.FStar_Syntax_Syntax.sigel with
-                  | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____500)
+                  | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____502)
                       ->
                       let quals1 =
                         FStar_All.pipe_right x.FStar_Syntax_Syntax.sigquals
                           (FStar_List.filter
-                             (fun uu___0_517  ->
-                                match uu___0_517 with
+                             (fun uu___0_519  ->
+                                match uu___0_519 with
                                 | FStar_Syntax_Syntax.Noeq  -> false
-                                | uu____520 -> true))
+                                | uu____522 -> true))
                          in
                       let lid =
                         match lb.FStar_Syntax_Syntax.lbname with
                         | FStar_Util.Inr fv ->
                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                        | uu____524 ->
+                        | uu____526 ->
                             failwith
                               "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: lid: impossible"
                          in
-                      ((let uu____531 =
-                          let uu____534 = FStar_ST.op_Bang in_progress  in
-                          lid :: uu____534  in
-                        FStar_ST.op_Colon_Equals in_progress uu____531);
+                      ((let uu____533 =
+                          let uu____536 = FStar_ST.op_Bang in_progress  in
+                          lid :: uu____536  in
+                        FStar_ST.op_Colon_Equals in_progress uu____533);
                        (match () with
                         | () ->
                             (remove_not_unfolded lid;
@@ -234,69 +238,69 @@ let (disentangle_abbrevs_from_bundle :
                                       lb.FStar_Syntax_Syntax.lbdef
                                      in
                                   let lb' =
-                                    let uu___146_587 = lb  in
+                                    let uu___146_589 = lb  in
                                     {
                                       FStar_Syntax_Syntax.lbname =
-                                        (uu___146_587.FStar_Syntax_Syntax.lbname);
+                                        (uu___146_589.FStar_Syntax_Syntax.lbname);
                                       FStar_Syntax_Syntax.lbunivs =
-                                        (uu___146_587.FStar_Syntax_Syntax.lbunivs);
+                                        (uu___146_589.FStar_Syntax_Syntax.lbunivs);
                                       FStar_Syntax_Syntax.lbtyp = ty';
                                       FStar_Syntax_Syntax.lbeff =
-                                        (uu___146_587.FStar_Syntax_Syntax.lbeff);
+                                        (uu___146_589.FStar_Syntax_Syntax.lbeff);
                                       FStar_Syntax_Syntax.lbdef = tm';
                                       FStar_Syntax_Syntax.lbattrs =
-                                        (uu___146_587.FStar_Syntax_Syntax.lbattrs);
+                                        (uu___146_589.FStar_Syntax_Syntax.lbattrs);
                                       FStar_Syntax_Syntax.lbpos =
-                                        (uu___146_587.FStar_Syntax_Syntax.lbpos)
+                                        (uu___146_589.FStar_Syntax_Syntax.lbpos)
                                     }  in
                                   let sigelt' =
                                     FStar_Syntax_Syntax.Sig_let
                                       ((false, [lb']), [lid])
                                      in
-                                  ((let uu____596 =
-                                      let uu____599 =
+                                  ((let uu____598 =
+                                      let uu____601 =
                                         FStar_ST.op_Bang
                                           rev_unfolded_type_abbrevs
                                          in
-                                      (let uu___150_626 = x  in
+                                      (let uu___150_628 = x  in
                                        {
                                          FStar_Syntax_Syntax.sigel = sigelt';
                                          FStar_Syntax_Syntax.sigrng =
-                                           (uu___150_626.FStar_Syntax_Syntax.sigrng);
+                                           (uu___150_628.FStar_Syntax_Syntax.sigrng);
                                          FStar_Syntax_Syntax.sigquals =
                                            quals1;
                                          FStar_Syntax_Syntax.sigmeta =
-                                           (uu___150_626.FStar_Syntax_Syntax.sigmeta);
+                                           (uu___150_628.FStar_Syntax_Syntax.sigmeta);
                                          FStar_Syntax_Syntax.sigattrs =
-                                           (uu___150_626.FStar_Syntax_Syntax.sigattrs);
+                                           (uu___150_628.FStar_Syntax_Syntax.sigattrs);
                                          FStar_Syntax_Syntax.sigopts =
-                                           (uu___150_626.FStar_Syntax_Syntax.sigopts)
-                                       }) :: uu____599
+                                           (uu___150_628.FStar_Syntax_Syntax.sigopts)
+                                       }) :: uu____601
                                        in
                                     FStar_ST.op_Colon_Equals
-                                      rev_unfolded_type_abbrevs uu____596);
+                                      rev_unfolded_type_abbrevs uu____598);
                                    (match () with
                                     | () ->
-                                        ((let uu____651 =
-                                            let uu____654 =
+                                        ((let uu____653 =
+                                            let uu____656 =
                                               FStar_ST.op_Bang in_progress
                                                in
-                                            FStar_List.tl uu____654  in
+                                            FStar_List.tl uu____656  in
                                           FStar_ST.op_Colon_Equals
-                                            in_progress uu____651);
+                                            in_progress uu____653);
                                          (match () with | () -> tm'))))))))
-                  | uu____703 ->
+                  | uu____705 ->
                       failwith
                         "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: impossible"
                  in
-                let rec aux uu____712 =
-                  let uu____713 = FStar_ST.op_Bang not_unfolded_yet  in
-                  match uu____713 with
-                  | x::uu____742 -> let _unused = unfold_abbrev x  in aux ()
-                  | uu____746 ->
-                      let uu____749 =
+                let rec aux uu____714 =
+                  let uu____715 = FStar_ST.op_Bang not_unfolded_yet  in
+                  match uu____715 with
+                  | x::uu____744 -> let _unused = unfold_abbrev x  in aux ()
+                  | uu____748 ->
+                      let uu____751 =
                         FStar_ST.op_Bang rev_unfolded_type_abbrevs  in
-                      FStar_List.rev uu____749
+                      FStar_List.rev uu____751
                    in
                 aux ()  in
               let filter_out_type_abbrevs l =
@@ -304,8 +308,8 @@ let (disentangle_abbrevs_from_bundle :
                   (fun lid  ->
                      FStar_List.for_all
                        (fun lid'  ->
-                          let uu____792 = FStar_Ident.lid_equals lid lid'  in
-                          Prims.op_Negation uu____792) type_abbrevs) l
+                          let uu____794 = FStar_Ident.lid_equals lid lid'  in
+                          Prims.op_Negation uu____794) type_abbrevs) l
                  in
               let inductives_with_abbrevs_unfolded =
                 let find_in_unfolded fv =
@@ -313,32 +317,32 @@ let (disentangle_abbrevs_from_bundle :
                     (fun x  ->
                        match x.FStar_Syntax_Syntax.sigel with
                        | FStar_Syntax_Syntax.Sig_let
-                           ((uu____824,{
+                           ((uu____826,{
                                          FStar_Syntax_Syntax.lbname =
                                            FStar_Util.Inr fv';
                                          FStar_Syntax_Syntax.lbunivs =
-                                           uu____826;
-                                         FStar_Syntax_Syntax.lbtyp =
-                                           uu____827;
-                                         FStar_Syntax_Syntax.lbeff =
                                            uu____828;
+                                         FStar_Syntax_Syntax.lbtyp =
+                                           uu____829;
+                                         FStar_Syntax_Syntax.lbeff =
+                                           uu____830;
                                          FStar_Syntax_Syntax.lbdef = tm;
                                          FStar_Syntax_Syntax.lbattrs =
-                                           uu____830;
+                                           uu____832;
                                          FStar_Syntax_Syntax.lbpos =
-                                           uu____831;_}::[]),uu____832)
+                                           uu____833;_}::[]),uu____834)
                            when
                            FStar_Ident.lid_equals
                              (fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                            -> FStar_Pervasives_Native.Some tm
-                       | uu____853 -> FStar_Pervasives_Native.None)
+                       | uu____855 -> FStar_Pervasives_Native.None)
                    in
                 let unfold_fv t fv =
-                  let uu____867 = find_in_unfolded fv  in
-                  match uu____867 with
+                  let uu____869 = find_in_unfolded fv  in
+                  match uu____869 with
                   | FStar_Pervasives_Native.Some t' -> t'
-                  | uu____877 -> t  in
+                  | uu____879 -> t  in
                 let unfold_in_sig x =
                   match x.FStar_Syntax_Syntax.sigel with
                   | FStar_Syntax_Syntax.Sig_inductive_typ
@@ -347,44 +351,44 @@ let (disentangle_abbrevs_from_bundle :
                         FStar_Syntax_InstFV.inst_binders unfold_fv bnd  in
                       let ty' = FStar_Syntax_InstFV.inst unfold_fv ty  in
                       let mut' = filter_out_type_abbrevs mut  in
-                      [(let uu___205_912 = x  in
+                      [(let uu___205_914 = x  in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_inductive_typ
                                (lid, univs, bnd', ty', mut', dc));
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___205_912.FStar_Syntax_Syntax.sigrng);
+                            (uu___205_914.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (uu___205_912.FStar_Syntax_Syntax.sigquals);
+                            (uu___205_914.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___205_912.FStar_Syntax_Syntax.sigmeta);
+                            (uu___205_914.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___205_912.FStar_Syntax_Syntax.sigattrs);
+                            (uu___205_914.FStar_Syntax_Syntax.sigattrs);
                           FStar_Syntax_Syntax.sigopts =
-                            (uu___205_912.FStar_Syntax_Syntax.sigopts)
+                            (uu___205_914.FStar_Syntax_Syntax.sigopts)
                         })]
                   | FStar_Syntax_Syntax.Sig_datacon
                       (lid,univs,ty,res,npars,mut) ->
                       let ty' = FStar_Syntax_InstFV.inst unfold_fv ty  in
                       let mut' = filter_out_type_abbrevs mut  in
-                      [(let uu___217_934 = x  in
+                      [(let uu___217_936 = x  in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_datacon
                                (lid, univs, ty', res, npars, mut'));
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___217_934.FStar_Syntax_Syntax.sigrng);
+                            (uu___217_936.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (uu___217_934.FStar_Syntax_Syntax.sigquals);
+                            (uu___217_936.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___217_934.FStar_Syntax_Syntax.sigmeta);
+                            (uu___217_936.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___217_934.FStar_Syntax_Syntax.sigattrs);
+                            (uu___217_936.FStar_Syntax_Syntax.sigattrs);
                           FStar_Syntax_Syntax.sigopts =
-                            (uu___217_934.FStar_Syntax_Syntax.sigopts)
+                            (uu___217_936.FStar_Syntax_Syntax.sigopts)
                         })]
-                  | FStar_Syntax_Syntax.Sig_let (uu____938,uu____939) -> []
-                  | uu____944 ->
+                  | FStar_Syntax_Syntax.Sig_let (uu____940,uu____941) -> []
+                  | uu____946 ->
                       failwith
                         "mutrecty: inductives_with_abbrevs_unfolded: unfold_in_sig: impossible"
                    in

--- a/src/ocaml-output/FStar_Syntax_Print.ml
+++ b/src/ocaml-output/FStar_Syntax_Print.ml
@@ -19,8 +19,10 @@ let (sli : FStar_Ident.lident -> Prims.string) =
   fun l  ->
     let uu____32 = FStar_Options.print_real_names ()  in
     if uu____32
-    then l.FStar_Ident.str
-    else (l.FStar_Ident.ident).FStar_Ident.idText
+    then FStar_Ident.string_of_lid l
+    else
+      (let uu____38 = FStar_Ident.ident_of_lid l  in
+       FStar_Ident.text_of_id uu____38)
   
 let (lid_to_string : FStar_Ident.lid -> Prims.string) = fun l  -> sli l 
 let (fv_to_string : FStar_Syntax_Syntax.fv -> Prims.string) =
@@ -29,26 +31,28 @@ let (fv_to_string : FStar_Syntax_Syntax.fv -> Prims.string) =
   
 let (bv_to_string : FStar_Syntax_Syntax.bv -> Prims.string) =
   fun bv  ->
-    let uu____59 =
-      let uu____61 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index
+    let uu____60 = FStar_Ident.text_of_id bv.FStar_Syntax_Syntax.ppname  in
+    let uu____62 =
+      let uu____64 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index
          in
-      Prims.op_Hat "#" uu____61  in
-    Prims.op_Hat (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText uu____59
+      Prims.op_Hat "#" uu____64  in
+    Prims.op_Hat uu____60 uu____62
   
 let (nm_to_string : FStar_Syntax_Syntax.bv -> Prims.string) =
   fun bv  ->
-    let uu____71 = FStar_Options.print_real_names ()  in
-    if uu____71
+    let uu____74 = FStar_Options.print_real_names ()  in
+    if uu____74
     then bv_to_string bv
-    else (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+    else FStar_Ident.text_of_id bv.FStar_Syntax_Syntax.ppname
   
 let (db_to_string : FStar_Syntax_Syntax.bv -> Prims.string) =
   fun bv  ->
-    let uu____84 =
-      let uu____86 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index
+    let uu____87 = FStar_Ident.text_of_id bv.FStar_Syntax_Syntax.ppname  in
+    let uu____89 =
+      let uu____91 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index
          in
-      Prims.op_Hat "@" uu____86  in
-    Prims.op_Hat (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText uu____84
+      Prims.op_Hat "@" uu____91  in
+    Prims.op_Hat uu____87 uu____89
   
 let (infix_prim_ops : (FStar_Ident.lident * Prims.string) Prims.list) =
   [(FStar_Parser_Const.op_Addition, "+");
@@ -86,7 +90,7 @@ let (is_prim_op :
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           FStar_All.pipe_right ps
             (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv))
-      | uu____308 -> false
+      | uu____313 -> false
   
 let (get_lid :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> FStar_Ident.lident)
@@ -95,7 +99,7 @@ let (get_lid :
     match f.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-    | uu____321 -> failwith "get_lid"
+    | uu____326 -> failwith "get_lid"
   
 let (is_infix_prim_op : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e  ->
@@ -124,65 +128,65 @@ let (is_lex_cons : exp -> Prims.bool) =
 let (is_lex_top : exp -> Prims.bool) =
   fun f  -> is_prim_op [FStar_Parser_Const.lextop_lid] f 
 let is_inr :
-  'uuuuuu424 'uuuuuu425 .
-    ('uuuuuu424,'uuuuuu425) FStar_Util.either -> Prims.bool
+  'uuuuuu429 'uuuuuu430 .
+    ('uuuuuu429,'uuuuuu430) FStar_Util.either -> Prims.bool
   =
-  fun uu___1_435  ->
-    match uu___1_435 with
-    | FStar_Util.Inl uu____440 -> false
-    | FStar_Util.Inr uu____442 -> true
+  fun uu___1_440  ->
+    match uu___1_440 with
+    | FStar_Util.Inl uu____445 -> false
+    | FStar_Util.Inr uu____447 -> true
   
 let filter_imp :
-  'uuuuuu449 .
-    ('uuuuuu449 * FStar_Syntax_Syntax.arg_qualifier
+  'uuuuuu454 .
+    ('uuuuuu454 * FStar_Syntax_Syntax.arg_qualifier
       FStar_Pervasives_Native.option) Prims.list ->
-      ('uuuuuu449 * FStar_Syntax_Syntax.arg_qualifier
+      ('uuuuuu454 * FStar_Syntax_Syntax.arg_qualifier
         FStar_Pervasives_Native.option) Prims.list
   =
   fun a  ->
     FStar_All.pipe_right a
       (FStar_List.filter
-         (fun uu___2_504  ->
-            match uu___2_504 with
-            | (uu____512,FStar_Pervasives_Native.Some
+         (fun uu___2_509  ->
+            match uu___2_509 with
+            | (uu____517,FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Meta t)) when
                 FStar_Syntax_Util.is_fvar FStar_Parser_Const.tcresolve_lid t
                 -> true
-            | (uu____519,FStar_Pervasives_Native.Some
-               (FStar_Syntax_Syntax.Implicit uu____520)) -> false
-            | (uu____525,FStar_Pervasives_Native.Some
-               (FStar_Syntax_Syntax.Meta uu____526)) -> false
-            | uu____532 -> true))
+            | (uu____524,FStar_Pervasives_Native.Some
+               (FStar_Syntax_Syntax.Implicit uu____525)) -> false
+            | (uu____530,FStar_Pervasives_Native.Some
+               (FStar_Syntax_Syntax.Meta uu____531)) -> false
+            | uu____537 -> true))
   
 let rec (reconstruct_lex :
   exp -> exp Prims.list FStar_Pervasives_Native.option) =
   fun e  ->
-    let uu____550 =
-      let uu____551 = FStar_Syntax_Subst.compress e  in
-      uu____551.FStar_Syntax_Syntax.n  in
-    match uu____550 with
+    let uu____555 =
+      let uu____556 = FStar_Syntax_Subst.compress e  in
+      uu____556.FStar_Syntax_Syntax.n  in
+    match uu____555 with
     | FStar_Syntax_Syntax.Tm_app (f,args) ->
         let args1 = filter_imp args  in
         let exps = FStar_List.map FStar_Pervasives_Native.fst args1  in
-        let uu____612 =
+        let uu____617 =
           (is_lex_cons f) && ((FStar_List.length exps) = (Prims.of_int (2)))
            in
-        if uu____612
+        if uu____617
         then
-          let uu____621 =
-            let uu____626 = FStar_List.nth exps Prims.int_one  in
-            reconstruct_lex uu____626  in
-          (match uu____621 with
+          let uu____626 =
+            let uu____631 = FStar_List.nth exps Prims.int_one  in
+            reconstruct_lex uu____631  in
+          (match uu____626 with
            | FStar_Pervasives_Native.Some xs ->
-               let uu____637 =
-                 let uu____640 = FStar_List.nth exps Prims.int_zero  in
-                 uu____640 :: xs  in
-               FStar_Pervasives_Native.Some uu____637
+               let uu____642 =
+                 let uu____645 = FStar_List.nth exps Prims.int_zero  in
+                 uu____645 :: xs  in
+               FStar_Pervasives_Native.Some uu____642
            | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None)
         else FStar_Pervasives_Native.None
-    | uu____652 ->
-        let uu____653 = is_lex_top e  in
-        if uu____653
+    | uu____657 ->
+        let uu____658 = is_lex_top e  in
+        if uu____658
         then FStar_Pervasives_Native.Some []
         else FStar_Pervasives_Native.None
   
@@ -192,7 +196,7 @@ let rec find : 'a . ('a -> Prims.bool) -> 'a Prims.list -> 'a =
       match l with
       | [] -> failwith "blah"
       | hd::tl ->
-          let uu____701 = f hd  in if uu____701 then hd else find f tl
+          let uu____706 = f hd  in if uu____706 then hd else find f tl
   
 let (find_lid :
   FStar_Ident.lident ->
@@ -200,67 +204,67 @@ let (find_lid :
   =
   fun x  ->
     fun xs  ->
-      let uu____733 =
+      let uu____738 =
         find
           (fun p  -> FStar_Ident.lid_equals x (FStar_Pervasives_Native.fst p))
           xs
          in
-      FStar_Pervasives_Native.snd uu____733
+      FStar_Pervasives_Native.snd uu____738
   
 let (infix_prim_op_to_string :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string) =
-  fun e  -> let uu____764 = get_lid e  in find_lid uu____764 infix_prim_ops 
+  fun e  -> let uu____769 = get_lid e  in find_lid uu____769 infix_prim_ops 
 let (unary_prim_op_to_string :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string) =
-  fun e  -> let uu____776 = get_lid e  in find_lid uu____776 unary_prim_ops 
+  fun e  -> let uu____781 = get_lid e  in find_lid uu____781 unary_prim_ops 
 let (quant_to_string :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string) =
-  fun t  -> let uu____788 = get_lid t  in find_lid uu____788 quants 
+  fun t  -> let uu____793 = get_lid t  in find_lid uu____793 quants 
 let (const_to_string : FStar_Const.sconst -> Prims.string) =
   fun x  -> FStar_Parser_Const.const_to_string x 
 let (lbname_to_string : FStar_Syntax_Syntax.lbname -> Prims.string) =
-  fun uu___3_802  ->
-    match uu___3_802 with
+  fun uu___3_807  ->
+    match uu___3_807 with
     | FStar_Util.Inl l -> bv_to_string l
     | FStar_Util.Inr l ->
         lid_to_string (l.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
   
 let (uvar_to_string : FStar_Syntax_Syntax.uvar -> Prims.string) =
   fun u  ->
-    let uu____813 = FStar_Options.hide_uvar_nums ()  in
-    if uu____813
+    let uu____818 = FStar_Options.hide_uvar_nums ()  in
+    if uu____818
     then "?"
     else
-      (let uu____820 =
-         let uu____822 = FStar_Syntax_Unionfind.uvar_id u  in
-         FStar_All.pipe_right uu____822 FStar_Util.string_of_int  in
-       Prims.op_Hat "?" uu____820)
+      (let uu____825 =
+         let uu____827 = FStar_Syntax_Unionfind.uvar_id u  in
+         FStar_All.pipe_right uu____827 FStar_Util.string_of_int  in
+       Prims.op_Hat "?" uu____825)
   
 let (version_to_string : FStar_Syntax_Syntax.version -> Prims.string) =
   fun v  ->
-    let uu____834 = FStar_Util.string_of_int v.FStar_Syntax_Syntax.major  in
-    let uu____836 = FStar_Util.string_of_int v.FStar_Syntax_Syntax.minor  in
-    FStar_Util.format2 "%s.%s" uu____834 uu____836
+    let uu____839 = FStar_Util.string_of_int v.FStar_Syntax_Syntax.major  in
+    let uu____841 = FStar_Util.string_of_int v.FStar_Syntax_Syntax.minor  in
+    FStar_Util.format2 "%s.%s" uu____839 uu____841
   
 let (univ_uvar_to_string :
   (FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option
     FStar_Unionfind.p_uvar * FStar_Syntax_Syntax.version) -> Prims.string)
   =
   fun u  ->
-    let uu____862 = FStar_Options.hide_uvar_nums ()  in
-    if uu____862
+    let uu____867 = FStar_Options.hide_uvar_nums ()  in
+    if uu____867
     then "?"
     else
-      (let uu____869 =
-         let uu____871 =
-           let uu____873 = FStar_Syntax_Unionfind.univ_uvar_id u  in
-           FStar_All.pipe_right uu____873 FStar_Util.string_of_int  in
-         let uu____877 =
-           let uu____879 = version_to_string (FStar_Pervasives_Native.snd u)
+      (let uu____874 =
+         let uu____876 =
+           let uu____878 = FStar_Syntax_Unionfind.univ_uvar_id u  in
+           FStar_All.pipe_right uu____878 FStar_Util.string_of_int  in
+         let uu____882 =
+           let uu____884 = version_to_string (FStar_Pervasives_Native.snd u)
               in
-           Prims.op_Hat ":" uu____879  in
-         Prims.op_Hat uu____871 uu____877  in
-       Prims.op_Hat "?" uu____869)
+           Prims.op_Hat ":" uu____884  in
+         Prims.op_Hat uu____876 uu____882  in
+       Prims.op_Hat "?" uu____874)
   
 let rec (int_of_univ :
   Prims.int ->
@@ -270,53 +274,55 @@ let rec (int_of_univ :
   =
   fun n  ->
     fun u  ->
-      let uu____907 = FStar_Syntax_Subst.compress_univ u  in
-      match uu____907 with
+      let uu____912 = FStar_Syntax_Subst.compress_univ u  in
+      match uu____912 with
       | FStar_Syntax_Syntax.U_zero  -> (n, FStar_Pervasives_Native.None)
       | FStar_Syntax_Syntax.U_succ u1 -> int_of_univ (n + Prims.int_one) u1
-      | uu____920 -> (n, (FStar_Pervasives_Native.Some u))
+      | uu____925 -> (n, (FStar_Pervasives_Native.Some u))
   
 let rec (univ_to_string : FStar_Syntax_Syntax.universe -> Prims.string) =
   fun u  ->
-    let uu____931 = FStar_Syntax_Subst.compress_univ u  in
-    match uu____931 with
+    let uu____936 = FStar_Syntax_Subst.compress_univ u  in
+    match uu____936 with
     | FStar_Syntax_Syntax.U_unif u1 ->
-        let uu____942 = univ_uvar_to_string u1  in
-        Prims.op_Hat "U_unif " uu____942
+        let uu____947 = univ_uvar_to_string u1  in
+        Prims.op_Hat "U_unif " uu____947
     | FStar_Syntax_Syntax.U_name x ->
-        Prims.op_Hat "U_name " x.FStar_Ident.idText
+        let uu____951 = FStar_Ident.text_of_id x  in
+        Prims.op_Hat "U_name " uu____951
     | FStar_Syntax_Syntax.U_bvar x ->
-        let uu____949 = FStar_Util.string_of_int x  in
-        Prims.op_Hat "@" uu____949
+        let uu____956 = FStar_Util.string_of_int x  in
+        Prims.op_Hat "@" uu____956
     | FStar_Syntax_Syntax.U_zero  -> "0"
     | FStar_Syntax_Syntax.U_succ u1 ->
-        let uu____954 = int_of_univ Prims.int_one u1  in
-        (match uu____954 with
+        let uu____961 = int_of_univ Prims.int_one u1  in
+        (match uu____961 with
          | (n,FStar_Pervasives_Native.None ) -> FStar_Util.string_of_int n
          | (n,FStar_Pervasives_Native.Some u2) ->
-             let uu____975 = univ_to_string u2  in
-             let uu____977 = FStar_Util.string_of_int n  in
-             FStar_Util.format2 "(%s + %s)" uu____975 uu____977)
+             let uu____982 = univ_to_string u2  in
+             let uu____984 = FStar_Util.string_of_int n  in
+             FStar_Util.format2 "(%s + %s)" uu____982 uu____984)
     | FStar_Syntax_Syntax.U_max us ->
-        let uu____983 =
-          let uu____985 = FStar_List.map univ_to_string us  in
-          FStar_All.pipe_right uu____985 (FStar_String.concat ", ")  in
-        FStar_Util.format1 "(max %s)" uu____983
+        let uu____990 =
+          let uu____992 = FStar_List.map univ_to_string us  in
+          FStar_All.pipe_right uu____992 (FStar_String.concat ", ")  in
+        FStar_Util.format1 "(max %s)" uu____990
     | FStar_Syntax_Syntax.U_unknown  -> "unknown"
   
 let (univs_to_string : FStar_Syntax_Syntax.universes -> Prims.string) =
   fun us  ->
-    let uu____1004 = FStar_List.map univ_to_string us  in
-    FStar_All.pipe_right uu____1004 (FStar_String.concat ", ")
+    let uu____1011 = FStar_List.map univ_to_string us  in
+    FStar_All.pipe_right uu____1011 (FStar_String.concat ", ")
   
 let (univ_names_to_string : FStar_Syntax_Syntax.univ_names -> Prims.string) =
   fun us  ->
-    let uu____1021 = FStar_List.map (fun x  -> x.FStar_Ident.idText) us  in
-    FStar_All.pipe_right uu____1021 (FStar_String.concat ", ")
+    let uu____1028 = FStar_List.map (fun x  -> FStar_Ident.text_of_id x) us
+       in
+    FStar_All.pipe_right uu____1028 (FStar_String.concat ", ")
   
 let (qual_to_string : FStar_Syntax_Syntax.qualifier -> Prims.string) =
-  fun uu___4_1039  ->
-    match uu___4_1039 with
+  fun uu___4_1046  ->
+    match uu___4_1046 with
     | FStar_Syntax_Syntax.Assumption  -> "assume"
     | FStar_Syntax_Syntax.New  -> "new"
     | FStar_Syntax_Syntax.Private  -> "private"
@@ -331,41 +337,42 @@ let (qual_to_string : FStar_Syntax_Syntax.qualifier -> Prims.string) =
     | FStar_Syntax_Syntax.Logic  -> "logic"
     | FStar_Syntax_Syntax.TotalEffect  -> "total"
     | FStar_Syntax_Syntax.Discriminator l ->
-        let uu____1055 = lid_to_string l  in
-        FStar_Util.format1 "(Discriminator %s)" uu____1055
+        let uu____1062 = lid_to_string l  in
+        FStar_Util.format1 "(Discriminator %s)" uu____1062
     | FStar_Syntax_Syntax.Projector (l,x) ->
-        let uu____1060 = lid_to_string l  in
-        FStar_Util.format2 "(Projector %s %s)" uu____1060
-          x.FStar_Ident.idText
+        let uu____1067 = lid_to_string l  in
+        let uu____1069 = FStar_Ident.text_of_id x  in
+        FStar_Util.format2 "(Projector %s %s)" uu____1067 uu____1069
     | FStar_Syntax_Syntax.RecordType (ns,fns) ->
-        let uu____1073 =
-          let uu____1075 = FStar_Ident.path_of_ns ns  in
-          FStar_Ident.text_of_path uu____1075  in
-        let uu____1076 =
-          let uu____1078 =
+        let uu____1082 =
+          let uu____1084 = FStar_Ident.path_of_ns ns  in
+          FStar_Ident.text_of_path uu____1084  in
+        let uu____1085 =
+          let uu____1087 =
             FStar_All.pipe_right fns (FStar_List.map FStar_Ident.text_of_id)
              in
-          FStar_All.pipe_right uu____1078 (FStar_String.concat ", ")  in
-        FStar_Util.format2 "(RecordType %s %s)" uu____1073 uu____1076
+          FStar_All.pipe_right uu____1087 (FStar_String.concat ", ")  in
+        FStar_Util.format2 "(RecordType %s %s)" uu____1082 uu____1085
     | FStar_Syntax_Syntax.RecordConstructor (ns,fns) ->
-        let uu____1104 =
-          let uu____1106 = FStar_Ident.path_of_ns ns  in
-          FStar_Ident.text_of_path uu____1106  in
-        let uu____1107 =
-          let uu____1109 =
+        let uu____1113 =
+          let uu____1115 = FStar_Ident.path_of_ns ns  in
+          FStar_Ident.text_of_path uu____1115  in
+        let uu____1116 =
+          let uu____1118 =
             FStar_All.pipe_right fns (FStar_List.map FStar_Ident.text_of_id)
              in
-          FStar_All.pipe_right uu____1109 (FStar_String.concat ", ")  in
-        FStar_Util.format2 "(RecordConstructor %s %s)" uu____1104 uu____1107
+          FStar_All.pipe_right uu____1118 (FStar_String.concat ", ")  in
+        FStar_Util.format2 "(RecordConstructor %s %s)" uu____1113 uu____1116
     | FStar_Syntax_Syntax.Action eff_lid ->
-        let uu____1126 = lid_to_string eff_lid  in
-        FStar_Util.format1 "(Action %s)" uu____1126
+        let uu____1135 = lid_to_string eff_lid  in
+        FStar_Util.format1 "(Action %s)" uu____1135
     | FStar_Syntax_Syntax.ExceptionConstructor  -> "ExceptionConstructor"
     | FStar_Syntax_Syntax.HasMaskedEffect  -> "HasMaskedEffect"
     | FStar_Syntax_Syntax.Effect  -> "Effect"
     | FStar_Syntax_Syntax.Reifiable  -> "reify"
     | FStar_Syntax_Syntax.Reflectable l ->
-        FStar_Util.format1 "(reflect %s)" l.FStar_Ident.str
+        let uu____1143 = FStar_Ident.string_of_lid l  in
+        FStar_Util.format1 "(reflect %s)" uu____1143
     | FStar_Syntax_Syntax.OnlyName  -> "OnlyName"
   
 let (quals_to_string :
@@ -373,19 +380,19 @@ let (quals_to_string :
   fun quals  ->
     match quals with
     | [] -> ""
-    | uu____1149 ->
-        let uu____1152 =
+    | uu____1160 ->
+        let uu____1163 =
           FStar_All.pipe_right quals (FStar_List.map qual_to_string)  in
-        FStar_All.pipe_right uu____1152 (FStar_String.concat " ")
+        FStar_All.pipe_right uu____1163 (FStar_String.concat " ")
   
 let (quals_to_string' :
   FStar_Syntax_Syntax.qualifier Prims.list -> Prims.string) =
   fun quals  ->
     match quals with
     | [] -> ""
-    | uu____1180 ->
-        let uu____1183 = quals_to_string quals  in
-        Prims.op_Hat uu____1183 " "
+    | uu____1191 ->
+        let uu____1194 = quals_to_string quals  in
+        Prims.op_Hat uu____1194 " "
   
 let (paren : Prims.string -> Prims.string) =
   fun s  -> Prims.op_Hat "(" (Prims.op_Hat s ")") 
@@ -393,52 +400,52 @@ let rec (tag_of_term : FStar_Syntax_Syntax.term -> Prims.string) =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_bvar x ->
-        let uu____1365 = db_to_string x  in
-        Prims.op_Hat "Tm_bvar: " uu____1365
+        let uu____1376 = db_to_string x  in
+        Prims.op_Hat "Tm_bvar: " uu____1376
     | FStar_Syntax_Syntax.Tm_name x ->
-        let uu____1369 = nm_to_string x  in
-        Prims.op_Hat "Tm_name: " uu____1369
+        let uu____1380 = nm_to_string x  in
+        Prims.op_Hat "Tm_name: " uu____1380
     | FStar_Syntax_Syntax.Tm_fvar x ->
-        let uu____1373 =
+        let uu____1384 =
           lid_to_string (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
            in
-        Prims.op_Hat "Tm_fvar: " uu____1373
-    | FStar_Syntax_Syntax.Tm_uinst uu____1376 -> "Tm_uinst"
-    | FStar_Syntax_Syntax.Tm_constant uu____1384 -> "Tm_constant"
-    | FStar_Syntax_Syntax.Tm_type uu____1386 -> "Tm_type"
+        Prims.op_Hat "Tm_fvar: " uu____1384
+    | FStar_Syntax_Syntax.Tm_uinst uu____1387 -> "Tm_uinst"
+    | FStar_Syntax_Syntax.Tm_constant uu____1395 -> "Tm_constant"
+    | FStar_Syntax_Syntax.Tm_type uu____1397 -> "Tm_type"
     | FStar_Syntax_Syntax.Tm_quoted
-        (uu____1388,{
+        (uu____1399,{
                       FStar_Syntax_Syntax.qkind =
                         FStar_Syntax_Syntax.Quote_static ;
-                      FStar_Syntax_Syntax.antiquotes = uu____1389;_})
+                      FStar_Syntax_Syntax.antiquotes = uu____1400;_})
         -> "Tm_quoted (static)"
     | FStar_Syntax_Syntax.Tm_quoted
-        (uu____1403,{
+        (uu____1414,{
                       FStar_Syntax_Syntax.qkind =
                         FStar_Syntax_Syntax.Quote_dynamic ;
-                      FStar_Syntax_Syntax.antiquotes = uu____1404;_})
+                      FStar_Syntax_Syntax.antiquotes = uu____1415;_})
         -> "Tm_quoted (dynamic)"
-    | FStar_Syntax_Syntax.Tm_abs uu____1418 -> "Tm_abs"
-    | FStar_Syntax_Syntax.Tm_arrow uu____1438 -> "Tm_arrow"
-    | FStar_Syntax_Syntax.Tm_refine uu____1454 -> "Tm_refine"
-    | FStar_Syntax_Syntax.Tm_app uu____1462 -> "Tm_app"
-    | FStar_Syntax_Syntax.Tm_match uu____1480 -> "Tm_match"
-    | FStar_Syntax_Syntax.Tm_ascribed uu____1504 -> "Tm_ascribed"
-    | FStar_Syntax_Syntax.Tm_let uu____1532 -> "Tm_let"
-    | FStar_Syntax_Syntax.Tm_uvar uu____1547 -> "Tm_uvar"
-    | FStar_Syntax_Syntax.Tm_delayed uu____1561 -> "Tm_delayed-resolved"
-    | FStar_Syntax_Syntax.Tm_meta (uu____1577,m) ->
-        let uu____1583 = metadata_to_string m  in
-        Prims.op_Hat "Tm_meta:" uu____1583
+    | FStar_Syntax_Syntax.Tm_abs uu____1429 -> "Tm_abs"
+    | FStar_Syntax_Syntax.Tm_arrow uu____1449 -> "Tm_arrow"
+    | FStar_Syntax_Syntax.Tm_refine uu____1465 -> "Tm_refine"
+    | FStar_Syntax_Syntax.Tm_app uu____1473 -> "Tm_app"
+    | FStar_Syntax_Syntax.Tm_match uu____1491 -> "Tm_match"
+    | FStar_Syntax_Syntax.Tm_ascribed uu____1515 -> "Tm_ascribed"
+    | FStar_Syntax_Syntax.Tm_let uu____1543 -> "Tm_let"
+    | FStar_Syntax_Syntax.Tm_uvar uu____1558 -> "Tm_uvar"
+    | FStar_Syntax_Syntax.Tm_delayed uu____1572 -> "Tm_delayed-resolved"
+    | FStar_Syntax_Syntax.Tm_meta (uu____1588,m) ->
+        let uu____1594 = metadata_to_string m  in
+        Prims.op_Hat "Tm_meta:" uu____1594
     | FStar_Syntax_Syntax.Tm_unknown  -> "Tm_unknown"
-    | FStar_Syntax_Syntax.Tm_lazy uu____1587 -> "Tm_lazy"
+    | FStar_Syntax_Syntax.Tm_lazy uu____1598 -> "Tm_lazy"
 
 and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
   fun x  ->
-    let uu____1590 =
-      let uu____1592 = FStar_Options.ugly ()  in Prims.op_Negation uu____1592
+    let uu____1601 =
+      let uu____1603 = FStar_Options.ugly ()  in Prims.op_Negation uu____1603
        in
-    if uu____1590
+    if uu____1601
     then
       let e = FStar_Syntax_Resugar.resugar_term x  in
       let d = FStar_Parser_ToDocument.term_to_document e  in
@@ -447,359 +454,363 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
     else
       (let x1 = FStar_Syntax_Subst.compress x  in
        let x2 =
-         let uu____1606 = FStar_Options.print_implicits ()  in
-         if uu____1606 then x1 else FStar_Syntax_Util.unmeta x1  in
+         let uu____1617 = FStar_Options.print_implicits ()  in
+         if uu____1617 then x1 else FStar_Syntax_Util.unmeta x1  in
        match x2.FStar_Syntax_Syntax.n with
-       | FStar_Syntax_Syntax.Tm_delayed uu____1614 -> failwith "impossible"
-       | FStar_Syntax_Syntax.Tm_app (uu____1631,[]) -> failwith "Empty args!"
+       | FStar_Syntax_Syntax.Tm_delayed uu____1625 -> failwith "impossible"
+       | FStar_Syntax_Syntax.Tm_app (uu____1642,[]) -> failwith "Empty args!"
        | FStar_Syntax_Syntax.Tm_lazy
            { FStar_Syntax_Syntax.blob = b;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               (uu____1657,thunk);
-             FStar_Syntax_Syntax.ltyp = uu____1659;
-             FStar_Syntax_Syntax.rng = uu____1660;_}
+               (uu____1668,thunk);
+             FStar_Syntax_Syntax.ltyp = uu____1670;
+             FStar_Syntax_Syntax.rng = uu____1671;_}
            ->
-           let uu____1671 =
-             let uu____1673 =
-               let uu____1675 = FStar_Thunk.force thunk  in
-               term_to_string uu____1675  in
-             Prims.op_Hat uu____1673 "]"  in
-           Prims.op_Hat "[LAZYEMB:" uu____1671
+           let uu____1682 =
+             let uu____1684 =
+               let uu____1686 = FStar_Thunk.force thunk  in
+               term_to_string uu____1686  in
+             Prims.op_Hat uu____1684 "]"  in
+           Prims.op_Hat "[LAZYEMB:" uu____1682
        | FStar_Syntax_Syntax.Tm_lazy i ->
-           let uu____1681 =
-             let uu____1683 =
-               let uu____1685 =
-                 let uu____1686 =
-                   let uu____1695 =
+           let uu____1692 =
+             let uu____1694 =
+               let uu____1696 =
+                 let uu____1697 =
+                   let uu____1706 =
                      FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser  in
-                   FStar_Util.must uu____1695  in
-                 uu____1686 i.FStar_Syntax_Syntax.lkind i  in
-               term_to_string uu____1685  in
-             Prims.op_Hat uu____1683 "]"  in
-           Prims.op_Hat "[lazy:" uu____1681
+                   FStar_Util.must uu____1706  in
+                 uu____1697 i.FStar_Syntax_Syntax.lkind i  in
+               term_to_string uu____1696  in
+             Prims.op_Hat uu____1694 "]"  in
+           Prims.op_Hat "[lazy:" uu____1692
        | FStar_Syntax_Syntax.Tm_quoted (tm,qi) ->
            (match qi.FStar_Syntax_Syntax.qkind with
             | FStar_Syntax_Syntax.Quote_static  ->
-                let print_aq uu____1764 =
-                  match uu____1764 with
+                let print_aq uu____1775 =
+                  match uu____1775 with
                   | (bv,t) ->
-                      let uu____1772 = bv_to_string bv  in
-                      let uu____1774 = term_to_string t  in
-                      FStar_Util.format2 "%s -> %s" uu____1772 uu____1774
+                      let uu____1783 = bv_to_string bv  in
+                      let uu____1785 = term_to_string t  in
+                      FStar_Util.format2 "%s -> %s" uu____1783 uu____1785
                    in
-                let uu____1777 = term_to_string tm  in
-                let uu____1779 =
+                let uu____1788 = term_to_string tm  in
+                let uu____1790 =
                   FStar_Common.string_of_list print_aq
                     qi.FStar_Syntax_Syntax.antiquotes
                    in
-                FStar_Util.format2 "`(%s)%s" uu____1777 uu____1779
+                FStar_Util.format2 "`(%s)%s" uu____1788 uu____1790
             | FStar_Syntax_Syntax.Quote_dynamic  ->
-                let uu____1788 = term_to_string tm  in
-                FStar_Util.format1 "quote (%s)" uu____1788)
+                let uu____1799 = term_to_string tm  in
+                FStar_Util.format1 "quote (%s)" uu____1799)
        | FStar_Syntax_Syntax.Tm_meta
-           (t,FStar_Syntax_Syntax.Meta_pattern (uu____1792,ps)) ->
+           (t,FStar_Syntax_Syntax.Meta_pattern (uu____1803,ps)) ->
            let pats =
-             let uu____1832 =
+             let uu____1843 =
                FStar_All.pipe_right ps
                  (FStar_List.map
                     (fun args  ->
-                       let uu____1869 =
+                       let uu____1880 =
                          FStar_All.pipe_right args
                            (FStar_List.map
-                              (fun uu____1894  ->
-                                 match uu____1894 with
-                                 | (t1,uu____1903) -> term_to_string t1))
+                              (fun uu____1905  ->
+                                 match uu____1905 with
+                                 | (t1,uu____1914) -> term_to_string t1))
                           in
-                       FStar_All.pipe_right uu____1869
+                       FStar_All.pipe_right uu____1880
                          (FStar_String.concat "; ")))
                 in
-             FStar_All.pipe_right uu____1832 (FStar_String.concat "\\/")  in
-           let uu____1918 = term_to_string t  in
-           FStar_Util.format2 "{:pattern %s} %s" pats uu____1918
+             FStar_All.pipe_right uu____1843 (FStar_String.concat "\\/")  in
+           let uu____1929 = term_to_string t  in
+           FStar_Util.format2 "{:pattern %s} %s" pats uu____1929
        | FStar_Syntax_Syntax.Tm_meta
            (t,FStar_Syntax_Syntax.Meta_monadic (m,t')) ->
-           let uu____1932 = tag_of_term t  in
-           let uu____1934 = sli m  in
-           let uu____1936 = term_to_string t'  in
-           let uu____1938 = term_to_string t  in
-           FStar_Util.format4 "(Monadic-%s{%s %s} %s)" uu____1932 uu____1934
-             uu____1936 uu____1938
+           let uu____1943 = tag_of_term t  in
+           let uu____1945 = sli m  in
+           let uu____1947 = term_to_string t'  in
+           let uu____1949 = term_to_string t  in
+           FStar_Util.format4 "(Monadic-%s{%s %s} %s)" uu____1943 uu____1945
+             uu____1947 uu____1949
        | FStar_Syntax_Syntax.Tm_meta
            (t,FStar_Syntax_Syntax.Meta_monadic_lift (m0,m1,t')) ->
-           let uu____1953 = tag_of_term t  in
-           let uu____1955 = term_to_string t'  in
-           let uu____1957 = sli m0  in
-           let uu____1959 = sli m1  in
-           let uu____1961 = term_to_string t  in
-           FStar_Util.format5 "(MonadicLift-%s{%s : %s -> %s} %s)" uu____1953
-             uu____1955 uu____1957 uu____1959 uu____1961
+           let uu____1964 = tag_of_term t  in
+           let uu____1966 = term_to_string t'  in
+           let uu____1968 = sli m0  in
+           let uu____1970 = sli m1  in
+           let uu____1972 = term_to_string t  in
+           FStar_Util.format5 "(MonadicLift-%s{%s : %s -> %s} %s)" uu____1964
+             uu____1966 uu____1968 uu____1970 uu____1972
        | FStar_Syntax_Syntax.Tm_meta
            (t,FStar_Syntax_Syntax.Meta_labeled (l,r,b)) ->
-           let uu____1976 = FStar_Range.string_of_range r  in
-           let uu____1978 = term_to_string t  in
-           FStar_Util.format3 "Meta_labeled(%s, %s){%s}" l uu____1976
-             uu____1978
+           let uu____1987 = FStar_Range.string_of_range r  in
+           let uu____1989 = term_to_string t  in
+           FStar_Util.format3 "Meta_labeled(%s, %s){%s}" l uu____1987
+             uu____1989
        | FStar_Syntax_Syntax.Tm_meta (t,FStar_Syntax_Syntax.Meta_named l) ->
-           let uu____1987 = lid_to_string l  in
-           let uu____1989 =
+           let uu____1998 = lid_to_string l  in
+           let uu____2000 =
              FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos  in
-           let uu____1991 = term_to_string t  in
-           FStar_Util.format3 "Meta_named(%s, %s){%s}" uu____1987 uu____1989
-             uu____1991
+           let uu____2002 = term_to_string t  in
+           FStar_Util.format3 "Meta_named(%s, %s){%s}" uu____1998 uu____2000
+             uu____2002
        | FStar_Syntax_Syntax.Tm_meta
-           (t,FStar_Syntax_Syntax.Meta_desugared uu____1995) ->
-           let uu____2000 = term_to_string t  in
-           FStar_Util.format1 "Meta_desugared{%s}" uu____2000
+           (t,FStar_Syntax_Syntax.Meta_desugared uu____2006) ->
+           let uu____2011 = term_to_string t  in
+           FStar_Util.format1 "Meta_desugared{%s}" uu____2011
        | FStar_Syntax_Syntax.Tm_bvar x3 ->
-           let uu____2004 = db_to_string x3  in
-           let uu____2006 =
-             let uu____2008 =
-               let uu____2010 = tag_of_term x3.FStar_Syntax_Syntax.sort  in
-               Prims.op_Hat uu____2010 ")"  in
-             Prims.op_Hat ":(" uu____2008  in
-           Prims.op_Hat uu____2004 uu____2006
+           let uu____2015 = db_to_string x3  in
+           let uu____2017 =
+             let uu____2019 =
+               let uu____2021 = tag_of_term x3.FStar_Syntax_Syntax.sort  in
+               Prims.op_Hat uu____2021 ")"  in
+             Prims.op_Hat ":(" uu____2019  in
+           Prims.op_Hat uu____2015 uu____2017
        | FStar_Syntax_Syntax.Tm_name x3 -> nm_to_string x3
        | FStar_Syntax_Syntax.Tm_fvar f -> fv_to_string f
-       | FStar_Syntax_Syntax.Tm_uvar (u,([],uu____2017)) ->
-           let uu____2032 =
+       | FStar_Syntax_Syntax.Tm_uvar (u,([],uu____2028)) ->
+           let uu____2043 =
              (FStar_Options.print_bound_var_types ()) &&
                (FStar_Options.print_effect_args ())
               in
-           if uu____2032
+           if uu____2043
            then ctx_uvar_to_string u
            else
-             (let uu____2038 =
-                let uu____2040 =
+             (let uu____2049 =
+                let uu____2051 =
                   FStar_Syntax_Unionfind.uvar_id
                     u.FStar_Syntax_Syntax.ctx_uvar_head
                    in
-                FStar_All.pipe_left FStar_Util.string_of_int uu____2040  in
-              Prims.op_Hat "?" uu____2038)
+                FStar_All.pipe_left FStar_Util.string_of_int uu____2051  in
+              Prims.op_Hat "?" uu____2049)
        | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
-           let uu____2063 =
+           let uu____2074 =
              (FStar_Options.print_bound_var_types ()) &&
                (FStar_Options.print_effect_args ())
               in
-           if uu____2063
+           if uu____2074
            then
-             let uu____2067 = ctx_uvar_to_string u  in
-             let uu____2069 =
-               let uu____2071 =
+             let uu____2078 = ctx_uvar_to_string u  in
+             let uu____2080 =
+               let uu____2082 =
                  FStar_List.map subst_to_string
                    (FStar_Pervasives_Native.fst s)
                   in
-               FStar_All.pipe_right uu____2071 (FStar_String.concat "; ")  in
-             FStar_Util.format2 "(%s @ %s)" uu____2067 uu____2069
+               FStar_All.pipe_right uu____2082 (FStar_String.concat "; ")  in
+             FStar_Util.format2 "(%s @ %s)" uu____2078 uu____2080
            else
-             (let uu____2090 =
-                let uu____2092 =
+             (let uu____2101 =
+                let uu____2103 =
                   FStar_Syntax_Unionfind.uvar_id
                     u.FStar_Syntax_Syntax.ctx_uvar_head
                    in
-                FStar_All.pipe_left FStar_Util.string_of_int uu____2092  in
-              Prims.op_Hat "?" uu____2090)
+                FStar_All.pipe_left FStar_Util.string_of_int uu____2103  in
+              Prims.op_Hat "?" uu____2101)
        | FStar_Syntax_Syntax.Tm_constant c -> const_to_string c
        | FStar_Syntax_Syntax.Tm_type u ->
-           let uu____2099 = FStar_Options.print_universes ()  in
-           if uu____2099
+           let uu____2110 = FStar_Options.print_universes ()  in
+           if uu____2110
            then
-             let uu____2103 = univ_to_string u  in
-             FStar_Util.format1 "Type u#(%s)" uu____2103
+             let uu____2114 = univ_to_string u  in
+             FStar_Util.format1 "Type u#(%s)" uu____2114
            else "Type"
        | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-           let uu____2131 = binders_to_string " -> " bs  in
-           let uu____2134 = comp_to_string c  in
-           FStar_Util.format2 "(%s -> %s)" uu____2131 uu____2134
+           let uu____2142 = binders_to_string " -> " bs  in
+           let uu____2145 = comp_to_string c  in
+           FStar_Util.format2 "(%s -> %s)" uu____2142 uu____2145
        | FStar_Syntax_Syntax.Tm_abs (bs,t2,lc) ->
            (match lc with
             | FStar_Pervasives_Native.Some rc when
                 FStar_Options.print_implicits () ->
-                let uu____2166 = binders_to_string " " bs  in
-                let uu____2169 = term_to_string t2  in
-                let uu____2171 =
+                let uu____2177 = binders_to_string " " bs  in
+                let uu____2180 = term_to_string t2  in
+                let uu____2182 =
+                  FStar_Ident.string_of_lid
+                    rc.FStar_Syntax_Syntax.residual_effect
+                   in
+                let uu____2184 =
                   if FStar_Option.isNone rc.FStar_Syntax_Syntax.residual_typ
                   then "None"
                   else
-                    (let uu____2180 =
+                    (let uu____2193 =
                        FStar_Option.get rc.FStar_Syntax_Syntax.residual_typ
                         in
-                     term_to_string uu____2180)
+                     term_to_string uu____2193)
                    in
                 FStar_Util.format4 "(fun %s -> (%s $$ (residual) %s %s))"
-                  uu____2166 uu____2169
-                  (rc.FStar_Syntax_Syntax.residual_effect).FStar_Ident.str
-                  uu____2171
-            | uu____2184 ->
-                let uu____2187 = binders_to_string " " bs  in
-                let uu____2190 = term_to_string t2  in
-                FStar_Util.format2 "(fun %s -> %s)" uu____2187 uu____2190)
+                  uu____2177 uu____2180 uu____2182 uu____2184
+            | uu____2197 ->
+                let uu____2200 = binders_to_string " " bs  in
+                let uu____2203 = term_to_string t2  in
+                FStar_Util.format2 "(fun %s -> %s)" uu____2200 uu____2203)
        | FStar_Syntax_Syntax.Tm_refine (xt,f) ->
-           let uu____2199 = bv_to_string xt  in
-           let uu____2201 =
+           let uu____2212 = bv_to_string xt  in
+           let uu____2214 =
              FStar_All.pipe_right xt.FStar_Syntax_Syntax.sort term_to_string
               in
-           let uu____2204 = FStar_All.pipe_right f formula_to_string  in
-           FStar_Util.format3 "(%s:%s{%s})" uu____2199 uu____2201 uu____2204
+           let uu____2217 = FStar_All.pipe_right f formula_to_string  in
+           FStar_Util.format3 "(%s:%s{%s})" uu____2212 uu____2214 uu____2217
        | FStar_Syntax_Syntax.Tm_app (t,args) ->
-           let uu____2236 = term_to_string t  in
-           let uu____2238 = args_to_string args  in
-           FStar_Util.format2 "(%s %s)" uu____2236 uu____2238
+           let uu____2249 = term_to_string t  in
+           let uu____2251 = args_to_string args  in
+           FStar_Util.format2 "(%s %s)" uu____2249 uu____2251
        | FStar_Syntax_Syntax.Tm_let (lbs,e) ->
-           let uu____2261 = lbs_to_string [] lbs  in
-           let uu____2263 = term_to_string e  in
-           FStar_Util.format2 "%s\nin\n%s" uu____2261 uu____2263
+           let uu____2274 = lbs_to_string [] lbs  in
+           let uu____2276 = term_to_string e  in
+           FStar_Util.format2 "%s\nin\n%s" uu____2274 uu____2276
        | FStar_Syntax_Syntax.Tm_ascribed (e,(annot,topt),eff_name) ->
            let annot1 =
              match annot with
              | FStar_Util.Inl t ->
-                 let uu____2328 =
-                   let uu____2330 =
-                     FStar_Util.map_opt eff_name FStar_Ident.text_of_lid  in
-                   FStar_All.pipe_right uu____2330
+                 let uu____2341 =
+                   let uu____2343 =
+                     FStar_Util.map_opt eff_name FStar_Ident.string_of_lid
+                      in
+                   FStar_All.pipe_right uu____2343
                      (FStar_Util.dflt "default")
                     in
-                 let uu____2341 = term_to_string t  in
-                 FStar_Util.format2 "[%s] %s" uu____2328 uu____2341
+                 let uu____2354 = term_to_string t  in
+                 FStar_Util.format2 "[%s] %s" uu____2341 uu____2354
              | FStar_Util.Inr c -> comp_to_string c  in
            let topt1 =
              match topt with
              | FStar_Pervasives_Native.None  -> ""
              | FStar_Pervasives_Native.Some t ->
-                 let uu____2362 = term_to_string t  in
-                 FStar_Util.format1 "by %s" uu____2362
+                 let uu____2375 = term_to_string t  in
+                 FStar_Util.format1 "by %s" uu____2375
               in
-           let uu____2365 = term_to_string e  in
-           FStar_Util.format3 "(%s <ascribed: %s %s)" uu____2365 annot1 topt1
+           let uu____2378 = term_to_string e  in
+           FStar_Util.format3 "(%s <ascribed: %s %s)" uu____2378 annot1 topt1
        | FStar_Syntax_Syntax.Tm_match (head,branches) ->
-           let uu____2406 = term_to_string head  in
-           let uu____2408 =
-             let uu____2410 =
+           let uu____2419 = term_to_string head  in
+           let uu____2421 =
+             let uu____2423 =
                FStar_All.pipe_right branches
                  (FStar_List.map branch_to_string)
                 in
-             FStar_Util.concat_l "\n\t|" uu____2410  in
-           FStar_Util.format2 "(match %s with\n\t| %s)" uu____2406 uu____2408
+             FStar_Util.concat_l "\n\t|" uu____2423  in
+           FStar_Util.format2 "(match %s with\n\t| %s)" uu____2419 uu____2421
        | FStar_Syntax_Syntax.Tm_uinst (t,us) ->
-           let uu____2428 = FStar_Options.print_universes ()  in
-           if uu____2428
+           let uu____2441 = FStar_Options.print_universes ()  in
+           if uu____2441
            then
-             let uu____2432 = term_to_string t  in
-             let uu____2434 = univs_to_string us  in
-             FStar_Util.format2 "%s<%s>" uu____2432 uu____2434
+             let uu____2445 = term_to_string t  in
+             let uu____2447 = univs_to_string us  in
+             FStar_Util.format2 "%s<%s>" uu____2445 uu____2447
            else term_to_string t
        | FStar_Syntax_Syntax.Tm_unknown  -> "_")
 
 and (branch_to_string : FStar_Syntax_Syntax.branch -> Prims.string) =
-  fun uu____2440  ->
-    match uu____2440 with
+  fun uu____2453  ->
+    match uu____2453 with
     | (p,wopt,e) ->
-        let uu____2462 = FStar_All.pipe_right p pat_to_string  in
-        let uu____2465 =
+        let uu____2475 = FStar_All.pipe_right p pat_to_string  in
+        let uu____2478 =
           match wopt with
           | FStar_Pervasives_Native.None  -> ""
           | FStar_Pervasives_Native.Some w ->
-              let uu____2476 = FStar_All.pipe_right w term_to_string  in
-              FStar_Util.format1 "when %s" uu____2476
+              let uu____2489 = FStar_All.pipe_right w term_to_string  in
+              FStar_Util.format1 "when %s" uu____2489
            in
-        let uu____2480 = FStar_All.pipe_right e term_to_string  in
-        FStar_Util.format3 "%s %s -> %s" uu____2462 uu____2465 uu____2480
+        let uu____2493 = FStar_All.pipe_right e term_to_string  in
+        FStar_Util.format3 "%s %s -> %s" uu____2475 uu____2478 uu____2493
 
 and (ctx_uvar_to_string : FStar_Syntax_Syntax.ctx_uvar -> Prims.string) =
   fun ctx_uvar  ->
-    let uu____2485 =
+    let uu____2498 =
       binders_to_string ", " ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_binders
        in
-    let uu____2488 =
+    let uu____2501 =
       uvar_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head  in
-    let uu____2490 = term_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ
+    let uu____2503 = term_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ
        in
     FStar_Util.format4 "(* %s *)\n(%s |- %s : %s)"
-      ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_reason uu____2485 uu____2488
-      uu____2490
+      ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_reason uu____2498 uu____2501
+      uu____2503
 
 and (subst_elt_to_string : FStar_Syntax_Syntax.subst_elt -> Prims.string) =
-  fun uu___5_2493  ->
-    match uu___5_2493 with
+  fun uu___5_2506  ->
+    match uu___5_2506 with
     | FStar_Syntax_Syntax.DB (i,x) ->
-        let uu____2499 = FStar_Util.string_of_int i  in
-        let uu____2501 = bv_to_string x  in
-        FStar_Util.format2 "DB (%s, %s)" uu____2499 uu____2501
+        let uu____2512 = FStar_Util.string_of_int i  in
+        let uu____2514 = bv_to_string x  in
+        FStar_Util.format2 "DB (%s, %s)" uu____2512 uu____2514
     | FStar_Syntax_Syntax.NM (x,i) ->
-        let uu____2508 = bv_to_string x  in
-        let uu____2510 = FStar_Util.string_of_int i  in
-        FStar_Util.format2 "NM (%s, %s)" uu____2508 uu____2510
+        let uu____2521 = bv_to_string x  in
+        let uu____2523 = FStar_Util.string_of_int i  in
+        FStar_Util.format2 "NM (%s, %s)" uu____2521 uu____2523
     | FStar_Syntax_Syntax.NT (x,t) ->
-        let uu____2519 = bv_to_string x  in
-        let uu____2521 = term_to_string t  in
-        FStar_Util.format2 "NT (%s, %s)" uu____2519 uu____2521
+        let uu____2532 = bv_to_string x  in
+        let uu____2534 = term_to_string t  in
+        FStar_Util.format2 "NT (%s, %s)" uu____2532 uu____2534
     | FStar_Syntax_Syntax.UN (i,u) ->
-        let uu____2528 = FStar_Util.string_of_int i  in
-        let uu____2530 = univ_to_string u  in
-        FStar_Util.format2 "UN (%s, %s)" uu____2528 uu____2530
+        let uu____2541 = FStar_Util.string_of_int i  in
+        let uu____2543 = univ_to_string u  in
+        FStar_Util.format2 "UN (%s, %s)" uu____2541 uu____2543
     | FStar_Syntax_Syntax.UD (u,i) ->
-        let uu____2537 = FStar_Util.string_of_int i  in
-        FStar_Util.format2 "UD (%s, %s)" u.FStar_Ident.idText uu____2537
+        let uu____2550 = FStar_Ident.text_of_id u  in
+        let uu____2552 = FStar_Util.string_of_int i  in
+        FStar_Util.format2 "UD (%s, %s)" uu____2550 uu____2552
 
 and (subst_to_string : FStar_Syntax_Syntax.subst_t -> Prims.string) =
   fun s  ->
-    let uu____2541 =
+    let uu____2556 =
       FStar_All.pipe_right s (FStar_List.map subst_elt_to_string)  in
-    FStar_All.pipe_right uu____2541 (FStar_String.concat "; ")
+    FStar_All.pipe_right uu____2556 (FStar_String.concat "; ")
 
 and (pat_to_string : FStar_Syntax_Syntax.pat -> Prims.string) =
   fun x  ->
-    let uu____2557 =
-      let uu____2559 = FStar_Options.ugly ()  in Prims.op_Negation uu____2559
+    let uu____2572 =
+      let uu____2574 = FStar_Options.ugly ()  in Prims.op_Negation uu____2574
        in
-    if uu____2557
+    if uu____2572
     then
       let e =
-        let uu____2564 = FStar_Syntax_Syntax.new_bv_set ()  in
-        FStar_Syntax_Resugar.resugar_pat x uu____2564  in
+        let uu____2579 = FStar_Syntax_Syntax.new_bv_set ()  in
+        FStar_Syntax_Resugar.resugar_pat x uu____2579  in
       let d = FStar_Parser_ToDocument.pat_to_document e  in
       FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
         (Prims.of_int (100)) d
     else
       (match x.FStar_Syntax_Syntax.v with
        | FStar_Syntax_Syntax.Pat_cons (l,pats) ->
-           let uu____2593 = fv_to_string l  in
-           let uu____2595 =
-             let uu____2597 =
+           let uu____2608 = fv_to_string l  in
+           let uu____2610 =
+             let uu____2612 =
                FStar_List.map
-                 (fun uu____2611  ->
-                    match uu____2611 with
+                 (fun uu____2626  ->
+                    match uu____2626 with
                     | (x1,b) ->
                         let p = pat_to_string x1  in
                         if b then Prims.op_Hat "#" p else p) pats
                 in
-             FStar_All.pipe_right uu____2597 (FStar_String.concat " ")  in
-           FStar_Util.format2 "(%s %s)" uu____2593 uu____2595
-       | FStar_Syntax_Syntax.Pat_dot_term (x1,uu____2636) ->
-           let uu____2641 = FStar_Options.print_bound_var_types ()  in
-           if uu____2641
-           then
-             let uu____2645 = bv_to_string x1  in
-             let uu____2647 = term_to_string x1.FStar_Syntax_Syntax.sort  in
-             FStar_Util.format2 ".%s:%s" uu____2645 uu____2647
-           else
-             (let uu____2652 = bv_to_string x1  in
-              FStar_Util.format1 ".%s" uu____2652)
-       | FStar_Syntax_Syntax.Pat_var x1 ->
+             FStar_All.pipe_right uu____2612 (FStar_String.concat " ")  in
+           FStar_Util.format2 "(%s %s)" uu____2608 uu____2610
+       | FStar_Syntax_Syntax.Pat_dot_term (x1,uu____2651) ->
            let uu____2656 = FStar_Options.print_bound_var_types ()  in
            if uu____2656
            then
              let uu____2660 = bv_to_string x1  in
              let uu____2662 = term_to_string x1.FStar_Syntax_Syntax.sort  in
-             FStar_Util.format2 "%s:%s" uu____2660 uu____2662
+             FStar_Util.format2 ".%s:%s" uu____2660 uu____2662
+           else
+             (let uu____2667 = bv_to_string x1  in
+              FStar_Util.format1 ".%s" uu____2667)
+       | FStar_Syntax_Syntax.Pat_var x1 ->
+           let uu____2671 = FStar_Options.print_bound_var_types ()  in
+           if uu____2671
+           then
+             let uu____2675 = bv_to_string x1  in
+             let uu____2677 = term_to_string x1.FStar_Syntax_Syntax.sort  in
+             FStar_Util.format2 "%s:%s" uu____2675 uu____2677
            else bv_to_string x1
        | FStar_Syntax_Syntax.Pat_constant c -> const_to_string c
        | FStar_Syntax_Syntax.Pat_wild x1 ->
-           let uu____2669 = FStar_Options.print_bound_var_types ()  in
-           if uu____2669
+           let uu____2684 = FStar_Options.print_bound_var_types ()  in
+           if uu____2684
            then
-             let uu____2673 = bv_to_string x1  in
-             let uu____2675 = term_to_string x1.FStar_Syntax_Syntax.sort  in
-             FStar_Util.format2 "_wild_%s:%s" uu____2673 uu____2675
+             let uu____2688 = bv_to_string x1  in
+             let uu____2690 = term_to_string x1.FStar_Syntax_Syntax.sort  in
+             FStar_Util.format2 "_wild_%s:%s" uu____2688 uu____2690
            else bv_to_string x1)
 
 and (lbs_to_string :
@@ -808,54 +819,54 @@ and (lbs_to_string :
   =
   fun quals  ->
     fun lbs  ->
-      let uu____2684 = quals_to_string' quals  in
-      let uu____2686 =
-        let uu____2688 =
+      let uu____2699 = quals_to_string' quals  in
+      let uu____2701 =
+        let uu____2703 =
           FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
             (FStar_List.map
                (fun lb  ->
-                  let uu____2708 =
+                  let uu____2723 =
                     attrs_to_string lb.FStar_Syntax_Syntax.lbattrs  in
-                  let uu____2710 =
+                  let uu____2725 =
                     lbname_to_string lb.FStar_Syntax_Syntax.lbname  in
-                  let uu____2712 =
-                    let uu____2714 = FStar_Options.print_universes ()  in
-                    if uu____2714
+                  let uu____2727 =
+                    let uu____2729 = FStar_Options.print_universes ()  in
+                    if uu____2729
                     then
-                      let uu____2718 =
-                        let uu____2720 =
+                      let uu____2733 =
+                        let uu____2735 =
                           univ_names_to_string lb.FStar_Syntax_Syntax.lbunivs
                            in
-                        Prims.op_Hat uu____2720 ">"  in
-                      Prims.op_Hat "<" uu____2718
+                        Prims.op_Hat uu____2735 ">"  in
+                      Prims.op_Hat "<" uu____2733
                     else ""  in
-                  let uu____2727 =
+                  let uu____2742 =
                     term_to_string lb.FStar_Syntax_Syntax.lbtyp  in
-                  let uu____2729 =
+                  let uu____2744 =
                     FStar_All.pipe_right lb.FStar_Syntax_Syntax.lbdef
                       term_to_string
                      in
-                  FStar_Util.format5 "%s%s %s : %s = %s" uu____2708
-                    uu____2710 uu____2712 uu____2727 uu____2729))
+                  FStar_Util.format5 "%s%s %s : %s = %s" uu____2723
+                    uu____2725 uu____2727 uu____2742 uu____2744))
            in
-        FStar_Util.concat_l "\n and " uu____2688  in
-      FStar_Util.format3 "%slet %s %s" uu____2684
-        (if FStar_Pervasives_Native.fst lbs then "rec" else "") uu____2686
+        FStar_Util.concat_l "\n and " uu____2703  in
+      FStar_Util.format3 "%slet %s %s" uu____2699
+        (if FStar_Pervasives_Native.fst lbs then "rec" else "") uu____2701
 
 and (attrs_to_string :
   FStar_Syntax_Syntax.attribute Prims.list -> Prims.string) =
-  fun uu___6_2744  ->
-    match uu___6_2744 with
+  fun uu___6_2759  ->
+    match uu___6_2759 with
     | [] -> ""
     | tms ->
-        let uu____2752 =
-          let uu____2754 =
+        let uu____2767 =
+          let uu____2769 =
             FStar_List.map
               (fun t  ->
-                 let uu____2762 = term_to_string t  in paren uu____2762) tms
+                 let uu____2777 = term_to_string t  in paren uu____2777) tms
              in
-          FStar_All.pipe_right uu____2754 (FStar_String.concat "; ")  in
-        FStar_Util.format1 "[@ %s]" uu____2752
+          FStar_All.pipe_right uu____2769 (FStar_String.concat "; ")  in
+        FStar_Util.format1 "[@ %s]" uu____2767
 
 and (aqual_to_string' :
   Prims.string ->
@@ -863,8 +874,8 @@ and (aqual_to_string' :
       Prims.string)
   =
   fun s  ->
-    fun uu___7_2771  ->
-      match uu___7_2771 with
+    fun uu___7_2786  ->
+      match uu___7_2786 with
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit (false ))
           -> Prims.op_Hat "#" s
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit (true ))
@@ -875,10 +886,10 @@ and (aqual_to_string' :
           FStar_Syntax_Util.is_fvar FStar_Parser_Const.tcresolve_lid t ->
           Prims.op_Hat "[|" (Prims.op_Hat s "|]")
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta t) ->
-          let uu____2789 =
-            let uu____2791 = term_to_string t  in
-            Prims.op_Hat uu____2791 (Prims.op_Hat "]" s)  in
-          Prims.op_Hat "#[" uu____2789
+          let uu____2804 =
+            let uu____2806 = term_to_string t  in
+            Prims.op_Hat uu____2806 (Prims.op_Hat "]" s)  in
+          Prims.op_Hat "#[" uu____2804
       | FStar_Pervasives_Native.None  -> s
 
 and (imp_to_string :
@@ -894,48 +905,48 @@ and (binder_to_string' :
   =
   fun is_arrow  ->
     fun b  ->
-      let uu____2809 =
-        let uu____2811 = FStar_Options.ugly ()  in
-        Prims.op_Negation uu____2811  in
-      if uu____2809
+      let uu____2824 =
+        let uu____2826 = FStar_Options.ugly ()  in
+        Prims.op_Negation uu____2826  in
+      if uu____2824
       then
-        let uu____2815 =
+        let uu____2830 =
           FStar_Syntax_Resugar.resugar_binder b FStar_Range.dummyRange  in
-        match uu____2815 with
+        match uu____2830 with
         | FStar_Pervasives_Native.None  -> ""
         | FStar_Pervasives_Native.Some e ->
             let d = FStar_Parser_ToDocument.binder_to_document e  in
             FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
               (Prims.of_int (100)) d
       else
-        (let uu____2826 = b  in
-         match uu____2826 with
+        (let uu____2841 = b  in
+         match uu____2841 with
          | (a,imp) ->
-             let uu____2840 = FStar_Syntax_Syntax.is_null_binder b  in
-             if uu____2840
+             let uu____2855 = FStar_Syntax_Syntax.is_null_binder b  in
+             if uu____2855
              then
-               let uu____2844 = term_to_string a.FStar_Syntax_Syntax.sort  in
-               Prims.op_Hat "_:" uu____2844
+               let uu____2859 = term_to_string a.FStar_Syntax_Syntax.sort  in
+               Prims.op_Hat "_:" uu____2859
              else
-               (let uu____2849 =
+               (let uu____2864 =
                   (Prims.op_Negation is_arrow) &&
-                    (let uu____2852 = FStar_Options.print_bound_var_types ()
+                    (let uu____2867 = FStar_Options.print_bound_var_types ()
                         in
-                     Prims.op_Negation uu____2852)
+                     Prims.op_Negation uu____2867)
                    in
-                if uu____2849
+                if uu____2864
                 then
-                  let uu____2856 = nm_to_string a  in
-                  imp_to_string uu____2856 imp
+                  let uu____2871 = nm_to_string a  in
+                  imp_to_string uu____2871 imp
                 else
-                  (let uu____2860 =
-                     let uu____2862 = nm_to_string a  in
-                     let uu____2864 =
-                       let uu____2866 =
+                  (let uu____2875 =
+                     let uu____2877 = nm_to_string a  in
+                     let uu____2879 =
+                       let uu____2881 =
                          term_to_string a.FStar_Syntax_Syntax.sort  in
-                       Prims.op_Hat ":" uu____2866  in
-                     Prims.op_Hat uu____2862 uu____2864  in
-                   imp_to_string uu____2860 imp)))
+                       Prims.op_Hat ":" uu____2881  in
+                     Prims.op_Hat uu____2877 uu____2879  in
+                   imp_to_string uu____2875 imp)))
 
 and (binder_to_string : FStar_Syntax_Syntax.binder -> Prims.string) =
   fun b  -> binder_to_string' false b
@@ -950,43 +961,43 @@ and (binders_to_string :
   fun sep  ->
     fun bs  ->
       let bs1 =
-        let uu____2885 = FStar_Options.print_implicits ()  in
-        if uu____2885 then bs else filter_imp bs  in
+        let uu____2900 = FStar_Options.print_implicits ()  in
+        if uu____2900 then bs else filter_imp bs  in
       if sep = " -> "
       then
-        let uu____2896 =
+        let uu____2911 =
           FStar_All.pipe_right bs1 (FStar_List.map arrow_binder_to_string)
            in
-        FStar_All.pipe_right uu____2896 (FStar_String.concat sep)
+        FStar_All.pipe_right uu____2911 (FStar_String.concat sep)
       else
-        (let uu____2924 =
+        (let uu____2939 =
            FStar_All.pipe_right bs1 (FStar_List.map binder_to_string)  in
-         FStar_All.pipe_right uu____2924 (FStar_String.concat sep))
+         FStar_All.pipe_right uu____2939 (FStar_String.concat sep))
 
 and (arg_to_string :
   (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.arg_qualifier
     FStar_Pervasives_Native.option) -> Prims.string)
   =
-  fun uu___8_2938  ->
-    match uu___8_2938 with
+  fun uu___8_2953  ->
+    match uu___8_2953 with
     | (a,imp) ->
-        let uu____2952 = term_to_string a  in imp_to_string uu____2952 imp
+        let uu____2967 = term_to_string a  in imp_to_string uu____2967 imp
 
 and (args_to_string : FStar_Syntax_Syntax.args -> Prims.string) =
   fun args  ->
     let args1 =
-      let uu____2964 = FStar_Options.print_implicits ()  in
-      if uu____2964 then args else filter_imp args  in
-    let uu____2979 =
+      let uu____2979 = FStar_Options.print_implicits ()  in
+      if uu____2979 then args else filter_imp args  in
+    let uu____2994 =
       FStar_All.pipe_right args1 (FStar_List.map arg_to_string)  in
-    FStar_All.pipe_right uu____2979 (FStar_String.concat " ")
+    FStar_All.pipe_right uu____2994 (FStar_String.concat " ")
 
 and (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =
   fun c  ->
-    let uu____3007 =
-      let uu____3009 = FStar_Options.ugly ()  in Prims.op_Negation uu____3009
+    let uu____3022 =
+      let uu____3024 = FStar_Options.ugly ()  in Prims.op_Negation uu____3024
        in
-    if uu____3007
+    if uu____3022
     then
       let e = FStar_Syntax_Resugar.resugar_comp c  in
       let d = FStar_Parser_ToDocument.term_to_document e  in
@@ -995,146 +1006,146 @@ and (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =
     else
       (match c.FStar_Syntax_Syntax.n with
        | FStar_Syntax_Syntax.Total (t,uopt) ->
-           let uu____3030 =
-             let uu____3031 = FStar_Syntax_Subst.compress t  in
-             uu____3031.FStar_Syntax_Syntax.n  in
-           (match uu____3030 with
-            | FStar_Syntax_Syntax.Tm_type uu____3035 when
-                let uu____3036 =
+           let uu____3045 =
+             let uu____3046 = FStar_Syntax_Subst.compress t  in
+             uu____3046.FStar_Syntax_Syntax.n  in
+           (match uu____3045 with
+            | FStar_Syntax_Syntax.Tm_type uu____3050 when
+                let uu____3051 =
                   (FStar_Options.print_implicits ()) ||
                     (FStar_Options.print_universes ())
                    in
-                Prims.op_Negation uu____3036 -> term_to_string t
-            | uu____3038 ->
+                Prims.op_Negation uu____3051 -> term_to_string t
+            | uu____3053 ->
                 (match uopt with
                  | FStar_Pervasives_Native.Some u when
                      FStar_Options.print_universes () ->
-                     let uu____3041 = univ_to_string u  in
-                     let uu____3043 = term_to_string t  in
-                     FStar_Util.format2 "Tot<%s> %s" uu____3041 uu____3043
-                 | uu____3046 ->
-                     let uu____3049 = term_to_string t  in
-                     FStar_Util.format1 "Tot %s" uu____3049))
+                     let uu____3056 = univ_to_string u  in
+                     let uu____3058 = term_to_string t  in
+                     FStar_Util.format2 "Tot<%s> %s" uu____3056 uu____3058
+                 | uu____3061 ->
+                     let uu____3064 = term_to_string t  in
+                     FStar_Util.format1 "Tot %s" uu____3064))
        | FStar_Syntax_Syntax.GTotal (t,uopt) ->
-           let uu____3062 =
-             let uu____3063 = FStar_Syntax_Subst.compress t  in
-             uu____3063.FStar_Syntax_Syntax.n  in
-           (match uu____3062 with
-            | FStar_Syntax_Syntax.Tm_type uu____3067 when
-                let uu____3068 =
+           let uu____3077 =
+             let uu____3078 = FStar_Syntax_Subst.compress t  in
+             uu____3078.FStar_Syntax_Syntax.n  in
+           (match uu____3077 with
+            | FStar_Syntax_Syntax.Tm_type uu____3082 when
+                let uu____3083 =
                   (FStar_Options.print_implicits ()) ||
                     (FStar_Options.print_universes ())
                    in
-                Prims.op_Negation uu____3068 -> term_to_string t
-            | uu____3070 ->
+                Prims.op_Negation uu____3083 -> term_to_string t
+            | uu____3085 ->
                 (match uopt with
                  | FStar_Pervasives_Native.Some u when
                      FStar_Options.print_universes () ->
-                     let uu____3073 = univ_to_string u  in
-                     let uu____3075 = term_to_string t  in
-                     FStar_Util.format2 "GTot<%s> %s" uu____3073 uu____3075
-                 | uu____3078 ->
-                     let uu____3081 = term_to_string t  in
-                     FStar_Util.format1 "GTot %s" uu____3081))
+                     let uu____3088 = univ_to_string u  in
+                     let uu____3090 = term_to_string t  in
+                     FStar_Util.format2 "GTot<%s> %s" uu____3088 uu____3090
+                 | uu____3093 ->
+                     let uu____3096 = term_to_string t  in
+                     FStar_Util.format1 "GTot %s" uu____3096))
        | FStar_Syntax_Syntax.Comp c1 ->
            let basic =
-             let uu____3087 = FStar_Options.print_effect_args ()  in
-             if uu____3087
+             let uu____3102 = FStar_Options.print_effect_args ()  in
+             if uu____3102
              then
-               let uu____3091 = sli c1.FStar_Syntax_Syntax.effect_name  in
-               let uu____3093 =
-                 let uu____3095 =
+               let uu____3106 = sli c1.FStar_Syntax_Syntax.effect_name  in
+               let uu____3108 =
+                 let uu____3110 =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.comp_univs
                      (FStar_List.map univ_to_string)
                     in
-                 FStar_All.pipe_right uu____3095 (FStar_String.concat ", ")
+                 FStar_All.pipe_right uu____3110 (FStar_String.concat ", ")
                   in
-               let uu____3110 =
+               let uu____3125 =
                  term_to_string c1.FStar_Syntax_Syntax.result_typ  in
-               let uu____3112 =
-                 let uu____3114 =
+               let uu____3127 =
+                 let uu____3129 =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.effect_args
                      (FStar_List.map arg_to_string)
                     in
-                 FStar_All.pipe_right uu____3114 (FStar_String.concat ", ")
+                 FStar_All.pipe_right uu____3129 (FStar_String.concat ", ")
                   in
-               let uu____3141 = cflags_to_string c1.FStar_Syntax_Syntax.flags
+               let uu____3156 = cflags_to_string c1.FStar_Syntax_Syntax.flags
                   in
-               FStar_Util.format5 "%s<%s> (%s) %s (attributes %s)" uu____3091
-                 uu____3093 uu____3110 uu____3112 uu____3141
+               FStar_Util.format5 "%s<%s> (%s) %s (attributes %s)" uu____3106
+                 uu____3108 uu____3125 uu____3127 uu____3156
              else
-               (let uu____3146 =
+               (let uu____3161 =
                   (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
                      (FStar_Util.for_some
-                        (fun uu___9_3152  ->
-                           match uu___9_3152 with
+                        (fun uu___9_3167  ->
+                           match uu___9_3167 with
                            | FStar_Syntax_Syntax.TOTAL  -> true
-                           | uu____3155 -> false)))
+                           | uu____3170 -> false)))
                     &&
-                    (let uu____3158 = FStar_Options.print_effect_args ()  in
-                     Prims.op_Negation uu____3158)
+                    (let uu____3173 = FStar_Options.print_effect_args ()  in
+                     Prims.op_Negation uu____3173)
                    in
-                if uu____3146
+                if uu____3161
                 then
-                  let uu____3162 =
+                  let uu____3177 =
                     term_to_string c1.FStar_Syntax_Syntax.result_typ  in
-                  FStar_Util.format1 "Tot %s" uu____3162
+                  FStar_Util.format1 "Tot %s" uu____3177
                 else
-                  (let uu____3167 =
-                     ((let uu____3171 = FStar_Options.print_effect_args ()
+                  (let uu____3182 =
+                     ((let uu____3186 = FStar_Options.print_effect_args ()
                           in
-                       Prims.op_Negation uu____3171) &&
-                        (let uu____3174 = FStar_Options.print_implicits ()
+                       Prims.op_Negation uu____3186) &&
+                        (let uu____3189 = FStar_Options.print_implicits ()
                             in
-                         Prims.op_Negation uu____3174))
+                         Prims.op_Negation uu____3189))
                        &&
                        (FStar_Ident.lid_equals
                           c1.FStar_Syntax_Syntax.effect_name
                           FStar_Parser_Const.effect_ML_lid)
                       in
-                   if uu____3167
+                   if uu____3182
                    then term_to_string c1.FStar_Syntax_Syntax.result_typ
                    else
-                     (let uu____3180 =
-                        (let uu____3184 = FStar_Options.print_effect_args ()
+                     (let uu____3195 =
+                        (let uu____3199 = FStar_Options.print_effect_args ()
                             in
-                         Prims.op_Negation uu____3184) &&
+                         Prims.op_Negation uu____3199) &&
                           (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
                              (FStar_Util.for_some
-                                (fun uu___10_3190  ->
-                                   match uu___10_3190 with
+                                (fun uu___10_3205  ->
+                                   match uu___10_3205 with
                                    | FStar_Syntax_Syntax.MLEFFECT  -> true
-                                   | uu____3193 -> false)))
+                                   | uu____3208 -> false)))
                          in
-                      if uu____3180
+                      if uu____3195
                       then
-                        let uu____3197 =
+                        let uu____3212 =
                           term_to_string c1.FStar_Syntax_Syntax.result_typ
                            in
-                        FStar_Util.format1 "ALL %s" uu____3197
+                        FStar_Util.format1 "ALL %s" uu____3212
                       else
-                        (let uu____3202 =
+                        (let uu____3217 =
                            sli c1.FStar_Syntax_Syntax.effect_name  in
-                         let uu____3204 =
+                         let uu____3219 =
                            term_to_string c1.FStar_Syntax_Syntax.result_typ
                             in
-                         FStar_Util.format2 "%s (%s)" uu____3202 uu____3204))))
+                         FStar_Util.format2 "%s (%s)" uu____3217 uu____3219))))
               in
            let dec =
-             let uu____3209 =
+             let uu____3224 =
                FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
                  (FStar_List.collect
-                    (fun uu___11_3222  ->
-                       match uu___11_3222 with
+                    (fun uu___11_3237  ->
+                       match uu___11_3237 with
                        | FStar_Syntax_Syntax.DECREASES e ->
-                           let uu____3229 =
-                             let uu____3231 = term_to_string e  in
-                             FStar_Util.format1 " (decreases %s)" uu____3231
+                           let uu____3244 =
+                             let uu____3246 = term_to_string e  in
+                             FStar_Util.format1 " (decreases %s)" uu____3246
                               in
-                           [uu____3229]
-                       | uu____3236 -> []))
+                           [uu____3244]
+                       | uu____3251 -> []))
                 in
-             FStar_All.pipe_right uu____3209 (FStar_String.concat " ")  in
+             FStar_All.pipe_right uu____3224 (FStar_String.concat " ")  in
            FStar_Util.format2 "%s%s" basic dec)
 
 and (cflag_to_string : FStar_Syntax_Syntax.cflag -> Prims.string) =
@@ -1149,7 +1160,7 @@ and (cflag_to_string : FStar_Syntax_Syntax.cflag -> Prims.string) =
     | FStar_Syntax_Syntax.SHOULD_NOT_INLINE  -> "should_not_inline"
     | FStar_Syntax_Syntax.LEMMA  -> "lemma"
     | FStar_Syntax_Syntax.CPS  -> "cps"
-    | FStar_Syntax_Syntax.DECREASES uu____3255 -> ""
+    | FStar_Syntax_Syntax.DECREASES uu____3270 -> ""
 
 and (cflags_to_string : FStar_Syntax_Syntax.cflag Prims.list -> Prims.string)
   = fun fs  -> FStar_Common.string_of_list cflag_to_string fs
@@ -1159,43 +1170,43 @@ and (formula_to_string :
   fun phi  -> term_to_string phi
 
 and (metadata_to_string : FStar_Syntax_Syntax.metadata -> Prims.string) =
-  fun uu___12_3265  ->
-    match uu___12_3265 with
-    | FStar_Syntax_Syntax.Meta_pattern (uu____3267,ps) ->
+  fun uu___12_3280  ->
+    match uu___12_3280 with
+    | FStar_Syntax_Syntax.Meta_pattern (uu____3282,ps) ->
         let pats =
-          let uu____3303 =
+          let uu____3318 =
             FStar_All.pipe_right ps
               (FStar_List.map
                  (fun args  ->
-                    let uu____3340 =
+                    let uu____3355 =
                       FStar_All.pipe_right args
                         (FStar_List.map
-                           (fun uu____3365  ->
-                              match uu____3365 with
-                              | (t,uu____3374) -> term_to_string t))
+                           (fun uu____3380  ->
+                              match uu____3380 with
+                              | (t,uu____3389) -> term_to_string t))
                        in
-                    FStar_All.pipe_right uu____3340
+                    FStar_All.pipe_right uu____3355
                       (FStar_String.concat "; ")))
              in
-          FStar_All.pipe_right uu____3303 (FStar_String.concat "\\/")  in
+          FStar_All.pipe_right uu____3318 (FStar_String.concat "\\/")  in
         FStar_Util.format1 "{Meta_pattern %s}" pats
     | FStar_Syntax_Syntax.Meta_named lid ->
-        let uu____3391 = sli lid  in
-        FStar_Util.format1 "{Meta_named %s}" uu____3391
-    | FStar_Syntax_Syntax.Meta_labeled (l,r,uu____3396) ->
-        let uu____3401 = FStar_Range.string_of_range r  in
-        FStar_Util.format2 "{Meta_labeled (%s, %s)}" l uu____3401
+        let uu____3406 = sli lid  in
+        FStar_Util.format1 "{Meta_named %s}" uu____3406
+    | FStar_Syntax_Syntax.Meta_labeled (l,r,uu____3411) ->
+        let uu____3416 = FStar_Range.string_of_range r  in
+        FStar_Util.format2 "{Meta_labeled (%s, %s)}" l uu____3416
     | FStar_Syntax_Syntax.Meta_desugared msi -> "{Meta_desugared}"
     | FStar_Syntax_Syntax.Meta_monadic (m,t) ->
-        let uu____3412 = sli m  in
-        let uu____3414 = term_to_string t  in
-        FStar_Util.format2 "{Meta_monadic(%s @ %s)}" uu____3412 uu____3414
+        let uu____3427 = sli m  in
+        let uu____3429 = term_to_string t  in
+        FStar_Util.format2 "{Meta_monadic(%s @ %s)}" uu____3427 uu____3429
     | FStar_Syntax_Syntax.Meta_monadic_lift (m,m',t) ->
-        let uu____3424 = sli m  in
-        let uu____3426 = sli m'  in
-        let uu____3428 = term_to_string t  in
-        FStar_Util.format3 "{Meta_monadic_lift(%s -> %s @ %s)}" uu____3424
-          uu____3426 uu____3428
+        let uu____3439 = sli m  in
+        let uu____3441 = sli m'  in
+        let uu____3443 = term_to_string t  in
+        FStar_Util.format3 "{Meta_monadic_lift(%s -> %s @ %s)}" uu____3439
+          uu____3441 uu____3443
 
 let (aqual_to_string : FStar_Syntax_Syntax.aqual -> Prims.string) =
   fun aq  -> aqual_to_string' "" aq 
@@ -1203,8 +1214,8 @@ let (comp_to_string' :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.comp -> Prims.string) =
   fun env  ->
     fun c  ->
-      let uu____3451 = FStar_Options.ugly ()  in
-      if uu____3451
+      let uu____3466 = FStar_Options.ugly ()  in
+      if uu____3466
       then comp_to_string c
       else
         (let e = FStar_Syntax_Resugar.resugar_comp' env c  in
@@ -1216,8 +1227,8 @@ let (term_to_string' :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.term -> Prims.string) =
   fun env  ->
     fun x  ->
-      let uu____3473 = FStar_Options.ugly ()  in
-      if uu____3473
+      let uu____3488 = FStar_Options.ugly ()  in
+      if uu____3488
       then term_to_string x
       else
         (let e = FStar_Syntax_Resugar.resugar_term' env x  in
@@ -1229,165 +1240,165 @@ let (binder_to_json :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.binder -> FStar_Util.json) =
   fun env  ->
     fun b  ->
-      let uu____3494 = b  in
-      match uu____3494 with
+      let uu____3509 = b  in
+      match uu____3509 with
       | (a,imp) ->
           let n =
-            let uu____3502 = FStar_Syntax_Syntax.is_null_binder b  in
-            if uu____3502
+            let uu____3517 = FStar_Syntax_Syntax.is_null_binder b  in
+            if uu____3517
             then FStar_Util.JsonNull
             else
-              (let uu____3507 =
-                 let uu____3509 = nm_to_string a  in
-                 imp_to_string uu____3509 imp  in
-               FStar_Util.JsonStr uu____3507)
+              (let uu____3522 =
+                 let uu____3524 = nm_to_string a  in
+                 imp_to_string uu____3524 imp  in
+               FStar_Util.JsonStr uu____3522)
              in
           let t =
-            let uu____3512 = term_to_string' env a.FStar_Syntax_Syntax.sort
+            let uu____3527 = term_to_string' env a.FStar_Syntax_Syntax.sort
                in
-            FStar_Util.JsonStr uu____3512  in
+            FStar_Util.JsonStr uu____3527  in
           FStar_Util.JsonAssoc [("name", n); ("type", t)]
   
 let (binders_to_json :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.binders -> FStar_Util.json) =
   fun env  ->
     fun bs  ->
-      let uu____3544 = FStar_List.map (binder_to_json env) bs  in
-      FStar_Util.JsonList uu____3544
+      let uu____3559 = FStar_List.map (binder_to_json env) bs  in
+      FStar_Util.JsonList uu____3559
   
 let (enclose_universes : Prims.string -> Prims.string) =
   fun s  ->
-    let uu____3562 = FStar_Options.print_universes ()  in
-    if uu____3562 then Prims.op_Hat "<" (Prims.op_Hat s ">") else ""
+    let uu____3577 = FStar_Options.print_universes ()  in
+    if uu____3577 then Prims.op_Hat "<" (Prims.op_Hat s ">") else ""
   
 let (tscheme_to_string : FStar_Syntax_Syntax.tscheme -> Prims.string) =
   fun s  ->
-    let uu____3578 =
-      let uu____3580 = FStar_Options.ugly ()  in Prims.op_Negation uu____3580
+    let uu____3593 =
+      let uu____3595 = FStar_Options.ugly ()  in Prims.op_Negation uu____3595
        in
-    if uu____3578
+    if uu____3593
     then
       let d = FStar_Syntax_Resugar.resugar_tscheme s  in
       let d1 = FStar_Parser_ToDocument.decl_to_document d  in
       FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
         (Prims.of_int (100)) d1
     else
-      (let uu____3590 = s  in
-       match uu____3590 with
+      (let uu____3605 = s  in
+       match uu____3605 with
        | (us,t) ->
-           let uu____3602 =
-             let uu____3604 = univ_names_to_string us  in
-             FStar_All.pipe_left enclose_universes uu____3604  in
-           let uu____3608 = term_to_string t  in
-           FStar_Util.format2 "%s%s" uu____3602 uu____3608)
+           let uu____3617 =
+             let uu____3619 = univ_names_to_string us  in
+             FStar_All.pipe_left enclose_universes uu____3619  in
+           let uu____3623 = term_to_string t  in
+           FStar_Util.format2 "%s%s" uu____3617 uu____3623)
   
 let (action_to_string : FStar_Syntax_Syntax.action -> Prims.string) =
   fun a  ->
-    let uu____3618 = sli a.FStar_Syntax_Syntax.action_name  in
-    let uu____3620 =
+    let uu____3633 = sli a.FStar_Syntax_Syntax.action_name  in
+    let uu____3635 =
       binders_to_string " " a.FStar_Syntax_Syntax.action_params  in
-    let uu____3623 =
-      let uu____3625 =
+    let uu____3638 =
+      let uu____3640 =
         univ_names_to_string a.FStar_Syntax_Syntax.action_univs  in
-      FStar_All.pipe_left enclose_universes uu____3625  in
-    let uu____3629 = term_to_string a.FStar_Syntax_Syntax.action_typ  in
-    let uu____3631 = term_to_string a.FStar_Syntax_Syntax.action_defn  in
-    FStar_Util.format5 "%s%s %s : %s = %s" uu____3618 uu____3620 uu____3623
-      uu____3629 uu____3631
+      FStar_All.pipe_left enclose_universes uu____3640  in
+    let uu____3644 = term_to_string a.FStar_Syntax_Syntax.action_typ  in
+    let uu____3646 = term_to_string a.FStar_Syntax_Syntax.action_defn  in
+    FStar_Util.format5 "%s%s %s : %s = %s" uu____3633 uu____3635 uu____3638
+      uu____3644 uu____3646
   
 let (wp_eff_combinators_to_string :
   FStar_Syntax_Syntax.wp_eff_combinators -> Prims.string) =
   fun combs  ->
-    let tscheme_opt_to_string uu___13_3649 =
-      match uu___13_3649 with
+    let tscheme_opt_to_string uu___13_3664 =
+      match uu___13_3664 with
       | FStar_Pervasives_Native.Some ts -> tscheme_to_string ts
       | FStar_Pervasives_Native.None  -> "None"  in
-    let uu____3655 =
-      let uu____3659 = tscheme_to_string combs.FStar_Syntax_Syntax.ret_wp  in
-      let uu____3661 =
-        let uu____3665 = tscheme_to_string combs.FStar_Syntax_Syntax.bind_wp
+    let uu____3670 =
+      let uu____3674 = tscheme_to_string combs.FStar_Syntax_Syntax.ret_wp  in
+      let uu____3676 =
+        let uu____3680 = tscheme_to_string combs.FStar_Syntax_Syntax.bind_wp
            in
-        let uu____3667 =
-          let uu____3671 =
+        let uu____3682 =
+          let uu____3686 =
             tscheme_to_string combs.FStar_Syntax_Syntax.stronger  in
-          let uu____3673 =
-            let uu____3677 =
+          let uu____3688 =
+            let uu____3692 =
               tscheme_to_string combs.FStar_Syntax_Syntax.if_then_else  in
-            let uu____3679 =
-              let uu____3683 =
+            let uu____3694 =
+              let uu____3698 =
                 tscheme_to_string combs.FStar_Syntax_Syntax.ite_wp  in
-              let uu____3685 =
-                let uu____3689 =
+              let uu____3700 =
+                let uu____3704 =
                   tscheme_to_string combs.FStar_Syntax_Syntax.close_wp  in
-                let uu____3691 =
-                  let uu____3695 =
+                let uu____3706 =
+                  let uu____3710 =
                     tscheme_to_string combs.FStar_Syntax_Syntax.trivial  in
-                  let uu____3697 =
-                    let uu____3701 =
+                  let uu____3712 =
+                    let uu____3716 =
                       tscheme_opt_to_string combs.FStar_Syntax_Syntax.repr
                        in
-                    let uu____3703 =
-                      let uu____3707 =
+                    let uu____3718 =
+                      let uu____3722 =
                         tscheme_opt_to_string
                           combs.FStar_Syntax_Syntax.return_repr
                          in
-                      let uu____3709 =
-                        let uu____3713 =
+                      let uu____3724 =
+                        let uu____3728 =
                           tscheme_opt_to_string
                             combs.FStar_Syntax_Syntax.bind_repr
                            in
-                        [uu____3713]  in
-                      uu____3707 :: uu____3709  in
-                    uu____3701 :: uu____3703  in
-                  uu____3695 :: uu____3697  in
-                uu____3689 :: uu____3691  in
-              uu____3683 :: uu____3685  in
-            uu____3677 :: uu____3679  in
-          uu____3671 :: uu____3673  in
-        uu____3665 :: uu____3667  in
-      uu____3659 :: uu____3661  in
+                        [uu____3728]  in
+                      uu____3722 :: uu____3724  in
+                    uu____3716 :: uu____3718  in
+                  uu____3710 :: uu____3712  in
+                uu____3704 :: uu____3706  in
+              uu____3698 :: uu____3700  in
+            uu____3692 :: uu____3694  in
+          uu____3686 :: uu____3688  in
+        uu____3680 :: uu____3682  in
+      uu____3674 :: uu____3676  in
     FStar_Util.format
       "{\nret_wp       = %s\n; bind_wp      = %s\n; stronger     = %s\n; if_then_else = %s\n; ite_wp       = %s\n; close_wp     = %s\n; trivial      = %s\n; repr         = %s\n; return_repr  = %s\n; bind_repr    = %s\n}\n"
-      uu____3655
+      uu____3670
   
 let (layered_eff_combinators_to_string :
   FStar_Syntax_Syntax.layered_eff_combinators -> Prims.string) =
   fun combs  ->
-    let to_str uu____3744 =
-      match uu____3744 with
+    let to_str uu____3759 =
+      match uu____3759 with
       | (ts_t,ts_ty) ->
-          let uu____3752 = tscheme_to_string ts_t  in
-          let uu____3754 = tscheme_to_string ts_ty  in
-          FStar_Util.format2 "(%s) : (%s)" uu____3752 uu____3754
+          let uu____3767 = tscheme_to_string ts_t  in
+          let uu____3769 = tscheme_to_string ts_ty  in
+          FStar_Util.format2 "(%s) : (%s)" uu____3767 uu____3769
        in
-    let uu____3757 =
-      let uu____3761 =
+    let uu____3772 =
+      let uu____3776 =
         FStar_Ident.string_of_lid combs.FStar_Syntax_Syntax.l_base_effect  in
-      let uu____3763 =
-        let uu____3767 = to_str combs.FStar_Syntax_Syntax.l_repr  in
-        let uu____3769 =
-          let uu____3773 = to_str combs.FStar_Syntax_Syntax.l_return  in
-          let uu____3775 =
-            let uu____3779 = to_str combs.FStar_Syntax_Syntax.l_bind  in
-            let uu____3781 =
-              let uu____3785 = to_str combs.FStar_Syntax_Syntax.l_subcomp  in
-              let uu____3787 =
-                let uu____3791 =
+      let uu____3778 =
+        let uu____3782 = to_str combs.FStar_Syntax_Syntax.l_repr  in
+        let uu____3784 =
+          let uu____3788 = to_str combs.FStar_Syntax_Syntax.l_return  in
+          let uu____3790 =
+            let uu____3794 = to_str combs.FStar_Syntax_Syntax.l_bind  in
+            let uu____3796 =
+              let uu____3800 = to_str combs.FStar_Syntax_Syntax.l_subcomp  in
+              let uu____3802 =
+                let uu____3806 =
                   to_str combs.FStar_Syntax_Syntax.l_if_then_else  in
-                [uu____3791]  in
-              uu____3785 :: uu____3787  in
-            uu____3779 :: uu____3781  in
-          uu____3773 :: uu____3775  in
-        uu____3767 :: uu____3769  in
-      uu____3761 :: uu____3763  in
+                [uu____3806]  in
+              uu____3800 :: uu____3802  in
+            uu____3794 :: uu____3796  in
+          uu____3788 :: uu____3790  in
+        uu____3782 :: uu____3784  in
+      uu____3776 :: uu____3778  in
     FStar_Util.format
       "{\nl_base_effect = %s\n; l_repr = %s\n; l_return = %s\n; l_bind = %s\n; l_subcomp = %s\n; l_if_then_else = %s\n\n  }\n"
-      uu____3757
+      uu____3772
   
 let (eff_combinators_to_string :
   FStar_Syntax_Syntax.eff_combinators -> Prims.string) =
-  fun uu___14_3807  ->
-    match uu___14_3807 with
+  fun uu___14_3822  ->
+    match uu___14_3822 with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         wp_eff_combinators_to_string combs
     | FStar_Syntax_Syntax.DM4F_eff combs ->
@@ -1405,10 +1416,10 @@ let (eff_decl_to_string' :
     fun r  ->
       fun q  ->
         fun ed  ->
-          let uu____3840 =
-            let uu____3842 = FStar_Options.ugly ()  in
-            Prims.op_Negation uu____3842  in
-          if uu____3840
+          let uu____3855 =
+            let uu____3857 = FStar_Options.ugly ()  in
+            Prims.op_Negation uu____3857  in
+          if uu____3855
           then
             let d = FStar_Syntax_Resugar.resugar_eff_decl r q ed  in
             let d1 = FStar_Parser_ToDocument.decl_to_document d  in
@@ -1416,55 +1427,55 @@ let (eff_decl_to_string' :
               (Prims.of_int (100)) d1
           else
             (let actions_to_string actions =
-               let uu____3863 =
+               let uu____3878 =
                  FStar_All.pipe_right actions
                    (FStar_List.map action_to_string)
                   in
-               FStar_All.pipe_right uu____3863 (FStar_String.concat ",\n\t")
+               FStar_All.pipe_right uu____3878 (FStar_String.concat ",\n\t")
                 in
              let eff_name =
-               let uu____3880 = FStar_Syntax_Util.is_layered ed  in
-               if uu____3880 then "layered_effect" else "new_effect"  in
-             let uu____3888 =
-               let uu____3892 =
-                 let uu____3896 =
-                   let uu____3900 =
+               let uu____3895 = FStar_Syntax_Util.is_layered ed  in
+               if uu____3895 then "layered_effect" else "new_effect"  in
+             let uu____3903 =
+               let uu____3907 =
+                 let uu____3911 =
+                   let uu____3915 =
                      lid_to_string ed.FStar_Syntax_Syntax.mname  in
-                   let uu____3902 =
-                     let uu____3906 =
-                       let uu____3908 =
+                   let uu____3917 =
+                     let uu____3921 =
+                       let uu____3923 =
                          univ_names_to_string ed.FStar_Syntax_Syntax.univs
                           in
-                       FStar_All.pipe_left enclose_universes uu____3908  in
-                     let uu____3912 =
-                       let uu____3916 =
+                       FStar_All.pipe_left enclose_universes uu____3923  in
+                     let uu____3927 =
+                       let uu____3931 =
                          binders_to_string " " ed.FStar_Syntax_Syntax.binders
                           in
-                       let uu____3919 =
-                         let uu____3923 =
+                       let uu____3934 =
+                         let uu____3938 =
                            tscheme_to_string ed.FStar_Syntax_Syntax.signature
                             in
-                         let uu____3925 =
-                           let uu____3929 =
+                         let uu____3940 =
+                           let uu____3944 =
                              eff_combinators_to_string
                                ed.FStar_Syntax_Syntax.combinators
                               in
-                           let uu____3931 =
-                             let uu____3935 =
+                           let uu____3946 =
+                             let uu____3950 =
                                actions_to_string
                                  ed.FStar_Syntax_Syntax.actions
                                 in
-                             [uu____3935]  in
-                           uu____3929 :: uu____3931  in
-                         uu____3923 :: uu____3925  in
-                       uu____3916 :: uu____3919  in
-                     uu____3906 :: uu____3912  in
-                   uu____3900 :: uu____3902  in
-                 (if for_free then "_for_free " else "") :: uu____3896  in
-               eff_name :: uu____3892  in
+                             [uu____3950]  in
+                           uu____3944 :: uu____3946  in
+                         uu____3938 :: uu____3940  in
+                       uu____3931 :: uu____3934  in
+                     uu____3921 :: uu____3927  in
+                   uu____3915 :: uu____3917  in
+                 (if for_free then "_for_free " else "") :: uu____3911  in
+               eff_name :: uu____3907  in
              FStar_Util.format
                "%s%s { %s%s %s : %s \n  %s\nand effect_actions\n\t%s\n}\n"
-               uu____3888)
+               uu____3903)
   
 let (eff_decl_to_string :
   Prims.bool -> FStar_Syntax_Syntax.eff_decl -> Prims.string) =
@@ -1476,15 +1487,15 @@ let (sub_eff_to_string : FStar_Syntax_Syntax.sub_eff -> Prims.string) =
     let tsopt_to_string ts_opt =
       if FStar_Util.is_some ts_opt
       then
-        let uu____3987 = FStar_All.pipe_right ts_opt FStar_Util.must  in
-        FStar_All.pipe_right uu____3987 tscheme_to_string
+        let uu____4002 = FStar_All.pipe_right ts_opt FStar_Util.must  in
+        FStar_All.pipe_right uu____4002 tscheme_to_string
       else "<None>"  in
-    let uu____3994 = lid_to_string se.FStar_Syntax_Syntax.source  in
-    let uu____3996 = lid_to_string se.FStar_Syntax_Syntax.target  in
-    let uu____3998 = tsopt_to_string se.FStar_Syntax_Syntax.lift  in
-    let uu____4000 = tsopt_to_string se.FStar_Syntax_Syntax.lift_wp  in
+    let uu____4009 = lid_to_string se.FStar_Syntax_Syntax.source  in
+    let uu____4011 = lid_to_string se.FStar_Syntax_Syntax.target  in
+    let uu____4013 = tsopt_to_string se.FStar_Syntax_Syntax.lift  in
+    let uu____4015 = tsopt_to_string se.FStar_Syntax_Syntax.lift_wp  in
     FStar_Util.format4 "sub_effect %s ~> %s : lift = %s ;; lift_wp = %s"
-      uu____3994 uu____3996 uu____3998 uu____4000
+      uu____4009 uu____4011 uu____4013 uu____4015
   
 let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
   fun x  ->
@@ -1509,198 +1520,204 @@ let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
       | FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.PopOptions ) ->
           "#pop-options"
       | FStar_Syntax_Syntax.Sig_inductive_typ
-          (lid,univs,tps,k,uu____4035,uu____4036) ->
+          (lid,univs,tps,k,uu____4050,uu____4051) ->
           let quals_str = quals_to_string' x.FStar_Syntax_Syntax.sigquals  in
           let binders_str = binders_to_string " " tps  in
           let term_str = term_to_string k  in
-          let uu____4052 = FStar_Options.print_universes ()  in
-          if uu____4052
+          let uu____4067 = FStar_Options.print_universes ()  in
+          if uu____4067
           then
-            let uu____4056 = univ_names_to_string univs  in
-            FStar_Util.format5 "%stype %s<%s> %s : %s" quals_str
-              lid.FStar_Ident.str uu____4056 binders_str term_str
+            let uu____4071 = FStar_Ident.string_of_lid lid  in
+            let uu____4073 = univ_names_to_string univs  in
+            FStar_Util.format5 "%stype %s<%s> %s : %s" quals_str uu____4071
+              uu____4073 binders_str term_str
           else
-            FStar_Util.format4 "%stype %s %s : %s" quals_str
-              lid.FStar_Ident.str binders_str term_str
+            (let uu____4078 = FStar_Ident.string_of_lid lid  in
+             FStar_Util.format4 "%stype %s %s : %s" quals_str uu____4078
+               binders_str term_str)
       | FStar_Syntax_Syntax.Sig_datacon
-          (lid,univs,t,uu____4065,uu____4066,uu____4067) ->
-          let uu____4074 = FStar_Options.print_universes ()  in
-          if uu____4074
+          (lid,univs,t,uu____4084,uu____4085,uu____4086) ->
+          let uu____4093 = FStar_Options.print_universes ()  in
+          if uu____4093
           then
-            let uu____4078 = univ_names_to_string univs  in
-            let uu____4080 = term_to_string t  in
-            FStar_Util.format3 "datacon<%s> %s : %s" uu____4078
-              lid.FStar_Ident.str uu____4080
+            let uu____4097 = univ_names_to_string univs  in
+            let uu____4099 = FStar_Ident.string_of_lid lid  in
+            let uu____4101 = term_to_string t  in
+            FStar_Util.format3 "datacon<%s> %s : %s" uu____4097 uu____4099
+              uu____4101
           else
-            (let uu____4085 = term_to_string t  in
-             FStar_Util.format2 "datacon %s : %s" lid.FStar_Ident.str
-               uu____4085)
+            (let uu____4106 = FStar_Ident.string_of_lid lid  in
+             let uu____4108 = term_to_string t  in
+             FStar_Util.format2 "datacon %s : %s" uu____4106 uu____4108)
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs,t) ->
-          let uu____4091 = quals_to_string' x.FStar_Syntax_Syntax.sigquals
+          let uu____4114 = quals_to_string' x.FStar_Syntax_Syntax.sigquals
              in
-          let uu____4093 =
-            let uu____4095 = FStar_Options.print_universes ()  in
-            if uu____4095
+          let uu____4116 = FStar_Ident.string_of_lid lid  in
+          let uu____4118 =
+            let uu____4120 = FStar_Options.print_universes ()  in
+            if uu____4120
             then
-              let uu____4099 = univ_names_to_string univs  in
-              FStar_Util.format1 "<%s>" uu____4099
+              let uu____4124 = univ_names_to_string univs  in
+              FStar_Util.format1 "<%s>" uu____4124
             else ""  in
-          let uu____4105 = term_to_string t  in
-          FStar_Util.format4 "%sval %s %s : %s" uu____4091
-            lid.FStar_Ident.str uu____4093 uu____4105
+          let uu____4130 = term_to_string t  in
+          FStar_Util.format4 "%sval %s %s : %s" uu____4114 uu____4116
+            uu____4118 uu____4130
       | FStar_Syntax_Syntax.Sig_assume (lid,us,f) ->
-          let uu____4111 = FStar_Options.print_universes ()  in
-          if uu____4111
+          let uu____4136 = FStar_Options.print_universes ()  in
+          if uu____4136
           then
-            let uu____4115 = univ_names_to_string us  in
-            let uu____4117 = term_to_string f  in
-            FStar_Util.format3 "val %s<%s> : %s" lid.FStar_Ident.str
-              uu____4115 uu____4117
+            let uu____4140 = FStar_Ident.string_of_lid lid  in
+            let uu____4142 = univ_names_to_string us  in
+            let uu____4144 = term_to_string f  in
+            FStar_Util.format3 "val %s<%s> : %s" uu____4140 uu____4142
+              uu____4144
           else
-            (let uu____4122 = term_to_string f  in
-             FStar_Util.format2 "val %s : %s" lid.FStar_Ident.str uu____4122)
-      | FStar_Syntax_Syntax.Sig_let (lbs,uu____4126) ->
+            (let uu____4149 = FStar_Ident.string_of_lid lid  in
+             let uu____4151 = term_to_string f  in
+             FStar_Util.format2 "val %s : %s" uu____4149 uu____4151)
+      | FStar_Syntax_Syntax.Sig_let (lbs,uu____4155) ->
           lbs_to_string x.FStar_Syntax_Syntax.sigquals lbs
       | FStar_Syntax_Syntax.Sig_main e ->
-          let uu____4132 = term_to_string e  in
-          FStar_Util.format1 "let _ = %s" uu____4132
-      | FStar_Syntax_Syntax.Sig_bundle (ses,uu____4136) ->
-          let uu____4145 =
-            let uu____4147 = FStar_List.map sigelt_to_string ses  in
-            FStar_All.pipe_right uu____4147 (FStar_String.concat "\n")  in
-          Prims.op_Hat "(* Sig_bundle *)" uu____4145
+          let uu____4161 = term_to_string e  in
+          FStar_Util.format1 "let _ = %s" uu____4161
+      | FStar_Syntax_Syntax.Sig_bundle (ses,uu____4165) ->
+          let uu____4174 =
+            let uu____4176 = FStar_List.map sigelt_to_string ses  in
+            FStar_All.pipe_right uu____4176 (FStar_String.concat "\n")  in
+          Prims.op_Hat "(* Sig_bundle *)" uu____4174
       | FStar_Syntax_Syntax.Sig_fail (errs,lax,ses) ->
-          let uu____4173 = FStar_Util.string_of_bool lax  in
-          let uu____4175 =
+          let uu____4202 = FStar_Util.string_of_bool lax  in
+          let uu____4204 =
             FStar_Common.string_of_list FStar_Util.string_of_int errs  in
-          let uu____4178 =
-            let uu____4180 = FStar_List.map sigelt_to_string ses  in
-            FStar_All.pipe_right uu____4180 (FStar_String.concat "\n")  in
+          let uu____4207 =
+            let uu____4209 = FStar_List.map sigelt_to_string ses  in
+            FStar_All.pipe_right uu____4209 (FStar_String.concat "\n")  in
           FStar_Util.format3 "(* Sig_fail %s %s *)\n%s\n(* / Sig_fail*)\n"
-            uu____4173 uu____4175 uu____4178
+            uu____4202 uu____4204 uu____4207
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____4192 = FStar_Syntax_Util.is_dm4f ed  in
-          eff_decl_to_string' uu____4192 x.FStar_Syntax_Syntax.sigrng
+          let uu____4221 = FStar_Syntax_Util.is_dm4f ed  in
+          eff_decl_to_string' uu____4221 x.FStar_Syntax_Syntax.sigrng
             x.FStar_Syntax_Syntax.sigquals ed
       | FStar_Syntax_Syntax.Sig_sub_effect se -> sub_eff_to_string se
       | FStar_Syntax_Syntax.Sig_effect_abbrev (l,univs,tps,c,flags) ->
-          let uu____4204 = FStar_Options.print_universes ()  in
-          if uu____4204
+          let uu____4233 = FStar_Options.print_universes ()  in
+          if uu____4233
           then
-            let uu____4208 =
-              let uu____4213 =
+            let uu____4237 =
+              let uu____4242 =
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_arrow (tps, c))
                   FStar_Pervasives_Native.None FStar_Range.dummyRange
                  in
-              FStar_Syntax_Subst.open_univ_vars univs uu____4213  in
-            (match uu____4208 with
+              FStar_Syntax_Subst.open_univ_vars univs uu____4242  in
+            (match uu____4237 with
              | (univs1,t) ->
-                 let uu____4227 =
-                   let uu____4232 =
-                     let uu____4233 = FStar_Syntax_Subst.compress t  in
-                     uu____4233.FStar_Syntax_Syntax.n  in
-                   match uu____4232 with
+                 let uu____4256 =
+                   let uu____4261 =
+                     let uu____4262 = FStar_Syntax_Subst.compress t  in
+                     uu____4262.FStar_Syntax_Syntax.n  in
+                   match uu____4261 with
                    | FStar_Syntax_Syntax.Tm_arrow (bs,c1) -> (bs, c1)
-                   | uu____4262 -> failwith "impossible"  in
-                 (match uu____4227 with
+                   | uu____4291 -> failwith "impossible"  in
+                 (match uu____4256 with
                   | (tps1,c1) ->
-                      let uu____4271 = sli l  in
-                      let uu____4273 = univ_names_to_string univs1  in
-                      let uu____4275 = binders_to_string " " tps1  in
-                      let uu____4278 = comp_to_string c1  in
-                      FStar_Util.format4 "effect %s<%s> %s = %s" uu____4271
-                        uu____4273 uu____4275 uu____4278))
+                      let uu____4300 = sli l  in
+                      let uu____4302 = univ_names_to_string univs1  in
+                      let uu____4304 = binders_to_string " " tps1  in
+                      let uu____4307 = comp_to_string c1  in
+                      FStar_Util.format4 "effect %s<%s> %s = %s" uu____4300
+                        uu____4302 uu____4304 uu____4307))
           else
-            (let uu____4283 = sli l  in
-             let uu____4285 = binders_to_string " " tps  in
-             let uu____4288 = comp_to_string c  in
-             FStar_Util.format3 "effect %s %s = %s" uu____4283 uu____4285
-               uu____4288)
+            (let uu____4312 = sli l  in
+             let uu____4314 = binders_to_string " " tps  in
+             let uu____4317 = comp_to_string c  in
+             FStar_Util.format3 "effect %s %s = %s" uu____4312 uu____4314
+               uu____4317)
       | FStar_Syntax_Syntax.Sig_splice (lids,t) ->
-          let uu____4297 =
-            let uu____4299 = FStar_List.map FStar_Ident.string_of_lid lids
+          let uu____4326 =
+            let uu____4328 = FStar_List.map FStar_Ident.string_of_lid lids
                in
-            FStar_All.pipe_left (FStar_String.concat "; ") uu____4299  in
-          let uu____4309 = term_to_string t  in
-          FStar_Util.format2 "splice[%s] (%s)" uu____4297 uu____4309
+            FStar_All.pipe_left (FStar_String.concat "; ") uu____4328  in
+          let uu____4338 = term_to_string t  in
+          FStar_Util.format2 "splice[%s] (%s)" uu____4326 uu____4338
       | FStar_Syntax_Syntax.Sig_polymonadic_bind (m,n,p,t,ty) ->
-          let uu____4317 = FStar_Ident.string_of_lid m  in
-          let uu____4319 = FStar_Ident.string_of_lid n  in
-          let uu____4321 = FStar_Ident.string_of_lid p  in
-          let uu____4323 = tscheme_to_string t  in
-          let uu____4325 = tscheme_to_string ty  in
+          let uu____4346 = FStar_Ident.string_of_lid m  in
+          let uu____4348 = FStar_Ident.string_of_lid n  in
+          let uu____4350 = FStar_Ident.string_of_lid p  in
+          let uu____4352 = tscheme_to_string t  in
+          let uu____4354 = tscheme_to_string ty  in
           FStar_Util.format5 "polymonadic_bind (%s, %s) |> %s = (%s, %s)"
-            uu____4317 uu____4319 uu____4321 uu____4323 uu____4325
+            uu____4346 uu____4348 uu____4350 uu____4352 uu____4354
        in
     match x.FStar_Syntax_Syntax.sigattrs with
     | [] -> Prims.op_Hat "[@ ]" (Prims.op_Hat "\n" basic)
-    | uu____4331 ->
-        let uu____4334 = attrs_to_string x.FStar_Syntax_Syntax.sigattrs  in
-        Prims.op_Hat uu____4334 (Prims.op_Hat "\n" basic)
+    | uu____4360 ->
+        let uu____4363 = attrs_to_string x.FStar_Syntax_Syntax.sigattrs  in
+        Prims.op_Hat uu____4363 (Prims.op_Hat "\n" basic)
   
 let (format_error : FStar_Range.range -> Prims.string -> Prims.string) =
   fun r  ->
     fun msg  ->
-      let uu____4351 = FStar_Range.string_of_range r  in
-      FStar_Util.format2 "%s: %s\n" uu____4351 msg
+      let uu____4380 = FStar_Range.string_of_range r  in
+      FStar_Util.format2 "%s: %s\n" uu____4380 msg
   
 let (sigelt_to_string_short : FStar_Syntax_Syntax.sigelt -> Prims.string) =
   fun x  ->
     match x.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_let
-        ((uu____4362,{ FStar_Syntax_Syntax.lbname = lb;
-                       FStar_Syntax_Syntax.lbunivs = uu____4364;
+        ((uu____4391,{ FStar_Syntax_Syntax.lbname = lb;
+                       FStar_Syntax_Syntax.lbunivs = uu____4393;
                        FStar_Syntax_Syntax.lbtyp = t;
-                       FStar_Syntax_Syntax.lbeff = uu____4366;
-                       FStar_Syntax_Syntax.lbdef = uu____4367;
-                       FStar_Syntax_Syntax.lbattrs = uu____4368;
-                       FStar_Syntax_Syntax.lbpos = uu____4369;_}::[]),uu____4370)
+                       FStar_Syntax_Syntax.lbeff = uu____4395;
+                       FStar_Syntax_Syntax.lbdef = uu____4396;
+                       FStar_Syntax_Syntax.lbattrs = uu____4397;
+                       FStar_Syntax_Syntax.lbpos = uu____4398;_}::[]),uu____4399)
         ->
-        let uu____4393 = lbname_to_string lb  in
-        let uu____4395 = term_to_string t  in
-        FStar_Util.format2 "let %s : %s" uu____4393 uu____4395
-    | uu____4398 ->
-        let uu____4399 =
+        let uu____4422 = lbname_to_string lb  in
+        let uu____4424 = term_to_string t  in
+        FStar_Util.format2 "let %s : %s" uu____4422 uu____4424
+    | uu____4427 ->
+        let uu____4428 =
           FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt x)
-            (FStar_List.map (fun l  -> l.FStar_Ident.str))
+            (FStar_List.map (fun l  -> FStar_Ident.string_of_lid l))
            in
-        FStar_All.pipe_right uu____4399 (FStar_String.concat ", ")
+        FStar_All.pipe_right uu____4428 (FStar_String.concat ", ")
   
 let (tag_of_sigelt : FStar_Syntax_Syntax.sigelt -> Prims.string) =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_inductive_typ uu____4425 -> "Sig_inductive_typ"
-    | FStar_Syntax_Syntax.Sig_bundle uu____4443 -> "Sig_bundle"
-    | FStar_Syntax_Syntax.Sig_datacon uu____4453 -> "Sig_datacon"
-    | FStar_Syntax_Syntax.Sig_declare_typ uu____4470 -> "Sig_declare_typ"
-    | FStar_Syntax_Syntax.Sig_let uu____4478 -> "Sig_let"
-    | FStar_Syntax_Syntax.Sig_main uu____4486 -> "Sig_main"
-    | FStar_Syntax_Syntax.Sig_assume uu____4488 -> "Sig_assume"
-    | FStar_Syntax_Syntax.Sig_new_effect uu____4496 -> "Sig_new_effect"
-    | FStar_Syntax_Syntax.Sig_sub_effect uu____4498 -> "Sig_sub_effect"
-    | FStar_Syntax_Syntax.Sig_effect_abbrev uu____4500 -> "Sig_effect_abbrev"
-    | FStar_Syntax_Syntax.Sig_pragma uu____4514 -> "Sig_pragma"
-    | FStar_Syntax_Syntax.Sig_splice uu____4516 -> "Sig_splice"
-    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____4524 ->
+    | FStar_Syntax_Syntax.Sig_inductive_typ uu____4454 -> "Sig_inductive_typ"
+    | FStar_Syntax_Syntax.Sig_bundle uu____4472 -> "Sig_bundle"
+    | FStar_Syntax_Syntax.Sig_datacon uu____4482 -> "Sig_datacon"
+    | FStar_Syntax_Syntax.Sig_declare_typ uu____4499 -> "Sig_declare_typ"
+    | FStar_Syntax_Syntax.Sig_let uu____4507 -> "Sig_let"
+    | FStar_Syntax_Syntax.Sig_main uu____4515 -> "Sig_main"
+    | FStar_Syntax_Syntax.Sig_assume uu____4517 -> "Sig_assume"
+    | FStar_Syntax_Syntax.Sig_new_effect uu____4525 -> "Sig_new_effect"
+    | FStar_Syntax_Syntax.Sig_sub_effect uu____4527 -> "Sig_sub_effect"
+    | FStar_Syntax_Syntax.Sig_effect_abbrev uu____4529 -> "Sig_effect_abbrev"
+    | FStar_Syntax_Syntax.Sig_pragma uu____4543 -> "Sig_pragma"
+    | FStar_Syntax_Syntax.Sig_splice uu____4545 -> "Sig_splice"
+    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____4553 ->
         "Sig_polymonadic_bind"
-    | FStar_Syntax_Syntax.Sig_fail uu____4536 -> "Sig_fail"
+    | FStar_Syntax_Syntax.Sig_fail uu____4565 -> "Sig_fail"
   
 let (modul_to_string : FStar_Syntax_Syntax.modul -> Prims.string) =
   fun m  ->
-    let uu____4557 = sli m.FStar_Syntax_Syntax.name  in
-    let uu____4559 =
-      let uu____4561 =
+    let uu____4586 = sli m.FStar_Syntax_Syntax.name  in
+    let uu____4588 =
+      let uu____4590 =
         FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.declarations
          in
-      FStar_All.pipe_right uu____4561 (FStar_String.concat "\n")  in
-    let uu____4571 =
-      let uu____4573 =
+      FStar_All.pipe_right uu____4590 (FStar_String.concat "\n")  in
+    let uu____4600 =
+      let uu____4602 =
         FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.exports  in
-      FStar_All.pipe_right uu____4573 (FStar_String.concat "\n")  in
+      FStar_All.pipe_right uu____4602 (FStar_String.concat "\n")  in
     FStar_Util.format3
-      "module %s\nDeclarations: [\n%s\n]\nExports: [\n%s\n]\n" uu____4557
-      uu____4559 uu____4571
+      "module %s\nDeclarations: [\n%s\n]\nExports: [\n%s\n]\n" uu____4586
+      uu____4588 uu____4600
   
 let list_to_string :
   'a . ('a -> Prims.string) -> 'a Prims.list -> Prims.string =
@@ -1711,13 +1728,13 @@ let list_to_string :
       | x::xs ->
           let strb = FStar_Util.new_string_builder ()  in
           (FStar_Util.string_builder_append strb "[";
-           (let uu____4623 = f x  in
-            FStar_Util.string_builder_append strb uu____4623);
+           (let uu____4652 = f x  in
+            FStar_Util.string_builder_append strb uu____4652);
            FStar_List.iter
              (fun x1  ->
                 FStar_Util.string_builder_append strb "; ";
-                (let uu____4632 = f x1  in
-                 FStar_Util.string_builder_append strb uu____4632)) xs;
+                (let uu____4661 = f x1  in
+                 FStar_Util.string_builder_append strb uu____4661)) xs;
            FStar_Util.string_builder_append strb "]";
            FStar_Util.string_of_string_builder strb)
   
@@ -1731,13 +1748,13 @@ let set_to_string :
       | x::xs ->
           let strb = FStar_Util.new_string_builder ()  in
           (FStar_Util.string_builder_append strb "{";
-           (let uu____4679 = f x  in
-            FStar_Util.string_builder_append strb uu____4679);
+           (let uu____4708 = f x  in
+            FStar_Util.string_builder_append strb uu____4708);
            FStar_List.iter
              (fun x1  ->
                 FStar_Util.string_builder_append strb ", ";
-                (let uu____4688 = f x1  in
-                 FStar_Util.string_builder_append strb uu____4688)) xs;
+                (let uu____4717 = f x1  in
+                 FStar_Util.string_builder_append strb uu____4717)) xs;
            FStar_Util.string_builder_append strb "}";
            FStar_Util.string_of_string_builder strb)
   
@@ -1745,31 +1762,31 @@ let (bvs_to_string :
   Prims.string -> FStar_Syntax_Syntax.bv Prims.list -> Prims.string) =
   fun sep  ->
     fun bvs  ->
-      let uu____4710 = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs  in
-      binders_to_string sep uu____4710
+      let uu____4739 = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs  in
+      binders_to_string sep uu____4739
   
 let rec (emb_typ_to_string : FStar_Syntax_Syntax.emb_typ -> Prims.string) =
-  fun uu___15_4723  ->
-    match uu___15_4723 with
+  fun uu___15_4752  ->
+    match uu___15_4752 with
     | FStar_Syntax_Syntax.ET_abstract  -> "abstract"
     | FStar_Syntax_Syntax.ET_app (h,[]) -> h
     | FStar_Syntax_Syntax.ET_app (h,args) ->
-        let uu____4739 =
-          let uu____4741 =
-            let uu____4743 =
-              let uu____4745 =
-                let uu____4747 = FStar_List.map emb_typ_to_string args  in
-                FStar_All.pipe_right uu____4747 (FStar_String.concat " ")  in
-              Prims.op_Hat uu____4745 ")"  in
-            Prims.op_Hat " " uu____4743  in
-          Prims.op_Hat h uu____4741  in
-        Prims.op_Hat "(" uu____4739
+        let uu____4768 =
+          let uu____4770 =
+            let uu____4772 =
+              let uu____4774 =
+                let uu____4776 = FStar_List.map emb_typ_to_string args  in
+                FStar_All.pipe_right uu____4776 (FStar_String.concat " ")  in
+              Prims.op_Hat uu____4774 ")"  in
+            Prims.op_Hat " " uu____4772  in
+          Prims.op_Hat h uu____4770  in
+        Prims.op_Hat "(" uu____4768
     | FStar_Syntax_Syntax.ET_fun (a,b) ->
-        let uu____4762 =
-          let uu____4764 = emb_typ_to_string a  in
-          let uu____4766 =
-            let uu____4768 = emb_typ_to_string b  in
-            Prims.op_Hat ") -> " uu____4768  in
-          Prims.op_Hat uu____4764 uu____4766  in
-        Prims.op_Hat "(" uu____4762
+        let uu____4791 =
+          let uu____4793 = emb_typ_to_string a  in
+          let uu____4795 =
+            let uu____4797 = emb_typ_to_string b  in
+            Prims.op_Hat ") -> " uu____4797  in
+          Prims.op_Hat uu____4793 uu____4795  in
+        Prims.op_Hat "(" uu____4791
   

--- a/src/ocaml-output/FStar_Syntax_Resugar.ml
+++ b/src/ocaml-output/FStar_Syntax_Resugar.ml
@@ -24,52 +24,56 @@ let (bv_as_unique_ident : FStar_Syntax_Syntax.bv -> FStar_Ident.ident) =
   fun x  ->
     let unique_name =
       let uu____60 =
-        (FStar_Util.starts_with FStar_Ident.reserved_prefix
-           (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText)
-          || (FStar_Options.print_real_names ())
+        (let uu____64 = FStar_Ident.text_of_id x.FStar_Syntax_Syntax.ppname
+            in
+         FStar_Util.starts_with FStar_Ident.reserved_prefix uu____64) ||
+          (FStar_Options.print_real_names ())
          in
       if uu____60
       then
-        let uu____64 = FStar_Util.string_of_int x.FStar_Syntax_Syntax.index
+        let uu____68 = FStar_Ident.text_of_id x.FStar_Syntax_Syntax.ppname
            in
-        Prims.op_Hat (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-          uu____64
-      else (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText  in
-    FStar_Ident.mk_ident
-      (unique_name, ((x.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange))
+        let uu____70 = FStar_Util.string_of_int x.FStar_Syntax_Syntax.index
+           in
+        Prims.op_Hat uu____68 uu____70
+      else FStar_Ident.text_of_id x.FStar_Syntax_Syntax.ppname  in
+    let uu____74 =
+      let uu____80 = FStar_Ident.range_of_id x.FStar_Syntax_Syntax.ppname  in
+      (unique_name, uu____80)  in
+    FStar_Ident.mk_ident uu____74
   
 let filter_imp :
-  'uuuuuu74 .
-    ('uuuuuu74 * FStar_Syntax_Syntax.arg_qualifier
+  'uuuuuu87 .
+    ('uuuuuu87 * FStar_Syntax_Syntax.arg_qualifier
       FStar_Pervasives_Native.option) Prims.list ->
-      ('uuuuuu74 * FStar_Syntax_Syntax.arg_qualifier
+      ('uuuuuu87 * FStar_Syntax_Syntax.arg_qualifier
         FStar_Pervasives_Native.option) Prims.list
   =
   fun a  ->
     FStar_All.pipe_right a
       (FStar_List.filter
-         (fun uu___0_129  ->
-            match uu___0_129 with
-            | (uu____137,FStar_Pervasives_Native.Some
+         (fun uu___0_142  ->
+            match uu___0_142 with
+            | (uu____150,FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Meta t)) when
                 FStar_Syntax_Util.is_fvar FStar_Parser_Const.tcresolve_lid t
                 -> true
-            | (uu____144,FStar_Pervasives_Native.Some
-               (FStar_Syntax_Syntax.Implicit uu____145)) -> false
-            | (uu____150,FStar_Pervasives_Native.Some
-               (FStar_Syntax_Syntax.Meta uu____151)) -> false
-            | uu____157 -> true))
+            | (uu____157,FStar_Pervasives_Native.Some
+               (FStar_Syntax_Syntax.Implicit uu____158)) -> false
+            | (uu____163,FStar_Pervasives_Native.Some
+               (FStar_Syntax_Syntax.Meta uu____164)) -> false
+            | uu____170 -> true))
   
 let filter_pattern_imp :
-  'uuuuuu170 .
-    ('uuuuuu170 * Prims.bool) Prims.list ->
-      ('uuuuuu170 * Prims.bool) Prims.list
+  'uuuuuu183 .
+    ('uuuuuu183 * Prims.bool) Prims.list ->
+      ('uuuuuu183 * Prims.bool) Prims.list
   =
   fun xs  ->
     FStar_List.filter
-      (fun uu____205  ->
-         match uu____205 with
-         | (uu____212,is_implicit) -> Prims.op_Negation is_implicit) xs
+      (fun uu____218  ->
+         match uu____218 with
+         | (uu____225,is_implicit) -> Prims.op_Negation is_implicit) xs
   
 let (label : Prims.string -> FStar_Parser_AST.term -> FStar_Parser_AST.term)
   =
@@ -91,16 +95,16 @@ let rec (universe_to_int :
       match u with
       | FStar_Syntax_Syntax.U_succ u1 ->
           universe_to_int (n + Prims.int_one) u1
-      | uu____262 -> (n, u)
+      | uu____275 -> (n, u)
   
 let (universe_to_string : FStar_Ident.ident Prims.list -> Prims.string) =
   fun univs  ->
-    let uu____275 = FStar_Options.print_universes ()  in
-    if uu____275
+    let uu____288 = FStar_Options.print_universes ()  in
+    if uu____288
     then
-      let uu____279 = FStar_List.map (fun x  -> x.FStar_Ident.idText) univs
-         in
-      FStar_All.pipe_right uu____279 (FStar_String.concat ", ")
+      let uu____292 =
+        FStar_List.map (fun x  -> FStar_Ident.text_of_id x) univs  in
+      FStar_All.pipe_right uu____292 (FStar_String.concat ", ")
     else ""
   
 let rec (resugar_universe :
@@ -114,65 +118,65 @@ let rec (resugar_universe :
           mk
             (FStar_Parser_AST.Const
                (FStar_Const.Const_int ("0", FStar_Pervasives_Native.None))) r
-      | FStar_Syntax_Syntax.U_succ uu____328 ->
-          let uu____329 = universe_to_int Prims.int_zero u  in
-          (match uu____329 with
+      | FStar_Syntax_Syntax.U_succ uu____341 ->
+          let uu____342 = universe_to_int Prims.int_zero u  in
+          (match uu____342 with
            | (n,u1) ->
                (match u1 with
                 | FStar_Syntax_Syntax.U_zero  ->
-                    let uu____340 =
-                      let uu____341 =
-                        let uu____342 =
-                          let uu____354 = FStar_Util.string_of_int n  in
-                          (uu____354, FStar_Pervasives_Native.None)  in
-                        FStar_Const.Const_int uu____342  in
-                      FStar_Parser_AST.Const uu____341  in
-                    mk uu____340 r
-                | uu____367 ->
+                    let uu____353 =
+                      let uu____354 =
+                        let uu____355 =
+                          let uu____367 = FStar_Util.string_of_int n  in
+                          (uu____367, FStar_Pervasives_Native.None)  in
+                        FStar_Const.Const_int uu____355  in
+                      FStar_Parser_AST.Const uu____354  in
+                    mk uu____353 r
+                | uu____380 ->
                     let e1 =
-                      let uu____369 =
-                        let uu____370 =
-                          let uu____371 =
-                            let uu____383 = FStar_Util.string_of_int n  in
-                            (uu____383, FStar_Pervasives_Native.None)  in
-                          FStar_Const.Const_int uu____371  in
-                        FStar_Parser_AST.Const uu____370  in
-                      mk uu____369 r  in
+                      let uu____382 =
+                        let uu____383 =
+                          let uu____384 =
+                            let uu____396 = FStar_Util.string_of_int n  in
+                            (uu____396, FStar_Pervasives_Native.None)  in
+                          FStar_Const.Const_int uu____384  in
+                        FStar_Parser_AST.Const uu____383  in
+                      mk uu____382 r  in
                     let e2 = resugar_universe u1 r  in
-                    let uu____397 =
-                      let uu____398 =
-                        let uu____405 = FStar_Ident.id_of_text "+"  in
-                        (uu____405, [e1; e2])  in
-                      FStar_Parser_AST.Op uu____398  in
-                    mk uu____397 r))
+                    let uu____410 =
+                      let uu____411 =
+                        let uu____418 = FStar_Ident.id_of_text "+"  in
+                        (uu____418, [e1; e2])  in
+                      FStar_Parser_AST.Op uu____411  in
+                    mk uu____410 r))
       | FStar_Syntax_Syntax.U_max l ->
           (match l with
            | [] -> failwith "Impossible: U_max without arguments"
-           | uu____413 ->
+           | uu____426 ->
                let t =
-                 let uu____417 =
-                   let uu____418 = FStar_Ident.lid_of_path ["max"] r  in
-                   FStar_Parser_AST.Var uu____418  in
-                 mk uu____417 r  in
+                 let uu____430 =
+                   let uu____431 = FStar_Ident.lid_of_path ["max"] r  in
+                   FStar_Parser_AST.Var uu____431  in
+                 mk uu____430 r  in
                FStar_List.fold_left
                  (fun acc  ->
                     fun x  ->
-                      let uu____427 =
-                        let uu____428 =
-                          let uu____435 = resugar_universe x r  in
-                          (acc, uu____435, FStar_Parser_AST.Nothing)  in
-                        FStar_Parser_AST.App uu____428  in
-                      mk uu____427 r) t l)
+                      let uu____440 =
+                        let uu____441 =
+                          let uu____448 = resugar_universe x r  in
+                          (acc, uu____448, FStar_Parser_AST.Nothing)  in
+                        FStar_Parser_AST.App uu____441  in
+                      mk uu____440 r) t l)
       | FStar_Syntax_Syntax.U_name u1 -> mk (FStar_Parser_AST.Uvar u1) r
-      | FStar_Syntax_Syntax.U_unif uu____437 -> mk FStar_Parser_AST.Wild r
+      | FStar_Syntax_Syntax.U_unif uu____450 -> mk FStar_Parser_AST.Wild r
       | FStar_Syntax_Syntax.U_bvar x ->
           let id =
-            let uu____449 =
-              let uu____455 =
-                let uu____457 = FStar_Util.string_of_int x  in
-                FStar_Util.strcat "uu__univ_bvar_" uu____457  in
-              (uu____455, r)  in
-            FStar_Ident.mk_ident uu____449  in
+            let uu____462 =
+              let uu____468 =
+                let uu____470 = FStar_Util.string_of_int x  in
+                FStar_Util.strcat "uu__univ_bvar_" uu____470  in
+              (uu____468, r)  in
+            FStar_Ident.mk_ident uu____462  in
           mk (FStar_Parser_AST.Uvar id) r
       | FStar_Syntax_Syntax.U_unknown  -> mk FStar_Parser_AST.Wild r
   
@@ -187,8 +191,8 @@ let (string_to_op :
       FStar_Pervasives_Native.option)
   =
   fun s  ->
-    let name_of_op uu___1_511 =
-      match uu___1_511 with
+    let name_of_op uu___1_524 =
+      match uu___1_524 with
       | "Amp" ->
           FStar_Pervasives_Native.Some ("&", FStar_Pervasives_Native.None)
       | "At" ->
@@ -232,7 +236,7 @@ let (string_to_op :
           FStar_Pervasives_Native.Some ("$", FStar_Pervasives_Native.None)
       | "Dot" ->
           FStar_Pervasives_Native.Some (".", FStar_Pervasives_Native.None)
-      | uu____839 -> FStar_Pervasives_Native.None  in
+      | uu____852 -> FStar_Pervasives_Native.None  in
     match s with
     | "op_String_Assignment" ->
         FStar_Pervasives_Native.Some (".[]<-", FStar_Pervasives_Native.None)
@@ -252,18 +256,18 @@ let (string_to_op :
         FStar_Pervasives_Native.Some (".[||]", FStar_Pervasives_Native.None)
     | "op_Lens_Access" ->
         FStar_Pervasives_Native.Some (".(||)", FStar_Pervasives_Native.None)
-    | uu____979 ->
+    | uu____992 ->
         if FStar_Util.starts_with s "op_"
         then
           let s1 =
-            let uu____997 =
+            let uu____1010 =
               FStar_Util.substring_from s (FStar_String.length "op_")  in
-            FStar_Util.split uu____997 "_"  in
+            FStar_Util.split uu____1010 "_"  in
           (match s1 with
            | op::[] -> name_of_op op
-           | uu____1015 ->
+           | uu____1028 ->
                let maybeop =
-                 let uu____1023 = FStar_List.map name_of_op s1  in
+                 let uu____1036 = FStar_List.map name_of_op s1  in
                  FStar_List.fold_left
                    (fun acc  ->
                       fun x  ->
@@ -272,13 +276,13 @@ let (string_to_op :
                             FStar_Pervasives_Native.None
                         | FStar_Pervasives_Native.Some acc1 ->
                             (match x with
-                             | FStar_Pervasives_Native.Some (op,uu____1089)
+                             | FStar_Pervasives_Native.Some (op,uu____1102)
                                  ->
                                  FStar_Pervasives_Native.Some
                                    (Prims.op_Hat acc1 op)
                              | FStar_Pervasives_Native.None  ->
                                  FStar_Pervasives_Native.None))
-                   (FStar_Pervasives_Native.Some "") uu____1023
+                   (FStar_Pervasives_Native.Some "") uu____1036
                   in
                FStar_Util.map_opt maybeop
                  (fun o  -> (o, FStar_Pervasives_Native.None)))
@@ -324,30 +328,35 @@ let rec (resugar_term_as_op :
       (FStar_Parser_Const.exists_lid, "exists");
       (FStar_Parser_Const.salloc_lid, "alloc")]  in
     let fallback fv =
-      let uu____1421 =
+      let uu____1434 =
         FStar_All.pipe_right infix_prim_ops
           (FStar_Util.find_opt
              (fun d  ->
                 FStar_Syntax_Syntax.fv_eq_lid fv
                   (FStar_Pervasives_Native.fst d)))
          in
-      match uu____1421 with
+      match uu____1434 with
       | FStar_Pervasives_Native.Some op ->
           FStar_Pervasives_Native.Some
             ((FStar_Pervasives_Native.snd op), FStar_Pervasives_Native.None)
-      | uu____1491 ->
+      | uu____1504 ->
           let length =
-            FStar_String.length
-              ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.nsstr
-             in
+            let uu____1513 =
+              FStar_Ident.nsstr
+                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+               in
+            FStar_String.length uu____1513  in
           let str =
             if length = Prims.int_zero
             then
-              ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
+              FStar_Ident.string_of_lid
+                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
             else
-              FStar_Util.substring_from
-                ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-                (length + Prims.int_one)
+              (let uu____1523 =
+                 FStar_Ident.string_of_lid
+                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                  in
+               FStar_Util.substring_from uu____1523 (length + Prims.int_one))
              in
           if FStar_Util.starts_with str "dtuple"
           then
@@ -364,54 +373,63 @@ let rec (resugar_term_as_op :
                 FStar_Pervasives_Native.Some
                   ("try_with", FStar_Pervasives_Native.None)
               else
-                (let uu____1593 =
+                (let uu____1610 =
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.sread_lid
                     in
-                 if uu____1593
+                 if uu____1610
                  then
-                   FStar_Pervasives_Native.Some
-                     ((((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str),
-                       FStar_Pervasives_Native.None)
+                   let uu____1623 =
+                     let uu____1632 =
+                       FStar_Ident.string_of_lid
+                         (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                        in
+                     (uu____1632, FStar_Pervasives_Native.None)  in
+                   FStar_Pervasives_Native.Some uu____1623
                  else FStar_Pervasives_Native.None)
        in
-    let uu____1629 =
-      let uu____1630 = FStar_Syntax_Subst.compress t  in
-      uu____1630.FStar_Syntax_Syntax.n  in
-    match uu____1629 with
+    let uu____1657 =
+      let uu____1658 = FStar_Syntax_Subst.compress t  in
+      uu____1658.FStar_Syntax_Syntax.n  in
+    match uu____1657 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         let length =
-          FStar_String.length
-            ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.nsstr
-           in
+          let uu____1670 =
+            FStar_Ident.nsstr
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+             in
+          FStar_String.length uu____1670  in
         let s =
           if length = Prims.int_zero
           then
-            ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
+            FStar_Ident.string_of_lid
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
           else
-            FStar_Util.substring_from
-              ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-              (length + Prims.int_one)
+            (let uu____1680 =
+               FStar_Ident.string_of_lid
+                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                in
+             FStar_Util.substring_from uu____1680 (length + Prims.int_one))
            in
-        let uu____1651 = string_to_op s  in
-        (match uu____1651 with
+        let uu____1683 = string_to_op s  in
+        (match uu____1683 with
          | FStar_Pervasives_Native.Some t1 -> FStar_Pervasives_Native.Some t1
-         | uu____1691 -> fallback fv)
+         | uu____1723 -> fallback fv)
     | FStar_Syntax_Syntax.Tm_uinst (e,us) -> resugar_term_as_op e
-    | uu____1708 -> FStar_Pervasives_Native.None
+    | uu____1740 -> FStar_Pervasives_Native.None
   
 let (is_true_pat : FStar_Syntax_Syntax.pat -> Prims.bool) =
   fun p  ->
     match p.FStar_Syntax_Syntax.v with
     | FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool (true )) ->
         true
-    | uu____1725 -> false
+    | uu____1757 -> false
   
 let (is_wild_pat : FStar_Syntax_Syntax.pat -> Prims.bool) =
   fun p  ->
     match p.FStar_Syntax_Syntax.v with
-    | FStar_Syntax_Syntax.Pat_wild uu____1736 -> true
-    | uu____1738 -> false
+    | FStar_Syntax_Syntax.Pat_wild uu____1768 -> true
+    | uu____1770 -> false
   
 let (is_tuple_constructor_lid : FStar_Ident.lident -> Prims.bool) =
   fun lid  ->
@@ -420,20 +438,21 @@ let (is_tuple_constructor_lid : FStar_Ident.lident -> Prims.bool) =
   
 let (may_shorten : FStar_Ident.lident -> Prims.bool) =
   fun lid  ->
-    match lid.FStar_Ident.str with
+    let uu____1786 = FStar_Ident.string_of_lid lid  in
+    match uu____1786 with
     | "Prims.Nil" -> false
     | "Prims.Cons" -> false
-    | uu____1759 ->
-        let uu____1761 = is_tuple_constructor_lid lid  in
-        Prims.op_Negation uu____1761
+    | uu____1793 ->
+        let uu____1795 = is_tuple_constructor_lid lid  in
+        Prims.op_Negation uu____1795
   
 let (maybe_shorten_fv :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.fv -> FStar_Ident.lident) =
   fun env  ->
     fun fv  ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-      let uu____1775 = may_shorten lid  in
-      if uu____1775 then FStar_Syntax_DsEnv.shorten_lid env lid else lid
+      let uu____1809 = may_shorten lid  in
+      if uu____1809 then FStar_Syntax_DsEnv.shorten_lid env lid else lid
   
 let rec (resugar_term' :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.term -> FStar_Parser_AST.term)
@@ -445,52 +464,54 @@ let rec (resugar_term' :
           FStar_Parser_AST.Un
          in
       let name a r =
-        let uu____1920 = FStar_Ident.lid_of_path [a] r  in
-        FStar_Parser_AST.Name uu____1920  in
-      let uu____1923 =
-        let uu____1924 = FStar_Syntax_Subst.compress t  in
-        uu____1924.FStar_Syntax_Syntax.n  in
-      match uu____1923 with
-      | FStar_Syntax_Syntax.Tm_delayed uu____1927 ->
+        let uu____1954 = FStar_Ident.lid_of_path [a] r  in
+        FStar_Parser_AST.Name uu____1954  in
+      let uu____1957 =
+        let uu____1958 = FStar_Syntax_Subst.compress t  in
+        uu____1958.FStar_Syntax_Syntax.n  in
+      match uu____1957 with
+      | FStar_Syntax_Syntax.Tm_delayed uu____1961 ->
           failwith "Tm_delayed is impossible after compress"
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____1944 = FStar_Syntax_Util.unfold_lazy i  in
-          resugar_term' env uu____1944
+          let uu____1978 = FStar_Syntax_Util.unfold_lazy i  in
+          resugar_term' env uu____1978
       | FStar_Syntax_Syntax.Tm_bvar x ->
           let l =
-            let uu____1947 =
-              let uu____1950 = bv_as_unique_ident x  in [uu____1950]  in
-            FStar_Ident.lid_of_ids uu____1947  in
+            let uu____1981 =
+              let uu____1982 = bv_as_unique_ident x  in [uu____1982]  in
+            FStar_Ident.lid_of_ids uu____1981  in
           mk (FStar_Parser_AST.Var l)
       | FStar_Syntax_Syntax.Tm_name x ->
           let l =
-            let uu____1953 =
-              let uu____1956 = bv_as_unique_ident x  in [uu____1956]  in
-            FStar_Ident.lid_of_ids uu____1953  in
+            let uu____1985 =
+              let uu____1986 = bv_as_unique_ident x  in [uu____1986]  in
+            FStar_Ident.lid_of_ids uu____1985  in
           mk (FStar_Parser_AST.Var l)
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let a = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
           let length =
-            FStar_String.length
-              ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.nsstr
-             in
+            let uu____1990 =
+              FStar_Ident.nsstr
+                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+               in
+            FStar_String.length uu____1990  in
           let s =
             if length = Prims.int_zero
-            then a.FStar_Ident.str
+            then FStar_Ident.string_of_lid a
             else
-              FStar_Util.substring_from a.FStar_Ident.str
-                (length + Prims.int_one)
+              (let uu____2000 = FStar_Ident.string_of_lid a  in
+               FStar_Util.substring_from uu____2000 (length + Prims.int_one))
              in
           let is_prefix = Prims.op_Hat FStar_Ident.reserved_prefix "is_"  in
           if FStar_Util.starts_with s is_prefix
           then
             let rest =
               FStar_Util.substring_from s (FStar_String.length is_prefix)  in
-            let uu____1975 =
-              let uu____1976 =
+            let uu____2009 =
+              let uu____2010 =
                 FStar_Ident.lid_of_path [rest] t.FStar_Syntax_Syntax.pos  in
-              FStar_Parser_AST.Discrim uu____1976  in
-            mk uu____1975
+              FStar_Parser_AST.Discrim uu____2010  in
+            mk uu____2009
           else
             if
               FStar_Util.starts_with s
@@ -513,67 +534,67 @@ let rec (resugar_term' :
                      FStar_Ident.mk_ident (snd, (t.FStar_Syntax_Syntax.pos))
                       in
                    mk (FStar_Parser_AST.Projector (l, r1))
-               | uu____2000 -> failwith "wrong projector format")
+               | uu____2034 -> failwith "wrong projector format")
             else
-              (let uu____2007 =
+              (let uu____2041 =
                  FStar_Ident.lid_equals a FStar_Parser_Const.smtpat_lid  in
-               if uu____2007
+               if uu____2041
                then
-                 let uu____2010 =
-                   let uu____2011 =
-                     let uu____2012 =
-                       let uu____2018 = FStar_Ident.range_of_lid a  in
-                       ("SMTPat", uu____2018)  in
-                     FStar_Ident.mk_ident uu____2012  in
-                   FStar_Parser_AST.Tvar uu____2011  in
-                 mk uu____2010
+                 let uu____2044 =
+                   let uu____2045 =
+                     let uu____2046 =
+                       let uu____2052 = FStar_Ident.range_of_lid a  in
+                       ("SMTPat", uu____2052)  in
+                     FStar_Ident.mk_ident uu____2046  in
+                   FStar_Parser_AST.Tvar uu____2045  in
+                 mk uu____2044
                else
-                 (let uu____2023 =
+                 (let uu____2057 =
                     FStar_Ident.lid_equals a FStar_Parser_Const.smtpatOr_lid
                      in
-                  if uu____2023
+                  if uu____2057
                   then
-                    let uu____2026 =
-                      let uu____2027 =
-                        let uu____2028 =
-                          let uu____2034 = FStar_Ident.range_of_lid a  in
-                          ("SMTPatOr", uu____2034)  in
-                        FStar_Ident.mk_ident uu____2028  in
-                      FStar_Parser_AST.Tvar uu____2027  in
-                    mk uu____2026
+                    let uu____2060 =
+                      let uu____2061 =
+                        let uu____2062 =
+                          let uu____2068 = FStar_Ident.range_of_lid a  in
+                          ("SMTPatOr", uu____2068)  in
+                        FStar_Ident.mk_ident uu____2062  in
+                      FStar_Parser_AST.Tvar uu____2061  in
+                    mk uu____2060
                   else
-                    (let uu____2039 =
+                    (let uu____2073 =
                        ((FStar_Ident.lid_equals a
                            FStar_Parser_Const.assert_lid)
                           ||
                           (FStar_Ident.lid_equals a
                              FStar_Parser_Const.assume_lid))
                          ||
-                         (let uu____2043 =
-                            let uu____2045 =
+                         (let uu____2077 =
+                            let uu____2079 =
                               FStar_String.get s Prims.int_zero  in
-                            FStar_Char.uppercase uu____2045  in
-                          let uu____2048 = FStar_String.get s Prims.int_zero
+                            FStar_Char.uppercase uu____2079  in
+                          let uu____2082 = FStar_String.get s Prims.int_zero
                              in
-                          uu____2043 <> uu____2048)
+                          uu____2077 <> uu____2082)
                         in
-                     if uu____2039
+                     if uu____2073
                      then
-                       let uu____2053 =
-                         let uu____2054 = maybe_shorten_fv env fv  in
-                         FStar_Parser_AST.Var uu____2054  in
-                       mk uu____2053
+                       let uu____2087 =
+                         let uu____2088 = maybe_shorten_fv env fv  in
+                         FStar_Parser_AST.Var uu____2088  in
+                       mk uu____2087
                      else
-                       (let uu____2057 =
-                          let uu____2058 =
-                            let uu____2069 = maybe_shorten_fv env fv  in
-                            (uu____2069, [])  in
-                          FStar_Parser_AST.Construct uu____2058  in
-                        mk uu____2057))))
+                       (let uu____2091 =
+                          let uu____2092 =
+                            let uu____2103 = maybe_shorten_fv env fv  in
+                            (uu____2103, [])  in
+                          FStar_Parser_AST.Construct uu____2092  in
+                        mk uu____2091))))
       | FStar_Syntax_Syntax.Tm_uinst (e,universes) ->
           let e1 = resugar_term' env e  in
-          let uu____2087 = FStar_Options.print_universes ()  in
-          if uu____2087
+          let uu____2121 = FStar_Options.print_universes ()  in
+          if uu____2121
           then
             let univs =
               FStar_List.map
@@ -584,14 +605,14 @@ let rec (resugar_term' :
              | { FStar_Parser_AST.tm = FStar_Parser_AST.Construct (hd,args);
                  FStar_Parser_AST.range = r; FStar_Parser_AST.level = l;_} ->
                  let args1 =
-                   let uu____2118 =
+                   let uu____2152 =
                      FStar_List.map (fun u  -> (u, FStar_Parser_AST.UnivApp))
                        univs
                       in
-                   FStar_List.append args uu____2118  in
+                   FStar_List.append args uu____2152  in
                  FStar_Parser_AST.mk_term
                    (FStar_Parser_AST.Construct (hd, args1)) r l
-             | uu____2141 ->
+             | uu____2175 ->
                  FStar_List.fold_left
                    (fun acc  ->
                       fun u  ->
@@ -600,70 +621,70 @@ let rec (resugar_term' :
                              (acc, u, FStar_Parser_AST.UnivApp))) e1 univs)
           else e1
       | FStar_Syntax_Syntax.Tm_constant c ->
-          let uu____2149 = FStar_Syntax_Syntax.is_teff t  in
-          if uu____2149
+          let uu____2183 = FStar_Syntax_Syntax.is_teff t  in
+          if uu____2183
           then
-            let uu____2152 = name "Effect" t.FStar_Syntax_Syntax.pos  in
-            mk uu____2152
+            let uu____2186 = name "Effect" t.FStar_Syntax_Syntax.pos  in
+            mk uu____2186
           else mk (FStar_Parser_AST.Const c)
       | FStar_Syntax_Syntax.Tm_type u ->
-          let uu____2157 =
+          let uu____2191 =
             match u with
             | FStar_Syntax_Syntax.U_zero  -> ("Type0", false)
             | FStar_Syntax_Syntax.U_unknown  -> ("Type", false)
-            | uu____2178 -> ("Type", true)  in
-          (match uu____2157 with
+            | uu____2212 -> ("Type", true)  in
+          (match uu____2191 with
            | (nm,needs_app) ->
                let typ =
-                 let uu____2190 = name nm t.FStar_Syntax_Syntax.pos  in
-                 mk uu____2190  in
-               let uu____2191 =
+                 let uu____2224 = name nm t.FStar_Syntax_Syntax.pos  in
+                 mk uu____2224  in
+               let uu____2225 =
                  needs_app && (FStar_Options.print_universes ())  in
-               if uu____2191
+               if uu____2225
                then
-                 let uu____2194 =
-                   let uu____2195 =
-                     let uu____2202 =
+                 let uu____2228 =
+                   let uu____2229 =
+                     let uu____2236 =
                        resugar_universe u t.FStar_Syntax_Syntax.pos  in
-                     (typ, uu____2202, FStar_Parser_AST.UnivApp)  in
-                   FStar_Parser_AST.App uu____2195  in
-                 mk uu____2194
+                     (typ, uu____2236, FStar_Parser_AST.UnivApp)  in
+                   FStar_Parser_AST.App uu____2229  in
+                 mk uu____2228
                else typ)
-      | FStar_Syntax_Syntax.Tm_abs (xs,body,uu____2207) ->
-          let uu____2232 = FStar_Syntax_Subst.open_term xs body  in
-          (match uu____2232 with
+      | FStar_Syntax_Syntax.Tm_abs (xs,body,uu____2241) ->
+          let uu____2266 = FStar_Syntax_Subst.open_term xs body  in
+          (match uu____2266 with
            | (xs1,body1) ->
                let xs2 =
-                 let uu____2248 = FStar_Options.print_implicits ()  in
-                 if uu____2248 then xs1 else filter_imp xs1  in
+                 let uu____2282 = FStar_Options.print_implicits ()  in
+                 if uu____2282 then xs1 else filter_imp xs1  in
                let body_bv = FStar_Syntax_Free.names body1  in
                let patterns =
                  FStar_All.pipe_right xs2
                    (FStar_List.choose
-                      (fun uu____2286  ->
-                         match uu____2286 with
+                      (fun uu____2320  ->
+                         match uu____2320 with
                          | (x,qual) -> resugar_bv_as_pat env x qual body_bv))
                   in
                let body2 = resugar_term' env body1  in
                mk (FStar_Parser_AST.Abs (patterns, body2)))
       | FStar_Syntax_Syntax.Tm_arrow (xs,body) ->
-          let uu____2326 = FStar_Syntax_Subst.open_comp xs body  in
-          (match uu____2326 with
+          let uu____2360 = FStar_Syntax_Subst.open_comp xs body  in
+          (match uu____2360 with
            | (xs1,body1) ->
                let xs2 =
-                 let uu____2336 = FStar_Options.print_implicits ()  in
-                 if uu____2336 then xs1 else filter_imp xs1  in
+                 let uu____2370 = FStar_Options.print_implicits ()  in
+                 if uu____2370 then xs1 else filter_imp xs1  in
                let body2 = resugar_comp' env body1  in
                let xs3 =
-                 let uu____2347 =
+                 let uu____2381 =
                    FStar_All.pipe_right xs2
                      ((map_opt ())
                         (fun b  ->
                            resugar_binder' env b t.FStar_Syntax_Syntax.pos))
                     in
-                 FStar_All.pipe_right uu____2347 FStar_List.rev  in
-               let rec aux body3 uu___2_2372 =
-                 match uu___2_2372 with
+                 FStar_All.pipe_right uu____2381 FStar_List.rev  in
+               let rec aux body3 uu___2_2406 =
+                 match uu___2_2406 with
                  | [] -> body3
                  | hd::tl ->
                      let body4 = mk (FStar_Parser_AST.Product ([hd], body3))
@@ -672,64 +693,64 @@ let rec (resugar_term' :
                   in
                aux body2 xs3)
       | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
-          let uu____2388 =
-            let uu____2393 =
-              let uu____2394 = FStar_Syntax_Syntax.mk_binder x  in
-              [uu____2394]  in
-            FStar_Syntax_Subst.open_term uu____2393 phi  in
-          (match uu____2388 with
+          let uu____2422 =
+            let uu____2427 =
+              let uu____2428 = FStar_Syntax_Syntax.mk_binder x  in
+              [uu____2428]  in
+            FStar_Syntax_Subst.open_term uu____2427 phi  in
+          (match uu____2422 with
            | (x1,phi1) ->
                let b =
-                 let uu____2416 =
-                   let uu____2419 = FStar_List.hd x1  in
-                   resugar_binder' env uu____2419 t.FStar_Syntax_Syntax.pos
+                 let uu____2450 =
+                   let uu____2453 = FStar_List.hd x1  in
+                   resugar_binder' env uu____2453 t.FStar_Syntax_Syntax.pos
                     in
-                 FStar_Util.must uu____2416  in
-               let uu____2426 =
-                 let uu____2427 =
-                   let uu____2432 = resugar_term' env phi1  in
-                   (b, uu____2432)  in
-                 FStar_Parser_AST.Refine uu____2427  in
-               mk uu____2426)
+                 FStar_Util.must uu____2450  in
+               let uu____2460 =
+                 let uu____2461 =
+                   let uu____2466 = resugar_term' env phi1  in
+                   (b, uu____2466)  in
+                 FStar_Parser_AST.Refine uu____2461  in
+               mk uu____2460)
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____2434;
-             FStar_Syntax_Syntax.vars = uu____2435;_},(e,uu____2437)::[])
+             FStar_Syntax_Syntax.pos = uu____2468;
+             FStar_Syntax_Syntax.vars = uu____2469;_},(e,uu____2471)::[])
           when
-          (let uu____2478 = FStar_Options.print_implicits ()  in
-           Prims.op_Negation uu____2478) &&
+          (let uu____2512 = FStar_Options.print_implicits ()  in
+           Prims.op_Negation uu____2512) &&
             (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.b2t_lid)
           -> resugar_term' env e
       | FStar_Syntax_Syntax.Tm_app (e,args) ->
-          let rec last uu___3_2527 =
-            match uu___3_2527 with
+          let rec last uu___3_2561 =
+            match uu___3_2561 with
             | hd::[] -> [hd]
             | hd::tl -> last tl
-            | uu____2597 -> failwith "last of an empty list"  in
+            | uu____2631 -> failwith "last of an empty list"  in
           let first_two_explicit args1 =
             let rec drop_implicits args2 =
               match args2 with
-              | (uu____2683,FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Syntax.Implicit uu____2684))::tl ->
+              | (uu____2717,FStar_Pervasives_Native.Some
+                 (FStar_Syntax_Syntax.Implicit uu____2718))::tl ->
                   drop_implicits tl
-              | uu____2703 -> args2  in
-            let uu____2712 = drop_implicits args1  in
-            match uu____2712 with
+              | uu____2737 -> args2  in
+            let uu____2746 = drop_implicits args1  in
+            match uu____2746 with
             | [] -> failwith "not_enough explicit_arguments"
-            | uu____2744::[] -> failwith "not_enough explicit_arguments"
-            | a1::a2::uu____2774 -> [a1; a2]  in
+            | uu____2778::[] -> failwith "not_enough explicit_arguments"
+            | a1::a2::uu____2808 -> [a1; a2]  in
           let resugar_as_app e1 args1 =
             let args2 =
               FStar_List.map
-                (fun uu____2874  ->
-                   match uu____2874 with
+                (fun uu____2908  ->
+                   match uu____2908 with
                    | (e2,qual) ->
-                       let uu____2891 = resugar_term' env e2  in
-                       let uu____2892 = resugar_imp env qual  in
-                       (uu____2891, uu____2892)) args1
+                       let uu____2925 = resugar_term' env e2  in
+                       let uu____2926 = resugar_imp env qual  in
+                       (uu____2925, uu____2926)) args1
                in
-            let uu____2893 = resugar_term' env e1  in
-            match uu____2893 with
+            let uu____2927 = resugar_term' env e1  in
+            match uu____2927 with
             | {
                 FStar_Parser_AST.tm = FStar_Parser_AST.Construct
                   (hd,previous_args);
@@ -740,61 +761,61 @@ let rec (resugar_term' :
             | e2 ->
                 FStar_List.fold_left
                   (fun acc  ->
-                     fun uu____2930  ->
-                       match uu____2930 with
+                     fun uu____2964  ->
+                       match uu____2964 with
                        | (x,qual) -> mk (FStar_Parser_AST.App (acc, x, qual)))
                   e2 args2
              in
           let args1 =
-            let uu____2946 = FStar_Options.print_implicits ()  in
-            if uu____2946 then args else filter_imp args  in
-          let uu____2961 = resugar_term_as_op e  in
-          (match uu____2961 with
+            let uu____2980 = FStar_Options.print_implicits ()  in
+            if uu____2980 then args else filter_imp args  in
+          let uu____2995 = resugar_term_as_op e  in
+          (match uu____2995 with
            | FStar_Pervasives_Native.None  -> resugar_as_app e args1
-           | FStar_Pervasives_Native.Some ("tuple",uu____2974) ->
+           | FStar_Pervasives_Native.Some ("tuple",uu____3008) ->
                let out =
                  FStar_List.fold_left
                    (fun out  ->
-                      fun uu____2999  ->
-                        match uu____2999 with
-                        | (x,uu____3011) ->
+                      fun uu____3033  ->
+                        match uu____3033 with
+                        | (x,uu____3045) ->
                             let x1 = resugar_term' env x  in
                             (match out with
                              | FStar_Pervasives_Native.None  ->
                                  FStar_Pervasives_Native.Some x1
                              | FStar_Pervasives_Native.Some prefix ->
-                                 let uu____3020 =
-                                   let uu____3021 =
-                                     let uu____3022 =
-                                       let uu____3029 =
+                                 let uu____3054 =
+                                   let uu____3055 =
+                                     let uu____3056 =
+                                       let uu____3063 =
                                          FStar_Ident.id_of_text "*"  in
-                                       (uu____3029, [prefix; x1])  in
-                                     FStar_Parser_AST.Op uu____3022  in
-                                   mk uu____3021  in
-                                 FStar_Pervasives_Native.Some uu____3020))
+                                       (uu____3063, [prefix; x1])  in
+                                     FStar_Parser_AST.Op uu____3056  in
+                                   mk uu____3055  in
+                                 FStar_Pervasives_Native.Some uu____3054))
                    FStar_Pervasives_Native.None args1
                   in
                FStar_Option.get out
-           | FStar_Pervasives_Native.Some ("dtuple",uu____3033) when
+           | FStar_Pervasives_Native.Some ("dtuple",uu____3067) when
                (FStar_List.length args1) > Prims.int_zero ->
                let args2 = last args1  in
                let body =
                  match args2 with
-                 | (b,uu____3059)::[] -> b
-                 | uu____3076 -> failwith "wrong arguments to dtuple"  in
-               let uu____3086 =
-                 let uu____3087 = FStar_Syntax_Subst.compress body  in
-                 uu____3087.FStar_Syntax_Syntax.n  in
-               (match uu____3086 with
-                | FStar_Syntax_Syntax.Tm_abs (xs,body1,uu____3092) ->
-                    let uu____3117 = FStar_Syntax_Subst.open_term xs body1
+                 | (b,uu____3093)::[] -> b
+                 | uu____3110 -> failwith "wrong arguments to dtuple"  in
+               let uu____3120 =
+                 let uu____3121 = FStar_Syntax_Subst.compress body  in
+                 uu____3121.FStar_Syntax_Syntax.n  in
+               (match uu____3120 with
+                | FStar_Syntax_Syntax.Tm_abs (xs,body1,uu____3126) ->
+                    let uu____3151 = FStar_Syntax_Subst.open_term xs body1
                        in
-                    (match uu____3117 with
+                    (match uu____3151 with
                      | (xs1,body2) ->
                          let xs2 =
-                           let uu____3127 = FStar_Options.print_implicits ()
+                           let uu____3161 = FStar_Options.print_implicits ()
                               in
-                           if uu____3127 then xs1 else filter_imp xs1  in
+                           if uu____3161 then xs1 else filter_imp xs1  in
                          let xs3 =
                            FStar_All.pipe_right xs2
                              ((map_opt ())
@@ -803,22 +824,22 @@ let rec (resugar_term' :
                                      t.FStar_Syntax_Syntax.pos))
                             in
                          let body3 = resugar_term' env body2  in
-                         let uu____3144 =
-                           let uu____3145 =
-                             let uu____3156 =
+                         let uu____3178 =
+                           let uu____3179 =
+                             let uu____3190 =
                                FStar_List.map
-                                 (fun uu____3167  ->
-                                    FStar_Util.Inl uu____3167) xs3
+                                 (fun uu____3201  ->
+                                    FStar_Util.Inl uu____3201) xs3
                                 in
-                             (uu____3156, body3)  in
-                           FStar_Parser_AST.Sum uu____3145  in
-                         mk uu____3144)
-                | uu____3174 ->
+                             (uu____3190, body3)  in
+                           FStar_Parser_AST.Sum uu____3179  in
+                         mk uu____3178)
+                | uu____3208 ->
                     let args3 =
                       FStar_All.pipe_right args2
                         (FStar_List.map
-                           (fun uu____3197  ->
-                              match uu____3197 with
+                           (fun uu____3231  ->
+                              match uu____3231 with
                               | (e1,qual) -> resugar_term' env e1))
                        in
                     let e1 = resugar_term' env e  in
@@ -828,94 +849,105 @@ let rec (resugar_term' :
                            mk
                              (FStar_Parser_AST.App
                                 (acc, x, FStar_Parser_AST.Nothing))) e1 args3)
-           | FStar_Pervasives_Native.Some ("dtuple",uu____3215) ->
+           | FStar_Pervasives_Native.Some ("dtuple",uu____3249) ->
                resugar_as_app e args1
-           | FStar_Pervasives_Native.Some (ref_read,uu____3224) when
-               ref_read = FStar_Parser_Const.sread_lid.FStar_Ident.str ->
-               let uu____3233 = FStar_List.hd args1  in
-               (match uu____3233 with
-                | (t1,uu____3247) ->
-                    let uu____3252 =
-                      let uu____3253 = FStar_Syntax_Subst.compress t1  in
-                      uu____3253.FStar_Syntax_Syntax.n  in
-                    (match uu____3252 with
+           | FStar_Pervasives_Native.Some (ref_read,uu____3258) when
+               let uu____3266 =
+                 FStar_Ident.string_of_lid FStar_Parser_Const.sread_lid  in
+               ref_read = uu____3266 ->
+               let uu____3269 = FStar_List.hd args1  in
+               (match uu____3269 with
+                | (t1,uu____3283) ->
+                    let uu____3288 =
+                      let uu____3289 = FStar_Syntax_Subst.compress t1  in
+                      uu____3289.FStar_Syntax_Syntax.n  in
+                    (match uu____3288 with
                      | FStar_Syntax_Syntax.Tm_fvar fv when
+                         let uu____3293 =
+                           FStar_Ident.string_of_lid
+                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                            in
                          FStar_Syntax_Util.field_projector_contains_constructor
-                           ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
+                           uu____3293
                          ->
                          let f =
-                           FStar_Ident.lid_of_path
-                             [((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str]
+                           let uu____3296 =
+                             let uu____3297 =
+                               FStar_Ident.string_of_lid
+                                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                                in
+                             [uu____3297]  in
+                           FStar_Ident.lid_of_path uu____3296
                              t1.FStar_Syntax_Syntax.pos
                             in
-                         let uu____3260 =
-                           let uu____3261 =
-                             let uu____3266 = resugar_term' env t1  in
-                             (uu____3266, f)  in
-                           FStar_Parser_AST.Project uu____3261  in
-                         mk uu____3260
-                     | uu____3267 -> resugar_term' env t1))
-           | FStar_Pervasives_Native.Some ("try_with",uu____3268) when
+                         let uu____3301 =
+                           let uu____3302 =
+                             let uu____3307 = resugar_term' env t1  in
+                             (uu____3307, f)  in
+                           FStar_Parser_AST.Project uu____3302  in
+                         mk uu____3301
+                     | uu____3308 -> resugar_term' env t1))
+           | FStar_Pervasives_Native.Some ("try_with",uu____3309) when
                (FStar_List.length args1) > Prims.int_one ->
                (try
-                  (fun uu___426_3295  ->
+                  (fun uu___426_3336  ->
                      match () with
                      | () ->
                          let new_args = first_two_explicit args1  in
-                         let uu____3305 =
+                         let uu____3346 =
                            match new_args with
-                           | (a1,uu____3315)::(a2,uu____3317)::[] -> (a1, a2)
-                           | uu____3344 ->
+                           | (a1,uu____3356)::(a2,uu____3358)::[] -> (a1, a2)
+                           | uu____3385 ->
                                failwith "wrong arguments to try_with"
                             in
-                         (match uu____3305 with
+                         (match uu____3346 with
                           | (body,handler) ->
                               let decomp term =
-                                let uu____3366 =
-                                  let uu____3367 =
+                                let uu____3407 =
+                                  let uu____3408 =
                                     FStar_Syntax_Subst.compress term  in
-                                  uu____3367.FStar_Syntax_Syntax.n  in
-                                match uu____3366 with
+                                  uu____3408.FStar_Syntax_Syntax.n  in
+                                match uu____3407 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (x,e1,uu____3372) ->
-                                    let uu____3397 =
+                                    (x,e1,uu____3413) ->
+                                    let uu____3438 =
                                       FStar_Syntax_Subst.open_term x e1  in
-                                    (match uu____3397 with | (x1,e2) -> e2)
-                                | uu____3404 ->
-                                    let uu____3405 =
-                                      let uu____3407 =
-                                        let uu____3409 =
+                                    (match uu____3438 with | (x1,e2) -> e2)
+                                | uu____3445 ->
+                                    let uu____3446 =
+                                      let uu____3448 =
+                                        let uu____3450 =
                                           resugar_term' env term  in
                                         FStar_Parser_AST.term_to_string
-                                          uu____3409
+                                          uu____3450
                                          in
                                       Prims.op_Hat
                                         "wrong argument format to try_with: "
-                                        uu____3407
+                                        uu____3448
                                        in
-                                    failwith uu____3405
+                                    failwith uu____3446
                                  in
                               let body1 =
-                                let uu____3412 = decomp body  in
-                                resugar_term' env uu____3412  in
+                                let uu____3453 = decomp body  in
+                                resugar_term' env uu____3453  in
                               let handler1 =
-                                let uu____3414 = decomp handler  in
-                                resugar_term' env uu____3414  in
+                                let uu____3455 = decomp handler  in
+                                resugar_term' env uu____3455  in
                               let rec resugar_body t1 =
                                 match t1.FStar_Parser_AST.tm with
                                 | FStar_Parser_AST.Match
-                                    (e1,(uu____3422,uu____3423,b)::[]) -> b
+                                    (e1,(uu____3463,uu____3464,b)::[]) -> b
                                 | FStar_Parser_AST.Let
-                                    (uu____3455,uu____3456,b) -> b
+                                    (uu____3496,uu____3497,b) -> b
                                 | FStar_Parser_AST.Ascribed (t11,t2,t3) ->
-                                    let uu____3493 =
-                                      let uu____3494 =
-                                        let uu____3503 = resugar_body t11  in
-                                        (uu____3503, t2, t3)  in
-                                      FStar_Parser_AST.Ascribed uu____3494
+                                    let uu____3534 =
+                                      let uu____3535 =
+                                        let uu____3544 = resugar_body t11  in
+                                        (uu____3544, t2, t3)  in
+                                      FStar_Parser_AST.Ascribed uu____3535
                                        in
-                                    mk uu____3493
-                                | uu____3506 ->
+                                    mk uu____3534
+                                | uu____3547 ->
                                     failwith
                                       "unexpected body format to try_with"
                                  in
@@ -926,14 +958,14 @@ let rec (resugar_term' :
                                     branches
                                 | FStar_Parser_AST.Ascribed (t11,t2,t3) ->
                                     resugar_branches t11
-                                | uu____3564 -> []  in
+                                | uu____3605 -> []  in
                               let branches = resugar_branches handler1  in
                               mk (FStar_Parser_AST.TryWith (e1, branches))))
                     ()
-                with | uu____3597 -> resugar_as_app e args1)
-           | FStar_Pervasives_Native.Some ("try_with",uu____3598) ->
+                with | uu____3638 -> resugar_as_app e args1)
+           | FStar_Pervasives_Native.Some ("try_with",uu____3639) ->
                resugar_as_app e args1
-           | FStar_Pervasives_Native.Some (op,uu____3607) when
+           | FStar_Pervasives_Native.Some (op,uu____3648) when
                (((((((op = "=") || (op = "==")) || (op = "===")) ||
                      (op = "@"))
                     || (op = ":="))
@@ -941,31 +973,31 @@ let rec (resugar_term' :
                   || (op = "<<"))
                  && (FStar_Options.print_implicits ())
                -> resugar_as_app e args1
-           | FStar_Pervasives_Native.Some (op,uu____3630) when
+           | FStar_Pervasives_Native.Some (op,uu____3671) when
                (op = "forall") || (op = "exists") ->
                let rec uncurry xs pats t1 =
                  match t1.FStar_Parser_AST.tm with
-                 | FStar_Parser_AST.QExists (xs',(uu____3695,pats'),body) ->
+                 | FStar_Parser_AST.QExists (xs',(uu____3736,pats'),body) ->
                      uncurry (FStar_List.append xs xs')
                        (FStar_List.append pats pats') body
-                 | FStar_Parser_AST.QForall (xs',(uu____3727,pats'),body) ->
+                 | FStar_Parser_AST.QForall (xs',(uu____3768,pats'),body) ->
                      uncurry (FStar_List.append xs xs')
                        (FStar_List.append pats pats') body
-                 | uu____3758 -> (xs, pats, t1)  in
+                 | uu____3799 -> (xs, pats, t1)  in
                let resugar_forall_body body =
-                 let uu____3771 =
-                   let uu____3772 = FStar_Syntax_Subst.compress body  in
-                   uu____3772.FStar_Syntax_Syntax.n  in
-                 match uu____3771 with
-                 | FStar_Syntax_Syntax.Tm_abs (xs,body1,uu____3777) ->
-                     let uu____3802 = FStar_Syntax_Subst.open_term xs body1
+                 let uu____3812 =
+                   let uu____3813 = FStar_Syntax_Subst.compress body  in
+                   uu____3813.FStar_Syntax_Syntax.n  in
+                 match uu____3812 with
+                 | FStar_Syntax_Syntax.Tm_abs (xs,body1,uu____3818) ->
+                     let uu____3843 = FStar_Syntax_Subst.open_term xs body1
                         in
-                     (match uu____3802 with
+                     (match uu____3843 with
                       | (xs1,body2) ->
                           let xs2 =
-                            let uu____3812 = FStar_Options.print_implicits ()
+                            let uu____3853 = FStar_Options.print_implicits ()
                                in
-                            if uu____3812 then xs1 else filter_imp xs1  in
+                            if uu____3853 then xs1 else filter_imp xs1  in
                           let xs3 =
                             FStar_All.pipe_right xs2
                               ((map_opt ())
@@ -973,120 +1005,120 @@ let rec (resugar_term' :
                                     resugar_binder' env b
                                       t.FStar_Syntax_Syntax.pos))
                              in
-                          let uu____3828 =
-                            let uu____3837 =
-                              let uu____3838 =
+                          let uu____3869 =
+                            let uu____3878 =
+                              let uu____3879 =
                                 FStar_Syntax_Subst.compress body2  in
-                              uu____3838.FStar_Syntax_Syntax.n  in
-                            match uu____3837 with
+                              uu____3879.FStar_Syntax_Syntax.n  in
+                            match uu____3878 with
                             | FStar_Syntax_Syntax.Tm_meta (e1,m) ->
                                 let body3 = resugar_term' env e1  in
-                                let uu____3856 =
+                                let uu____3897 =
                                   match m with
                                   | FStar_Syntax_Syntax.Meta_pattern
-                                      (uu____3873,pats) ->
-                                      let uu____3907 =
+                                      (uu____3914,pats) ->
+                                      let uu____3948 =
                                         FStar_List.map
                                           (fun es  ->
                                              FStar_All.pipe_right es
                                                (FStar_List.map
-                                                  (fun uu____3951  ->
-                                                     match uu____3951 with
-                                                     | (e2,uu____3959) ->
+                                                  (fun uu____3992  ->
+                                                     match uu____3992 with
+                                                     | (e2,uu____4000) ->
                                                          resugar_term' env e2)))
                                           pats
                                          in
-                                      (uu____3907, body3)
+                                      (uu____3948, body3)
                                   | FStar_Syntax_Syntax.Meta_labeled 
                                       (s,r,p) ->
-                                      let uu____3975 =
+                                      let uu____4016 =
                                         mk
                                           (FStar_Parser_AST.Labeled
                                              (body3, s, p))
                                          in
-                                      ([], uu____3975)
-                                  | uu____3984 ->
+                                      ([], uu____4016)
+                                  | uu____4025 ->
                                       failwith
                                         "wrong pattern format for QForall/QExists"
                                    in
-                                (match uu____3856 with
+                                (match uu____3897 with
                                  | (pats,body4) -> (pats, body4))
-                            | uu____4016 ->
-                                let uu____4017 = resugar_term' env body2  in
-                                ([], uu____4017)
+                            | uu____4057 ->
+                                let uu____4058 = resugar_term' env body2  in
+                                ([], uu____4058)
                              in
-                          (match uu____3828 with
+                          (match uu____3869 with
                            | (pats,body3) ->
-                               let uu____4034 = uncurry xs3 pats body3  in
-                               (match uu____4034 with
+                               let uu____4075 = uncurry xs3 pats body3  in
+                               (match uu____4075 with
                                 | (xs4,pats1,body4) ->
                                     if op = "forall"
                                     then
-                                      let uu____4065 =
-                                        let uu____4066 =
-                                          let uu____4085 =
-                                            let uu____4096 =
+                                      let uu____4106 =
+                                        let uu____4107 =
+                                          let uu____4126 =
+                                            let uu____4137 =
                                               FStar_Parser_AST.idents_of_binders
                                                 xs4 t.FStar_Syntax_Syntax.pos
                                                in
-                                            (uu____4096, pats1)  in
-                                          (xs4, uu____4085, body4)  in
-                                        FStar_Parser_AST.QForall uu____4066
+                                            (uu____4137, pats1)  in
+                                          (xs4, uu____4126, body4)  in
+                                        FStar_Parser_AST.QForall uu____4107
                                          in
-                                      mk uu____4065
+                                      mk uu____4106
                                     else
-                                      (let uu____4119 =
-                                         let uu____4120 =
-                                           let uu____4139 =
-                                             let uu____4150 =
+                                      (let uu____4160 =
+                                         let uu____4161 =
+                                           let uu____4180 =
+                                             let uu____4191 =
                                                FStar_Parser_AST.idents_of_binders
                                                  xs4
                                                  t.FStar_Syntax_Syntax.pos
                                                 in
-                                             (uu____4150, pats1)  in
-                                           (xs4, uu____4139, body4)  in
-                                         FStar_Parser_AST.QExists uu____4120
+                                             (uu____4191, pats1)  in
+                                           (xs4, uu____4180, body4)  in
+                                         FStar_Parser_AST.QExists uu____4161
                                           in
-                                       mk uu____4119))))
-                 | uu____4171 ->
+                                       mk uu____4160))))
+                 | uu____4212 ->
                      if op = "forall"
                      then
-                       let uu____4175 =
-                         let uu____4176 =
-                           let uu____4195 = resugar_term' env body  in
-                           ([], ([], []), uu____4195)  in
-                         FStar_Parser_AST.QForall uu____4176  in
-                       mk uu____4175
+                       let uu____4216 =
+                         let uu____4217 =
+                           let uu____4236 = resugar_term' env body  in
+                           ([], ([], []), uu____4236)  in
+                         FStar_Parser_AST.QForall uu____4217  in
+                       mk uu____4216
                      else
-                       (let uu____4218 =
-                          let uu____4219 =
-                            let uu____4238 = resugar_term' env body  in
-                            ([], ([], []), uu____4238)  in
-                          FStar_Parser_AST.QExists uu____4219  in
-                        mk uu____4218)
+                       (let uu____4259 =
+                          let uu____4260 =
+                            let uu____4279 = resugar_term' env body  in
+                            ([], ([], []), uu____4279)  in
+                          FStar_Parser_AST.QExists uu____4260  in
+                        mk uu____4259)
                   in
                if (FStar_List.length args1) > Prims.int_zero
                then
                  let args2 = last args1  in
                  (match args2 with
-                  | (b,uu____4277)::[] -> resugar_forall_body b
-                  | uu____4294 -> failwith "wrong args format to QForall")
+                  | (b,uu____4318)::[] -> resugar_forall_body b
+                  | uu____4335 -> failwith "wrong args format to QForall")
                else resugar_as_app e args1
-           | FStar_Pervasives_Native.Some ("alloc",uu____4306) ->
-               let uu____4314 = FStar_List.hd args1  in
-               (match uu____4314 with
-                | (e1,uu____4328) -> resugar_term' env e1)
+           | FStar_Pervasives_Native.Some ("alloc",uu____4347) ->
+               let uu____4355 = FStar_List.hd args1  in
+               (match uu____4355 with
+                | (e1,uu____4369) -> resugar_term' env e1)
            | FStar_Pervasives_Native.Some (op,expected_arity1) ->
                let op1 = FStar_Ident.id_of_text op  in
                let resugar args2 =
                  FStar_All.pipe_right args2
                    (FStar_List.map
-                      (fun uu____4400  ->
-                         match uu____4400 with
+                      (fun uu____4441  ->
+                         match uu____4441 with
                          | (e1,qual) ->
-                             let uu____4417 = resugar_term' env e1  in
-                             let uu____4418 = resugar_imp env qual  in
-                             (uu____4417, uu____4418)))
+                             let uu____4458 = resugar_term' env e1  in
+                             let uu____4459 = resugar_imp env qual  in
+                             (uu____4458, uu____4459)))
                   in
                (match expected_arity1 with
                 | FStar_Pervasives_Native.None  ->
@@ -1095,24 +1127,24 @@ let rec (resugar_term' :
                       FStar_Parser_ToDocument.handleable_args_length op1  in
                     if (FStar_List.length resugared_args) >= expect_n
                     then
-                      let uu____4434 =
+                      let uu____4475 =
                         FStar_Util.first_N expect_n resugared_args  in
-                      (match uu____4434 with
+                      (match uu____4475 with
                        | (op_args,rest) ->
                            let head =
-                             let uu____4482 =
-                               let uu____4483 =
-                                 let uu____4490 =
+                             let uu____4523 =
+                               let uu____4524 =
+                                 let uu____4531 =
                                    FStar_List.map FStar_Pervasives_Native.fst
                                      op_args
                                     in
-                                 (op1, uu____4490)  in
-                               FStar_Parser_AST.Op uu____4483  in
-                             mk uu____4482  in
+                                 (op1, uu____4531)  in
+                               FStar_Parser_AST.Op uu____4524  in
+                             mk uu____4523  in
                            FStar_List.fold_left
                              (fun head1  ->
-                                fun uu____4508  ->
-                                  match uu____4508 with
+                                fun uu____4549  ->
+                                  match uu____4549 with
                                   | (arg,qual) ->
                                       mk
                                         (FStar_Parser_AST.App
@@ -1120,52 +1152,52 @@ let rec (resugar_term' :
                     else resugar_as_app e args1
                 | FStar_Pervasives_Native.Some n when
                     (FStar_List.length args1) = n ->
-                    let uu____4527 =
-                      let uu____4528 =
-                        let uu____4535 =
-                          let uu____4538 = resugar args1  in
+                    let uu____4568 =
+                      let uu____4569 =
+                        let uu____4576 =
+                          let uu____4579 = resugar args1  in
                           FStar_List.map FStar_Pervasives_Native.fst
-                            uu____4538
+                            uu____4579
                            in
-                        (op1, uu____4535)  in
-                      FStar_Parser_AST.Op uu____4528  in
-                    mk uu____4527
-                | uu____4551 -> resugar_as_app e args1))
+                        (op1, uu____4576)  in
+                      FStar_Parser_AST.Op uu____4569  in
+                    mk uu____4568
+                | uu____4592 -> resugar_as_app e args1))
       | FStar_Syntax_Syntax.Tm_match (e,(pat,wopt,t1)::[]) ->
-          let uu____4620 = FStar_Syntax_Subst.open_branch (pat, wopt, t1)  in
-          (match uu____4620 with
+          let uu____4661 = FStar_Syntax_Subst.open_branch (pat, wopt, t1)  in
+          (match uu____4661 with
            | (pat1,wopt1,t2) ->
                let branch_bv = FStar_Syntax_Free.names t2  in
                let bnds =
-                 let uu____4666 =
-                   let uu____4679 =
-                     let uu____4684 = resugar_pat' env pat1 branch_bv  in
-                     let uu____4685 = resugar_term' env e  in
-                     (uu____4684, uu____4685)  in
-                   (FStar_Pervasives_Native.None, uu____4679)  in
-                 [uu____4666]  in
+                 let uu____4707 =
+                   let uu____4720 =
+                     let uu____4725 = resugar_pat' env pat1 branch_bv  in
+                     let uu____4726 = resugar_term' env e  in
+                     (uu____4725, uu____4726)  in
+                   (FStar_Pervasives_Native.None, uu____4720)  in
+                 [uu____4707]  in
                let body = resugar_term' env t2  in
                mk
                  (FStar_Parser_AST.Let
                     (FStar_Parser_AST.NoLetQualifier, bnds, body)))
       | FStar_Syntax_Syntax.Tm_match
-          (e,(pat1,uu____4737,t1)::(pat2,uu____4740,t2)::[]) when
+          (e,(pat1,uu____4778,t1)::(pat2,uu____4781,t2)::[]) when
           (is_true_pat pat1) && (is_wild_pat pat2) ->
-          let uu____4836 =
-            let uu____4837 =
-              let uu____4844 = resugar_term' env e  in
-              let uu____4845 = resugar_term' env t1  in
-              let uu____4846 = resugar_term' env t2  in
-              (uu____4844, uu____4845, uu____4846)  in
-            FStar_Parser_AST.If uu____4837  in
-          mk uu____4836
+          let uu____4877 =
+            let uu____4878 =
+              let uu____4885 = resugar_term' env e  in
+              let uu____4886 = resugar_term' env t1  in
+              let uu____4887 = resugar_term' env t2  in
+              (uu____4885, uu____4886, uu____4887)  in
+            FStar_Parser_AST.If uu____4878  in
+          mk uu____4877
       | FStar_Syntax_Syntax.Tm_match (e,branches) ->
-          let resugar_branch uu____4912 =
-            match uu____4912 with
+          let resugar_branch uu____4953 =
+            match uu____4953 with
             | (pat,wopt,b) ->
-                let uu____4954 =
+                let uu____4995 =
                   FStar_Syntax_Subst.open_branch (pat, wopt, b)  in
-                (match uu____4954 with
+                (match uu____4995 with
                  | (pat1,wopt1,b1) ->
                      let branch_bv = FStar_Syntax_Free.names b1  in
                      let pat2 = resugar_pat' env pat1 branch_bv  in
@@ -1174,90 +1206,90 @@ let rec (resugar_term' :
                        | FStar_Pervasives_Native.None  ->
                            FStar_Pervasives_Native.None
                        | FStar_Pervasives_Native.Some e1 ->
-                           let uu____5006 = resugar_term' env e1  in
-                           FStar_Pervasives_Native.Some uu____5006
+                           let uu____5047 = resugar_term' env e1  in
+                           FStar_Pervasives_Native.Some uu____5047
                         in
                      let b2 = resugar_term' env b1  in (pat2, wopt2, b2))
              in
-          let uu____5010 =
-            let uu____5011 =
-              let uu____5026 = resugar_term' env e  in
-              let uu____5027 = FStar_List.map resugar_branch branches  in
-              (uu____5026, uu____5027)  in
-            FStar_Parser_AST.Match uu____5011  in
-          mk uu____5010
-      | FStar_Syntax_Syntax.Tm_ascribed (e,(asc,tac_opt),uu____5073) ->
+          let uu____5051 =
+            let uu____5052 =
+              let uu____5067 = resugar_term' env e  in
+              let uu____5068 = FStar_List.map resugar_branch branches  in
+              (uu____5067, uu____5068)  in
+            FStar_Parser_AST.Match uu____5052  in
+          mk uu____5051
+      | FStar_Syntax_Syntax.Tm_ascribed (e,(asc,tac_opt),uu____5114) ->
           let term =
             match asc with
             | FStar_Util.Inl n -> resugar_term' env n
             | FStar_Util.Inr n -> resugar_comp' env n  in
           let tac_opt1 = FStar_Option.map (resugar_term' env) tac_opt  in
-          let uu____5142 =
-            let uu____5143 =
-              let uu____5152 = resugar_term' env e  in
-              (uu____5152, term, tac_opt1)  in
-            FStar_Parser_AST.Ascribed uu____5143  in
-          mk uu____5142
+          let uu____5183 =
+            let uu____5184 =
+              let uu____5193 = resugar_term' env e  in
+              (uu____5193, term, tac_opt1)  in
+            FStar_Parser_AST.Ascribed uu____5184  in
+          mk uu____5183
       | FStar_Syntax_Syntax.Tm_let ((is_rec,source_lbs),body) ->
           let mk_pat a =
             FStar_Parser_AST.mk_pattern a t.FStar_Syntax_Syntax.pos  in
-          let uu____5181 = FStar_Syntax_Subst.open_let_rec source_lbs body
+          let uu____5222 = FStar_Syntax_Subst.open_let_rec source_lbs body
              in
-          (match uu____5181 with
+          (match uu____5222 with
            | (source_lbs1,body1) ->
                let resugar_one_binding bnd =
                  let attrs_opt =
                    match bnd.FStar_Syntax_Syntax.lbattrs with
                    | [] -> FStar_Pervasives_Native.None
                    | tms ->
-                       let uu____5235 =
+                       let uu____5276 =
                          FStar_List.map (resugar_term' env) tms  in
-                       FStar_Pervasives_Native.Some uu____5235
+                       FStar_Pervasives_Native.Some uu____5276
                     in
-                 let uu____5242 =
-                   let uu____5247 =
+                 let uu____5283 =
+                   let uu____5288 =
                      FStar_Syntax_Util.mk_conj bnd.FStar_Syntax_Syntax.lbtyp
                        bnd.FStar_Syntax_Syntax.lbdef
                       in
                    FStar_Syntax_Subst.open_univ_vars
-                     bnd.FStar_Syntax_Syntax.lbunivs uu____5247
+                     bnd.FStar_Syntax_Syntax.lbunivs uu____5288
                     in
-                 match uu____5242 with
+                 match uu____5283 with
                  | (univs,td) ->
-                     let uu____5267 =
-                       let uu____5274 =
-                         let uu____5275 = FStar_Syntax_Subst.compress td  in
-                         uu____5275.FStar_Syntax_Syntax.n  in
-                       match uu____5274 with
+                     let uu____5308 =
+                       let uu____5315 =
+                         let uu____5316 = FStar_Syntax_Subst.compress td  in
+                         uu____5316.FStar_Syntax_Syntax.n  in
+                       match uu____5315 with
                        | FStar_Syntax_Syntax.Tm_app
-                           (uu____5284,(t1,uu____5286)::(d,uu____5288)::[])
+                           (uu____5325,(t1,uu____5327)::(d,uu____5329)::[])
                            -> (t1, d)
-                       | uu____5345 -> failwith "wrong let binding format"
+                       | uu____5386 -> failwith "wrong let binding format"
                         in
-                     (match uu____5267 with
+                     (match uu____5308 with
                       | (typ,def) ->
-                          let uu____5376 =
-                            let uu____5392 =
-                              let uu____5393 =
+                          let uu____5417 =
+                            let uu____5433 =
+                              let uu____5434 =
                                 FStar_Syntax_Subst.compress def  in
-                              uu____5393.FStar_Syntax_Syntax.n  in
-                            match uu____5392 with
-                            | FStar_Syntax_Syntax.Tm_abs (b,t1,uu____5413) ->
-                                let uu____5438 =
+                              uu____5434.FStar_Syntax_Syntax.n  in
+                            match uu____5433 with
+                            | FStar_Syntax_Syntax.Tm_abs (b,t1,uu____5454) ->
+                                let uu____5479 =
                                   FStar_Syntax_Subst.open_term b t1  in
-                                (match uu____5438 with
+                                (match uu____5479 with
                                  | (b1,t2) ->
                                      let b2 =
-                                       let uu____5469 =
+                                       let uu____5510 =
                                          FStar_Options.print_implicits ()  in
-                                       if uu____5469
+                                       if uu____5510
                                        then b1
                                        else filter_imp b1  in
                                      (b2, t2, true))
-                            | uu____5492 -> ([], def, false)  in
-                          (match uu____5376 with
+                            | uu____5533 -> ([], def, false)  in
+                          (match uu____5417 with
                            | (binders,term,is_pat_app) ->
-                               let uu____5547 =
+                               let uu____5588 =
                                  match bnd.FStar_Syntax_Syntax.lbname with
                                  | FStar_Util.Inr fv ->
                                      ((mk_pat
@@ -1265,83 +1297,83 @@ let rec (resugar_term' :
                                             ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v))),
                                        term)
                                  | FStar_Util.Inl bv ->
-                                     let uu____5558 =
-                                       let uu____5559 =
-                                         let uu____5560 =
-                                           let uu____5567 =
+                                     let uu____5599 =
+                                       let uu____5600 =
+                                         let uu____5601 =
+                                           let uu____5608 =
                                              bv_as_unique_ident bv  in
-                                           (uu____5567,
+                                           (uu____5608,
                                              FStar_Pervasives_Native.None)
                                             in
-                                         FStar_Parser_AST.PatVar uu____5560
+                                         FStar_Parser_AST.PatVar uu____5601
                                           in
-                                       mk_pat uu____5559  in
-                                     (uu____5558, term)
+                                       mk_pat uu____5600  in
+                                     (uu____5599, term)
                                   in
-                               (match uu____5547 with
+                               (match uu____5588 with
                                 | (pat,term1) ->
-                                    let uu____5589 =
+                                    let uu____5630 =
                                       if is_pat_app
                                       then
                                         let args =
                                           FStar_All.pipe_right binders
                                             ((map_opt ())
-                                               (fun uu____5632  ->
-                                                  match uu____5632 with
+                                               (fun uu____5673  ->
+                                                  match uu____5673 with
                                                   | (bv,q) ->
-                                                      let uu____5647 =
+                                                      let uu____5688 =
                                                         resugar_arg_qual env
                                                           q
                                                          in
                                                       FStar_Util.map_opt
-                                                        uu____5647
+                                                        uu____5688
                                                         (fun q1  ->
-                                                           let uu____5659 =
-                                                             let uu____5660 =
-                                                               let uu____5667
+                                                           let uu____5700 =
+                                                             let uu____5701 =
+                                                               let uu____5708
                                                                  =
                                                                  bv_as_unique_ident
                                                                    bv
                                                                   in
-                                                               (uu____5667,
+                                                               (uu____5708,
                                                                  q1)
                                                                 in
                                                              FStar_Parser_AST.PatVar
-                                                               uu____5660
+                                                               uu____5701
                                                               in
-                                                           mk_pat uu____5659)))
+                                                           mk_pat uu____5700)))
                                            in
-                                        let uu____5670 =
-                                          let uu____5675 =
+                                        let uu____5711 =
+                                          let uu____5716 =
                                             resugar_term' env term1  in
                                           ((mk_pat
                                               (FStar_Parser_AST.PatApp
-                                                 (pat, args))), uu____5675)
+                                                 (pat, args))), uu____5716)
                                            in
-                                        let uu____5678 =
+                                        let uu____5719 =
                                           universe_to_string univs  in
-                                        (uu____5670, uu____5678)
+                                        (uu____5711, uu____5719)
                                       else
-                                        (let uu____5687 =
-                                           let uu____5692 =
+                                        (let uu____5728 =
+                                           let uu____5733 =
                                              resugar_term' env term1  in
-                                           (pat, uu____5692)  in
-                                         let uu____5693 =
+                                           (pat, uu____5733)  in
+                                         let uu____5734 =
                                            universe_to_string univs  in
-                                         (uu____5687, uu____5693))
+                                         (uu____5728, uu____5734))
                                        in
-                                    (attrs_opt, uu____5589))))
+                                    (attrs_opt, uu____5630))))
                   in
                let r = FStar_List.map resugar_one_binding source_lbs1  in
                let bnds =
-                 let f uu____5799 =
-                   match uu____5799 with
+                 let f uu____5840 =
+                   match uu____5840 with
                    | (attrs,(pb,univs)) ->
-                       let uu____5859 =
-                         let uu____5861 = FStar_Options.print_universes ()
+                       let uu____5900 =
+                         let uu____5902 = FStar_Options.print_universes ()
                             in
-                         Prims.op_Negation uu____5861  in
-                       if uu____5859
+                         Prims.op_Negation uu____5902  in
+                       if uu____5900
                        then (attrs, pb)
                        else
                          (attrs,
@@ -1355,67 +1387,67 @@ let rec (resugar_term' :
                     ((if is_rec
                       then FStar_Parser_AST.Rec
                       else FStar_Parser_AST.NoLetQualifier), bnds, body2)))
-      | FStar_Syntax_Syntax.Tm_uvar (u,uu____5942) ->
+      | FStar_Syntax_Syntax.Tm_uvar (u,uu____5983) ->
           let s =
-            let uu____5961 =
-              let uu____5963 =
+            let uu____6002 =
+              let uu____6004 =
                 FStar_Syntax_Unionfind.uvar_id
                   u.FStar_Syntax_Syntax.ctx_uvar_head
                  in
-              FStar_All.pipe_right uu____5963 FStar_Util.string_of_int  in
-            Prims.op_Hat "?u" uu____5961  in
-          let uu____5968 = mk FStar_Parser_AST.Wild  in label s uu____5968
+              FStar_All.pipe_right uu____6004 FStar_Util.string_of_int  in
+            Prims.op_Hat "?u" uu____6002  in
+          let uu____6009 = mk FStar_Parser_AST.Wild  in label s uu____6009
       | FStar_Syntax_Syntax.Tm_quoted (tm,qi) ->
           let qi1 =
             match qi.FStar_Syntax_Syntax.qkind with
             | FStar_Syntax_Syntax.Quote_static  -> FStar_Parser_AST.Static
             | FStar_Syntax_Syntax.Quote_dynamic  -> FStar_Parser_AST.Dynamic
              in
-          let uu____5976 =
-            let uu____5977 =
-              let uu____5982 = resugar_term' env tm  in (uu____5982, qi1)  in
-            FStar_Parser_AST.Quote uu____5977  in
-          mk uu____5976
+          let uu____6017 =
+            let uu____6018 =
+              let uu____6023 = resugar_term' env tm  in (uu____6023, qi1)  in
+            FStar_Parser_AST.Quote uu____6018  in
+          mk uu____6017
       | FStar_Syntax_Syntax.Tm_meta (e,m) ->
-          let resugar_meta_desugared uu___4_5994 =
-            match uu___4_5994 with
+          let resugar_meta_desugared uu___4_6035 =
+            match uu___4_6035 with
             | FStar_Syntax_Syntax.Sequence  ->
                 let term = resugar_term' env e  in
                 let rec resugar_seq t1 =
                   match t1.FStar_Parser_AST.tm with
                   | FStar_Parser_AST.Let
-                      (uu____6002,(uu____6003,(p,t11))::[],t2) ->
+                      (uu____6043,(uu____6044,(p,t11))::[],t2) ->
                       mk (FStar_Parser_AST.Seq (t11, t2))
                   | FStar_Parser_AST.Ascribed (t11,t2,t3) ->
-                      let uu____6064 =
-                        let uu____6065 =
-                          let uu____6074 = resugar_seq t11  in
-                          (uu____6074, t2, t3)  in
-                        FStar_Parser_AST.Ascribed uu____6065  in
-                      mk uu____6064
-                  | uu____6077 -> t1  in
+                      let uu____6105 =
+                        let uu____6106 =
+                          let uu____6115 = resugar_seq t11  in
+                          (uu____6115, t2, t3)  in
+                        FStar_Parser_AST.Ascribed uu____6106  in
+                      mk uu____6105
+                  | uu____6118 -> t1  in
                 resugar_seq term
             | FStar_Syntax_Syntax.Primop  -> resugar_term' env e
             | FStar_Syntax_Syntax.Masked_effect  -> resugar_term' env e
             | FStar_Syntax_Syntax.Meta_smt_pat  -> resugar_term' env e  in
           (match m with
-           | FStar_Syntax_Syntax.Meta_pattern (uu____6078,pats) ->
+           | FStar_Syntax_Syntax.Meta_pattern (uu____6119,pats) ->
                let pats1 =
                  FStar_All.pipe_right (FStar_List.flatten pats)
                    (FStar_List.map
-                      (fun uu____6142  ->
-                         match uu____6142 with
-                         | (x,uu____6150) -> resugar_term' env x))
+                      (fun uu____6183  ->
+                         match uu____6183 with
+                         | (x,uu____6191) -> resugar_term' env x))
                   in
                mk (FStar_Parser_AST.Attributes pats1)
-           | FStar_Syntax_Syntax.Meta_labeled uu____6155 ->
+           | FStar_Syntax_Syntax.Meta_labeled uu____6196 ->
                resugar_term' env e
            | FStar_Syntax_Syntax.Meta_desugared i -> resugar_meta_desugared i
            | FStar_Syntax_Syntax.Meta_named t1 ->
                mk (FStar_Parser_AST.Name t1)
-           | FStar_Syntax_Syntax.Meta_monadic (uu____6166,t1) ->
+           | FStar_Syntax_Syntax.Meta_monadic (uu____6207,t1) ->
                resugar_term' env e
-           | FStar_Syntax_Syntax.Meta_monadic_lift (uu____6172,uu____6173,t1)
+           | FStar_Syntax_Syntax.Meta_monadic_lift (uu____6213,uu____6214,t1)
                -> resugar_term' env e)
       | FStar_Syntax_Syntax.Tm_unknown  -> mk FStar_Parser_AST.Wild
 
@@ -1438,8 +1470,8 @@ and (resugar_comp' :
                     (FStar_Parser_Const.effect_Tot_lid,
                       [(t, FStar_Parser_AST.Nothing)]))
            | FStar_Pervasives_Native.Some u1 ->
-               let uu____6213 = FStar_Options.print_universes ()  in
-               if uu____6213
+               let uu____6254 = FStar_Options.print_universes ()  in
+               if uu____6254
                then
                  let u2 = resugar_universe u1 c.FStar_Syntax_Syntax.pos  in
                  mk
@@ -1461,8 +1493,8 @@ and (resugar_comp' :
                     (FStar_Parser_Const.effect_GTot_lid,
                       [(t, FStar_Parser_AST.Nothing)]))
            | FStar_Pervasives_Native.Some u1 ->
-               let uu____6277 = FStar_Options.print_universes ()  in
-               if uu____6277
+               let uu____6318 = FStar_Options.print_universes ()  in
+               if uu____6318
                then
                  let u2 = resugar_universe u1 c.FStar_Syntax_Syntax.pos  in
                  mk
@@ -1477,72 +1509,72 @@ and (resugar_comp' :
                         [(t, FStar_Parser_AST.Nothing)])))
       | FStar_Syntax_Syntax.Comp c1 ->
           let result =
-            let uu____6321 =
+            let uu____6362 =
               resugar_term' env c1.FStar_Syntax_Syntax.result_typ  in
-            (uu____6321, FStar_Parser_AST.Nothing)  in
-          let uu____6322 =
+            (uu____6362, FStar_Parser_AST.Nothing)  in
+          let uu____6363 =
             (FStar_Options.print_effect_args ()) ||
               (FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name
                  FStar_Parser_Const.effect_Lemma_lid)
              in
-          if uu____6322
+          if uu____6363
           then
             let universe =
               FStar_List.map (fun u  -> resugar_universe u)
                 c1.FStar_Syntax_Syntax.comp_univs
                in
             let args =
-              let uu____6345 =
+              let uu____6386 =
                 FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name
                   FStar_Parser_Const.effect_Lemma_lid
                  in
-              if uu____6345
+              if uu____6386
               then
                 match c1.FStar_Syntax_Syntax.effect_args with
                 | pre::post::pats::[] ->
                     let post1 =
-                      let uu____6430 =
+                      let uu____6471 =
                         FStar_Syntax_Util.unthunk_lemma_post
                           (FStar_Pervasives_Native.fst post)
                          in
-                      (uu____6430, (FStar_Pervasives_Native.snd post))  in
-                    let uu____6441 =
-                      let uu____6450 =
+                      (uu____6471, (FStar_Pervasives_Native.snd post))  in
+                    let uu____6482 =
+                      let uu____6491 =
                         FStar_Syntax_Util.is_fvar FStar_Parser_Const.true_lid
                           (FStar_Pervasives_Native.fst pre)
                          in
-                      if uu____6450 then [] else [pre]  in
-                    let uu____6485 =
-                      let uu____6494 =
-                        let uu____6503 =
+                      if uu____6491 then [] else [pre]  in
+                    let uu____6526 =
+                      let uu____6535 =
+                        let uu____6544 =
                           FStar_Syntax_Util.is_fvar
                             FStar_Parser_Const.nil_lid
                             (FStar_Pervasives_Native.fst pats)
                            in
-                        if uu____6503 then [] else [pats]  in
-                      FStar_List.append [post1] uu____6494  in
-                    FStar_List.append uu____6441 uu____6485
-                | uu____6562 -> c1.FStar_Syntax_Syntax.effect_args
+                        if uu____6544 then [] else [pats]  in
+                      FStar_List.append [post1] uu____6535  in
+                    FStar_List.append uu____6482 uu____6526
+                | uu____6603 -> c1.FStar_Syntax_Syntax.effect_args
               else c1.FStar_Syntax_Syntax.effect_args  in
             let args1 =
               FStar_List.map
-                (fun uu____6596  ->
-                   match uu____6596 with
-                   | (e,uu____6608) ->
-                       let uu____6613 = resugar_term' env e  in
-                       (uu____6613, FStar_Parser_AST.Nothing)) args
+                (fun uu____6637  ->
+                   match uu____6637 with
+                   | (e,uu____6649) ->
+                       let uu____6654 = resugar_term' env e  in
+                       (uu____6654, FStar_Parser_AST.Nothing)) args
                in
-            let rec aux l uu___5_6638 =
-              match uu___5_6638 with
+            let rec aux l uu___5_6679 =
+              match uu___5_6679 with
               | [] -> l
               | hd::tl ->
                   (match hd with
                    | FStar_Syntax_Syntax.DECREASES e ->
                        let e1 =
-                         let uu____6671 = resugar_term' env e  in
-                         (uu____6671, FStar_Parser_AST.Nothing)  in
+                         let uu____6712 = resugar_term' env e  in
+                         (uu____6712, FStar_Parser_AST.Nothing)  in
                        aux (e1 :: l) tl
-                   | uu____6676 -> aux l tl)
+                   | uu____6717 -> aux l tl)
                in
             let decrease = aux [] c1.FStar_Syntax_Syntax.flags  in
             mk
@@ -1563,33 +1595,33 @@ and (resugar_binder' :
   fun env  ->
     fun b  ->
       fun r  ->
-        let uu____6723 = b  in
-        match uu____6723 with
+        let uu____6764 = b  in
+        match uu____6764 with
         | (x,aq) ->
-            let uu____6732 = resugar_arg_qual env aq  in
-            FStar_Util.map_opt uu____6732
+            let uu____6773 = resugar_arg_qual env aq  in
+            FStar_Util.map_opt uu____6773
               (fun imp  ->
                  let e = resugar_term' env x.FStar_Syntax_Syntax.sort  in
                  match e.FStar_Parser_AST.tm with
                  | FStar_Parser_AST.Wild  ->
-                     let uu____6746 =
-                       let uu____6747 = bv_as_unique_ident x  in
-                       FStar_Parser_AST.Variable uu____6747  in
-                     FStar_Parser_AST.mk_binder uu____6746 r
+                     let uu____6787 =
+                       let uu____6788 = bv_as_unique_ident x  in
+                       FStar_Parser_AST.Variable uu____6788  in
+                     FStar_Parser_AST.mk_binder uu____6787 r
                        FStar_Parser_AST.Type_level imp
-                 | uu____6748 ->
-                     let uu____6749 = FStar_Syntax_Syntax.is_null_bv x  in
-                     if uu____6749
+                 | uu____6789 ->
+                     let uu____6790 = FStar_Syntax_Syntax.is_null_bv x  in
+                     if uu____6790
                      then
                        FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName e)
                          r FStar_Parser_AST.Type_level imp
                      else
-                       (let uu____6754 =
-                          let uu____6755 =
-                            let uu____6760 = bv_as_unique_ident x  in
-                            (uu____6760, e)  in
-                          FStar_Parser_AST.Annotated uu____6755  in
-                        FStar_Parser_AST.mk_binder uu____6754 r
+                       (let uu____6795 =
+                          let uu____6796 =
+                            let uu____6801 = bv_as_unique_ident x  in
+                            (uu____6801, e)  in
+                          FStar_Parser_AST.Annotated uu____6796  in
+                        FStar_Parser_AST.mk_binder uu____6795 r
                           FStar_Parser_AST.Type_level imp))
 
 and (resugar_bv_as_pat' :
@@ -1606,38 +1638,38 @@ and (resugar_bv_as_pat' :
         fun body_bv  ->
           fun typ_opt  ->
             let mk a =
-              let uu____6780 = FStar_Syntax_Syntax.range_of_bv v  in
-              FStar_Parser_AST.mk_pattern a uu____6780  in
+              let uu____6821 = FStar_Syntax_Syntax.range_of_bv v  in
+              FStar_Parser_AST.mk_pattern a uu____6821  in
             let used = FStar_Util.set_mem v body_bv  in
             let pat =
-              let uu____6784 =
+              let uu____6825 =
                 if used
                 then
-                  let uu____6786 =
-                    let uu____6793 = bv_as_unique_ident v  in
-                    (uu____6793, aqual)  in
-                  FStar_Parser_AST.PatVar uu____6786
+                  let uu____6827 =
+                    let uu____6834 = bv_as_unique_ident v  in
+                    (uu____6834, aqual)  in
+                  FStar_Parser_AST.PatVar uu____6827
                 else FStar_Parser_AST.PatWild aqual  in
-              mk uu____6784  in
+              mk uu____6825  in
             match typ_opt with
             | FStar_Pervasives_Native.None  -> pat
             | FStar_Pervasives_Native.Some
                 { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_unknown ;
-                  FStar_Syntax_Syntax.pos = uu____6800;
-                  FStar_Syntax_Syntax.vars = uu____6801;_}
+                  FStar_Syntax_Syntax.pos = uu____6841;
+                  FStar_Syntax_Syntax.vars = uu____6842;_}
                 -> pat
             | FStar_Pervasives_Native.Some typ ->
-                let uu____6811 = FStar_Options.print_bound_var_types ()  in
-                if uu____6811
+                let uu____6852 = FStar_Options.print_bound_var_types ()  in
+                if uu____6852
                 then
-                  let uu____6814 =
-                    let uu____6815 =
-                      let uu____6826 =
-                        let uu____6833 = resugar_term' env typ  in
-                        (uu____6833, FStar_Pervasives_Native.None)  in
-                      (pat, uu____6826)  in
-                    FStar_Parser_AST.PatAscribed uu____6815  in
-                  mk uu____6814
+                  let uu____6855 =
+                    let uu____6856 =
+                      let uu____6867 =
+                        let uu____6874 = resugar_term' env typ  in
+                        (uu____6874, FStar_Pervasives_Native.None)  in
+                      (pat, uu____6867)  in
+                    FStar_Parser_AST.PatAscribed uu____6856  in
+                  mk uu____6855
                 else pat
 
 and (resugar_bv_as_pat :
@@ -1651,17 +1683,17 @@ and (resugar_bv_as_pat :
     fun x  ->
       fun qual  ->
         fun body_bv  ->
-          let uu____6854 = resugar_arg_qual env qual  in
-          FStar_Util.map_opt uu____6854
+          let uu____6895 = resugar_arg_qual env qual  in
+          FStar_Util.map_opt uu____6895
             (fun aqual  ->
-               let uu____6866 =
-                 let uu____6871 =
+               let uu____6907 =
+                 let uu____6912 =
                    FStar_Syntax_Subst.compress x.FStar_Syntax_Syntax.sort  in
                  FStar_All.pipe_left
-                   (fun uu____6882  ->
-                      FStar_Pervasives_Native.Some uu____6882) uu____6871
+                   (fun uu____6923  ->
+                      FStar_Pervasives_Native.Some uu____6923) uu____6912
                   in
-               resugar_bv_as_pat' env x aqual body_bv uu____6866)
+               resugar_bv_as_pat' env x aqual body_bv uu____6907)
 
 and (resugar_pat' :
   FStar_Syntax_DsEnv.env ->
@@ -1680,24 +1712,24 @@ and (resugar_pat' :
                else FStar_Pervasives_Native.None)
            in
         let may_drop_implicits args =
-          (let uu____6944 = FStar_Options.print_implicits ()  in
-           Prims.op_Negation uu____6944) &&
-            (let uu____6947 =
+          (let uu____6985 = FStar_Options.print_implicits ()  in
+           Prims.op_Negation uu____6985) &&
+            (let uu____6988 =
                FStar_List.existsML
-                 (fun uu____6960  ->
-                    match uu____6960 with
+                 (fun uu____7001  ->
+                    match uu____7001 with
                     | (pattern,is_implicit) ->
                         let might_be_used =
                           match pattern.FStar_Syntax_Syntax.v with
                           | FStar_Syntax_Syntax.Pat_var bv ->
                               FStar_Util.set_mem bv branch_bv
-                          | FStar_Syntax_Syntax.Pat_dot_term (bv,uu____6982)
+                          | FStar_Syntax_Syntax.Pat_dot_term (bv,uu____7023)
                               -> FStar_Util.set_mem bv branch_bv
-                          | FStar_Syntax_Syntax.Pat_wild uu____6987 -> false
-                          | uu____6989 -> true  in
+                          | FStar_Syntax_Syntax.Pat_wild uu____7028 -> false
+                          | uu____7030 -> true  in
                         is_implicit && might_be_used) args
                 in
-             Prims.op_Negation uu____6947)
+             Prims.op_Negation uu____6988)
            in
         let resugar_plain_pat_cons' fv args =
           mk
@@ -1709,12 +1741,12 @@ and (resugar_pat' :
            in
         let rec resugar_plain_pat_cons fv args =
           let args1 =
-            let uu____7057 = may_drop_implicits args  in
-            if uu____7057 then filter_pattern_imp args else args  in
+            let uu____7098 = may_drop_implicits args  in
+            if uu____7098 then filter_pattern_imp args else args  in
           let args2 =
             FStar_List.map
-              (fun uu____7082  ->
-                 match uu____7082 with
+              (fun uu____7123  ->
+                 match uu____7123 with
                  | (p1,b) -> aux p1 (FStar_Pervasives_Native.Some b)) args1
              in
           resugar_plain_pat_cons' fv args2
@@ -1733,12 +1765,12 @@ and (resugar_pat' :
                  FStar_Parser_Const.nil_lid)
                 && (may_drop_implicits args)
               ->
-              ((let uu____7137 =
-                  let uu____7139 =
-                    let uu____7141 = filter_pattern_imp args  in
-                    FStar_List.isEmpty uu____7141  in
-                  Prims.op_Negation uu____7139  in
-                if uu____7137
+              ((let uu____7178 =
+                  let uu____7180 =
+                    let uu____7182 = filter_pattern_imp args  in
+                    FStar_List.isEmpty uu____7182  in
+                  Prims.op_Negation uu____7180  in
+                if uu____7178
                 then
                   FStar_Errors.log_issue p1.FStar_Syntax_Syntax.p
                     (FStar_Errors.Warning_NilGivenExplicitArgs,
@@ -1751,34 +1783,34 @@ and (resugar_pat' :
                  FStar_Parser_Const.cons_lid)
                 && (may_drop_implicits args)
               ->
-              let uu____7185 = filter_pattern_imp args  in
-              (match uu____7185 with
+              let uu____7226 = filter_pattern_imp args  in
+              (match uu____7226 with
                | (hd,false )::(tl,false )::[] ->
                    let hd' = aux hd (FStar_Pervasives_Native.Some false)  in
-                   let uu____7235 =
+                   let uu____7276 =
                      aux tl (FStar_Pervasives_Native.Some false)  in
-                   (match uu____7235 with
+                   (match uu____7276 with
                     | { FStar_Parser_AST.pat = FStar_Parser_AST.PatList tl';
                         FStar_Parser_AST.prange = p2;_} ->
                         FStar_Parser_AST.mk_pattern
                           (FStar_Parser_AST.PatList (hd' :: tl')) p2
                     | tl' -> resugar_plain_pat_cons' fv [hd'; tl'])
                | args' ->
-                   ((let uu____7254 =
-                       let uu____7260 =
-                         let uu____7262 =
+                   ((let uu____7295 =
+                       let uu____7301 =
+                         let uu____7303 =
                            FStar_All.pipe_left FStar_Util.string_of_int
                              (FStar_List.length args')
                             in
                          FStar_Util.format1
                            "Prims.Cons applied to %s explicit arguments"
-                           uu____7262
+                           uu____7303
                           in
                        (FStar_Errors.Warning_ConsAppliedExplicitArgs,
-                         uu____7260)
+                         uu____7301)
                         in
                      FStar_Errors.log_issue p1.FStar_Syntax_Syntax.p
-                       uu____7254);
+                       uu____7295);
                     resugar_plain_pat_cons fv args))
           | FStar_Syntax_Syntax.Pat_cons (fv,args) when
               (is_tuple_constructor_lid
@@ -1788,16 +1820,16 @@ and (resugar_pat' :
               let args1 =
                 FStar_All.pipe_right args
                   (FStar_List.filter_map
-                     (fun uu____7315  ->
-                        match uu____7315 with
+                     (fun uu____7356  ->
+                        match uu____7356 with
                         | (p2,is_implicit) ->
                             if is_implicit
                             then FStar_Pervasives_Native.None
                             else
-                              (let uu____7332 =
+                              (let uu____7373 =
                                  aux p2 (FStar_Pervasives_Native.Some false)
                                   in
-                               FStar_Pervasives_Native.Some uu____7332)))
+                               FStar_Pervasives_Native.Some uu____7373)))
                  in
               let is_dependent_tuple =
                 FStar_Parser_Const.is_dtuple_data_lid'
@@ -1805,71 +1837,74 @@ and (resugar_pat' :
                  in
               mk (FStar_Parser_AST.PatTuple (args1, is_dependent_tuple))
           | FStar_Syntax_Syntax.Pat_cons
-              ({ FStar_Syntax_Syntax.fv_name = uu____7340;
-                 FStar_Syntax_Syntax.fv_delta = uu____7341;
+              ({ FStar_Syntax_Syntax.fv_name = uu____7381;
+                 FStar_Syntax_Syntax.fv_delta = uu____7382;
                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
                    (FStar_Syntax_Syntax.Record_ctor (name,fields));_},args)
               ->
               let fields1 =
-                let uu____7370 =
+                let uu____7411 =
                   FStar_All.pipe_right fields
                     (FStar_List.map (fun f  -> FStar_Ident.lid_of_ids [f]))
                    in
-                FStar_All.pipe_right uu____7370 FStar_List.rev  in
+                FStar_All.pipe_right uu____7411 FStar_List.rev  in
               let args1 =
-                let uu____7386 =
+                let uu____7427 =
                   FStar_All.pipe_right args
                     (FStar_List.map
-                       (fun uu____7406  ->
-                          match uu____7406 with
+                       (fun uu____7447  ->
+                          match uu____7447 with
                           | (p2,b) -> aux p2 (FStar_Pervasives_Native.Some b)))
                    in
-                FStar_All.pipe_right uu____7386 FStar_List.rev  in
+                FStar_All.pipe_right uu____7427 FStar_List.rev  in
               let rec map2 l1 l2 =
                 match (l1, l2) with
                 | ([],[]) -> []
                 | ([],hd::tl) -> []
                 | (hd::tl,[]) ->
-                    let uu____7484 = map2 tl []  in
+                    let uu____7525 = map2 tl []  in
                     (hd,
                       (mk
                          (FStar_Parser_AST.PatWild
                             FStar_Pervasives_Native.None)))
-                      :: uu____7484
+                      :: uu____7525
                 | (hd1::tl1,hd2::tl2) ->
-                    let uu____7507 = map2 tl1 tl2  in (hd1, hd2) ::
-                      uu____7507
+                    let uu____7548 = map2 tl1 tl2  in (hd1, hd2) ::
+                      uu____7548
                  in
               let args2 =
-                let uu____7525 = map2 fields1 args1  in
-                FStar_All.pipe_right uu____7525 FStar_List.rev  in
+                let uu____7566 = map2 fields1 args1  in
+                FStar_All.pipe_right uu____7566 FStar_List.rev  in
               mk (FStar_Parser_AST.PatRecord args2)
           | FStar_Syntax_Syntax.Pat_cons (fv,args) ->
               resugar_plain_pat_cons fv args
           | FStar_Syntax_Syntax.Pat_var v ->
-              let uu____7569 =
-                string_to_op
-                  (v.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                 in
-              (match uu____7569 with
-               | FStar_Pervasives_Native.Some (op,uu____7581) ->
-                   let uu____7598 =
-                     let uu____7599 =
-                       FStar_Ident.mk_ident
-                         (op,
-                           ((v.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange))
-                        in
-                     FStar_Parser_AST.PatOp uu____7599  in
-                   mk uu____7598
+              let uu____7610 =
+                let uu____7621 =
+                  FStar_Ident.text_of_id v.FStar_Syntax_Syntax.ppname  in
+                string_to_op uu____7621  in
+              (match uu____7610 with
+               | FStar_Pervasives_Native.Some (op,uu____7624) ->
+                   let uu____7641 =
+                     let uu____7642 =
+                       let uu____7643 =
+                         let uu____7649 =
+                           FStar_Ident.range_of_id
+                             v.FStar_Syntax_Syntax.ppname
+                            in
+                         (op, uu____7649)  in
+                       FStar_Ident.mk_ident uu____7643  in
+                     FStar_Parser_AST.PatOp uu____7642  in
+                   mk uu____7641
                | FStar_Pervasives_Native.None  ->
-                   let uu____7609 = to_arg_qual imp_opt  in
-                   resugar_bv_as_pat' env v uu____7609 branch_bv
+                   let uu____7659 = to_arg_qual imp_opt  in
+                   resugar_bv_as_pat' env v uu____7659 branch_bv
                      FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Pat_wild uu____7614 ->
-              let uu____7615 =
-                let uu____7616 = to_arg_qual imp_opt  in
-                FStar_Parser_AST.PatWild uu____7616  in
-              mk uu____7615
+          | FStar_Syntax_Syntax.Pat_wild uu____7664 ->
+              let uu____7665 =
+                let uu____7666 = to_arg_qual imp_opt  in
+                FStar_Parser_AST.PatWild uu____7666  in
+              mk uu____7665
           | FStar_Syntax_Syntax.Pat_dot_term (bv,term) ->
               resugar_bv_as_pat' env bv
                 (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit)
@@ -1897,12 +1932,12 @@ and (resugar_arg_qual :
           FStar_Pervasives_Native.Some
             (FStar_Pervasives_Native.Some FStar_Parser_AST.Equality)
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta t) ->
-          let uu____7656 =
-            let uu____7659 =
-              let uu____7660 = resugar_term' env t  in
-              FStar_Parser_AST.Meta uu____7660  in
-            FStar_Pervasives_Native.Some uu____7659  in
-          FStar_Pervasives_Native.Some uu____7656
+          let uu____7706 =
+            let uu____7709 =
+              let uu____7710 = resugar_term' env t  in
+              FStar_Parser_AST.Meta uu____7710  in
+            FStar_Pervasives_Native.Some uu____7709  in
+          FStar_Pervasives_Native.Some uu____7706
 
 and (resugar_imp :
   FStar_Syntax_DsEnv.env ->
@@ -1920,15 +1955,15 @@ and (resugar_imp :
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit (true ))
           -> FStar_Parser_AST.Nothing
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta t) ->
-          let uu____7672 = resugar_term' env t  in
-          FStar_Parser_AST.HashBrace uu____7672
+          let uu____7722 = resugar_term' env t  in
+          FStar_Parser_AST.HashBrace uu____7722
 
 let (resugar_qualifier :
   FStar_Syntax_Syntax.qualifier ->
     FStar_Parser_AST.qualifier FStar_Pervasives_Native.option)
   =
-  fun uu___6_7680  ->
-    match uu___6_7680 with
+  fun uu___6_7730  ->
+    match uu___6_7730 with
     | FStar_Syntax_Syntax.Assumption  ->
         FStar_Pervasives_Native.Some FStar_Parser_AST.Assumption
     | FStar_Syntax_Syntax.New  ->
@@ -1956,17 +1991,17 @@ let (resugar_qualifier :
     | FStar_Syntax_Syntax.Logic  -> FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.Reifiable  ->
         FStar_Pervasives_Native.Some FStar_Parser_AST.Reifiable
-    | FStar_Syntax_Syntax.Reflectable uu____7687 ->
+    | FStar_Syntax_Syntax.Reflectable uu____7737 ->
         FStar_Pervasives_Native.Some FStar_Parser_AST.Reflectable
-    | FStar_Syntax_Syntax.Discriminator uu____7688 ->
+    | FStar_Syntax_Syntax.Discriminator uu____7738 ->
         FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.Projector uu____7689 ->
+    | FStar_Syntax_Syntax.Projector uu____7739 ->
         FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.RecordType uu____7694 ->
+    | FStar_Syntax_Syntax.RecordType uu____7744 ->
         FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.RecordConstructor uu____7703 ->
+    | FStar_Syntax_Syntax.RecordConstructor uu____7753 ->
         FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.Action uu____7712 -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.Action uu____7762 -> FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.ExceptionConstructor  ->
         FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.HasMaskedEffect  -> FStar_Pervasives_Native.None
@@ -1976,8 +2011,8 @@ let (resugar_qualifier :
   
 let (resugar_pragma : FStar_Syntax_Syntax.pragma -> FStar_Parser_AST.pragma)
   =
-  fun uu___7_7718  ->
-    match uu___7_7718 with
+  fun uu___7_7768  ->
+    match uu___7_7768 with
     | FStar_Syntax_Syntax.SetOptions s -> FStar_Parser_AST.SetOptions s
     | FStar_Syntax_Syntax.ResetOptions s -> FStar_Parser_AST.ResetOptions s
     | FStar_Syntax_Syntax.PushOptions s -> FStar_Parser_AST.PushOptions s
@@ -1996,22 +2031,22 @@ let (resugar_typ :
       fun se  ->
         match se.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ
-            (tylid,uvs,bs,t,uu____7761,datacons) ->
-            let uu____7771 =
+            (tylid,uvs,bs,t,uu____7811,datacons) ->
+            let uu____7821 =
               FStar_All.pipe_right datacon_ses
                 (FStar_List.partition
                    (fun se1  ->
                       match se1.FStar_Syntax_Syntax.sigel with
                       | FStar_Syntax_Syntax.Sig_datacon
-                          (uu____7799,uu____7800,uu____7801,inductive_lid,uu____7803,uu____7804)
+                          (uu____7849,uu____7850,uu____7851,inductive_lid,uu____7853,uu____7854)
                           -> FStar_Ident.lid_equals inductive_lid tylid
-                      | uu____7811 -> failwith "unexpected"))
+                      | uu____7861 -> failwith "unexpected"))
                in
-            (match uu____7771 with
+            (match uu____7821 with
              | (current_datacons,other_datacons) ->
                  let bs1 =
-                   let uu____7832 = FStar_Options.print_implicits ()  in
-                   if uu____7832 then bs else filter_imp bs  in
+                   let uu____7882 = FStar_Options.print_implicits ()  in
+                   if uu____7882 then bs else filter_imp bs  in
                  let bs2 =
                    FStar_All.pipe_right bs1
                      ((map_opt ())
@@ -2019,75 +2054,82 @@ let (resugar_typ :
                            resugar_binder' env b t.FStar_Syntax_Syntax.pos))
                     in
                  let tyc =
-                   let uu____7849 =
+                   let uu____7899 =
                      FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                        (FStar_Util.for_some
-                          (fun uu___8_7856  ->
-                             match uu___8_7856 with
-                             | FStar_Syntax_Syntax.RecordType uu____7858 ->
+                          (fun uu___8_7906  ->
+                             match uu___8_7906 with
+                             | FStar_Syntax_Syntax.RecordType uu____7908 ->
                                  true
-                             | uu____7868 -> false))
+                             | uu____7918 -> false))
                       in
-                   if uu____7849
+                   if uu____7899
                    then
                      let resugar_datacon_as_fields fields se1 =
                        match se1.FStar_Syntax_Syntax.sigel with
                        | FStar_Syntax_Syntax.Sig_datacon
-                           (uu____7906,univs,term,uu____7909,num,uu____7911)
+                           (uu____7956,univs,term,uu____7959,num,uu____7961)
                            ->
-                           let uu____7918 =
-                             let uu____7919 =
+                           let uu____7968 =
+                             let uu____7969 =
                                FStar_Syntax_Subst.compress term  in
-                             uu____7919.FStar_Syntax_Syntax.n  in
-                           (match uu____7918 with
-                            | FStar_Syntax_Syntax.Tm_arrow (bs3,uu____7929)
+                             uu____7969.FStar_Syntax_Syntax.n  in
+                           (match uu____7968 with
+                            | FStar_Syntax_Syntax.Tm_arrow (bs3,uu____7979)
                                 ->
                                 let mfields =
                                   FStar_All.pipe_right bs3
                                     (FStar_List.map
-                                       (fun uu____7986  ->
-                                          match uu____7986 with
+                                       (fun uu____8036  ->
+                                          match uu____8036 with
                                           | (b,qual) ->
-                                              let uu____8003 =
+                                              let uu____8053 =
                                                 bv_as_unique_ident b  in
-                                              let uu____8004 =
+                                              let uu____8054 =
                                                 resugar_term' env
                                                   b.FStar_Syntax_Syntax.sort
                                                  in
-                                              (uu____8003, uu____8004)))
+                                              (uu____8053, uu____8054)))
                                    in
                                 FStar_List.append mfields fields
-                            | uu____8009 -> failwith "unexpected")
-                       | uu____8017 -> failwith "unexpected"  in
+                            | uu____8059 -> failwith "unexpected")
+                       | uu____8067 -> failwith "unexpected"  in
                      let fields =
                        FStar_List.fold_left resugar_datacon_as_fields []
                          current_datacons
                         in
-                     FStar_Parser_AST.TyconRecord
-                       ((tylid.FStar_Ident.ident), bs2,
-                         FStar_Pervasives_Native.None, fields)
+                     let uu____8092 =
+                       let uu____8111 = FStar_Ident.ident_of_lid tylid  in
+                       (uu____8111, bs2, FStar_Pervasives_Native.None,
+                         fields)
+                        in
+                     FStar_Parser_AST.TyconRecord uu____8092
                    else
                      (let resugar_datacon constructors se1 =
                         match se1.FStar_Syntax_Syntax.sigel with
                         | FStar_Syntax_Syntax.Sig_datacon
-                            (l,univs,term,uu____8112,num,uu____8114) ->
+                            (l,univs,term,uu____8182,num,uu____8184) ->
                             let c =
-                              let uu____8131 =
-                                let uu____8134 = resugar_term' env term  in
-                                FStar_Pervasives_Native.Some uu____8134  in
-                              ((l.FStar_Ident.ident), uu____8131, false)  in
+                              let uu____8201 = FStar_Ident.ident_of_lid l  in
+                              let uu____8202 =
+                                let uu____8205 = resugar_term' env term  in
+                                FStar_Pervasives_Native.Some uu____8205  in
+                              (uu____8201, uu____8202, false)  in
                             c :: constructors
-                        | uu____8148 -> failwith "unexpected"  in
+                        | uu____8219 -> failwith "unexpected"  in
                       let constructors =
                         FStar_List.fold_left resugar_datacon []
                           current_datacons
                          in
-                      FStar_Parser_AST.TyconVariant
-                        ((tylid.FStar_Ident.ident), bs2,
-                          FStar_Pervasives_Native.None, constructors))
+                      let uu____8264 =
+                        let uu____8288 = FStar_Ident.ident_of_lid tylid  in
+                        (uu____8288, bs2, FStar_Pervasives_Native.None,
+                          constructors)
+                         in
+                      FStar_Parser_AST.TyconVariant uu____8264)
                     in
                  (other_datacons, tyc))
-        | uu____8208 ->
+        | uu____8304 ->
             failwith
               "Impossible : only Sig_inductive_typ can be resugared as types"
   
@@ -2099,11 +2141,11 @@ let (mk_decl :
   fun r  ->
     fun q  ->
       fun d'  ->
-        let uu____8234 = FStar_List.choose resugar_qualifier q  in
+        let uu____8330 = FStar_List.choose resugar_qualifier q  in
         {
           FStar_Parser_AST.d = d';
           FStar_Parser_AST.drange = r;
-          FStar_Parser_AST.quals = uu____8234;
+          FStar_Parser_AST.quals = uu____8330;
           FStar_Parser_AST.attrs = []
         }
   
@@ -2123,24 +2165,24 @@ let (resugar_tscheme'' :
   fun env  ->
     fun name  ->
       fun ts  ->
-        let uu____8264 = ts  in
-        match uu____8264 with
+        let uu____8360 = ts  in
+        match uu____8360 with
         | (univs,typ) ->
             let name1 =
               FStar_Ident.mk_ident (name, (typ.FStar_Syntax_Syntax.pos))  in
-            let uu____8277 =
-              let uu____8278 =
-                let uu____8289 =
-                  let uu____8292 =
-                    let uu____8293 =
-                      let uu____8306 = resugar_term' env typ  in
-                      (name1, [], FStar_Pervasives_Native.None, uu____8306)
+            let uu____8373 =
+              let uu____8374 =
+                let uu____8385 =
+                  let uu____8388 =
+                    let uu____8389 =
+                      let uu____8402 = resugar_term' env typ  in
+                      (name1, [], FStar_Pervasives_Native.None, uu____8402)
                        in
-                    FStar_Parser_AST.TyconAbbrev uu____8293  in
-                  [uu____8292]  in
-                (false, false, uu____8289)  in
-              FStar_Parser_AST.Tycon uu____8278  in
-            mk_decl typ.FStar_Syntax_Syntax.pos [] uu____8277
+                    FStar_Parser_AST.TyconAbbrev uu____8389  in
+                  [uu____8388]  in
+                (false, false, uu____8385)  in
+              FStar_Parser_AST.Tycon uu____8374  in
+            mk_decl typ.FStar_Syntax_Syntax.pos [] uu____8373
   
 let (resugar_tscheme' :
   FStar_Syntax_DsEnv.env ->
@@ -2158,7 +2200,7 @@ let (resugar_wp_eff_combinators :
         let resugar_opt name tsopt =
           match tsopt with
           | FStar_Pervasives_Native.Some ts ->
-              let uu____8371 = resugar_tscheme'' env name ts  in [uu____8371]
+              let uu____8467 = resugar_tscheme'' env name ts  in [uu____8467]
           | FStar_Pervasives_Native.None  -> []  in
         let repr = resugar_opt "repr" combs.FStar_Syntax_Syntax.repr  in
         let return_repr =
@@ -2168,49 +2210,49 @@ let (resugar_wp_eff_combinators :
         if for_free
         then FStar_List.append repr (FStar_List.append return_repr bind_repr)
         else
-          (let uu____8389 =
+          (let uu____8485 =
              resugar_tscheme'' env "ret_wp" combs.FStar_Syntax_Syntax.ret_wp
               in
-           let uu____8391 =
-             let uu____8394 =
+           let uu____8487 =
+             let uu____8490 =
                resugar_tscheme'' env "bind_wp"
                  combs.FStar_Syntax_Syntax.bind_wp
                 in
-             let uu____8396 =
-               let uu____8399 =
+             let uu____8492 =
+               let uu____8495 =
                  resugar_tscheme'' env "stronger"
                    combs.FStar_Syntax_Syntax.stronger
                   in
-               let uu____8401 =
-                 let uu____8404 =
+               let uu____8497 =
+                 let uu____8500 =
                    resugar_tscheme'' env "if_then_else"
                      combs.FStar_Syntax_Syntax.if_then_else
                     in
-                 let uu____8406 =
-                   let uu____8409 =
+                 let uu____8502 =
+                   let uu____8505 =
                      resugar_tscheme'' env "ite_wp"
                        combs.FStar_Syntax_Syntax.ite_wp
                       in
-                   let uu____8411 =
-                     let uu____8414 =
+                   let uu____8507 =
+                     let uu____8510 =
                        resugar_tscheme'' env "close_wp"
                          combs.FStar_Syntax_Syntax.close_wp
                         in
-                     let uu____8416 =
-                       let uu____8419 =
+                     let uu____8512 =
+                       let uu____8515 =
                          resugar_tscheme'' env "trivial"
                            combs.FStar_Syntax_Syntax.trivial
                           in
-                       uu____8419 ::
+                       uu____8515 ::
                          (FStar_List.append repr
                             (FStar_List.append return_repr bind_repr))
                         in
-                     uu____8414 :: uu____8416  in
-                   uu____8409 :: uu____8411  in
-                 uu____8404 :: uu____8406  in
-               uu____8399 :: uu____8401  in
-             uu____8394 :: uu____8396  in
-           uu____8389 :: uu____8391)
+                     uu____8510 :: uu____8512  in
+                   uu____8505 :: uu____8507  in
+                 uu____8500 :: uu____8502  in
+               uu____8495 :: uu____8497  in
+             uu____8490 :: uu____8492  in
+           uu____8485 :: uu____8487)
   
 let (resugar_layered_eff_combinators :
   FStar_Syntax_DsEnv.env ->
@@ -2219,29 +2261,29 @@ let (resugar_layered_eff_combinators :
   =
   fun env  ->
     fun combs  ->
-      let resugar name uu____8449 =
-        match uu____8449 with
-        | (ts,uu____8456) -> resugar_tscheme'' env name ts  in
-      let uu____8457 = resugar "repr" combs.FStar_Syntax_Syntax.l_repr  in
-      let uu____8459 =
-        let uu____8462 = resugar "return" combs.FStar_Syntax_Syntax.l_return
+      let resugar name uu____8545 =
+        match uu____8545 with
+        | (ts,uu____8552) -> resugar_tscheme'' env name ts  in
+      let uu____8553 = resugar "repr" combs.FStar_Syntax_Syntax.l_repr  in
+      let uu____8555 =
+        let uu____8558 = resugar "return" combs.FStar_Syntax_Syntax.l_return
            in
-        let uu____8464 =
-          let uu____8467 = resugar "bind" combs.FStar_Syntax_Syntax.l_bind
+        let uu____8560 =
+          let uu____8563 = resugar "bind" combs.FStar_Syntax_Syntax.l_bind
              in
-          let uu____8469 =
-            let uu____8472 =
+          let uu____8565 =
+            let uu____8568 =
               resugar "subcomp" combs.FStar_Syntax_Syntax.l_subcomp  in
-            let uu____8474 =
-              let uu____8477 =
+            let uu____8570 =
+              let uu____8573 =
                 resugar "if_then_else"
                   combs.FStar_Syntax_Syntax.l_if_then_else
                  in
-              [uu____8477]  in
-            uu____8472 :: uu____8474  in
-          uu____8467 :: uu____8469  in
-        uu____8462 :: uu____8464  in
-      uu____8457 :: uu____8459
+              [uu____8573]  in
+            uu____8568 :: uu____8570  in
+          uu____8563 :: uu____8565  in
+        uu____8558 :: uu____8560  in
+      uu____8553 :: uu____8555
   
 let (resugar_combinators :
   FStar_Syntax_DsEnv.env ->
@@ -2272,82 +2314,103 @@ let (resugar_eff_decl' :
               FStar_Syntax_Subst.open_binders
                 d.FStar_Syntax_Syntax.action_params
                in
-            let uu____8538 =
+            let uu____8634 =
               FStar_Syntax_Subst.open_term action_params
                 d.FStar_Syntax_Syntax.action_defn
                in
-            match uu____8538 with
+            match uu____8634 with
             | (bs,action_defn) ->
-                let uu____8545 =
+                let uu____8641 =
                   FStar_Syntax_Subst.open_term action_params
                     d.FStar_Syntax_Syntax.action_typ
                    in
-                (match uu____8545 with
+                (match uu____8641 with
                  | (bs1,action_typ) ->
                      let action_params1 =
-                       let uu____8555 = FStar_Options.print_implicits ()  in
-                       if uu____8555
+                       let uu____8651 = FStar_Options.print_implicits ()  in
+                       if uu____8651
                        then action_params
                        else filter_imp action_params  in
                      let action_params2 =
-                       let uu____8565 =
+                       let uu____8661 =
                          FStar_All.pipe_right action_params1
                            ((map_opt ()) (fun b  -> resugar_binder' env b r))
                           in
-                       FStar_All.pipe_right uu____8565 FStar_List.rev  in
+                       FStar_All.pipe_right uu____8661 FStar_List.rev  in
                      let action_defn1 = resugar_term' env action_defn  in
                      let action_typ1 = resugar_term' env action_typ  in
                      if for_free
                      then
                        let a =
-                         let uu____8582 =
-                           let uu____8593 =
+                         let uu____8678 =
+                           let uu____8689 =
                              FStar_Ident.lid_of_str "construct"  in
-                           (uu____8593,
+                           (uu____8689,
                              [(action_defn1, FStar_Parser_AST.Nothing);
                              (action_typ1, FStar_Parser_AST.Nothing)])
                             in
-                         FStar_Parser_AST.Construct uu____8582  in
+                         FStar_Parser_AST.Construct uu____8678  in
                        let t =
                          FStar_Parser_AST.mk_term a r FStar_Parser_AST.Un  in
-                       mk_decl r q
-                         (FStar_Parser_AST.Tycon
-                            (false, false,
-                              [FStar_Parser_AST.TyconAbbrev
-                                 (((d.FStar_Syntax_Syntax.action_name).FStar_Ident.ident),
-                                   action_params2,
-                                   FStar_Pervasives_Native.None, t)]))
+                       let uu____8710 =
+                         let uu____8711 =
+                           let uu____8722 =
+                             let uu____8725 =
+                               let uu____8726 =
+                                 let uu____8739 =
+                                   FStar_Ident.ident_of_lid
+                                     d.FStar_Syntax_Syntax.action_name
+                                    in
+                                 (uu____8739, action_params2,
+                                   FStar_Pervasives_Native.None, t)
+                                  in
+                               FStar_Parser_AST.TyconAbbrev uu____8726  in
+                             [uu____8725]  in
+                           (false, false, uu____8722)  in
+                         FStar_Parser_AST.Tycon uu____8711  in
+                       mk_decl r q uu____8710
                      else
-                       mk_decl r q
-                         (FStar_Parser_AST.Tycon
-                            (false, false,
-                              [FStar_Parser_AST.TyconAbbrev
-                                 (((d.FStar_Syntax_Syntax.action_name).FStar_Ident.ident),
-                                   action_params2,
-                                   FStar_Pervasives_Native.None,
-                                   action_defn1)])))
+                       (let uu____8752 =
+                          let uu____8753 =
+                            let uu____8764 =
+                              let uu____8767 =
+                                let uu____8768 =
+                                  let uu____8781 =
+                                    FStar_Ident.ident_of_lid
+                                      d.FStar_Syntax_Syntax.action_name
+                                     in
+                                  (uu____8781, action_params2,
+                                    FStar_Pervasives_Native.None,
+                                    action_defn1)
+                                   in
+                                FStar_Parser_AST.TyconAbbrev uu____8768  in
+                              [uu____8767]  in
+                            (false, false, uu____8764)  in
+                          FStar_Parser_AST.Tycon uu____8753  in
+                        mk_decl r q uu____8752))
              in
-          let eff_name = (ed.FStar_Syntax_Syntax.mname).FStar_Ident.ident  in
-          let uu____8637 =
-            let uu____8642 =
+          let eff_name =
+            FStar_Ident.ident_of_lid ed.FStar_Syntax_Syntax.mname  in
+          let uu____8793 =
+            let uu____8798 =
               FStar_All.pipe_right ed.FStar_Syntax_Syntax.signature
                 FStar_Pervasives_Native.snd
                in
             FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders
-              uu____8642
+              uu____8798
              in
-          match uu____8637 with
+          match uu____8793 with
           | (eff_binders,eff_typ) ->
               let eff_binders1 =
-                let uu____8660 = FStar_Options.print_implicits ()  in
-                if uu____8660 then eff_binders else filter_imp eff_binders
+                let uu____8816 = FStar_Options.print_implicits ()  in
+                if uu____8816 then eff_binders else filter_imp eff_binders
                  in
               let eff_binders2 =
-                let uu____8670 =
+                let uu____8826 =
                   FStar_All.pipe_right eff_binders1
                     ((map_opt ()) (fun b  -> resugar_binder' env b r))
                    in
-                FStar_All.pipe_right uu____8670 FStar_List.rev  in
+                FStar_All.pipe_right uu____8826 FStar_List.rev  in
               let eff_typ1 = resugar_term' env eff_typ  in
               let mandatory_members_decls =
                 resugar_combinators env ed.FStar_Syntax_Syntax.combinators
@@ -2371,72 +2434,76 @@ let (resugar_sigelt' :
   fun env  ->
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle (ses,uu____8720) ->
-          let uu____8729 =
+      | FStar_Syntax_Syntax.Sig_bundle (ses,uu____8876) ->
+          let uu____8885 =
             FStar_All.pipe_right ses
               (FStar_List.partition
                  (fun se1  ->
                     match se1.FStar_Syntax_Syntax.sigel with
-                    | FStar_Syntax_Syntax.Sig_inductive_typ uu____8752 ->
+                    | FStar_Syntax_Syntax.Sig_inductive_typ uu____8908 ->
                         true
-                    | FStar_Syntax_Syntax.Sig_declare_typ uu____8770 -> true
-                    | FStar_Syntax_Syntax.Sig_datacon uu____8778 -> false
-                    | uu____8795 ->
+                    | FStar_Syntax_Syntax.Sig_declare_typ uu____8926 -> true
+                    | FStar_Syntax_Syntax.Sig_datacon uu____8934 -> false
+                    | uu____8951 ->
                         failwith
                           "Found a sigelt which is neither a type declaration or a data constructor in a sigelt"))
              in
-          (match uu____8729 with
+          (match uu____8885 with
            | (decl_typ_ses,datacon_ses) ->
-               let retrieve_datacons_and_resugar uu____8833 se1 =
-                 match uu____8833 with
+               let retrieve_datacons_and_resugar uu____8989 se1 =
+                 match uu____8989 with
                  | (datacon_ses1,tycons) ->
-                     let uu____8859 = resugar_typ env datacon_ses1 se1  in
-                     (match uu____8859 with
+                     let uu____9015 = resugar_typ env datacon_ses1 se1  in
+                     (match uu____9015 with
                       | (datacon_ses2,tyc) -> (datacon_ses2, (tyc :: tycons)))
                   in
-               let uu____8874 =
+               let uu____9030 =
                  FStar_List.fold_left retrieve_datacons_and_resugar
                    (datacon_ses, []) decl_typ_ses
                   in
-               (match uu____8874 with
+               (match uu____9030 with
                 | (leftover_datacons,tycons) ->
                     (match leftover_datacons with
                      | [] ->
-                         let uu____8909 =
+                         let uu____9065 =
                            decl'_to_decl se
                              (FStar_Parser_AST.Tycon (false, false, tycons))
                             in
-                         FStar_Pervasives_Native.Some uu____8909
+                         FStar_Pervasives_Native.Some uu____9065
                      | se1::[] ->
                          (match se1.FStar_Syntax_Syntax.sigel with
                           | FStar_Syntax_Syntax.Sig_datacon
-                              (l,uu____8920,uu____8921,uu____8922,uu____8923,uu____8924)
+                              (l,uu____9076,uu____9077,uu____9078,uu____9079,uu____9080)
                               ->
-                              let uu____8931 =
-                                decl'_to_decl se1
-                                  (FStar_Parser_AST.Exception
-                                     ((l.FStar_Ident.ident),
-                                       FStar_Pervasives_Native.None))
-                                 in
-                              FStar_Pervasives_Native.Some uu____8931
-                          | uu____8934 ->
+                              let uu____9087 =
+                                let uu____9088 =
+                                  let uu____9089 =
+                                    let uu____9096 =
+                                      FStar_Ident.ident_of_lid l  in
+                                    (uu____9096,
+                                      FStar_Pervasives_Native.None)
+                                     in
+                                  FStar_Parser_AST.Exception uu____9089  in
+                                decl'_to_decl se1 uu____9088  in
+                              FStar_Pervasives_Native.Some uu____9087
+                          | uu____9099 ->
                               failwith
                                 "wrong format for resguar to Exception")
-                     | uu____8938 -> failwith "Should not happen hopefully")))
-      | FStar_Syntax_Syntax.Sig_fail uu____8944 ->
+                     | uu____9103 -> failwith "Should not happen hopefully")))
+      | FStar_Syntax_Syntax.Sig_fail uu____9109 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Sig_let (lbs,uu____8958) ->
-          let uu____8963 =
+      | FStar_Syntax_Syntax.Sig_let (lbs,uu____9123) ->
+          let uu____9128 =
             FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
               (FStar_Util.for_some
-                 (fun uu___9_8971  ->
-                    match uu___9_8971 with
-                    | FStar_Syntax_Syntax.Projector (uu____8973,uu____8974)
+                 (fun uu___9_9136  ->
+                    match uu___9_9136 with
+                    | FStar_Syntax_Syntax.Projector (uu____9138,uu____9139)
                         -> true
-                    | FStar_Syntax_Syntax.Discriminator uu____8976 -> true
-                    | uu____8978 -> false))
+                    | FStar_Syntax_Syntax.Discriminator uu____9141 -> true
+                    | uu____9143 -> false))
              in
-          if uu____8963
+          if uu____9128
           then FStar_Pervasives_Native.None
           else
             (let mk e =
@@ -2448,47 +2515,48 @@ let (resugar_sigelt' :
                 in
              let t = resugar_term' env desugared_let  in
              match t.FStar_Parser_AST.tm with
-             | FStar_Parser_AST.Let (isrec,lets,uu____9013) ->
-                 let uu____9042 =
-                   let uu____9043 =
-                     let uu____9044 =
-                       let uu____9055 =
+             | FStar_Parser_AST.Let (isrec,lets,uu____9178) ->
+                 let uu____9207 =
+                   let uu____9208 =
+                     let uu____9209 =
+                       let uu____9220 =
                          FStar_List.map FStar_Pervasives_Native.snd lets  in
-                       (isrec, uu____9055)  in
-                     FStar_Parser_AST.TopLevelLet uu____9044  in
-                   decl'_to_decl se uu____9043  in
-                 FStar_Pervasives_Native.Some uu____9042
-             | uu____9092 -> failwith "Should not happen hopefully")
-      | FStar_Syntax_Syntax.Sig_assume (lid,uu____9097,fml) ->
-          let uu____9099 =
-            let uu____9100 =
-              let uu____9101 =
-                let uu____9106 = resugar_term' env fml  in
-                ((lid.FStar_Ident.ident), uu____9106)  in
-              FStar_Parser_AST.Assume uu____9101  in
-            decl'_to_decl se uu____9100  in
-          FStar_Pervasives_Native.Some uu____9099
+                       (isrec, uu____9220)  in
+                     FStar_Parser_AST.TopLevelLet uu____9209  in
+                   decl'_to_decl se uu____9208  in
+                 FStar_Pervasives_Native.Some uu____9207
+             | uu____9257 -> failwith "Should not happen hopefully")
+      | FStar_Syntax_Syntax.Sig_assume (lid,uu____9262,fml) ->
+          let uu____9264 =
+            let uu____9265 =
+              let uu____9266 =
+                let uu____9271 = FStar_Ident.ident_of_lid lid  in
+                let uu____9272 = resugar_term' env fml  in
+                (uu____9271, uu____9272)  in
+              FStar_Parser_AST.Assume uu____9266  in
+            decl'_to_decl se uu____9265  in
+          FStar_Pervasives_Native.Some uu____9264
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____9108 =
+          let uu____9274 =
             resugar_eff_decl' env se.FStar_Syntax_Syntax.sigrng
               se.FStar_Syntax_Syntax.sigquals ed
              in
-          FStar_Pervasives_Native.Some uu____9108
+          FStar_Pervasives_Native.Some uu____9274
       | FStar_Syntax_Syntax.Sig_sub_effect e ->
           let src = e.FStar_Syntax_Syntax.source  in
           let dst = e.FStar_Syntax_Syntax.target  in
           let lift_wp =
             match e.FStar_Syntax_Syntax.lift_wp with
-            | FStar_Pervasives_Native.Some (uu____9117,t) ->
-                let uu____9127 = resugar_term' env t  in
-                FStar_Pervasives_Native.Some uu____9127
-            | uu____9128 -> FStar_Pervasives_Native.None  in
+            | FStar_Pervasives_Native.Some (uu____9283,t) ->
+                let uu____9293 = resugar_term' env t  in
+                FStar_Pervasives_Native.Some uu____9293
+            | uu____9294 -> FStar_Pervasives_Native.None  in
           let lift =
             match e.FStar_Syntax_Syntax.lift with
-            | FStar_Pervasives_Native.Some (uu____9136,t) ->
-                let uu____9146 = resugar_term' env t  in
-                FStar_Pervasives_Native.Some uu____9146
-            | uu____9147 -> FStar_Pervasives_Native.None  in
+            | FStar_Pervasives_Native.Some (uu____9302,t) ->
+                let uu____9312 = resugar_term' env t  in
+                FStar_Pervasives_Native.Some uu____9312
+            | uu____9313 -> FStar_Pervasives_Native.None  in
           let op =
             match (lift_wp, lift) with
             | (FStar_Pervasives_Native.Some t,FStar_Pervasives_Native.None )
@@ -2497,8 +2565,8 @@ let (resugar_sigelt' :
                t) -> FStar_Parser_AST.ReifiableLift (wp, t)
             | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.Some t)
                 -> FStar_Parser_AST.LiftForFree t
-            | uu____9171 -> failwith "Should not happen hopefully"  in
-          let uu____9181 =
+            | uu____9337 -> failwith "Should not happen hopefully"  in
+          let uu____9347 =
             decl'_to_decl se
               (FStar_Parser_AST.SubEffect
                  {
@@ -2507,121 +2575,126 @@ let (resugar_sigelt' :
                    FStar_Parser_AST.lift_op = op
                  })
              in
-          FStar_Pervasives_Native.Some uu____9181
+          FStar_Pervasives_Native.Some uu____9347
       | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,vs,bs,c,flags) ->
-          let uu____9191 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____9191 with
+          let uu____9357 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____9357 with
            | (bs1,c1) ->
                let bs2 =
-                 let uu____9203 = FStar_Options.print_implicits ()  in
-                 if uu____9203 then bs1 else filter_imp bs1  in
+                 let uu____9369 = FStar_Options.print_implicits ()  in
+                 if uu____9369 then bs1 else filter_imp bs1  in
                let bs3 =
                  FStar_All.pipe_right bs2
                    ((map_opt ())
                       (fun b  ->
                          resugar_binder' env b se.FStar_Syntax_Syntax.sigrng))
                   in
-               let uu____9219 =
-                 let uu____9220 =
-                   let uu____9221 =
-                     let uu____9232 =
-                       let uu____9235 =
-                         let uu____9236 =
-                           let uu____9249 = resugar_comp' env c1  in
-                           ((lid.FStar_Ident.ident), bs3,
-                             FStar_Pervasives_Native.None, uu____9249)
+               let uu____9385 =
+                 let uu____9386 =
+                   let uu____9387 =
+                     let uu____9398 =
+                       let uu____9401 =
+                         let uu____9402 =
+                           let uu____9415 = FStar_Ident.ident_of_lid lid  in
+                           let uu____9416 = resugar_comp' env c1  in
+                           (uu____9415, bs3, FStar_Pervasives_Native.None,
+                             uu____9416)
                             in
-                         FStar_Parser_AST.TyconAbbrev uu____9236  in
-                       [uu____9235]  in
-                     (false, false, uu____9232)  in
-                   FStar_Parser_AST.Tycon uu____9221  in
-                 decl'_to_decl se uu____9220  in
-               FStar_Pervasives_Native.Some uu____9219)
+                         FStar_Parser_AST.TyconAbbrev uu____9402  in
+                       [uu____9401]  in
+                     (false, false, uu____9398)  in
+                   FStar_Parser_AST.Tycon uu____9387  in
+                 decl'_to_decl se uu____9386  in
+               FStar_Pervasives_Native.Some uu____9385)
       | FStar_Syntax_Syntax.Sig_pragma p ->
-          let uu____9261 =
+          let uu____9428 =
             decl'_to_decl se (FStar_Parser_AST.Pragma (resugar_pragma p))  in
-          FStar_Pervasives_Native.Some uu____9261
+          FStar_Pervasives_Native.Some uu____9428
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
-          let uu____9265 =
+          let uu____9432 =
             FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
               (FStar_Util.for_some
-                 (fun uu___10_9273  ->
-                    match uu___10_9273 with
-                    | FStar_Syntax_Syntax.Projector (uu____9275,uu____9276)
+                 (fun uu___10_9440  ->
+                    match uu___10_9440 with
+                    | FStar_Syntax_Syntax.Projector (uu____9442,uu____9443)
                         -> true
-                    | FStar_Syntax_Syntax.Discriminator uu____9278 -> true
-                    | uu____9280 -> false))
+                    | FStar_Syntax_Syntax.Discriminator uu____9445 -> true
+                    | uu____9447 -> false))
              in
-          if uu____9265
+          if uu____9432
           then FStar_Pervasives_Native.None
           else
             (let t' =
-               let uu____9288 =
-                 (let uu____9292 = FStar_Options.print_universes ()  in
-                  Prims.op_Negation uu____9292) || (FStar_List.isEmpty uvs)
+               let uu____9455 =
+                 (let uu____9459 = FStar_Options.print_universes ()  in
+                  Prims.op_Negation uu____9459) || (FStar_List.isEmpty uvs)
                   in
-               if uu____9288
+               if uu____9455
                then resugar_term' env t
                else
-                 (let uu____9297 = FStar_Syntax_Subst.open_univ_vars uvs t
+                 (let uu____9464 = FStar_Syntax_Subst.open_univ_vars uvs t
                      in
-                  match uu____9297 with
+                  match uu____9464 with
                   | (uvs1,t1) ->
                       let universes = universe_to_string uvs1  in
-                      let uu____9306 = resugar_term' env t1  in
-                      label universes uu____9306)
+                      let uu____9473 = resugar_term' env t1  in
+                      label universes uu____9473)
                 in
-             let uu____9307 =
-               decl'_to_decl se
-                 (FStar_Parser_AST.Val ((lid.FStar_Ident.ident), t'))
-                in
-             FStar_Pervasives_Native.Some uu____9307)
+             let uu____9474 =
+               let uu____9475 =
+                 let uu____9476 =
+                   let uu____9481 = FStar_Ident.ident_of_lid lid  in
+                   (uu____9481, t')  in
+                 FStar_Parser_AST.Val uu____9476  in
+               decl'_to_decl se uu____9475  in
+             FStar_Pervasives_Native.Some uu____9474)
       | FStar_Syntax_Syntax.Sig_splice (ids,t) ->
-          let uu____9314 =
-            let uu____9315 =
-              let uu____9316 =
-                let uu____9323 =
-                  FStar_List.map (fun l  -> l.FStar_Ident.ident) ids  in
-                let uu____9328 = resugar_term' env t  in
-                (uu____9323, uu____9328)  in
-              FStar_Parser_AST.Splice uu____9316  in
-            decl'_to_decl se uu____9315  in
-          FStar_Pervasives_Native.Some uu____9314
-      | FStar_Syntax_Syntax.Sig_inductive_typ uu____9331 ->
+          let uu____9488 =
+            let uu____9489 =
+              let uu____9490 =
+                let uu____9497 =
+                  FStar_List.map (fun l  -> FStar_Ident.ident_of_lid l) ids
+                   in
+                let uu____9502 = resugar_term' env t  in
+                (uu____9497, uu____9502)  in
+              FStar_Parser_AST.Splice uu____9490  in
+            decl'_to_decl se uu____9489  in
+          FStar_Pervasives_Native.Some uu____9488
+      | FStar_Syntax_Syntax.Sig_inductive_typ uu____9505 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Sig_datacon uu____9348 ->
+      | FStar_Syntax_Syntax.Sig_datacon uu____9522 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Sig_main uu____9364 ->
+      | FStar_Syntax_Syntax.Sig_main uu____9538 ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Sig_polymonadic_bind
-          (m,n,p,(uu____9368,t),uu____9370) ->
-          let uu____9379 =
-            let uu____9380 =
-              let uu____9381 =
-                let uu____9390 = resugar_term' env t  in
-                (m, n, p, uu____9390)  in
-              FStar_Parser_AST.Polymonadic_bind uu____9381  in
-            decl'_to_decl se uu____9380  in
-          FStar_Pervasives_Native.Some uu____9379
+          (m,n,p,(uu____9542,t),uu____9544) ->
+          let uu____9553 =
+            let uu____9554 =
+              let uu____9555 =
+                let uu____9564 = resugar_term' env t  in
+                (m, n, p, uu____9564)  in
+              FStar_Parser_AST.Polymonadic_bind uu____9555  in
+            decl'_to_decl se uu____9554  in
+          FStar_Pervasives_Native.Some uu____9553
   
 let (empty_env : FStar_Syntax_DsEnv.env) =
   FStar_Syntax_DsEnv.empty_env FStar_Parser_Dep.empty_deps 
 let noenv : 'a . (FStar_Syntax_DsEnv.env -> 'a) -> 'a = fun f  -> f empty_env 
 let (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
-  fun t  -> let uu____9414 = noenv resugar_term'  in uu____9414 t 
+  fun t  -> let uu____9588 = noenv resugar_term'  in uu____9588 t 
 let (resugar_sigelt :
   FStar_Syntax_Syntax.sigelt ->
     FStar_Parser_AST.decl FStar_Pervasives_Native.option)
-  = fun se  -> let uu____9432 = noenv resugar_sigelt'  in uu____9432 se 
+  = fun se  -> let uu____9606 = noenv resugar_sigelt'  in uu____9606 se 
 let (resugar_comp : FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term) =
-  fun c  -> let uu____9450 = noenv resugar_comp'  in uu____9450 c 
+  fun c  -> let uu____9624 = noenv resugar_comp'  in uu____9624 c 
 let (resugar_pat :
   FStar_Syntax_Syntax.pat ->
     FStar_Syntax_Syntax.bv FStar_Util.set -> FStar_Parser_AST.pattern)
   =
   fun p  ->
     fun branch_bv  ->
-      let uu____9473 = noenv resugar_pat'  in uu____9473 p branch_bv
+      let uu____9647 = noenv resugar_pat'  in uu____9647 p branch_bv
   
 let (resugar_binder :
   FStar_Syntax_Syntax.binder ->
@@ -2629,10 +2702,10 @@ let (resugar_binder :
       FStar_Parser_AST.binder FStar_Pervasives_Native.option)
   =
   fun b  ->
-    fun r  -> let uu____9507 = noenv resugar_binder'  in uu____9507 b r
+    fun r  -> let uu____9681 = noenv resugar_binder'  in uu____9681 b r
   
 let (resugar_tscheme : FStar_Syntax_Syntax.tscheme -> FStar_Parser_AST.decl)
-  = fun ts  -> let uu____9532 = noenv resugar_tscheme'  in uu____9532 ts 
+  = fun ts  -> let uu____9706 = noenv resugar_tscheme'  in uu____9706 ts 
 let (resugar_eff_decl :
   FStar_Range.range ->
     FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -2641,5 +2714,5 @@ let (resugar_eff_decl :
   fun r  ->
     fun q  ->
       fun ed  ->
-        let uu____9560 = noenv resugar_eff_decl'  in uu____9560 r q ed
+        let uu____9734 = noenv resugar_eff_decl'  in uu____9734 r q ed
   

--- a/src/ocaml-output/FStar_Syntax_Subst.ml
+++ b/src/ocaml-output/FStar_Syntax_Subst.ml
@@ -8,7 +8,7 @@ let subst_to_string :
            (fun uu____44  ->
               match uu____44 with
               | (b,uu____51) ->
-                  (b.FStar_Syntax_Syntax.ppname).FStar_Ident.idText))
+                  FStar_Ident.text_of_id b.FStar_Syntax_Syntax.ppname))
        in
     FStar_All.pipe_right uu____23 (FStar_String.concat ", ")
   
@@ -216,10 +216,9 @@ let (subst_univ_nm :
       FStar_Util.find_map s
         (fun uu___4_723  ->
            match uu___4_723 with
-           | FStar_Syntax_Syntax.UD (y,i) when
-               x.FStar_Ident.idText = y.FStar_Ident.idText ->
-               FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.U_bvar i)
-           | uu____731 -> FStar_Pervasives_Native.None)
+           | FStar_Syntax_Syntax.UD (y,i) when FStar_Ident.ident_equals x y
+               -> FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.U_bvar i)
+           | uu____730 -> FStar_Pervasives_Native.None)
   
 let rec (subst_univ :
   FStar_Syntax_Syntax.subst_elt Prims.list Prims.list ->
@@ -235,18 +234,18 @@ let rec (subst_univ :
           apply_until_some_then_map (subst_univ_nm x) s subst_univ u1
       | FStar_Syntax_Syntax.U_zero  -> u1
       | FStar_Syntax_Syntax.U_unknown  -> u1
-      | FStar_Syntax_Syntax.U_unif uu____759 -> u1
+      | FStar_Syntax_Syntax.U_unif uu____758 -> u1
       | FStar_Syntax_Syntax.U_succ u2 ->
-          let uu____769 = subst_univ s u2  in
-          FStar_Syntax_Syntax.U_succ uu____769
+          let uu____768 = subst_univ s u2  in
+          FStar_Syntax_Syntax.U_succ uu____768
       | FStar_Syntax_Syntax.U_max us ->
-          let uu____773 = FStar_List.map (subst_univ s) us  in
-          FStar_Syntax_Syntax.U_max uu____773
+          let uu____772 = FStar_List.map (subst_univ s) us  in
+          FStar_Syntax_Syntax.U_max uu____772
   
 let tag_with_range :
-  'uuuuuu783 .
+  'uuuuuu782 .
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      ('uuuuuu783 * FStar_Syntax_Syntax.maybe_set_use_range) ->
+      ('uuuuuu782 * FStar_Syntax_Syntax.maybe_set_use_range) ->
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun t  ->
@@ -254,61 +253,61 @@ let tag_with_range :
       match FStar_Pervasives_Native.snd s with
       | FStar_Syntax_Syntax.NoUseRange  -> t
       | FStar_Syntax_Syntax.SomeUseRange r ->
-          let uu____809 =
-            let uu____811 = FStar_Range.use_range t.FStar_Syntax_Syntax.pos
+          let uu____808 =
+            let uu____810 = FStar_Range.use_range t.FStar_Syntax_Syntax.pos
                in
-            let uu____812 = FStar_Range.use_range r  in
-            FStar_Range.rng_included uu____811 uu____812  in
-          if uu____809
+            let uu____811 = FStar_Range.use_range r  in
+            FStar_Range.rng_included uu____810 uu____811  in
+          if uu____808
           then t
           else
             (let r1 =
-               let uu____819 = FStar_Range.use_range r  in
-               FStar_Range.set_use_range t.FStar_Syntax_Syntax.pos uu____819
+               let uu____818 = FStar_Range.use_range r  in
+               FStar_Range.set_use_range t.FStar_Syntax_Syntax.pos uu____818
                 in
              let t' =
                match t.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_bvar bv ->
-                   let uu____822 = FStar_Syntax_Syntax.set_range_of_bv bv r1
+                   let uu____821 = FStar_Syntax_Syntax.set_range_of_bv bv r1
                       in
-                   FStar_Syntax_Syntax.Tm_bvar uu____822
+                   FStar_Syntax_Syntax.Tm_bvar uu____821
                | FStar_Syntax_Syntax.Tm_name bv ->
-                   let uu____824 = FStar_Syntax_Syntax.set_range_of_bv bv r1
+                   let uu____823 = FStar_Syntax_Syntax.set_range_of_bv bv r1
                       in
-                   FStar_Syntax_Syntax.Tm_name uu____824
+                   FStar_Syntax_Syntax.Tm_name uu____823
                | FStar_Syntax_Syntax.Tm_fvar fv ->
                    let l = FStar_Syntax_Syntax.lid_of_fv fv  in
                    let v =
-                     let uu___143_830 = fv.FStar_Syntax_Syntax.fv_name  in
-                     let uu____831 = FStar_Ident.set_lid_range l r1  in
+                     let uu___143_829 = fv.FStar_Syntax_Syntax.fv_name  in
+                     let uu____830 = FStar_Ident.set_lid_range l r1  in
                      {
-                       FStar_Syntax_Syntax.v = uu____831;
+                       FStar_Syntax_Syntax.v = uu____830;
                        FStar_Syntax_Syntax.p =
-                         (uu___143_830.FStar_Syntax_Syntax.p)
+                         (uu___143_829.FStar_Syntax_Syntax.p)
                      }  in
                    let fv1 =
-                     let uu___146_833 = fv  in
+                     let uu___146_832 = fv  in
                      {
                        FStar_Syntax_Syntax.fv_name = v;
                        FStar_Syntax_Syntax.fv_delta =
-                         (uu___146_833.FStar_Syntax_Syntax.fv_delta);
+                         (uu___146_832.FStar_Syntax_Syntax.fv_delta);
                        FStar_Syntax_Syntax.fv_qual =
-                         (uu___146_833.FStar_Syntax_Syntax.fv_qual)
+                         (uu___146_832.FStar_Syntax_Syntax.fv_qual)
                      }  in
                    FStar_Syntax_Syntax.Tm_fvar fv1
                | t' -> t'  in
-             let uu___151_835 = t  in
+             let uu___151_834 = t  in
              {
                FStar_Syntax_Syntax.n = t';
                FStar_Syntax_Syntax.pos = r1;
                FStar_Syntax_Syntax.vars =
-                 (uu___151_835.FStar_Syntax_Syntax.vars)
+                 (uu___151_834.FStar_Syntax_Syntax.vars)
              })
   
 let tag_lid_with_range :
-  'uuuuuu845 .
+  'uuuuuu844 .
     FStar_Ident.lident ->
-      ('uuuuuu845 * FStar_Syntax_Syntax.maybe_set_use_range) ->
+      ('uuuuuu844 * FStar_Syntax_Syntax.maybe_set_use_range) ->
         FStar_Ident.lident
   =
   fun l  ->
@@ -316,20 +315,20 @@ let tag_lid_with_range :
       match FStar_Pervasives_Native.snd s with
       | FStar_Syntax_Syntax.NoUseRange  -> l
       | FStar_Syntax_Syntax.SomeUseRange r ->
-          let uu____865 =
-            let uu____867 =
-              let uu____868 = FStar_Ident.range_of_lid l  in
-              FStar_Range.use_range uu____868  in
-            let uu____869 = FStar_Range.use_range r  in
-            FStar_Range.rng_included uu____867 uu____869  in
-          if uu____865
+          let uu____864 =
+            let uu____866 =
+              let uu____867 = FStar_Ident.range_of_lid l  in
+              FStar_Range.use_range uu____867  in
+            let uu____868 = FStar_Range.use_range r  in
+            FStar_Range.rng_included uu____866 uu____868  in
+          if uu____864
           then l
           else
-            (let uu____873 =
-               let uu____874 = FStar_Ident.range_of_lid l  in
-               let uu____875 = FStar_Range.use_range r  in
-               FStar_Range.set_use_range uu____874 uu____875  in
-             FStar_Ident.set_lid_range l uu____873)
+            (let uu____872 =
+               let uu____873 = FStar_Ident.range_of_lid l  in
+               let uu____874 = FStar_Range.use_range r  in
+               FStar_Range.set_use_range uu____873 uu____874  in
+             FStar_Ident.set_lid_range l uu____872)
   
 let (mk_range :
   FStar_Range.range -> FStar_Syntax_Syntax.subst_ts -> FStar_Range.range) =
@@ -338,15 +337,15 @@ let (mk_range :
       match FStar_Pervasives_Native.snd s with
       | FStar_Syntax_Syntax.NoUseRange  -> r
       | FStar_Syntax_Syntax.SomeUseRange r' ->
-          let uu____892 =
-            let uu____894 = FStar_Range.use_range r  in
-            let uu____895 = FStar_Range.use_range r'  in
-            FStar_Range.rng_included uu____894 uu____895  in
-          if uu____892
+          let uu____891 =
+            let uu____893 = FStar_Range.use_range r  in
+            let uu____894 = FStar_Range.use_range r'  in
+            FStar_Range.rng_included uu____893 uu____894  in
+          if uu____891
           then r
           else
-            (let uu____899 = FStar_Range.use_range r'  in
-             FStar_Range.set_use_range r uu____899)
+            (let uu____898 = FStar_Range.use_range r'  in
+             FStar_Range.set_use_range r uu____898)
   
 let rec (subst' :
   FStar_Syntax_Syntax.subst_ts ->
@@ -358,12 +357,12 @@ let rec (subst' :
       match s with
       | ([],FStar_Syntax_Syntax.NoUseRange ) -> t
       | ([]::[],FStar_Syntax_Syntax.NoUseRange ) -> t
-      | uu____952 ->
+      | uu____951 ->
           let t0 = t  in
           (match t0.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_unknown  -> tag_with_range t0 s
-           | FStar_Syntax_Syntax.Tm_constant uu____958 -> tag_with_range t0 s
-           | FStar_Syntax_Syntax.Tm_fvar uu____963 -> tag_with_range t0 s
+           | FStar_Syntax_Syntax.Tm_constant uu____957 -> tag_with_range t0 s
+           | FStar_Syntax_Syntax.Tm_fvar uu____962 -> tag_with_range t0 s
            | FStar_Syntax_Syntax.Tm_delayed (t',s') ->
                FStar_Syntax_Syntax.mk_Tm_delayed (t', (compose_subst s' s))
                  t.FStar_Syntax_Syntax.pos
@@ -374,17 +373,17 @@ let rec (subst' :
                apply_until_some_then_map (subst_nm a)
                  (FStar_Pervasives_Native.fst s) subst_tail t0
            | FStar_Syntax_Syntax.Tm_type u ->
-               let uu____1009 = mk_range t0.FStar_Syntax_Syntax.pos s  in
-               let uu____1010 =
-                 let uu____1017 =
-                   let uu____1018 =
+               let uu____1008 = mk_range t0.FStar_Syntax_Syntax.pos s  in
+               let uu____1009 =
+                 let uu____1016 =
+                   let uu____1017 =
                      subst_univ (FStar_Pervasives_Native.fst s) u  in
-                   FStar_Syntax_Syntax.Tm_type uu____1018  in
-                 FStar_Syntax_Syntax.mk uu____1017  in
-               uu____1010 FStar_Pervasives_Native.None uu____1009
-           | uu____1023 ->
-               let uu____1024 = mk_range t.FStar_Syntax_Syntax.pos s  in
-               FStar_Syntax_Syntax.mk_Tm_delayed (t0, s) uu____1024)
+                   FStar_Syntax_Syntax.Tm_type uu____1017  in
+                 FStar_Syntax_Syntax.mk uu____1016  in
+               uu____1009 FStar_Pervasives_Native.None uu____1008
+           | uu____1022 ->
+               let uu____1023 = mk_range t.FStar_Syntax_Syntax.pos s  in
+               FStar_Syntax_Syntax.mk_Tm_delayed (t0, s) uu____1023)
   
 let (subst_flags' :
   FStar_Syntax_Syntax.subst_ts ->
@@ -395,11 +394,11 @@ let (subst_flags' :
     fun flags  ->
       FStar_All.pipe_right flags
         (FStar_List.map
-           (fun uu___5_1049  ->
-              match uu___5_1049 with
+           (fun uu___5_1048  ->
+              match uu___5_1048 with
               | FStar_Syntax_Syntax.DECREASES a ->
-                  let uu____1053 = subst' s a  in
-                  FStar_Syntax_Syntax.DECREASES uu____1053
+                  let uu____1052 = subst' s a  in
+                  FStar_Syntax_Syntax.DECREASES uu____1052
               | f -> f))
   
 let (subst_imp' :
@@ -411,10 +410,10 @@ let (subst_imp' :
     fun i  ->
       match i with
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta t) ->
-          let uu____1079 =
-            let uu____1080 = subst' s t  in
-            FStar_Syntax_Syntax.Meta uu____1080  in
-          FStar_Pervasives_Native.Some uu____1079
+          let uu____1078 =
+            let uu____1079 = subst' s t  in
+            FStar_Syntax_Syntax.Meta uu____1079  in
+          FStar_Pervasives_Native.Some uu____1078
       | i1 -> i1
   
 let (subst_comp_typ' :
@@ -427,32 +426,32 @@ let (subst_comp_typ' :
       match s with
       | ([],FStar_Syntax_Syntax.NoUseRange ) -> t
       | ([]::[],FStar_Syntax_Syntax.NoUseRange ) -> t
-      | uu____1127 ->
-          let uu___216_1136 = t  in
-          let uu____1137 =
+      | uu____1126 ->
+          let uu___216_1135 = t  in
+          let uu____1136 =
             FStar_List.map (subst_univ (FStar_Pervasives_Native.fst s))
               t.FStar_Syntax_Syntax.comp_univs
              in
-          let uu____1142 =
+          let uu____1141 =
             tag_lid_with_range t.FStar_Syntax_Syntax.effect_name s  in
-          let uu____1147 = subst' s t.FStar_Syntax_Syntax.result_typ  in
-          let uu____1150 =
+          let uu____1146 = subst' s t.FStar_Syntax_Syntax.result_typ  in
+          let uu____1149 =
             FStar_List.map
-              (fun uu____1178  ->
-                 match uu____1178 with
+              (fun uu____1177  ->
+                 match uu____1177 with
                  | (t1,imp) ->
-                     let uu____1197 = subst' s t1  in
-                     let uu____1198 = subst_imp' s imp  in
-                     (uu____1197, uu____1198))
+                     let uu____1196 = subst' s t1  in
+                     let uu____1197 = subst_imp' s imp  in
+                     (uu____1196, uu____1197))
               t.FStar_Syntax_Syntax.effect_args
              in
-          let uu____1203 = subst_flags' s t.FStar_Syntax_Syntax.flags  in
+          let uu____1202 = subst_flags' s t.FStar_Syntax_Syntax.flags  in
           {
-            FStar_Syntax_Syntax.comp_univs = uu____1137;
-            FStar_Syntax_Syntax.effect_name = uu____1142;
-            FStar_Syntax_Syntax.result_typ = uu____1147;
-            FStar_Syntax_Syntax.effect_args = uu____1150;
-            FStar_Syntax_Syntax.flags = uu____1203
+            FStar_Syntax_Syntax.comp_univs = uu____1136;
+            FStar_Syntax_Syntax.effect_name = uu____1141;
+            FStar_Syntax_Syntax.result_typ = uu____1146;
+            FStar_Syntax_Syntax.effect_args = uu____1149;
+            FStar_Syntax_Syntax.flags = uu____1202
           }
   
 let (subst_comp' :
@@ -466,25 +465,25 @@ let (subst_comp' :
       match s with
       | ([],FStar_Syntax_Syntax.NoUseRange ) -> t
       | ([]::[],FStar_Syntax_Syntax.NoUseRange ) -> t
-      | uu____1255 ->
+      | uu____1254 ->
           (match t.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Total (t1,uopt) ->
-               let uu____1276 = subst' s t1  in
-               let uu____1277 =
+               let uu____1275 = subst' s t1  in
+               let uu____1276 =
                  FStar_Option.map
                    (subst_univ (FStar_Pervasives_Native.fst s)) uopt
                   in
-               FStar_Syntax_Syntax.mk_Total' uu____1276 uu____1277
+               FStar_Syntax_Syntax.mk_Total' uu____1275 uu____1276
            | FStar_Syntax_Syntax.GTotal (t1,uopt) ->
-               let uu____1294 = subst' s t1  in
-               let uu____1295 =
+               let uu____1293 = subst' s t1  in
+               let uu____1294 =
                  FStar_Option.map
                    (subst_univ (FStar_Pervasives_Native.fst s)) uopt
                   in
-               FStar_Syntax_Syntax.mk_GTotal' uu____1294 uu____1295
+               FStar_Syntax_Syntax.mk_GTotal' uu____1293 uu____1294
            | FStar_Syntax_Syntax.Comp ct ->
-               let uu____1303 = subst_comp_typ' s ct  in
-               FStar_Syntax_Syntax.mk_Comp uu____1303)
+               let uu____1302 = subst_comp_typ' s ct  in
+               FStar_Syntax_Syntax.mk_Comp uu____1302)
   
 let (shift :
   Prims.int -> FStar_Syntax_Syntax.subst_elt -> FStar_Syntax_Syntax.subst_elt)
@@ -496,24 +495,24 @@ let (shift :
       | FStar_Syntax_Syntax.UN (i,t) -> FStar_Syntax_Syntax.UN ((i + n), t)
       | FStar_Syntax_Syntax.NM (x,i) -> FStar_Syntax_Syntax.NM (x, (i + n))
       | FStar_Syntax_Syntax.UD (x,i) -> FStar_Syntax_Syntax.UD (x, (i + n))
-      | FStar_Syntax_Syntax.NT uu____1337 -> s
+      | FStar_Syntax_Syntax.NT uu____1336 -> s
   
 let (shift_subst :
   Prims.int -> FStar_Syntax_Syntax.subst_t -> FStar_Syntax_Syntax.subst_t) =
   fun n  -> fun s  -> FStar_List.map (shift n) s 
 let shift_subst' :
-  'uuuuuu1364 .
+  'uuuuuu1363 .
     Prims.int ->
-      (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuuu1364) ->
-        (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuuu1364)
+      (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuuu1363) ->
+        (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuuu1363)
   =
   fun n  ->
     fun s  ->
-      let uu____1395 =
+      let uu____1394 =
         FStar_All.pipe_right (FStar_Pervasives_Native.fst s)
           (FStar_List.map (shift_subst n))
          in
-      (uu____1395, (FStar_Pervasives_Native.snd s))
+      (uu____1394, (FStar_Pervasives_Native.snd s))
   
 let (subst_binder' :
   FStar_Syntax_Syntax.subst_ts ->
@@ -523,20 +522,20 @@ let (subst_binder' :
         FStar_Pervasives_Native.option))
   =
   fun s  ->
-    fun uu____1430  ->
-      match uu____1430 with
+    fun uu____1429  ->
+      match uu____1429 with
       | (x,imp) ->
-          let uu____1449 =
-            let uu___269_1450 = x  in
-            let uu____1451 = subst' s x.FStar_Syntax_Syntax.sort  in
+          let uu____1448 =
+            let uu___269_1449 = x  in
+            let uu____1450 = subst' s x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___269_1450.FStar_Syntax_Syntax.ppname);
+                (uu___269_1449.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___269_1450.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____1451
+                (uu___269_1449.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____1450
             }  in
-          let uu____1454 = subst_imp' s imp  in (uu____1449, uu____1454)
+          let uu____1453 = subst_imp' s imp  in (uu____1448, uu____1453)
   
 let (subst_binders' :
   (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list *
@@ -555,8 +554,8 @@ let (subst_binders' :
                 if i = Prims.int_zero
                 then subst_binder' s b
                 else
-                  (let uu____1560 = shift_subst' i s  in
-                   subst_binder' uu____1560 b)))
+                  (let uu____1559 = shift_subst' i s  in
+                   subst_binder' uu____1559 b)))
   
 let (subst_binders :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
@@ -566,21 +565,21 @@ let (subst_binders :
     fun bs  -> subst_binders' ([s], FStar_Syntax_Syntax.NoUseRange) bs
   
 let subst_arg' :
-  'uuuuuu1591 .
+  'uuuuuu1590 .
     FStar_Syntax_Syntax.subst_ts ->
-      (FStar_Syntax_Syntax.term * 'uuuuuu1591) ->
-        (FStar_Syntax_Syntax.term * 'uuuuuu1591)
+      (FStar_Syntax_Syntax.term * 'uuuuuu1590) ->
+        (FStar_Syntax_Syntax.term * 'uuuuuu1590)
   =
   fun s  ->
-    fun uu____1609  ->
-      match uu____1609 with
-      | (t,imp) -> let uu____1616 = subst' s t  in (uu____1616, imp)
+    fun uu____1608  ->
+      match uu____1608 with
+      | (t,imp) -> let uu____1615 = subst' s t  in (uu____1615, imp)
   
 let subst_args' :
-  'uuuuuu1623 .
+  'uuuuuu1622 .
     FStar_Syntax_Syntax.subst_ts ->
-      (FStar_Syntax_Syntax.term * 'uuuuuu1623) Prims.list ->
-        (FStar_Syntax_Syntax.term * 'uuuuuu1623) Prims.list
+      (FStar_Syntax_Syntax.term * 'uuuuuu1622) Prims.list ->
+        (FStar_Syntax_Syntax.term * 'uuuuuu1622) Prims.list
   = fun s  -> FStar_List.map (subst_arg' s) 
 let (subst_pat' :
   (FStar_Syntax_Syntax.subst_t Prims.list *
@@ -592,82 +591,82 @@ let (subst_pat' :
     fun p  ->
       let rec aux n p1 =
         match p1.FStar_Syntax_Syntax.v with
-        | FStar_Syntax_Syntax.Pat_constant uu____1717 -> (p1, n)
+        | FStar_Syntax_Syntax.Pat_constant uu____1716 -> (p1, n)
         | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-            let uu____1739 =
+            let uu____1738 =
               FStar_All.pipe_right pats
                 (FStar_List.fold_left
-                   (fun uu____1801  ->
-                      fun uu____1802  ->
-                        match (uu____1801, uu____1802) with
+                   (fun uu____1800  ->
+                      fun uu____1801  ->
+                        match (uu____1800, uu____1801) with
                         | ((pats1,n1),(p2,imp)) ->
-                            let uu____1898 = aux n1 p2  in
-                            (match uu____1898 with
+                            let uu____1897 = aux n1 p2  in
+                            (match uu____1897 with
                              | (p3,m) -> (((p3, imp) :: pats1), m))) 
                    ([], n))
                in
-            (match uu____1739 with
+            (match uu____1738 with
              | (pats1,n1) ->
-                 ((let uu___306_1972 = p1  in
+                 ((let uu___306_1971 = p1  in
                    {
                      FStar_Syntax_Syntax.v =
                        (FStar_Syntax_Syntax.Pat_cons
                           (fv, (FStar_List.rev pats1)));
                      FStar_Syntax_Syntax.p =
-                       (uu___306_1972.FStar_Syntax_Syntax.p)
+                       (uu___306_1971.FStar_Syntax_Syntax.p)
                    }), n1))
         | FStar_Syntax_Syntax.Pat_var x ->
             let s1 = shift_subst' n s  in
             let x1 =
-              let uu___311_1998 = x  in
-              let uu____1999 = subst' s1 x.FStar_Syntax_Syntax.sort  in
+              let uu___311_1997 = x  in
+              let uu____1998 = subst' s1 x.FStar_Syntax_Syntax.sort  in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___311_1998.FStar_Syntax_Syntax.ppname);
+                  (uu___311_1997.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
-                  (uu___311_1998.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____1999
+                  (uu___311_1997.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu____1998
               }  in
-            ((let uu___314_2004 = p1  in
+            ((let uu___314_2003 = p1  in
               {
                 FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
-                FStar_Syntax_Syntax.p = (uu___314_2004.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.p = (uu___314_2003.FStar_Syntax_Syntax.p)
               }), (n + Prims.int_one))
         | FStar_Syntax_Syntax.Pat_wild x ->
             let s1 = shift_subst' n s  in
             let x1 =
-              let uu___319_2017 = x  in
-              let uu____2018 = subst' s1 x.FStar_Syntax_Syntax.sort  in
+              let uu___319_2016 = x  in
+              let uu____2017 = subst' s1 x.FStar_Syntax_Syntax.sort  in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___319_2017.FStar_Syntax_Syntax.ppname);
+                  (uu___319_2016.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
-                  (uu___319_2017.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____2018
+                  (uu___319_2016.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu____2017
               }  in
-            ((let uu___322_2023 = p1  in
+            ((let uu___322_2022 = p1  in
               {
                 FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
-                FStar_Syntax_Syntax.p = (uu___322_2023.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.p = (uu___322_2022.FStar_Syntax_Syntax.p)
               }), (n + Prims.int_one))
         | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
             let s1 = shift_subst' n s  in
             let x1 =
-              let uu___329_2041 = x  in
-              let uu____2042 = subst' s1 x.FStar_Syntax_Syntax.sort  in
+              let uu___329_2040 = x  in
+              let uu____2041 = subst' s1 x.FStar_Syntax_Syntax.sort  in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___329_2041.FStar_Syntax_Syntax.ppname);
+                  (uu___329_2040.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
-                  (uu___329_2041.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____2042
+                  (uu___329_2040.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu____2041
               }  in
             let t01 = subst' s1 t0  in
-            ((let uu___333_2048 = p1  in
+            ((let uu___333_2047 = p1  in
               {
                 FStar_Syntax_Syntax.v =
                   (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-                FStar_Syntax_Syntax.p = (uu___333_2048.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.p = (uu___333_2047.FStar_Syntax_Syntax.p)
               }), n)
          in
       aux Prims.int_zero p
@@ -682,20 +681,20 @@ let (push_subst_lcomp :
       match lopt with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some rc ->
-          let uu____2074 =
-            let uu___340_2075 = rc  in
-            let uu____2076 =
+          let uu____2073 =
+            let uu___340_2074 = rc  in
+            let uu____2075 =
               FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                 (subst' s)
                in
             {
               FStar_Syntax_Syntax.residual_effect =
-                (uu___340_2075.FStar_Syntax_Syntax.residual_effect);
-              FStar_Syntax_Syntax.residual_typ = uu____2076;
+                (uu___340_2074.FStar_Syntax_Syntax.residual_effect);
+              FStar_Syntax_Syntax.residual_typ = uu____2075;
               FStar_Syntax_Syntax.residual_flags =
-                (uu___340_2075.FStar_Syntax_Syntax.residual_flags)
+                (uu___340_2074.FStar_Syntax_Syntax.residual_flags)
             }  in
-          FStar_Pervasives_Native.Some uu____2074
+          FStar_Pervasives_Native.Some uu____2073
   
 let (compose_uvar_subst :
   FStar_Syntax_Syntax.ctx_uvar ->
@@ -708,46 +707,46 @@ let (compose_uvar_subst :
         let should_retain x =
           FStar_All.pipe_right u.FStar_Syntax_Syntax.ctx_uvar_binders
             (FStar_Util.for_some
-               (fun uu____2126  ->
-                  match uu____2126 with
-                  | (x',uu____2135) -> FStar_Syntax_Syntax.bv_eq x x'))
+               (fun uu____2125  ->
+                  match uu____2125 with
+                  | (x',uu____2134) -> FStar_Syntax_Syntax.bv_eq x x'))
            in
-        let rec aux uu___7_2151 =
-          match uu___7_2151 with
+        let rec aux uu___7_2150 =
+          match uu___7_2150 with
           | [] -> []
           | hd_subst::rest ->
               let hd =
                 FStar_All.pipe_right hd_subst
                   (FStar_List.collect
-                     (fun uu___6_2182  ->
-                        match uu___6_2182 with
+                     (fun uu___6_2181  ->
+                        match uu___6_2181 with
                         | FStar_Syntax_Syntax.NT (x,t) ->
-                            let uu____2191 = should_retain x  in
-                            if uu____2191
+                            let uu____2190 = should_retain x  in
+                            if uu____2190
                             then
-                              let uu____2196 =
-                                let uu____2197 =
-                                  let uu____2204 =
+                              let uu____2195 =
+                                let uu____2196 =
+                                  let uu____2203 =
                                     delay t
                                       (rest, FStar_Syntax_Syntax.NoUseRange)
                                      in
-                                  (x, uu____2204)  in
-                                FStar_Syntax_Syntax.NT uu____2197  in
-                              [uu____2196]
+                                  (x, uu____2203)  in
+                                FStar_Syntax_Syntax.NT uu____2196  in
+                              [uu____2195]
                             else []
                         | FStar_Syntax_Syntax.NM (x,i) ->
-                            let uu____2219 = should_retain x  in
-                            if uu____2219
+                            let uu____2218 = should_retain x  in
+                            if uu____2218
                             then
                               let x_i =
                                 FStar_Syntax_Syntax.bv_to_tm
-                                  (let uu___367_2227 = x  in
+                                  (let uu___367_2226 = x  in
                                    {
                                      FStar_Syntax_Syntax.ppname =
-                                       (uu___367_2227.FStar_Syntax_Syntax.ppname);
+                                       (uu___367_2226.FStar_Syntax_Syntax.ppname);
                                      FStar_Syntax_Syntax.index = i;
                                      FStar_Syntax_Syntax.sort =
-                                       (uu___367_2227.FStar_Syntax_Syntax.sort)
+                                       (uu___367_2226.FStar_Syntax_Syntax.sort)
                                    })
                                  in
                               let t =
@@ -758,19 +757,19 @@ let (compose_uvar_subst :
                                | FStar_Syntax_Syntax.Tm_bvar x_j ->
                                    [FStar_Syntax_Syntax.NM
                                       (x, (x_j.FStar_Syntax_Syntax.index))]
-                               | uu____2237 ->
+                               | uu____2236 ->
                                    [FStar_Syntax_Syntax.NT (x, t)])
                             else []
-                        | uu____2242 -> []))
+                        | uu____2241 -> []))
                  in
-              let uu____2243 = aux rest  in FStar_List.append hd uu____2243
+              let uu____2242 = aux rest  in FStar_List.append hd uu____2242
            in
-        let uu____2246 =
+        let uu____2245 =
           aux
             (FStar_List.append (FStar_Pervasives_Native.fst s0)
                (FStar_Pervasives_Native.fst s))
            in
-        match uu____2246 with
+        match uu____2245 with
         | [] -> ([], (FStar_Pervasives_Native.snd s))
         | s' -> ([s'], (FStar_Pervasives_Native.snd s))
   
@@ -782,129 +781,129 @@ let rec (push_subst :
   fun s  ->
     fun t  ->
       let mk t' =
-        let uu____2309 = mk_range t.FStar_Syntax_Syntax.pos s  in
-        FStar_Syntax_Syntax.mk t' FStar_Pervasives_Native.None uu____2309  in
+        let uu____2308 = mk_range t.FStar_Syntax_Syntax.pos s  in
+        FStar_Syntax_Syntax.mk t' FStar_Pervasives_Native.None uu____2308  in
       match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____2312 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____2311 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_lazy i ->
           (match i.FStar_Syntax_Syntax.lkind with
-           | FStar_Syntax_Syntax.Lazy_embedding uu____2333 ->
+           | FStar_Syntax_Syntax.Lazy_embedding uu____2332 ->
                let t1 =
-                 let uu____2343 =
-                   let uu____2352 =
+                 let uu____2342 =
+                   let uu____2351 =
                      FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser  in
-                   FStar_Util.must uu____2352  in
-                 uu____2343 i.FStar_Syntax_Syntax.lkind i  in
+                   FStar_Util.must uu____2351  in
+                 uu____2342 i.FStar_Syntax_Syntax.lkind i  in
                push_subst s t1
-           | uu____2402 -> t)
-      | FStar_Syntax_Syntax.Tm_constant uu____2403 -> tag_with_range t s
-      | FStar_Syntax_Syntax.Tm_fvar uu____2408 -> tag_with_range t s
+           | uu____2401 -> t)
+      | FStar_Syntax_Syntax.Tm_constant uu____2402 -> tag_with_range t s
+      | FStar_Syntax_Syntax.Tm_fvar uu____2407 -> tag_with_range t s
       | FStar_Syntax_Syntax.Tm_unknown  -> tag_with_range t s
       | FStar_Syntax_Syntax.Tm_uvar (uv,s0) ->
-          let uu____2435 =
+          let uu____2434 =
             FStar_Syntax_Unionfind.find uv.FStar_Syntax_Syntax.ctx_uvar_head
              in
-          (match uu____2435 with
+          (match uu____2434 with
            | FStar_Pervasives_Native.None  ->
-               let uu____2440 =
-                 let uu___400_2443 = t  in
-                 let uu____2446 =
-                   let uu____2447 =
-                     let uu____2460 = compose_uvar_subst uv s0 s  in
-                     (uv, uu____2460)  in
-                   FStar_Syntax_Syntax.Tm_uvar uu____2447  in
+               let uu____2439 =
+                 let uu___400_2442 = t  in
+                 let uu____2445 =
+                   let uu____2446 =
+                     let uu____2459 = compose_uvar_subst uv s0 s  in
+                     (uv, uu____2459)  in
+                   FStar_Syntax_Syntax.Tm_uvar uu____2446  in
                  {
-                   FStar_Syntax_Syntax.n = uu____2446;
+                   FStar_Syntax_Syntax.n = uu____2445;
                    FStar_Syntax_Syntax.pos =
-                     (uu___400_2443.FStar_Syntax_Syntax.pos);
+                     (uu___400_2442.FStar_Syntax_Syntax.pos);
                    FStar_Syntax_Syntax.vars =
-                     (uu___400_2443.FStar_Syntax_Syntax.vars)
+                     (uu___400_2442.FStar_Syntax_Syntax.vars)
                  }  in
-               tag_with_range uu____2440 s
+               tag_with_range uu____2439 s
            | FStar_Pervasives_Native.Some t1 ->
                push_subst (compose_subst s0 s) t1)
-      | FStar_Syntax_Syntax.Tm_type uu____2484 -> subst' s t
-      | FStar_Syntax_Syntax.Tm_bvar uu____2485 -> subst' s t
-      | FStar_Syntax_Syntax.Tm_name uu____2486 -> subst' s t
+      | FStar_Syntax_Syntax.Tm_type uu____2483 -> subst' s t
+      | FStar_Syntax_Syntax.Tm_bvar uu____2484 -> subst' s t
+      | FStar_Syntax_Syntax.Tm_name uu____2485 -> subst' s t
       | FStar_Syntax_Syntax.Tm_uinst (t',us) ->
           let us1 =
             FStar_List.map (subst_univ (FStar_Pervasives_Native.fst s)) us
              in
-          let uu____2500 = FStar_Syntax_Syntax.mk_Tm_uinst t' us1  in
-          tag_with_range uu____2500 s
+          let uu____2499 = FStar_Syntax_Syntax.mk_Tm_uinst t' us1  in
+          tag_with_range uu____2499 s
       | FStar_Syntax_Syntax.Tm_app (t0,args) ->
-          let uu____2533 =
-            let uu____2534 =
-              let uu____2551 = subst' s t0  in
-              let uu____2554 = subst_args' s args  in
-              (uu____2551, uu____2554)  in
-            FStar_Syntax_Syntax.Tm_app uu____2534  in
-          mk uu____2533
+          let uu____2532 =
+            let uu____2533 =
+              let uu____2550 = subst' s t0  in
+              let uu____2553 = subst_args' s args  in
+              (uu____2550, uu____2553)  in
+            FStar_Syntax_Syntax.Tm_app uu____2533  in
+          mk uu____2532
       | FStar_Syntax_Syntax.Tm_ascribed (t0,(annot,topt),lopt) ->
           let annot1 =
             match annot with
             | FStar_Util.Inl t1 ->
-                let uu____2655 = subst' s t1  in FStar_Util.Inl uu____2655
+                let uu____2654 = subst' s t1  in FStar_Util.Inl uu____2654
             | FStar_Util.Inr c ->
-                let uu____2669 = subst_comp' s c  in
-                FStar_Util.Inr uu____2669
+                let uu____2668 = subst_comp' s c  in
+                FStar_Util.Inr uu____2668
              in
-          let uu____2676 =
-            let uu____2677 =
-              let uu____2704 = subst' s t0  in
-              let uu____2707 =
-                let uu____2724 = FStar_Util.map_opt topt (subst' s)  in
-                (annot1, uu____2724)  in
-              (uu____2704, uu____2707, lopt)  in
-            FStar_Syntax_Syntax.Tm_ascribed uu____2677  in
-          mk uu____2676
+          let uu____2675 =
+            let uu____2676 =
+              let uu____2703 = subst' s t0  in
+              let uu____2706 =
+                let uu____2723 = FStar_Util.map_opt topt (subst' s)  in
+                (annot1, uu____2723)  in
+              (uu____2703, uu____2706, lopt)  in
+            FStar_Syntax_Syntax.Tm_ascribed uu____2676  in
+          mk uu____2675
       | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
           let n = FStar_List.length bs  in
           let s' = shift_subst' n s  in
-          let uu____2806 =
-            let uu____2807 =
-              let uu____2826 = subst_binders' s bs  in
-              let uu____2835 = subst' s' body  in
-              let uu____2838 = push_subst_lcomp s' lopt  in
-              (uu____2826, uu____2835, uu____2838)  in
-            FStar_Syntax_Syntax.Tm_abs uu____2807  in
-          mk uu____2806
+          let uu____2805 =
+            let uu____2806 =
+              let uu____2825 = subst_binders' s bs  in
+              let uu____2834 = subst' s' body  in
+              let uu____2837 = push_subst_lcomp s' lopt  in
+              (uu____2825, uu____2834, uu____2837)  in
+            FStar_Syntax_Syntax.Tm_abs uu____2806  in
+          mk uu____2805
       | FStar_Syntax_Syntax.Tm_arrow (bs,comp) ->
           let n = FStar_List.length bs  in
-          let uu____2882 =
-            let uu____2883 =
-              let uu____2898 = subst_binders' s bs  in
-              let uu____2907 =
-                let uu____2910 = shift_subst' n s  in
-                subst_comp' uu____2910 comp  in
-              (uu____2898, uu____2907)  in
-            FStar_Syntax_Syntax.Tm_arrow uu____2883  in
-          mk uu____2882
+          let uu____2881 =
+            let uu____2882 =
+              let uu____2897 = subst_binders' s bs  in
+              let uu____2906 =
+                let uu____2909 = shift_subst' n s  in
+                subst_comp' uu____2909 comp  in
+              (uu____2897, uu____2906)  in
+            FStar_Syntax_Syntax.Tm_arrow uu____2882  in
+          mk uu____2881
       | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
           let x1 =
-            let uu___447_2936 = x  in
-            let uu____2937 = subst' s x.FStar_Syntax_Syntax.sort  in
+            let uu___447_2935 = x  in
+            let uu____2936 = subst' s x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___447_2936.FStar_Syntax_Syntax.ppname);
+                (uu___447_2935.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___447_2936.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____2937
+                (uu___447_2935.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____2936
             }  in
           let phi1 =
-            let uu____2941 = shift_subst' Prims.int_one s  in
-            subst' uu____2941 phi  in
+            let uu____2940 = shift_subst' Prims.int_one s  in
+            subst' uu____2940 phi  in
           mk (FStar_Syntax_Syntax.Tm_refine (x1, phi1))
       | FStar_Syntax_Syntax.Tm_match (t0,pats) ->
           let t01 = subst' s t0  in
           let pats1 =
             FStar_All.pipe_right pats
               (FStar_List.map
-                 (fun uu____3057  ->
-                    match uu____3057 with
+                 (fun uu____3056  ->
+                    match uu____3056 with
                     | (pat,wopt,branch) ->
-                        let uu____3087 = subst_pat' s pat  in
-                        (match uu____3087 with
+                        let uu____3086 = subst_pat' s pat  in
+                        (match uu____3086 with
                          | (pat1,n) ->
                              let s1 = shift_subst' n s  in
                              let wopt1 =
@@ -912,8 +911,8 @@ let rec (push_subst :
                                | FStar_Pervasives_Native.None  ->
                                    FStar_Pervasives_Native.None
                                | FStar_Pervasives_Native.Some w ->
-                                   let uu____3118 = subst' s1 w  in
-                                   FStar_Pervasives_Native.Some uu____3118
+                                   let uu____3117 = subst' s1 w  in
+                                   FStar_Pervasives_Native.Some uu____3117
                                 in
                              let branch1 = subst' s1 branch  in
                              (pat1, wopt1, branch1))))
@@ -929,23 +928,23 @@ let rec (push_subst :
                  (fun lb  ->
                     let lbt = subst' s lb.FStar_Syntax_Syntax.lbtyp  in
                     let lbd =
-                      let uu____3187 =
+                      let uu____3186 =
                         is_rec &&
                           (FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname)
                          in
-                      if uu____3187
+                      if uu____3186
                       then subst' sn lb.FStar_Syntax_Syntax.lbdef
                       else subst' s lb.FStar_Syntax_Syntax.lbdef  in
                     let lbname =
                       match lb.FStar_Syntax_Syntax.lbname with
                       | FStar_Util.Inl x ->
                           FStar_Util.Inl
-                            (let uu___485_3205 = x  in
+                            (let uu___485_3204 = x  in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___485_3205.FStar_Syntax_Syntax.ppname);
+                                 (uu___485_3204.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___485_3205.FStar_Syntax_Syntax.index);
+                                 (uu___485_3204.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort = lbt
                              })
                       | FStar_Util.Inr fv -> FStar_Util.Inr fv  in
@@ -953,78 +952,78 @@ let rec (push_subst :
                       FStar_List.map (subst' s)
                         lb.FStar_Syntax_Syntax.lbattrs
                        in
-                    let uu___491_3216 = lb  in
+                    let uu___491_3215 = lb  in
                     {
                       FStar_Syntax_Syntax.lbname = lbname;
                       FStar_Syntax_Syntax.lbunivs =
-                        (uu___491_3216.FStar_Syntax_Syntax.lbunivs);
+                        (uu___491_3215.FStar_Syntax_Syntax.lbunivs);
                       FStar_Syntax_Syntax.lbtyp = lbt;
                       FStar_Syntax_Syntax.lbeff =
-                        (uu___491_3216.FStar_Syntax_Syntax.lbeff);
+                        (uu___491_3215.FStar_Syntax_Syntax.lbeff);
                       FStar_Syntax_Syntax.lbdef = lbd;
                       FStar_Syntax_Syntax.lbattrs = lbattrs;
                       FStar_Syntax_Syntax.lbpos =
-                        (uu___491_3216.FStar_Syntax_Syntax.lbpos)
+                        (uu___491_3215.FStar_Syntax_Syntax.lbpos)
                     }))
              in
           mk (FStar_Syntax_Syntax.Tm_let ((is_rec, lbs1), body1))
       | FStar_Syntax_Syntax.Tm_meta
           (t0,FStar_Syntax_Syntax.Meta_pattern (bs,ps)) ->
-          let uu____3268 =
-            let uu____3269 =
-              let uu____3276 = subst' s t0  in
-              let uu____3279 =
-                let uu____3280 =
-                  let uu____3301 = FStar_List.map (subst' s) bs  in
-                  let uu____3310 =
+          let uu____3267 =
+            let uu____3268 =
+              let uu____3275 = subst' s t0  in
+              let uu____3278 =
+                let uu____3279 =
+                  let uu____3300 = FStar_List.map (subst' s) bs  in
+                  let uu____3309 =
                     FStar_All.pipe_right ps (FStar_List.map (subst_args' s))
                      in
-                  (uu____3301, uu____3310)  in
-                FStar_Syntax_Syntax.Meta_pattern uu____3280  in
-              (uu____3276, uu____3279)  in
-            FStar_Syntax_Syntax.Tm_meta uu____3269  in
-          mk uu____3268
+                  (uu____3300, uu____3309)  in
+                FStar_Syntax_Syntax.Meta_pattern uu____3279  in
+              (uu____3275, uu____3278)  in
+            FStar_Syntax_Syntax.Tm_meta uu____3268  in
+          mk uu____3267
       | FStar_Syntax_Syntax.Tm_meta
           (t0,FStar_Syntax_Syntax.Meta_monadic (m,t1)) ->
-          let uu____3392 =
-            let uu____3393 =
-              let uu____3400 = subst' s t0  in
-              let uu____3403 =
-                let uu____3404 =
-                  let uu____3411 = subst' s t1  in (m, uu____3411)  in
-                FStar_Syntax_Syntax.Meta_monadic uu____3404  in
-              (uu____3400, uu____3403)  in
-            FStar_Syntax_Syntax.Tm_meta uu____3393  in
-          mk uu____3392
+          let uu____3391 =
+            let uu____3392 =
+              let uu____3399 = subst' s t0  in
+              let uu____3402 =
+                let uu____3403 =
+                  let uu____3410 = subst' s t1  in (m, uu____3410)  in
+                FStar_Syntax_Syntax.Meta_monadic uu____3403  in
+              (uu____3399, uu____3402)  in
+            FStar_Syntax_Syntax.Tm_meta uu____3392  in
+          mk uu____3391
       | FStar_Syntax_Syntax.Tm_meta
           (t0,FStar_Syntax_Syntax.Meta_monadic_lift (m1,m2,t1)) ->
-          let uu____3430 =
-            let uu____3431 =
-              let uu____3438 = subst' s t0  in
-              let uu____3441 =
-                let uu____3442 =
-                  let uu____3451 = subst' s t1  in (m1, m2, uu____3451)  in
-                FStar_Syntax_Syntax.Meta_monadic_lift uu____3442  in
-              (uu____3438, uu____3441)  in
-            FStar_Syntax_Syntax.Tm_meta uu____3431  in
-          mk uu____3430
+          let uu____3429 =
+            let uu____3430 =
+              let uu____3437 = subst' s t0  in
+              let uu____3440 =
+                let uu____3441 =
+                  let uu____3450 = subst' s t1  in (m1, m2, uu____3450)  in
+                FStar_Syntax_Syntax.Meta_monadic_lift uu____3441  in
+              (uu____3437, uu____3440)  in
+            FStar_Syntax_Syntax.Tm_meta uu____3430  in
+          mk uu____3429
       | FStar_Syntax_Syntax.Tm_quoted (tm,qi) ->
           (match qi.FStar_Syntax_Syntax.qkind with
            | FStar_Syntax_Syntax.Quote_dynamic  ->
-               let uu____3466 =
-                 let uu____3467 =
-                   let uu____3474 = subst' s tm  in (uu____3474, qi)  in
-                 FStar_Syntax_Syntax.Tm_quoted uu____3467  in
-               mk uu____3466
+               let uu____3465 =
+                 let uu____3466 =
+                   let uu____3473 = subst' s tm  in (uu____3473, qi)  in
+                 FStar_Syntax_Syntax.Tm_quoted uu____3466  in
+               mk uu____3465
            | FStar_Syntax_Syntax.Quote_static  ->
                let qi1 = FStar_Syntax_Syntax.on_antiquoted (subst' s) qi  in
                mk (FStar_Syntax_Syntax.Tm_quoted (tm, qi1)))
       | FStar_Syntax_Syntax.Tm_meta (t1,m) ->
-          let uu____3488 =
-            let uu____3489 = let uu____3496 = subst' s t1  in (uu____3496, m)
+          let uu____3487 =
+            let uu____3488 = let uu____3495 = subst' s t1  in (uu____3495, m)
                in
-            FStar_Syntax_Syntax.Tm_meta uu____3489  in
-          mk uu____3488
+            FStar_Syntax_Syntax.Tm_meta uu____3488  in
+          mk uu____3487
   
 let (compress_slow :
   FStar_Syntax_Syntax.term ->
@@ -1034,15 +1033,15 @@ let (compress_slow :
     let t1 = force_uvar t  in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_delayed (t',s) -> push_subst s t'
-    | uu____3536 -> t1
+    | uu____3535 -> t1
   
 let (compress : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed (uu____3543,uu____3544) ->
+    | FStar_Syntax_Syntax.Tm_delayed (uu____3542,uu____3543) ->
         compress_slow t
-    | FStar_Syntax_Syntax.Tm_uvar (uu____3565,uu____3566) -> compress_slow t
-    | uu____3583 -> t
+    | FStar_Syntax_Syntax.Tm_uvar (uu____3564,uu____3565) -> compress_slow t
+    | uu____3582 -> t
   
 let (subst :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
@@ -1053,14 +1052,14 @@ let (set_use_range :
   =
   fun r  ->
     fun t  ->
-      let uu____3618 =
-        let uu____3619 =
-          let uu____3620 =
-            let uu____3621 = FStar_Range.use_range r  in
-            FStar_Range.set_def_range r uu____3621  in
-          FStar_Syntax_Syntax.SomeUseRange uu____3620  in
-        ([], uu____3619)  in
-      subst' uu____3618 t
+      let uu____3617 =
+        let uu____3618 =
+          let uu____3619 =
+            let uu____3620 = FStar_Range.use_range r  in
+            FStar_Range.set_def_range r uu____3620  in
+          FStar_Syntax_Syntax.SomeUseRange uu____3619  in
+        ([], uu____3618)  in
+      subst' uu____3617 t
   
 let (subst_comp :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
@@ -1074,16 +1073,16 @@ let (subst_imp :
 let (closing_subst :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_elt Prims.list) =
   fun bs  ->
-    let uu____3682 =
+    let uu____3681 =
       FStar_List.fold_right
-        (fun uu____3709  ->
-           fun uu____3710  ->
-             match (uu____3709, uu____3710) with
-             | ((x,uu____3745),(subst1,n)) ->
+        (fun uu____3708  ->
+           fun uu____3709  ->
+             match (uu____3708, uu____3709) with
+             | ((x,uu____3744),(subst1,n)) ->
                  (((FStar_Syntax_Syntax.NM (x, n)) :: subst1),
                    (n + Prims.int_one))) bs ([], Prims.int_zero)
        in
-    FStar_All.pipe_right uu____3682 FStar_Pervasives_Native.fst
+    FStar_All.pipe_right uu____3681 FStar_Pervasives_Native.fst
   
 let (open_binders' :
   FStar_Syntax_Syntax.binders ->
@@ -1095,29 +1094,29 @@ let (open_binders' :
       | [] -> ([], o)
       | (x,imp)::bs' ->
           let x' =
-            let uu___569_3883 = FStar_Syntax_Syntax.freshen_bv x  in
-            let uu____3884 = subst o x.FStar_Syntax_Syntax.sort  in
+            let uu___569_3882 = FStar_Syntax_Syntax.freshen_bv x  in
+            let uu____3883 = subst o x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___569_3883.FStar_Syntax_Syntax.ppname);
+                (uu___569_3882.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___569_3883.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____3884
+                (uu___569_3882.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____3883
             }  in
           let imp1 = subst_imp o imp  in
           let o1 =
-            let uu____3891 = shift_subst Prims.int_one o  in
-            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____3891  in
-          let uu____3897 = aux bs' o1  in
-          (match uu____3897 with | (bs'1,o2) -> (((x', imp1) :: bs'1), o2))
+            let uu____3890 = shift_subst Prims.int_one o  in
+            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____3890  in
+          let uu____3896 = aux bs' o1  in
+          (match uu____3896 with | (bs'1,o2) -> (((x', imp1) :: bs'1), o2))
        in
     aux bs []
   
 let (open_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders) =
   fun bs  ->
-    let uu____3958 = open_binders' bs  in
-    FStar_Pervasives_Native.fst uu____3958
+    let uu____3957 = open_binders' bs  in
+    FStar_Pervasives_Native.fst uu____3957
   
 let (open_term' :
   FStar_Syntax_Syntax.binders ->
@@ -1127,10 +1126,10 @@ let (open_term' :
   =
   fun bs  ->
     fun t  ->
-      let uu____3980 = open_binders' bs  in
-      match uu____3980 with
+      let uu____3979 = open_binders' bs  in
+      match uu____3979 with
       | (bs',opening) ->
-          let uu____3993 = subst opening t  in (bs', uu____3993, opening)
+          let uu____3992 = subst opening t  in (bs', uu____3992, opening)
   
 let (open_term :
   FStar_Syntax_Syntax.binders ->
@@ -1139,8 +1138,8 @@ let (open_term :
   =
   fun bs  ->
     fun t  ->
-      let uu____4009 = open_term' bs t  in
-      match uu____4009 with | (b,t1,uu____4022) -> (b, t1)
+      let uu____4008 = open_term' bs t  in
+      match uu____4008 with | (b,t1,uu____4021) -> (b, t1)
   
 let (open_comp :
   FStar_Syntax_Syntax.binders ->
@@ -1149,10 +1148,10 @@ let (open_comp :
   =
   fun bs  ->
     fun t  ->
-      let uu____4038 = open_binders' bs  in
-      match uu____4038 with
+      let uu____4037 = open_binders' bs  in
+      match uu____4037 with
       | (bs',opening) ->
-          let uu____4049 = subst_comp opening t  in (bs', uu____4049)
+          let uu____4048 = subst_comp opening t  in (bs', uu____4048)
   
 let (open_pat :
   FStar_Syntax_Syntax.pat ->
@@ -1161,85 +1160,85 @@ let (open_pat :
   fun p  ->
     let rec open_pat_aux sub p1 =
       match p1.FStar_Syntax_Syntax.v with
-      | FStar_Syntax_Syntax.Pat_constant uu____4099 -> (p1, sub)
+      | FStar_Syntax_Syntax.Pat_constant uu____4098 -> (p1, sub)
       | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-          let uu____4124 =
+          let uu____4123 =
             FStar_All.pipe_right pats
               (FStar_List.fold_left
-                 (fun uu____4195  ->
-                    fun uu____4196  ->
-                      match (uu____4195, uu____4196) with
+                 (fun uu____4194  ->
+                    fun uu____4195  ->
+                      match (uu____4194, uu____4195) with
                       | ((pats1,sub1),(p2,imp)) ->
-                          let uu____4310 = open_pat_aux sub1 p2  in
-                          (match uu____4310 with
+                          let uu____4309 = open_pat_aux sub1 p2  in
+                          (match uu____4309 with
                            | (p3,sub2) -> (((p3, imp) :: pats1), sub2)))
                  ([], sub))
              in
-          (match uu____4124 with
+          (match uu____4123 with
            | (pats1,sub1) ->
-               ((let uu___616_4420 = p1  in
+               ((let uu___616_4419 = p1  in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons
                         (fv, (FStar_List.rev pats1)));
                    FStar_Syntax_Syntax.p =
-                     (uu___616_4420.FStar_Syntax_Syntax.p)
+                     (uu___616_4419.FStar_Syntax_Syntax.p)
                  }), sub1))
       | FStar_Syntax_Syntax.Pat_var x ->
           let x' =
-            let uu___620_4441 = FStar_Syntax_Syntax.freshen_bv x  in
-            let uu____4442 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___620_4440 = FStar_Syntax_Syntax.freshen_bv x  in
+            let uu____4441 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___620_4441.FStar_Syntax_Syntax.ppname);
+                (uu___620_4440.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___620_4441.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4442
+                (uu___620_4440.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____4441
             }  in
           let sub1 =
-            let uu____4448 = shift_subst Prims.int_one sub  in
-            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____4448  in
-          ((let uu___624_4459 = p1  in
+            let uu____4447 = shift_subst Prims.int_one sub  in
+            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____4447  in
+          ((let uu___624_4458 = p1  in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x');
-              FStar_Syntax_Syntax.p = (uu___624_4459.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___624_4458.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_wild x ->
           let x' =
-            let uu___628_4464 = FStar_Syntax_Syntax.freshen_bv x  in
-            let uu____4465 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___628_4463 = FStar_Syntax_Syntax.freshen_bv x  in
+            let uu____4464 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___628_4464.FStar_Syntax_Syntax.ppname);
+                (uu___628_4463.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___628_4464.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4465
+                (uu___628_4463.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____4464
             }  in
           let sub1 =
-            let uu____4471 = shift_subst Prims.int_one sub  in
-            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____4471  in
-          ((let uu___632_4482 = p1  in
+            let uu____4470 = shift_subst Prims.int_one sub  in
+            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____4470  in
+          ((let uu___632_4481 = p1  in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x');
-              FStar_Syntax_Syntax.p = (uu___632_4482.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___632_4481.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
           let x1 =
-            let uu___638_4492 = x  in
-            let uu____4493 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___638_4491 = x  in
+            let uu____4492 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___638_4492.FStar_Syntax_Syntax.ppname);
+                (uu___638_4491.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___638_4492.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4493
+                (uu___638_4491.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____4492
             }  in
           let t01 = subst sub t0  in
-          ((let uu___642_4502 = p1  in
+          ((let uu___642_4501 = p1  in
             {
               FStar_Syntax_Syntax.v =
                 (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-              FStar_Syntax_Syntax.p = (uu___642_4502.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___642_4501.FStar_Syntax_Syntax.p)
             }), sub)
        in
     open_pat_aux [] p
@@ -1248,41 +1247,41 @@ let (open_branch' :
   FStar_Syntax_Syntax.branch ->
     (FStar_Syntax_Syntax.branch * FStar_Syntax_Syntax.subst_t))
   =
-  fun uu____4516  ->
-    match uu____4516 with
+  fun uu____4515  ->
+    match uu____4515 with
     | (p,wopt,e) ->
-        let uu____4540 = open_pat p  in
-        (match uu____4540 with
+        let uu____4539 = open_pat p  in
+        (match uu____4539 with
          | (p1,opening) ->
              let wopt1 =
                match wopt with
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some w ->
-                   let uu____4569 = subst opening w  in
-                   FStar_Pervasives_Native.Some uu____4569
+                   let uu____4568 = subst opening w  in
+                   FStar_Pervasives_Native.Some uu____4568
                 in
              let e1 = subst opening e  in ((p1, wopt1, e1), opening))
   
 let (open_branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch)
   =
   fun br  ->
-    let uu____4589 = open_branch' br  in
-    match uu____4589 with | (br1,uu____4595) -> br1
+    let uu____4588 = open_branch' br  in
+    match uu____4588 with | (br1,uu____4594) -> br1
   
 let (close :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
   fun bs  ->
-    fun t  -> let uu____4607 = closing_subst bs  in subst uu____4607 t
+    fun t  -> let uu____4606 = closing_subst bs  in subst uu____4606 t
   
 let (close_comp :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
   =
   fun bs  ->
-    fun c  -> let uu____4621 = closing_subst bs  in subst_comp uu____4621 c
+    fun c  -> let uu____4620 = closing_subst bs  in subst_comp uu____4620 c
   
 let (close_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders) =
@@ -1292,20 +1291,20 @@ let (close_binders :
       | [] -> []
       | (x,imp)::tl ->
           let x1 =
-            let uu___674_4689 = x  in
-            let uu____4690 = subst s x.FStar_Syntax_Syntax.sort  in
+            let uu___674_4688 = x  in
+            let uu____4689 = subst s x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___674_4689.FStar_Syntax_Syntax.ppname);
+                (uu___674_4688.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___674_4689.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4690
+                (uu___674_4688.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____4689
             }  in
           let imp1 = subst_imp s imp  in
           let s' =
-            let uu____4697 = shift_subst Prims.int_one s  in
-            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____4697  in
-          let uu____4703 = aux s' tl  in (x1, imp1) :: uu____4703
+            let uu____4696 = shift_subst Prims.int_one s  in
+            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____4696  in
+          let uu____4702 = aux s' tl  in (x1, imp1) :: uu____4702
        in
     aux [] bs
   
@@ -1317,104 +1316,104 @@ let (close_pat :
   fun p  ->
     let rec aux sub p1 =
       match p1.FStar_Syntax_Syntax.v with
-      | FStar_Syntax_Syntax.Pat_constant uu____4767 -> (p1, sub)
+      | FStar_Syntax_Syntax.Pat_constant uu____4766 -> (p1, sub)
       | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-          let uu____4792 =
+          let uu____4791 =
             FStar_All.pipe_right pats
               (FStar_List.fold_left
-                 (fun uu____4863  ->
-                    fun uu____4864  ->
-                      match (uu____4863, uu____4864) with
+                 (fun uu____4862  ->
+                    fun uu____4863  ->
+                      match (uu____4862, uu____4863) with
                       | ((pats1,sub1),(p2,imp)) ->
-                          let uu____4978 = aux sub1 p2  in
-                          (match uu____4978 with
+                          let uu____4977 = aux sub1 p2  in
+                          (match uu____4977 with
                            | (p3,sub2) -> (((p3, imp) :: pats1), sub2)))
                  ([], sub))
              in
-          (match uu____4792 with
+          (match uu____4791 with
            | (pats1,sub1) ->
-               ((let uu___701_5088 = p1  in
+               ((let uu___701_5087 = p1  in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons
                         (fv, (FStar_List.rev pats1)));
                    FStar_Syntax_Syntax.p =
-                     (uu___701_5088.FStar_Syntax_Syntax.p)
+                     (uu___701_5087.FStar_Syntax_Syntax.p)
                  }), sub1))
       | FStar_Syntax_Syntax.Pat_var x ->
           let x1 =
-            let uu___705_5109 = x  in
-            let uu____5110 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___705_5108 = x  in
+            let uu____5109 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___705_5109.FStar_Syntax_Syntax.ppname);
+                (uu___705_5108.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___705_5109.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____5110
+                (uu___705_5108.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____5109
             }  in
           let sub1 =
-            let uu____5116 = shift_subst Prims.int_one sub  in
-            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____5116  in
-          ((let uu___709_5127 = p1  in
+            let uu____5115 = shift_subst Prims.int_one sub  in
+            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____5115  in
+          ((let uu___709_5126 = p1  in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
-              FStar_Syntax_Syntax.p = (uu___709_5127.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___709_5126.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_wild x ->
           let x1 =
-            let uu___713_5132 = x  in
-            let uu____5133 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___713_5131 = x  in
+            let uu____5132 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___713_5132.FStar_Syntax_Syntax.ppname);
+                (uu___713_5131.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___713_5132.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____5133
+                (uu___713_5131.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____5132
             }  in
           let sub1 =
-            let uu____5139 = shift_subst Prims.int_one sub  in
-            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____5139  in
-          ((let uu___717_5150 = p1  in
+            let uu____5138 = shift_subst Prims.int_one sub  in
+            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____5138  in
+          ((let uu___717_5149 = p1  in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
-              FStar_Syntax_Syntax.p = (uu___717_5150.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___717_5149.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
           let x1 =
-            let uu___723_5160 = x  in
-            let uu____5161 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___723_5159 = x  in
+            let uu____5160 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___723_5160.FStar_Syntax_Syntax.ppname);
+                (uu___723_5159.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___723_5160.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____5161
+                (uu___723_5159.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____5160
             }  in
           let t01 = subst sub t0  in
-          ((let uu___727_5170 = p1  in
+          ((let uu___727_5169 = p1  in
             {
               FStar_Syntax_Syntax.v =
                 (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-              FStar_Syntax_Syntax.p = (uu___727_5170.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___727_5169.FStar_Syntax_Syntax.p)
             }), sub)
        in
     aux [] p
   
 let (close_branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch)
   =
-  fun uu____5180  ->
-    match uu____5180 with
+  fun uu____5179  ->
+    match uu____5179 with
     | (p,wopt,e) ->
-        let uu____5200 = close_pat p  in
-        (match uu____5200 with
+        let uu____5199 = close_pat p  in
+        (match uu____5199 with
          | (p1,closing) ->
              let wopt1 =
                match wopt with
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some w ->
-                   let uu____5237 = subst closing w  in
-                   FStar_Pervasives_Native.Some uu____5237
+                   let uu____5236 = subst closing w  in
+                   FStar_Pervasives_Native.Some uu____5236
                 in
              let e1 = subst closing e  in (p1, wopt1, e1))
   
@@ -1451,8 +1450,8 @@ let (open_univ_vars :
   =
   fun us  ->
     fun t  ->
-      let uu____5325 = univ_var_opening us  in
-      match uu____5325 with | (s,us') -> let t1 = subst s t  in (us', t1)
+      let uu____5324 = univ_var_opening us  in
+      match uu____5324 with | (s,us') -> let t1 = subst s t  in (us', t1)
   
 let (open_univ_vars_comp :
   FStar_Syntax_Syntax.univ_names ->
@@ -1461,9 +1460,9 @@ let (open_univ_vars_comp :
   =
   fun us  ->
     fun c  ->
-      let uu____5368 = univ_var_opening us  in
-      match uu____5368 with
-      | (s,us') -> let uu____5391 = subst_comp s c  in (us', uu____5391)
+      let uu____5367 = univ_var_opening us  in
+      match uu____5367 with
+      | (s,us') -> let uu____5390 = subst_comp s c  in (us', uu____5390)
   
 let (close_univ_vars :
   FStar_Syntax_Syntax.univ_names ->
@@ -1490,50 +1489,50 @@ let (open_let_rec :
   =
   fun lbs  ->
     fun t  ->
-      let uu____5454 =
-        let uu____5466 = FStar_Syntax_Syntax.is_top_level lbs  in
-        if uu____5466
+      let uu____5453 =
+        let uu____5465 = FStar_Syntax_Syntax.is_top_level lbs  in
+        if uu____5465
         then (Prims.int_zero, lbs, [])
         else
           FStar_List.fold_right
             (fun lb  ->
-               fun uu____5506  ->
-                 match uu____5506 with
+               fun uu____5505  ->
+                 match uu____5505 with
                  | (i,lbs1,out) ->
                      let x =
-                       let uu____5543 =
+                       let uu____5542 =
                          FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                       FStar_Syntax_Syntax.freshen_bv uu____5543  in
+                       FStar_Syntax_Syntax.freshen_bv uu____5542  in
                      ((i + Prims.int_one),
-                       ((let uu___779_5551 = lb  in
+                       ((let uu___779_5550 = lb  in
                          {
                            FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
                            FStar_Syntax_Syntax.lbunivs =
-                             (uu___779_5551.FStar_Syntax_Syntax.lbunivs);
+                             (uu___779_5550.FStar_Syntax_Syntax.lbunivs);
                            FStar_Syntax_Syntax.lbtyp =
-                             (uu___779_5551.FStar_Syntax_Syntax.lbtyp);
+                             (uu___779_5550.FStar_Syntax_Syntax.lbtyp);
                            FStar_Syntax_Syntax.lbeff =
-                             (uu___779_5551.FStar_Syntax_Syntax.lbeff);
+                             (uu___779_5550.FStar_Syntax_Syntax.lbeff);
                            FStar_Syntax_Syntax.lbdef =
-                             (uu___779_5551.FStar_Syntax_Syntax.lbdef);
+                             (uu___779_5550.FStar_Syntax_Syntax.lbdef);
                            FStar_Syntax_Syntax.lbattrs =
-                             (uu___779_5551.FStar_Syntax_Syntax.lbattrs);
+                             (uu___779_5550.FStar_Syntax_Syntax.lbattrs);
                            FStar_Syntax_Syntax.lbpos =
-                             (uu___779_5551.FStar_Syntax_Syntax.lbpos)
+                             (uu___779_5550.FStar_Syntax_Syntax.lbpos)
                          }) :: lbs1), ((FStar_Syntax_Syntax.DB (i, x)) ::
                        out))) lbs (Prims.int_zero, [], [])
          in
-      match uu____5454 with
+      match uu____5453 with
       | (n_let_recs,lbs1,let_rec_opening) ->
           let lbs2 =
             FStar_All.pipe_right lbs1
               (FStar_List.map
                  (fun lb  ->
-                    let uu____5594 =
+                    let uu____5593 =
                       FStar_List.fold_right
                         (fun u  ->
-                           fun uu____5624  ->
-                             match uu____5624 with
+                           fun uu____5623  ->
+                             match uu____5623 with
                              | (i,us,out) ->
                                  let u1 =
                                    FStar_Syntax_Syntax.new_univ_name
@@ -1545,29 +1544,29 @@ let (open_let_rec :
                                    :: out))) lb.FStar_Syntax_Syntax.lbunivs
                         (n_let_recs, [], let_rec_opening)
                        in
-                    match uu____5594 with
-                    | (uu____5673,us,u_let_rec_opening) ->
-                        let uu___796_5686 = lb  in
-                        let uu____5687 =
+                    match uu____5593 with
+                    | (uu____5672,us,u_let_rec_opening) ->
+                        let uu___796_5685 = lb  in
+                        let uu____5686 =
                           subst u_let_rec_opening
                             lb.FStar_Syntax_Syntax.lbtyp
                            in
-                        let uu____5690 =
+                        let uu____5689 =
                           subst u_let_rec_opening
                             lb.FStar_Syntax_Syntax.lbdef
                            in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___796_5686.FStar_Syntax_Syntax.lbname);
+                            (uu___796_5685.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs = us;
-                          FStar_Syntax_Syntax.lbtyp = uu____5687;
+                          FStar_Syntax_Syntax.lbtyp = uu____5686;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___796_5686.FStar_Syntax_Syntax.lbeff);
-                          FStar_Syntax_Syntax.lbdef = uu____5690;
+                            (uu___796_5685.FStar_Syntax_Syntax.lbeff);
+                          FStar_Syntax_Syntax.lbdef = uu____5689;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___796_5686.FStar_Syntax_Syntax.lbattrs);
+                            (uu___796_5685.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___796_5686.FStar_Syntax_Syntax.lbpos)
+                            (uu___796_5685.FStar_Syntax_Syntax.lbpos)
                         }))
              in
           let t1 = subst let_rec_opening t  in (lbs2, t1)
@@ -1579,69 +1578,69 @@ let (close_let_rec :
   =
   fun lbs  ->
     fun t  ->
-      let uu____5717 =
-        let uu____5725 = FStar_Syntax_Syntax.is_top_level lbs  in
-        if uu____5725
+      let uu____5716 =
+        let uu____5724 = FStar_Syntax_Syntax.is_top_level lbs  in
+        if uu____5724
         then (Prims.int_zero, [])
         else
           FStar_List.fold_right
             (fun lb  ->
-               fun uu____5754  ->
-                 match uu____5754 with
+               fun uu____5753  ->
+                 match uu____5753 with
                  | (i,out) ->
-                     let uu____5777 =
-                       let uu____5780 =
-                         let uu____5781 =
-                           let uu____5787 =
+                     let uu____5776 =
+                       let uu____5779 =
+                         let uu____5780 =
+                           let uu____5786 =
                              FStar_Util.left lb.FStar_Syntax_Syntax.lbname
                               in
-                           (uu____5787, i)  in
-                         FStar_Syntax_Syntax.NM uu____5781  in
-                       uu____5780 :: out  in
-                     ((i + Prims.int_one), uu____5777)) lbs
+                           (uu____5786, i)  in
+                         FStar_Syntax_Syntax.NM uu____5780  in
+                       uu____5779 :: out  in
+                     ((i + Prims.int_one), uu____5776)) lbs
             (Prims.int_zero, [])
          in
-      match uu____5717 with
+      match uu____5716 with
       | (n_let_recs,let_rec_closing) ->
           let lbs1 =
             FStar_All.pipe_right lbs
               (FStar_List.map
                  (fun lb  ->
-                    let uu____5826 =
+                    let uu____5825 =
                       FStar_List.fold_right
                         (fun u  ->
-                           fun uu____5846  ->
-                             match uu____5846 with
+                           fun uu____5845  ->
+                             match uu____5845 with
                              | (i,out) ->
                                  ((i + Prims.int_one),
                                    ((FStar_Syntax_Syntax.UD (u, i)) :: out)))
                         lb.FStar_Syntax_Syntax.lbunivs
                         (n_let_recs, let_rec_closing)
                        in
-                    match uu____5826 with
-                    | (uu____5877,u_let_rec_closing) ->
-                        let uu___818_5885 = lb  in
-                        let uu____5886 =
+                    match uu____5825 with
+                    | (uu____5876,u_let_rec_closing) ->
+                        let uu___818_5884 = lb  in
+                        let uu____5885 =
                           subst u_let_rec_closing
                             lb.FStar_Syntax_Syntax.lbtyp
                            in
-                        let uu____5889 =
+                        let uu____5888 =
                           subst u_let_rec_closing
                             lb.FStar_Syntax_Syntax.lbdef
                            in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___818_5885.FStar_Syntax_Syntax.lbname);
+                            (uu___818_5884.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs =
-                            (uu___818_5885.FStar_Syntax_Syntax.lbunivs);
-                          FStar_Syntax_Syntax.lbtyp = uu____5886;
+                            (uu___818_5884.FStar_Syntax_Syntax.lbunivs);
+                          FStar_Syntax_Syntax.lbtyp = uu____5885;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___818_5885.FStar_Syntax_Syntax.lbeff);
-                          FStar_Syntax_Syntax.lbdef = uu____5889;
+                            (uu___818_5884.FStar_Syntax_Syntax.lbeff);
+                          FStar_Syntax_Syntax.lbdef = uu____5888;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___818_5885.FStar_Syntax_Syntax.lbattrs);
+                            (uu___818_5884.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___818_5885.FStar_Syntax_Syntax.lbpos)
+                            (uu___818_5884.FStar_Syntax_Syntax.lbpos)
                         }))
              in
           let t1 = subst let_rec_closing t  in (lbs1, t1)
@@ -1651,17 +1650,17 @@ let (close_tscheme :
     FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
   =
   fun binders  ->
-    fun uu____5905  ->
-      match uu____5905 with
+    fun uu____5904  ->
+      match uu____5904 with
       | (us,t) ->
           let n = (FStar_List.length binders) - Prims.int_one  in
           let k = FStar_List.length us  in
           let s =
             FStar_List.mapi
               (fun i  ->
-                 fun uu____5940  ->
-                   match uu____5940 with
-                   | (x,uu____5949) ->
+                 fun uu____5939  ->
+                   match uu____5939 with
+                   | (x,uu____5948) ->
                        FStar_Syntax_Syntax.NM (x, (k + (n - i)))) binders
              in
           let t1 = subst s t  in (us, t1)
@@ -1671,8 +1670,8 @@ let (close_univ_vars_tscheme :
     FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
   =
   fun us  ->
-    fun uu____5970  ->
-      match uu____5970 with
+    fun uu____5969  ->
+      match uu____5969 with
       | (us',t) ->
           let n = (FStar_List.length us) - Prims.int_one  in
           let k = FStar_List.length us'  in
@@ -1681,18 +1680,18 @@ let (close_univ_vars_tscheme :
               (fun i  -> fun x  -> FStar_Syntax_Syntax.UD (x, (k + (n - i))))
               us
              in
-          let uu____5994 = subst s t  in (us', uu____5994)
+          let uu____5993 = subst s t  in (us', uu____5993)
   
 let (subst_tscheme :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
     FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
   =
   fun s  ->
-    fun uu____6013  ->
-      match uu____6013 with
+    fun uu____6012  ->
+      match uu____6012 with
       | (us,t) ->
           let s1 = shift_subst (FStar_List.length us) s  in
-          let uu____6027 = subst s1 t  in (us, uu____6027)
+          let uu____6026 = subst s1 t  in (us, uu____6026)
   
 let (opening_of_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t) =
@@ -1701,9 +1700,9 @@ let (opening_of_binders :
     FStar_All.pipe_right bs
       (FStar_List.mapi
          (fun i  ->
-            fun uu____6068  ->
-              match uu____6068 with
-              | (x,uu____6077) -> FStar_Syntax_Syntax.DB ((n - i), x)))
+            fun uu____6067  ->
+              match uu____6067 with
+              | (x,uu____6076) -> FStar_Syntax_Syntax.DB ((n - i), x)))
   
 let (closing_of_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t) =
@@ -1715,10 +1714,10 @@ let (open_term_1 :
   =
   fun b  ->
     fun t  ->
-      let uu____6104 = open_term [b] t  in
-      match uu____6104 with
+      let uu____6103 = open_term [b] t  in
+      match uu____6103 with
       | (b1::[],t1) -> (b1, t1)
-      | uu____6145 -> failwith "impossible: open_term_1"
+      | uu____6144 -> failwith "impossible: open_term_1"
   
 let (open_term_bvs :
   FStar_Syntax_Syntax.bv Prims.list ->
@@ -1727,13 +1726,13 @@ let (open_term_bvs :
   =
   fun bvs  ->
     fun t  ->
-      let uu____6176 =
-        let uu____6181 = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs  in
-        open_term uu____6181 t  in
-      match uu____6176 with
+      let uu____6175 =
+        let uu____6180 = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs  in
+        open_term uu____6180 t  in
+      match uu____6175 with
       | (bs,t1) ->
-          let uu____6196 = FStar_List.map FStar_Pervasives_Native.fst bs  in
-          (uu____6196, t1)
+          let uu____6195 = FStar_List.map FStar_Pervasives_Native.fst bs  in
+          (uu____6195, t1)
   
 let (open_term_bv :
   FStar_Syntax_Syntax.bv ->
@@ -1742,8 +1741,8 @@ let (open_term_bv :
   =
   fun bv  ->
     fun t  ->
-      let uu____6224 = open_term_bvs [bv] t  in
-      match uu____6224 with
+      let uu____6223 = open_term_bvs [bv] t  in
+      match uu____6223 with
       | (bv1::[],t1) -> (bv1, t1)
-      | uu____6239 -> failwith "impossible: open_term_bv"
+      | uu____6238 -> failwith "impossible: open_term_bv"
   

--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -1714,44 +1714,49 @@ let withsort : 'a . 'a -> 'a withinfo_t =
 let (bv_eq : bv -> bv -> Prims.bool) =
   fun bv1  ->
     fun bv2  ->
-      ((bv1.ppname).FStar_Ident.idText = (bv2.ppname).FStar_Ident.idText) &&
+      (FStar_Ident.ident_equals bv1.ppname bv2.ppname) &&
         (bv1.index = bv2.index)
   
 let (order_bv : bv -> bv -> Prims.int) =
   fun x  ->
     fun y  ->
       let i =
-        FStar_String.compare (x.ppname).FStar_Ident.idText
-          (y.ppname).FStar_Ident.idText
-         in
+        let uu____8191 = FStar_Ident.text_of_id x.ppname  in
+        let uu____8193 = FStar_Ident.text_of_id y.ppname  in
+        FStar_String.compare uu____8191 uu____8193  in
       if i = Prims.int_zero then x.index - y.index else i
   
 let (order_ident : FStar_Ident.ident -> FStar_Ident.ident -> Prims.int) =
   fun x  ->
-    fun y  -> FStar_String.compare x.FStar_Ident.idText y.FStar_Ident.idText
+    fun y  ->
+      let uu____8213 = FStar_Ident.text_of_id x  in
+      let uu____8215 = FStar_Ident.text_of_id y  in
+      FStar_String.compare uu____8213 uu____8215
   
 let (order_fv : FStar_Ident.lident -> FStar_Ident.lident -> Prims.int) =
   fun x  ->
-    fun y  -> FStar_String.compare x.FStar_Ident.str y.FStar_Ident.str
+    fun y  ->
+      let uu____8229 = FStar_Ident.string_of_lid x  in
+      let uu____8231 = FStar_Ident.string_of_lid y  in
+      FStar_String.compare uu____8229 uu____8231
   
 let (range_of_lbname : lbname -> FStar_Range.range) =
   fun l  ->
     match l with
-    | FStar_Util.Inl x -> (x.ppname).FStar_Ident.idRange
+    | FStar_Util.Inl x -> FStar_Ident.range_of_id x.ppname
     | FStar_Util.Inr fv1 -> FStar_Ident.range_of_lid (fv1.fv_name).v
   
 let (range_of_bv : bv -> FStar_Range.range) =
-  fun x  -> (x.ppname).FStar_Ident.idRange 
+  fun x  -> FStar_Ident.range_of_id x.ppname 
 let (set_range_of_bv : bv -> FStar_Range.range -> bv) =
   fun x  ->
     fun r  ->
-      let uu___414_8247 = x  in
-      let uu____8248 =
-        FStar_Ident.mk_ident (((x.ppname).FStar_Ident.idText), r)  in
+      let uu___414_8258 = x  in
+      let uu____8259 = FStar_Ident.set_id_range r x.ppname  in
       {
-        ppname = uu____8248;
-        index = (uu___414_8247.index);
-        sort = (uu___414_8247.sort)
+        ppname = uu____8259;
+        index = (uu___414_8258.index);
+        sort = (uu___414_8258.sort)
       }
   
 let (on_antiquoted : (term -> term) -> quoteinfo -> quoteinfo) =
@@ -1759,66 +1764,66 @@ let (on_antiquoted : (term -> term) -> quoteinfo -> quoteinfo) =
     fun qi  ->
       let aq =
         FStar_List.map
-          (fun uu____8285  ->
-             match uu____8285 with
-             | (bv1,t) -> let uu____8296 = f t  in (bv1, uu____8296))
+          (fun uu____8295  ->
+             match uu____8295 with
+             | (bv1,t) -> let uu____8306 = f t  in (bv1, uu____8306))
           qi.antiquotes
          in
-      let uu___422_8297 = qi  in
-      { qkind = (uu___422_8297.qkind); antiquotes = aq }
+      let uu___422_8307 = qi  in
+      { qkind = (uu___422_8307.qkind); antiquotes = aq }
   
 let (lookup_aq : bv -> antiquotations -> term FStar_Pervasives_Native.option)
   =
   fun bv1  ->
     fun aq  ->
-      let uu____8313 =
+      let uu____8323 =
         FStar_List.tryFind
-          (fun uu____8331  ->
-             match uu____8331 with | (bv',uu____8340) -> bv_eq bv1 bv') aq
+          (fun uu____8341  ->
+             match uu____8341 with | (bv',uu____8350) -> bv_eq bv1 bv') aq
          in
-      match uu____8313 with
-      | FStar_Pervasives_Native.Some (uu____8347,e) ->
+      match uu____8323 with
+      | FStar_Pervasives_Native.Some (uu____8357,e) ->
           FStar_Pervasives_Native.Some e
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
   
 let syn :
-  'uuuuuu8378 'uuuuuu8379 'uuuuuu8380 .
-    'uuuuuu8378 ->
-      'uuuuuu8379 ->
-        ('uuuuuu8379 -> 'uuuuuu8378 -> 'uuuuuu8380) -> 'uuuuuu8380
+  'uuuuuu8388 'uuuuuu8389 'uuuuuu8390 .
+    'uuuuuu8388 ->
+      'uuuuuu8389 ->
+        ('uuuuuu8389 -> 'uuuuuu8388 -> 'uuuuuu8390) -> 'uuuuuu8390
   = fun p  -> fun k  -> fun f  -> f k p 
 let mk_fvs :
-  'uuuuuu8411 .
-    unit -> 'uuuuuu8411 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____8420  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
+  'uuuuuu8421 .
+    unit -> 'uuuuuu8421 FStar_Pervasives_Native.option FStar_ST.ref
+  = fun uu____8430  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
 let mk_uvs :
-  'uuuuuu8428 .
-    unit -> 'uuuuuu8428 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____8437  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
+  'uuuuuu8438 .
+    unit -> 'uuuuuu8438 FStar_Pervasives_Native.option FStar_ST.ref
+  = fun uu____8447  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
 let (new_bv_set : unit -> bv FStar_Util.set) =
-  fun uu____8447  -> FStar_Util.new_set order_bv 
+  fun uu____8457  -> FStar_Util.new_set order_bv 
 let (new_id_set : unit -> FStar_Ident.ident FStar_Util.set) =
-  fun uu____8457  -> FStar_Util.new_set order_ident 
+  fun uu____8467  -> FStar_Util.new_set order_ident 
 let (new_fv_set : unit -> FStar_Ident.lident FStar_Util.set) =
-  fun uu____8467  -> FStar_Util.new_set order_fv 
+  fun uu____8477  -> FStar_Util.new_set order_fv 
 let (order_univ_name : univ_name -> univ_name -> Prims.int) =
   fun x  ->
     fun y  ->
-      let uu____8482 = FStar_Ident.text_of_id x  in
-      let uu____8484 = FStar_Ident.text_of_id y  in
-      FStar_String.compare uu____8482 uu____8484
+      let uu____8492 = FStar_Ident.text_of_id x  in
+      let uu____8494 = FStar_Ident.text_of_id y  in
+      FStar_String.compare uu____8492 uu____8494
   
 let (new_universe_names_set : unit -> univ_name FStar_Util.set) =
-  fun uu____8493  -> FStar_Util.new_set order_univ_name 
+  fun uu____8503  -> FStar_Util.new_set order_univ_name 
 let (eq_binding : binding -> binding -> Prims.bool) =
   fun b1  ->
     fun b2  ->
       match (b1, b2) with
       | (Binding_var bv1,Binding_var bv2) -> bv_eq bv1 bv2
-      | (Binding_lid (lid1,uu____8512),Binding_lid (lid2,uu____8514)) ->
+      | (Binding_lid (lid1,uu____8522),Binding_lid (lid2,uu____8524)) ->
           FStar_Ident.lid_equals lid1 lid2
       | (Binding_univ u1,Binding_univ u2) -> FStar_Ident.ident_equals u1 u2
-      | uu____8549 -> false
+      | uu____8559 -> false
   
 let (no_names : freenames) = new_bv_set () 
 let (no_fvars : FStar_Ident.lident FStar_Util.set) = new_fv_set () 
@@ -1830,27 +1835,27 @@ let (list_of_freenames : freenames -> bv Prims.list) =
   fun fvs  -> FStar_Util.set_elements fvs 
 let mk : 'a . 'a -> 'a mk_t_a =
   fun t  ->
-    fun uu____8603  ->
+    fun uu____8613  ->
       fun r  ->
-        let uu____8607 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-        { n = t; pos = r; vars = uu____8607 }
+        let uu____8617 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+        { n = t; pos = r; vars = uu____8617 }
   
 let (bv_to_tm : bv -> term) =
   fun bv1  ->
-    let uu____8618 = range_of_bv bv1  in
-    mk (Tm_bvar bv1) FStar_Pervasives_Native.None uu____8618
+    let uu____8628 = range_of_bv bv1  in
+    mk (Tm_bvar bv1) FStar_Pervasives_Native.None uu____8628
   
 let (bv_to_name : bv -> term) =
   fun bv1  ->
-    let uu____8625 = range_of_bv bv1  in
-    mk (Tm_name bv1) FStar_Pervasives_Native.None uu____8625
+    let uu____8635 = range_of_bv bv1  in
+    mk (Tm_name bv1) FStar_Pervasives_Native.None uu____8635
   
 let (binders_to_names : binders -> term Prims.list) =
   fun bs  ->
     FStar_All.pipe_right bs
       (FStar_List.map
-         (fun uu____8655  ->
-            match uu____8655 with | (x,uu____8663) -> bv_to_name x))
+         (fun uu____8665  ->
+            match uu____8665 with | (x,uu____8673) -> bv_to_name x))
   
 let (mk_Tm_app : term -> args -> mk_t) =
   fun t1  ->
@@ -1859,19 +1864,19 @@ let (mk_Tm_app : term -> args -> mk_t) =
         fun p  ->
           match args1 with
           | [] -> t1
-          | uu____8693 ->
+          | uu____8703 ->
               mk (Tm_app (t1, args1)) FStar_Pervasives_Native.None p
   
 let (mk_Tm_uinst : term -> universes -> term) =
   fun t  ->
-    fun uu___1_8718  ->
-      match uu___1_8718 with
+    fun uu___1_8728  ->
+      match uu___1_8728 with
       | [] -> t
       | us ->
           (match t.n with
-           | Tm_fvar uu____8720 ->
+           | Tm_fvar uu____8730 ->
                mk (Tm_uinst (t, us)) FStar_Pervasives_Native.None t.pos
-           | uu____8723 -> failwith "Unexpected universe instantiation")
+           | uu____8733 -> failwith "Unexpected universe instantiation")
   
 let (extend_app_n : term -> args -> mk_t) =
   fun t  ->
@@ -1881,7 +1886,7 @@ let (extend_app_n : term -> args -> mk_t) =
           match t.n with
           | Tm_app (head,args1) ->
               mk_Tm_app head (FStar_List.append args1 args') kopt r
-          | uu____8782 -> mk_Tm_app t args' kopt r
+          | uu____8792 -> mk_Tm_app t args' kopt r
   
 let (extend_app : term -> arg -> mk_t) =
   fun t  -> fun arg1  -> fun kopt  -> fun r  -> extend_app_n t [arg1] kopt r 
@@ -1901,8 +1906,8 @@ let (mk_lb :
   (lbname * univ_name Prims.list * FStar_Ident.lident * typ * term *
     attribute Prims.list * FStar_Range.range) -> letbinding)
   =
-  fun uu____8918  ->
-    match uu____8918 with
+  fun uu____8928  ->
+    match uu____8928 with
     | (x,univs,eff,t,e,attrs,pos) ->
         {
           lbname = x;
@@ -1953,10 +1958,10 @@ let (is_teff : term -> Prims.bool) =
   fun t  ->
     match t.n with
     | Tm_constant (FStar_Const.Const_effect ) -> true
-    | uu____9017 -> false
+    | uu____9027 -> false
   
 let (is_type : term -> Prims.bool) =
-  fun t  -> match t.n with | Tm_type uu____9027 -> true | uu____9029 -> false 
+  fun t  -> match t.n with | Tm_type uu____9037 -> true | uu____9039 -> false 
 let (null_id : FStar_Ident.ident) =
   FStar_Ident.mk_ident ("_", FStar_Range.dummyRange) 
 let (null_bv : term -> bv) =
@@ -1964,30 +1969,34 @@ let (null_bv : term -> bv) =
 let (mk_binder : bv -> binder) = fun a  -> (a, FStar_Pervasives_Native.None) 
 let (null_binder : term -> binder) =
   fun t  ->
-    let uu____9055 = null_bv t  in (uu____9055, FStar_Pervasives_Native.None)
+    let uu____9065 = null_bv t  in (uu____9065, FStar_Pervasives_Native.None)
   
 let (imp_tag : arg_qualifier) = Implicit false 
 let (iarg : term -> arg) =
   fun t  -> (t, (FStar_Pervasives_Native.Some imp_tag)) 
 let (as_arg : term -> arg) = fun t  -> (t, FStar_Pervasives_Native.None) 
 let (is_null_bv : bv -> Prims.bool) =
-  fun b  -> (b.ppname).FStar_Ident.idText = null_id.FStar_Ident.idText 
+  fun b  ->
+    let uu____9097 = FStar_Ident.text_of_id b.ppname  in
+    let uu____9099 = FStar_Ident.text_of_id null_id  in
+    uu____9097 = uu____9099
+  
 let (is_null_binder : binder -> Prims.bool) =
   fun b  -> is_null_bv (FStar_Pervasives_Native.fst b) 
 let (is_top_level : letbinding Prims.list -> Prims.bool) =
-  fun uu___2_9105  ->
-    match uu___2_9105 with
-    | { lbname = FStar_Util.Inr uu____9109; lbunivs = uu____9110;
-        lbtyp = uu____9111; lbeff = uu____9112; lbdef = uu____9113;
-        lbattrs = uu____9114; lbpos = uu____9115;_}::uu____9116 -> true
-    | uu____9130 -> false
+  fun uu___2_9119  ->
+    match uu___2_9119 with
+    | { lbname = FStar_Util.Inr uu____9123; lbunivs = uu____9124;
+        lbtyp = uu____9125; lbeff = uu____9126; lbdef = uu____9127;
+        lbattrs = uu____9128; lbpos = uu____9129;_}::uu____9130 -> true
+    | uu____9144 -> false
   
 let (freenames_of_binders : binders -> freenames) =
   fun bs  ->
     FStar_List.fold_right
-      (fun uu____9152  ->
+      (fun uu____9166  ->
          fun out  ->
-           match uu____9152 with | (x,uu____9165) -> FStar_Util.set_add x out)
+           match uu____9166 with | (x,uu____9179) -> FStar_Util.set_add x out)
       bs no_names
   
 let (binders_of_list : bv Prims.list -> binders) =
@@ -1997,18 +2006,18 @@ let (binders_of_list : bv Prims.list -> binders) =
   
 let (binders_of_freenames : freenames -> binders) =
   fun fvs  ->
-    let uu____9198 = FStar_Util.set_elements fvs  in
-    FStar_All.pipe_right uu____9198 binders_of_list
+    let uu____9212 = FStar_Util.set_elements fvs  in
+    FStar_All.pipe_right uu____9212 binders_of_list
   
 let (is_implicit : aqual -> Prims.bool) =
-  fun uu___3_9209  ->
-    match uu___3_9209 with
-    | FStar_Pervasives_Native.Some (Implicit uu____9211) -> true
-    | uu____9214 -> false
+  fun uu___3_9223  ->
+    match uu___3_9223 with
+    | FStar_Pervasives_Native.Some (Implicit uu____9225) -> true
+    | uu____9228 -> false
   
 let (as_implicit : Prims.bool -> aqual) =
-  fun uu___4_9222  ->
-    if uu___4_9222
+  fun uu___4_9236  ->
+    if uu___4_9236
     then FStar_Pervasives_Native.Some imp_tag
     else FStar_Pervasives_Native.None
   
@@ -2016,23 +2025,23 @@ let (pat_bvs : pat -> bv Prims.list) =
   fun p  ->
     let rec aux b p1 =
       match p1.v with
-      | Pat_dot_term uu____9260 -> b
-      | Pat_constant uu____9267 -> b
+      | Pat_dot_term uu____9274 -> b
+      | Pat_constant uu____9281 -> b
       | Pat_wild x -> x :: b
       | Pat_var x -> x :: b
-      | Pat_cons (uu____9270,pats) ->
+      | Pat_cons (uu____9284,pats) ->
           FStar_List.fold_left
             (fun b1  ->
-               fun uu____9304  ->
-                 match uu____9304 with | (p2,uu____9317) -> aux b1 p2) b pats
+               fun uu____9318  ->
+                 match uu____9318 with | (p2,uu____9331) -> aux b1 p2) b pats
        in
-    let uu____9324 = aux [] p  in
-    FStar_All.pipe_left FStar_List.rev uu____9324
+    let uu____9338 = aux [] p  in
+    FStar_All.pipe_left FStar_List.rev uu____9338
   
 let (range_of_ropt :
   FStar_Range.range FStar_Pervasives_Native.option -> FStar_Range.range) =
-  fun uu___5_9338  ->
-    match uu___5_9338 with
+  fun uu___5_9352  ->
+    match uu___5_9352 with
     | FStar_Pervasives_Native.None  -> FStar_Range.dummyRange
     | FStar_Pervasives_Native.Some r -> r
   
@@ -2044,45 +2053,45 @@ let (gen_bv :
     fun r  ->
       fun t  ->
         let id = FStar_Ident.mk_ident (s, (range_of_ropt r))  in
-        let uu____9378 = FStar_Ident.next_id ()  in
-        { ppname = id; index = uu____9378; sort = t }
+        let uu____9392 = FStar_Ident.next_id ()  in
+        { ppname = id; index = uu____9392; sort = t }
   
 let (new_bv : FStar_Range.range FStar_Pervasives_Native.option -> typ -> bv)
   = fun ropt  -> fun t  -> gen_bv FStar_Ident.reserved_prefix ropt t 
 let (freshen_bv : bv -> bv) =
   fun bv1  ->
-    let uu____9401 = is_null_bv bv1  in
-    if uu____9401
+    let uu____9415 = is_null_bv bv1  in
+    if uu____9415
     then
-      let uu____9404 =
-        let uu____9407 = range_of_bv bv1  in
-        FStar_Pervasives_Native.Some uu____9407  in
-      new_bv uu____9404 bv1.sort
+      let uu____9418 =
+        let uu____9421 = range_of_bv bv1  in
+        FStar_Pervasives_Native.Some uu____9421  in
+      new_bv uu____9418 bv1.sort
     else
-      (let uu___604_9410 = bv1  in
-       let uu____9411 = FStar_Ident.next_id ()  in
+      (let uu___604_9424 = bv1  in
+       let uu____9425 = FStar_Ident.next_id ()  in
        {
-         ppname = (uu___604_9410.ppname);
-         index = uu____9411;
-         sort = (uu___604_9410.sort)
+         ppname = (uu___604_9424.ppname);
+         index = uu____9425;
+         sort = (uu___604_9424.sort)
        })
   
 let (freshen_binder : binder -> binder) =
   fun b  ->
-    let uu____9419 = b  in
-    match uu____9419 with
-    | (bv1,aq) -> let uu____9426 = freshen_bv bv1  in (uu____9426, aq)
+    let uu____9433 = b  in
+    match uu____9433 with
+    | (bv1,aq) -> let uu____9440 = freshen_bv bv1  in (uu____9440, aq)
   
 let (new_univ_name :
   FStar_Range.range FStar_Pervasives_Native.option -> univ_name) =
   fun ropt  ->
     let id = FStar_Ident.next_id ()  in
-    let uu____9441 =
-      let uu____9447 =
-        let uu____9449 = FStar_Util.string_of_int id  in
-        Prims.op_Hat FStar_Ident.reserved_prefix uu____9449  in
-      (uu____9447, (range_of_ropt ropt))  in
-    FStar_Ident.mk_ident uu____9441
+    let uu____9455 =
+      let uu____9461 =
+        let uu____9463 = FStar_Util.string_of_int id  in
+        Prims.op_Hat FStar_Ident.reserved_prefix uu____9463  in
+      (uu____9461, (range_of_ropt ropt))  in
+    FStar_Ident.mk_ident uu____9455
   
 let (lbname_eq :
   (bv,FStar_Ident.lident) FStar_Util.either ->
@@ -2093,7 +2102,7 @@ let (lbname_eq :
       match (l1, l2) with
       | (FStar_Util.Inl x,FStar_Util.Inl y) -> bv_eq x y
       | (FStar_Util.Inr l,FStar_Util.Inr m) -> FStar_Ident.lid_equals l m
-      | uu____9509 -> false
+      | uu____9523 -> false
   
 let (fv_eq : fv -> fv -> Prims.bool) =
   fun fv1  ->
@@ -2104,13 +2113,12 @@ let (fv_eq_lid : fv -> FStar_Ident.lident -> Prims.bool) =
 let (set_bv_range : bv -> FStar_Range.range -> bv) =
   fun bv1  ->
     fun r  ->
-      let uu___631_9558 = bv1  in
-      let uu____9559 =
-        FStar_Ident.mk_ident (((bv1.ppname).FStar_Ident.idText), r)  in
+      let uu___631_9572 = bv1  in
+      let uu____9573 = FStar_Ident.set_id_range r bv1.ppname  in
       {
-        ppname = uu____9559;
-        index = (uu___631_9558.index);
-        sort = (uu___631_9558.sort)
+        ppname = uu____9573;
+        index = (uu___631_9572.index);
+        sort = (uu___631_9572.sort)
       }
   
 let (lid_as_fv :
@@ -2120,15 +2128,15 @@ let (lid_as_fv :
   fun l  ->
     fun dd  ->
       fun dq  ->
-        let uu____9581 =
-          let uu____9582 = FStar_Ident.range_of_lid l  in
-          withinfo l uu____9582  in
-        { fv_name = uu____9581; fv_delta = dd; fv_qual = dq }
+        let uu____9594 =
+          let uu____9595 = FStar_Ident.range_of_lid l  in
+          withinfo l uu____9595  in
+        { fv_name = uu____9594; fv_delta = dd; fv_qual = dq }
   
 let (fv_to_tm : fv -> term) =
   fun fv1  ->
-    let uu____9589 = FStar_Ident.range_of_lid (fv1.fv_name).v  in
-    mk (Tm_fvar fv1) FStar_Pervasives_Native.None uu____9589
+    let uu____9602 = FStar_Ident.range_of_lid (fv1.fv_name).v  in
+    mk (Tm_fvar fv1) FStar_Pervasives_Native.None uu____9602
   
 let (fvar :
   FStar_Ident.lident ->
@@ -2136,38 +2144,38 @@ let (fvar :
   =
   fun l  ->
     fun dd  ->
-      fun dq  -> let uu____9610 = lid_as_fv l dd dq  in fv_to_tm uu____9610
+      fun dq  -> let uu____9623 = lid_as_fv l dd dq  in fv_to_tm uu____9623
   
 let (lid_of_fv : fv -> FStar_Ident.lid) = fun fv1  -> (fv1.fv_name).v 
 let (range_of_fv : fv -> FStar_Range.range) =
   fun fv1  ->
-    let uu____9623 = lid_of_fv fv1  in FStar_Ident.range_of_lid uu____9623
+    let uu____9636 = lid_of_fv fv1  in FStar_Ident.range_of_lid uu____9636
   
 let (set_range_of_fv : fv -> FStar_Range.range -> fv) =
   fun fv1  ->
     fun r  ->
-      let uu___644_9635 = fv1  in
-      let uu____9636 =
-        let uu___646_9637 = fv1.fv_name  in
-        let uu____9638 =
-          let uu____9639 = lid_of_fv fv1  in
-          FStar_Ident.set_lid_range uu____9639 r  in
-        { v = uu____9638; p = (uu___646_9637.p) }  in
+      let uu___644_9648 = fv1  in
+      let uu____9649 =
+        let uu___646_9650 = fv1.fv_name  in
+        let uu____9651 =
+          let uu____9652 = lid_of_fv fv1  in
+          FStar_Ident.set_lid_range uu____9652 r  in
+        { v = uu____9651; p = (uu___646_9650.p) }  in
       {
-        fv_name = uu____9636;
-        fv_delta = (uu___644_9635.fv_delta);
-        fv_qual = (uu___644_9635.fv_qual)
+        fv_name = uu____9649;
+        fv_delta = (uu___644_9648.fv_delta);
+        fv_qual = (uu___644_9648.fv_qual)
       }
   
 let (has_simple_attribute : term Prims.list -> Prims.string -> Prims.bool) =
   fun l  ->
     fun s  ->
       FStar_List.existsb
-        (fun uu___6_9665  ->
-           match uu___6_9665 with
-           | { n = Tm_constant (FStar_Const.Const_string (data,uu____9670));
-               pos = uu____9671; vars = uu____9672;_} when data = s -> true
-           | uu____9679 -> false) l
+        (fun uu___6_9678  ->
+           match uu___6_9678 with
+           | { n = Tm_constant (FStar_Const.Const_string (data,uu____9683));
+               pos = uu____9684; vars = uu____9685;_} when data = s -> true
+           | uu____9692 -> false) l
   
 let rec (eq_pat : pat -> pat -> Prims.bool) =
   fun p1  ->
@@ -2175,20 +2183,20 @@ let rec (eq_pat : pat -> pat -> Prims.bool) =
       match ((p1.v), (p2.v)) with
       | (Pat_constant c1,Pat_constant c2) -> FStar_Const.eq_const c1 c2
       | (Pat_cons (fv1,as1),Pat_cons (fv2,as2)) ->
-          let uu____9738 = fv_eq fv1 fv2  in
-          if uu____9738
+          let uu____9751 = fv_eq fv1 fv2  in
+          if uu____9751
           then
-            let uu____9743 = FStar_List.zip as1 as2  in
-            FStar_All.pipe_right uu____9743
+            let uu____9756 = FStar_List.zip as1 as2  in
+            FStar_All.pipe_right uu____9756
               (FStar_List.for_all
-                 (fun uu____9810  ->
-                    match uu____9810 with
+                 (fun uu____9823  ->
+                    match uu____9823 with
                     | ((p11,b1),(p21,b2)) -> (b1 = b2) && (eq_pat p11 p21)))
           else false
-      | (Pat_var uu____9848,Pat_var uu____9849) -> true
-      | (Pat_wild uu____9851,Pat_wild uu____9852) -> true
+      | (Pat_var uu____9861,Pat_var uu____9862) -> true
+      | (Pat_wild uu____9864,Pat_wild uu____9865) -> true
       | (Pat_dot_term (bv1,t1),Pat_dot_term (bv2,t2)) -> true
-      | (uu____9867,uu____9868) -> false
+      | (uu____9880,uu____9881) -> false
   
 let (delta_constant : delta_depth) = Delta_constant_at_level Prims.int_zero 
 let (delta_equational : delta_depth) =
@@ -2197,28 +2205,28 @@ let (fvconst : FStar_Ident.lident -> fv) =
   fun l  -> lid_as_fv l delta_constant FStar_Pervasives_Native.None 
 let (tconst : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9886 =
-      let uu____9893 = let uu____9894 = fvconst l  in Tm_fvar uu____9894  in
-      mk uu____9893  in
-    uu____9886 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____9899 =
+      let uu____9906 = let uu____9907 = fvconst l  in Tm_fvar uu____9907  in
+      mk uu____9906  in
+    uu____9899 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (tabbrev : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9901 =
-      let uu____9908 =
-        let uu____9909 =
+    let uu____9914 =
+      let uu____9921 =
+        let uu____9922 =
           lid_as_fv l (Delta_constant_at_level Prims.int_one)
             FStar_Pervasives_Native.None
            in
-        Tm_fvar uu____9909  in
-      mk uu____9908  in
-    uu____9901 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        Tm_fvar uu____9922  in
+      mk uu____9921  in
+    uu____9914 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (tdataconstr : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9917 =
+    let uu____9930 =
       lid_as_fv l delta_constant (FStar_Pervasives_Native.Some Data_ctor)  in
-    fv_to_tm uu____9917
+    fv_to_tm uu____9930
   
 let (t_unit : term) = tconst FStar_Parser_Const.unit_lid 
 let (t_bool : term) = tconst FStar_Parser_Const.bool_lid 
@@ -2241,75 +2249,75 @@ let (t_norm_step : term) = tconst FStar_Parser_Const.norm_step_lid
 let (t_tac_of : term -> term -> term) =
   fun a  ->
     fun b  ->
-      let uu____9947 =
-        let uu____9952 =
-          let uu____9953 = tabbrev FStar_Parser_Const.tac_lid  in
-          mk_Tm_uinst uu____9953 [U_zero; U_zero]  in
-        let uu____9954 =
-          let uu____9955 = as_arg a  in
-          let uu____9964 = let uu____9975 = as_arg b  in [uu____9975]  in
-          uu____9955 :: uu____9964  in
-        mk_Tm_app uu____9952 uu____9954  in
-      uu____9947 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____9960 =
+        let uu____9965 =
+          let uu____9966 = tabbrev FStar_Parser_Const.tac_lid  in
+          mk_Tm_uinst uu____9966 [U_zero; U_zero]  in
+        let uu____9967 =
+          let uu____9968 = as_arg a  in
+          let uu____9977 = let uu____9988 = as_arg b  in [uu____9988]  in
+          uu____9968 :: uu____9977  in
+        mk_Tm_app uu____9965 uu____9967  in
+      uu____9960 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_tactic_of : term -> term) =
   fun t  ->
-    let uu____10014 =
-      let uu____10019 =
-        let uu____10020 = tabbrev FStar_Parser_Const.tactic_lid  in
-        mk_Tm_uinst uu____10020 [U_zero]  in
-      let uu____10021 = let uu____10022 = as_arg t  in [uu____10022]  in
-      mk_Tm_app uu____10019 uu____10021  in
-    uu____10014 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____10027 =
+      let uu____10032 =
+        let uu____10033 = tabbrev FStar_Parser_Const.tactic_lid  in
+        mk_Tm_uinst uu____10033 [U_zero]  in
+      let uu____10034 = let uu____10035 = as_arg t  in [uu____10035]  in
+      mk_Tm_app uu____10032 uu____10034  in
+    uu____10027 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_tactic_unit : term) = t_tactic_of t_unit 
 let (t_list_of : term -> term) =
   fun t  ->
-    let uu____10054 =
-      let uu____10059 =
-        let uu____10060 = tabbrev FStar_Parser_Const.list_lid  in
-        mk_Tm_uinst uu____10060 [U_zero]  in
-      let uu____10061 = let uu____10062 = as_arg t  in [uu____10062]  in
-      mk_Tm_app uu____10059 uu____10061  in
-    uu____10054 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____10067 =
+      let uu____10072 =
+        let uu____10073 = tabbrev FStar_Parser_Const.list_lid  in
+        mk_Tm_uinst uu____10073 [U_zero]  in
+      let uu____10074 = let uu____10075 = as_arg t  in [uu____10075]  in
+      mk_Tm_app uu____10072 uu____10074  in
+    uu____10067 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_option_of : term -> term) =
   fun t  ->
-    let uu____10093 =
-      let uu____10098 =
-        let uu____10099 = tabbrev FStar_Parser_Const.option_lid  in
-        mk_Tm_uinst uu____10099 [U_zero]  in
-      let uu____10100 = let uu____10101 = as_arg t  in [uu____10101]  in
-      mk_Tm_app uu____10098 uu____10100  in
-    uu____10093 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____10106 =
+      let uu____10111 =
+        let uu____10112 = tabbrev FStar_Parser_Const.option_lid  in
+        mk_Tm_uinst uu____10112 [U_zero]  in
+      let uu____10113 = let uu____10114 = as_arg t  in [uu____10114]  in
+      mk_Tm_app uu____10111 uu____10113  in
+    uu____10106 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_tuple2_of : term -> term -> term) =
   fun t1  ->
     fun t2  ->
-      let uu____10137 =
-        let uu____10142 =
-          let uu____10143 = tabbrev FStar_Parser_Const.lid_tuple2  in
-          mk_Tm_uinst uu____10143 [U_zero; U_zero]  in
-        let uu____10144 =
-          let uu____10145 = as_arg t1  in
-          let uu____10154 = let uu____10165 = as_arg t2  in [uu____10165]  in
-          uu____10145 :: uu____10154  in
-        mk_Tm_app uu____10142 uu____10144  in
-      uu____10137 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____10150 =
+        let uu____10155 =
+          let uu____10156 = tabbrev FStar_Parser_Const.lid_tuple2  in
+          mk_Tm_uinst uu____10156 [U_zero; U_zero]  in
+        let uu____10157 =
+          let uu____10158 = as_arg t1  in
+          let uu____10167 = let uu____10178 = as_arg t2  in [uu____10178]  in
+          uu____10158 :: uu____10167  in
+        mk_Tm_app uu____10155 uu____10157  in
+      uu____10150 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_either_of : term -> term -> term) =
   fun t1  ->
     fun t2  ->
-      let uu____10209 =
-        let uu____10214 =
-          let uu____10215 = tabbrev FStar_Parser_Const.either_lid  in
-          mk_Tm_uinst uu____10215 [U_zero; U_zero]  in
-        let uu____10216 =
-          let uu____10217 = as_arg t1  in
-          let uu____10226 = let uu____10237 = as_arg t2  in [uu____10237]  in
-          uu____10217 :: uu____10226  in
-        mk_Tm_app uu____10214 uu____10216  in
-      uu____10209 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____10222 =
+        let uu____10227 =
+          let uu____10228 = tabbrev FStar_Parser_Const.either_lid  in
+          mk_Tm_uinst uu____10228 [U_zero; U_zero]  in
+        let uu____10229 =
+          let uu____10230 = as_arg t1  in
+          let uu____10239 = let uu____10250 = as_arg t2  in [uu____10250]  in
+          uu____10230 :: uu____10239  in
+        mk_Tm_app uu____10227 uu____10229  in
+      uu____10222 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (unit_const : term) =
   mk (Tm_constant FStar_Const.Const_unit) FStar_Pervasives_Native.None

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -10,48 +10,45 @@ let (tts : FStar_Syntax_Syntax.term -> Prims.string) =
     | FStar_Pervasives_Native.None  -> "<<hook unset>>"
     | FStar_Pervasives_Native.Some f -> f t
   
-let (qual_id : FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident)
-  =
-  fun lid  ->
-    fun id  ->
-      let uu____90 =
-        FStar_Ident.lid_of_ids
-          (FStar_List.append lid.FStar_Ident.ns [lid.FStar_Ident.ident; id])
-         in
-      FStar_Ident.set_lid_range uu____90 id.FStar_Ident.idRange
-  
 let (mk_discriminator : FStar_Ident.lident -> FStar_Ident.lident) =
   fun lid  ->
-    let uu____97 =
-      let uu____100 =
-        let uu____103 =
-          FStar_Ident.mk_ident
-            ((Prims.op_Hat FStar_Ident.reserved_prefix
-                (Prims.op_Hat "is_"
-                   (lid.FStar_Ident.ident).FStar_Ident.idText)),
-              ((lid.FStar_Ident.ident).FStar_Ident.idRange))
-           in
-        [uu____103]  in
-      FStar_List.append lid.FStar_Ident.ns uu____100  in
-    FStar_Ident.lid_of_ids uu____97
+    let uu____85 =
+      let uu____86 = FStar_Ident.ns_of_lid lid  in
+      let uu____89 =
+        let uu____92 =
+          let uu____93 =
+            let uu____99 =
+              let uu____101 =
+                let uu____103 =
+                  let uu____105 = FStar_Ident.ident_of_lid lid  in
+                  FStar_Ident.text_of_id uu____105  in
+                Prims.op_Hat "is_" uu____103  in
+              Prims.op_Hat FStar_Ident.reserved_prefix uu____101  in
+            let uu____107 = FStar_Ident.range_of_lid lid  in
+            (uu____99, uu____107)  in
+          FStar_Ident.mk_ident uu____93  in
+        [uu____92]  in
+      FStar_List.append uu____86 uu____89  in
+    FStar_Ident.lid_of_ids uu____85
   
 let (is_name : FStar_Ident.lident -> Prims.bool) =
   fun lid  ->
     let c =
-      FStar_Util.char_at (lid.FStar_Ident.ident).FStar_Ident.idText
-        Prims.int_zero
-       in
+      let uu____118 =
+        let uu____120 = FStar_Ident.ident_of_lid lid  in
+        FStar_Ident.text_of_id uu____120  in
+      FStar_Util.char_at uu____118 Prims.int_zero  in
     FStar_Util.is_upper c
   
 let arg_of_non_null_binder :
-  'uuuuuu121 .
-    (FStar_Syntax_Syntax.bv * 'uuuuuu121) ->
-      (FStar_Syntax_Syntax.term * 'uuuuuu121)
+  'uuuuuu127 .
+    (FStar_Syntax_Syntax.bv * 'uuuuuu127) ->
+      (FStar_Syntax_Syntax.term * 'uuuuuu127)
   =
-  fun uu____134  ->
-    match uu____134 with
+  fun uu____140  ->
+    match uu____140 with
     | (b,imp) ->
-        let uu____141 = FStar_Syntax_Syntax.bv_to_name b  in (uu____141, imp)
+        let uu____147 = FStar_Syntax_Syntax.bv_to_name b  in (uu____147, imp)
   
 let (args_of_non_null_binders :
   FStar_Syntax_Syntax.binders ->
@@ -62,34 +59,34 @@ let (args_of_non_null_binders :
     FStar_All.pipe_right binders
       (FStar_List.collect
          (fun b  ->
-            let uu____193 = FStar_Syntax_Syntax.is_null_binder b  in
-            if uu____193
+            let uu____199 = FStar_Syntax_Syntax.is_null_binder b  in
+            if uu____199
             then []
-            else (let uu____212 = arg_of_non_null_binder b  in [uu____212])))
+            else (let uu____218 = arg_of_non_null_binder b  in [uu____218])))
   
 let (args_of_binders :
   FStar_Syntax_Syntax.binders ->
     (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.args))
   =
   fun binders  ->
-    let uu____247 =
+    let uu____253 =
       FStar_All.pipe_right binders
         (FStar_List.map
            (fun b  ->
-              let uu____329 = FStar_Syntax_Syntax.is_null_binder b  in
-              if uu____329
+              let uu____335 = FStar_Syntax_Syntax.is_null_binder b  in
+              if uu____335
               then
                 let b1 =
-                  let uu____355 =
+                  let uu____361 =
                     FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
                       (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                      in
-                  (uu____355, (FStar_Pervasives_Native.snd b))  in
-                let uu____362 = arg_of_non_null_binder b1  in (b1, uu____362)
+                  (uu____361, (FStar_Pervasives_Native.snd b))  in
+                let uu____368 = arg_of_non_null_binder b1  in (b1, uu____368)
               else
-                (let uu____385 = arg_of_non_null_binder b  in (b, uu____385))))
+                (let uu____391 = arg_of_non_null_binder b  in (b, uu____391))))
        in
-    FStar_All.pipe_right uu____247 FStar_List.unzip
+    FStar_All.pipe_right uu____253 FStar_List.unzip
   
 let (name_binders :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -102,17 +99,17 @@ let (name_binders :
       (FStar_List.mapi
          (fun i  ->
             fun b  ->
-              let uu____519 = FStar_Syntax_Syntax.is_null_binder b  in
-              if uu____519
+              let uu____525 = FStar_Syntax_Syntax.is_null_binder b  in
+              if uu____525
               then
-                let uu____528 = b  in
-                match uu____528 with
+                let uu____534 = b  in
+                match uu____534 with
                 | (a,imp) ->
                     let b1 =
-                      let uu____548 =
-                        let uu____550 = FStar_Util.string_of_int i  in
-                        Prims.op_Hat "_" uu____550  in
-                      FStar_Ident.id_of_text uu____548  in
+                      let uu____554 =
+                        let uu____556 = FStar_Util.string_of_int i  in
+                        Prims.op_Hat "_" uu____556  in
+                      FStar_Ident.id_of_text uu____554  in
                     let b2 =
                       {
                         FStar_Syntax_Syntax.ppname = b1;
@@ -130,14 +127,14 @@ let (name_function_binders :
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
-        let uu____595 =
-          let uu____602 =
-            let uu____603 =
-              let uu____618 = name_binders binders  in (uu____618, comp)  in
-            FStar_Syntax_Syntax.Tm_arrow uu____603  in
-          FStar_Syntax_Syntax.mk uu____602  in
-        uu____595 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
-    | uu____637 -> t
+        let uu____601 =
+          let uu____608 =
+            let uu____609 =
+              let uu____624 = name_binders binders  in (uu____624, comp)  in
+            FStar_Syntax_Syntax.Tm_arrow uu____609  in
+          FStar_Syntax_Syntax.mk uu____608  in
+        uu____601 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+    | uu____643 -> t
   
 let (null_binders_of_tks :
   (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.aqual) Prims.list ->
@@ -146,14 +143,14 @@ let (null_binders_of_tks :
   fun tks  ->
     FStar_All.pipe_right tks
       (FStar_List.map
-         (fun uu____674  ->
-            match uu____674 with
+         (fun uu____680  ->
+            match uu____680 with
             | (t,imp) ->
-                let uu____685 =
-                  let uu____686 = FStar_Syntax_Syntax.null_binder t  in
-                  FStar_All.pipe_left FStar_Pervasives_Native.fst uu____686
+                let uu____691 =
+                  let uu____692 = FStar_Syntax_Syntax.null_binder t  in
+                  FStar_All.pipe_left FStar_Pervasives_Native.fst uu____692
                    in
-                (uu____685, imp)))
+                (uu____691, imp)))
   
 let (binders_of_tks :
   (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.aqual) Prims.list ->
@@ -162,26 +159,26 @@ let (binders_of_tks :
   fun tks  ->
     FStar_All.pipe_right tks
       (FStar_List.map
-         (fun uu____741  ->
-            match uu____741 with
+         (fun uu____747  ->
+            match uu____747 with
             | (t,imp) ->
-                let uu____758 =
+                let uu____764 =
                   FStar_Syntax_Syntax.new_bv
                     (FStar_Pervasives_Native.Some (t.FStar_Syntax_Syntax.pos))
                     t
                    in
-                (uu____758, imp)))
+                (uu____764, imp)))
   
 let (binders_of_freevars :
   FStar_Syntax_Syntax.bv FStar_Util.set ->
     FStar_Syntax_Syntax.binder Prims.list)
   =
   fun fvs  ->
-    let uu____771 = FStar_Util.set_elements fvs  in
-    FStar_All.pipe_right uu____771
+    let uu____777 = FStar_Util.set_elements fvs  in
+    FStar_All.pipe_right uu____777
       (FStar_List.map FStar_Syntax_Syntax.mk_binder)
   
-let mk_subst : 'uuuuuu783 . 'uuuuuu783 -> 'uuuuuu783 Prims.list =
+let mk_subst : 'uuuuuu789 . 'uuuuuu789 -> 'uuuuuu789 Prims.list =
   fun s  -> [s] 
 let (subst_of_list :
   FStar_Syntax_Syntax.binders ->
@@ -210,23 +207,23 @@ let (rename_binders :
       if (FStar_List.length replace_xs) = (FStar_List.length with_ys)
       then
         FStar_List.map2
-          (fun uu____909  ->
-             fun uu____910  ->
-               match (uu____909, uu____910) with
-               | ((x,uu____936),(y,uu____938)) ->
-                   let uu____959 =
-                     let uu____966 = FStar_Syntax_Syntax.bv_to_name y  in
-                     (x, uu____966)  in
-                   FStar_Syntax_Syntax.NT uu____959) replace_xs with_ys
+          (fun uu____915  ->
+             fun uu____916  ->
+               match (uu____915, uu____916) with
+               | ((x,uu____942),(y,uu____944)) ->
+                   let uu____965 =
+                     let uu____972 = FStar_Syntax_Syntax.bv_to_name y  in
+                     (x, uu____972)  in
+                   FStar_Syntax_Syntax.NT uu____965) replace_xs with_ys
       else failwith "Ill-formed substitution"
   
 let rec (unmeta : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun e  ->
     let e1 = FStar_Syntax_Subst.compress e  in
     match e1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_meta (e2,uu____982) -> unmeta e2
-    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____988,uu____989) -> unmeta e2
-    | uu____1030 -> e1
+    | FStar_Syntax_Syntax.Tm_meta (e2,uu____988) -> unmeta e2
+    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____994,uu____995) -> unmeta e2
+    | uu____1036 -> e1
   
 let rec (unmeta_safe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
@@ -235,12 +232,12 @@ let rec (unmeta_safe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
     match e1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_meta (e',m) ->
         (match m with
-         | FStar_Syntax_Syntax.Meta_monadic uu____1044 -> e1
-         | FStar_Syntax_Syntax.Meta_monadic_lift uu____1051 -> e1
-         | uu____1060 -> unmeta_safe e')
-    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____1062,uu____1063) ->
+         | FStar_Syntax_Syntax.Meta_monadic uu____1050 -> e1
+         | FStar_Syntax_Syntax.Meta_monadic_lift uu____1057 -> e1
+         | uu____1066 -> unmeta_safe e')
+    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____1068,uu____1069) ->
         unmeta_safe e2
-    | uu____1104 -> e1
+    | uu____1110 -> e1
   
 let rec (univ_kernel :
   FStar_Syntax_Syntax.universe -> (FStar_Syntax_Syntax.universe * Prims.int))
@@ -248,20 +245,20 @@ let rec (univ_kernel :
   fun u  ->
     match u with
     | FStar_Syntax_Syntax.U_unknown  -> (u, Prims.int_zero)
-    | FStar_Syntax_Syntax.U_name uu____1123 -> (u, Prims.int_zero)
-    | FStar_Syntax_Syntax.U_unif uu____1126 -> (u, Prims.int_zero)
+    | FStar_Syntax_Syntax.U_name uu____1129 -> (u, Prims.int_zero)
+    | FStar_Syntax_Syntax.U_unif uu____1132 -> (u, Prims.int_zero)
     | FStar_Syntax_Syntax.U_zero  -> (u, Prims.int_zero)
     | FStar_Syntax_Syntax.U_succ u1 ->
-        let uu____1140 = univ_kernel u1  in
-        (match uu____1140 with | (k,n) -> (k, (n + Prims.int_one)))
-    | FStar_Syntax_Syntax.U_max uu____1157 ->
+        let uu____1146 = univ_kernel u1  in
+        (match uu____1146 with | (k,n) -> (k, (n + Prims.int_one)))
+    | FStar_Syntax_Syntax.U_max uu____1163 ->
         failwith "Imposible: univ_kernel (U_max _)"
-    | FStar_Syntax_Syntax.U_bvar uu____1166 ->
+    | FStar_Syntax_Syntax.U_bvar uu____1172 ->
         failwith "Imposible: univ_kernel (U_bvar _)"
   
 let (constant_univ_as_nat : FStar_Syntax_Syntax.universe -> Prims.int) =
   fun u  ->
-    let uu____1181 = univ_kernel u  in FStar_Pervasives_Native.snd uu____1181
+    let uu____1187 = univ_kernel u  in FStar_Pervasives_Native.snd uu____1187
   
 let rec (compare_univs :
   FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe -> Prims.int)
@@ -269,28 +266,30 @@ let rec (compare_univs :
   fun u1  ->
     fun u2  ->
       match (u1, u2) with
-      | (FStar_Syntax_Syntax.U_bvar uu____1201,uu____1202) ->
+      | (FStar_Syntax_Syntax.U_bvar uu____1207,uu____1208) ->
           failwith "Impossible: compare_univs"
-      | (uu____1206,FStar_Syntax_Syntax.U_bvar uu____1207) ->
+      | (uu____1212,FStar_Syntax_Syntax.U_bvar uu____1213) ->
           failwith "Impossible: compare_univs"
       | (FStar_Syntax_Syntax.U_unknown ,FStar_Syntax_Syntax.U_unknown ) ->
           Prims.int_zero
-      | (FStar_Syntax_Syntax.U_unknown ,uu____1212) -> ~- Prims.int_one
-      | (uu____1214,FStar_Syntax_Syntax.U_unknown ) -> Prims.int_one
+      | (FStar_Syntax_Syntax.U_unknown ,uu____1218) -> ~- Prims.int_one
+      | (uu____1220,FStar_Syntax_Syntax.U_unknown ) -> Prims.int_one
       | (FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_zero ) ->
           Prims.int_zero
-      | (FStar_Syntax_Syntax.U_zero ,uu____1217) -> ~- Prims.int_one
-      | (uu____1219,FStar_Syntax_Syntax.U_zero ) -> Prims.int_one
+      | (FStar_Syntax_Syntax.U_zero ,uu____1223) -> ~- Prims.int_one
+      | (uu____1225,FStar_Syntax_Syntax.U_zero ) -> Prims.int_one
       | (FStar_Syntax_Syntax.U_name u11,FStar_Syntax_Syntax.U_name u21) ->
-          FStar_String.compare u11.FStar_Ident.idText u21.FStar_Ident.idText
-      | (FStar_Syntax_Syntax.U_name uu____1223,FStar_Syntax_Syntax.U_unif
-         uu____1224) -> ~- Prims.int_one
-      | (FStar_Syntax_Syntax.U_unif uu____1234,FStar_Syntax_Syntax.U_name
-         uu____1235) -> Prims.int_one
+          let uu____1229 = FStar_Ident.text_of_id u11  in
+          let uu____1231 = FStar_Ident.text_of_id u21  in
+          FStar_String.compare uu____1229 uu____1231
+      | (FStar_Syntax_Syntax.U_name uu____1233,FStar_Syntax_Syntax.U_unif
+         uu____1234) -> ~- Prims.int_one
+      | (FStar_Syntax_Syntax.U_unif uu____1244,FStar_Syntax_Syntax.U_name
+         uu____1245) -> Prims.int_one
       | (FStar_Syntax_Syntax.U_unif u11,FStar_Syntax_Syntax.U_unif u21) ->
-          let uu____1263 = FStar_Syntax_Unionfind.univ_uvar_id u11  in
-          let uu____1265 = FStar_Syntax_Unionfind.univ_uvar_id u21  in
-          uu____1263 - uu____1265
+          let uu____1273 = FStar_Syntax_Unionfind.univ_uvar_id u11  in
+          let uu____1275 = FStar_Syntax_Unionfind.univ_uvar_id u21  in
+          uu____1273 - uu____1275
       | (FStar_Syntax_Syntax.U_max us1,FStar_Syntax_Syntax.U_max us2) ->
           let n1 = FStar_List.length us1  in
           let n2 = FStar_List.length us2  in
@@ -298,10 +297,10 @@ let rec (compare_univs :
           then n1 - n2
           else
             (let copt =
-               let uu____1283 = FStar_List.zip us1 us2  in
-               FStar_Util.find_map uu____1283
-                 (fun uu____1299  ->
-                    match uu____1299 with
+               let uu____1293 = FStar_List.zip us1 us2  in
+               FStar_Util.find_map uu____1293
+                 (fun uu____1309  ->
+                    match uu____1309 with
                     | (u11,u21) ->
                         let c = compare_univs u11 u21  in
                         if c <> Prims.int_zero
@@ -311,14 +310,14 @@ let rec (compare_univs :
              match copt with
              | FStar_Pervasives_Native.None  -> Prims.int_zero
              | FStar_Pervasives_Native.Some c -> c)
-      | (FStar_Syntax_Syntax.U_max uu____1327,uu____1328) -> ~- Prims.int_one
-      | (uu____1332,FStar_Syntax_Syntax.U_max uu____1333) -> Prims.int_one
-      | uu____1337 ->
-          let uu____1342 = univ_kernel u1  in
-          (match uu____1342 with
+      | (FStar_Syntax_Syntax.U_max uu____1337,uu____1338) -> ~- Prims.int_one
+      | (uu____1342,FStar_Syntax_Syntax.U_max uu____1343) -> Prims.int_one
+      | uu____1347 ->
+          let uu____1352 = univ_kernel u1  in
+          (match uu____1352 with
            | (k1,n1) ->
-               let uu____1353 = univ_kernel u2  in
-               (match uu____1353 with
+               let uu____1363 = univ_kernel u2  in
+               (match uu____1363 with
                 | (k2,n2) ->
                     let r = compare_univs k1 k2  in
                     if r = Prims.int_zero then n1 - n2 else r))
@@ -328,7 +327,7 @@ let (eq_univs :
   =
   fun u1  ->
     fun u2  ->
-      let uu____1384 = compare_univs u1 u2  in uu____1384 = Prims.int_zero
+      let uu____1394 = compare_univs u1 u2  in uu____1394 = Prims.int_zero
   
 let (ml_comp :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -336,17 +335,17 @@ let (ml_comp :
   =
   fun t  ->
     fun r  ->
-      let uu____1403 =
-        let uu____1404 =
+      let uu____1413 =
+        let uu____1414 =
           FStar_Ident.set_lid_range FStar_Parser_Const.effect_ML_lid r  in
         {
           FStar_Syntax_Syntax.comp_univs = [FStar_Syntax_Syntax.U_zero];
-          FStar_Syntax_Syntax.effect_name = uu____1404;
+          FStar_Syntax_Syntax.effect_name = uu____1414;
           FStar_Syntax_Syntax.result_typ = t;
           FStar_Syntax_Syntax.effect_args = [];
           FStar_Syntax_Syntax.flags = [FStar_Syntax_Syntax.MLEFFECT]
         }  in
-      FStar_Syntax_Syntax.mk_Comp uu____1403
+      FStar_Syntax_Syntax.mk_Comp uu____1413
   
 let (comp_effect_name :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> FStar_Ident.lident)
@@ -354,9 +353,9 @@ let (comp_effect_name :
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp c1 -> c1.FStar_Syntax_Syntax.effect_name
-    | FStar_Syntax_Syntax.Total uu____1424 ->
+    | FStar_Syntax_Syntax.Total uu____1434 ->
         FStar_Parser_Const.effect_Tot_lid
-    | FStar_Syntax_Syntax.GTotal uu____1433 ->
+    | FStar_Syntax_Syntax.GTotal uu____1443 ->
         FStar_Parser_Const.effect_GTot_lid
   
 let (comp_flags :
@@ -365,8 +364,8 @@ let (comp_flags :
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____1456 -> [FStar_Syntax_Syntax.TOTAL]
-    | FStar_Syntax_Syntax.GTotal uu____1465 ->
+    | FStar_Syntax_Syntax.Total uu____1466 -> [FStar_Syntax_Syntax.TOTAL]
+    | FStar_Syntax_Syntax.GTotal uu____1475 ->
         [FStar_Syntax_Syntax.SOMETRIVIAL]
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.flags
   
@@ -376,22 +375,22 @@ let (comp_to_comp_typ_nouniv :
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp c1 -> c1
     | FStar_Syntax_Syntax.Total (t,u_opt) ->
-        let uu____1492 =
-          let uu____1493 = FStar_Util.map_opt u_opt (fun x  -> [x])  in
-          FStar_Util.dflt [] uu____1493  in
+        let uu____1502 =
+          let uu____1503 = FStar_Util.map_opt u_opt (fun x  -> [x])  in
+          FStar_Util.dflt [] uu____1503  in
         {
-          FStar_Syntax_Syntax.comp_univs = uu____1492;
+          FStar_Syntax_Syntax.comp_univs = uu____1502;
           FStar_Syntax_Syntax.effect_name = (comp_effect_name c);
           FStar_Syntax_Syntax.result_typ = t;
           FStar_Syntax_Syntax.effect_args = [];
           FStar_Syntax_Syntax.flags = (comp_flags c)
         }
     | FStar_Syntax_Syntax.GTotal (t,u_opt) ->
-        let uu____1522 =
-          let uu____1523 = FStar_Util.map_opt u_opt (fun x  -> [x])  in
-          FStar_Util.dflt [] uu____1523  in
+        let uu____1532 =
+          let uu____1533 = FStar_Util.map_opt u_opt (fun x  -> [x])  in
+          FStar_Util.dflt [] uu____1533  in
         {
-          FStar_Syntax_Syntax.comp_univs = uu____1522;
+          FStar_Syntax_Syntax.comp_univs = uu____1532;
           FStar_Syntax_Syntax.effect_name = (comp_effect_name c);
           FStar_Syntax_Syntax.result_typ = t;
           FStar_Syntax_Syntax.effect_args = [];
@@ -405,26 +404,26 @@ let (comp_set_flags :
   =
   fun c  ->
     fun f  ->
-      let uu___225_1559 = c  in
-      let uu____1560 =
-        let uu____1561 =
-          let uu___227_1562 = comp_to_comp_typ_nouniv c  in
+      let uu___223_1569 = c  in
+      let uu____1570 =
+        let uu____1571 =
+          let uu___225_1572 = comp_to_comp_typ_nouniv c  in
           {
             FStar_Syntax_Syntax.comp_univs =
-              (uu___227_1562.FStar_Syntax_Syntax.comp_univs);
+              (uu___225_1572.FStar_Syntax_Syntax.comp_univs);
             FStar_Syntax_Syntax.effect_name =
-              (uu___227_1562.FStar_Syntax_Syntax.effect_name);
+              (uu___225_1572.FStar_Syntax_Syntax.effect_name);
             FStar_Syntax_Syntax.result_typ =
-              (uu___227_1562.FStar_Syntax_Syntax.result_typ);
+              (uu___225_1572.FStar_Syntax_Syntax.result_typ);
             FStar_Syntax_Syntax.effect_args =
-              (uu___227_1562.FStar_Syntax_Syntax.effect_args);
+              (uu___225_1572.FStar_Syntax_Syntax.effect_args);
             FStar_Syntax_Syntax.flags = f
           }  in
-        FStar_Syntax_Syntax.Comp uu____1561  in
+        FStar_Syntax_Syntax.Comp uu____1571  in
       {
-        FStar_Syntax_Syntax.n = uu____1560;
-        FStar_Syntax_Syntax.pos = (uu___225_1559.FStar_Syntax_Syntax.pos);
-        FStar_Syntax_Syntax.vars = (uu___225_1559.FStar_Syntax_Syntax.vars)
+        FStar_Syntax_Syntax.n = uu____1570;
+        FStar_Syntax_Syntax.pos = (uu___223_1569.FStar_Syntax_Syntax.pos);
+        FStar_Syntax_Syntax.vars = (uu___223_1569.FStar_Syntax_Syntax.vars)
       }
   
 let (comp_to_comp_typ :
@@ -448,7 +447,7 @@ let (comp_to_comp_typ :
           FStar_Syntax_Syntax.effect_args = [];
           FStar_Syntax_Syntax.flags = (comp_flags c)
         }
-    | uu____1602 ->
+    | uu____1612 ->
         failwith "Assertion failed: Computation type without universe"
   
 let (destruct_comp :
@@ -459,23 +458,25 @@ let (destruct_comp :
   fun c  ->
     let wp =
       match c.FStar_Syntax_Syntax.effect_args with
-      | (wp,uu____1624)::[] -> wp
-      | uu____1649 ->
-          let uu____1660 =
-            let uu____1662 =
-              let uu____1664 =
+      | (wp,uu____1634)::[] -> wp
+      | uu____1659 ->
+          let uu____1670 =
+            let uu____1672 =
+              FStar_Ident.string_of_lid c.FStar_Syntax_Syntax.effect_name  in
+            let uu____1674 =
+              let uu____1676 =
                 FStar_All.pipe_right c.FStar_Syntax_Syntax.effect_args
                   FStar_List.length
                  in
-              FStar_All.pipe_right uu____1664 FStar_Util.string_of_int  in
+              FStar_All.pipe_right uu____1676 FStar_Util.string_of_int  in
             FStar_Util.format2
               "Impossible: Got a computation %s with %s effect args"
-              (c.FStar_Syntax_Syntax.effect_name).FStar_Ident.str uu____1662
+              uu____1672 uu____1674
              in
-          failwith uu____1660
+          failwith uu____1670
        in
-    let uu____1688 = FStar_List.hd c.FStar_Syntax_Syntax.comp_univs  in
-    (uu____1688, (c.FStar_Syntax_Syntax.result_typ), wp)
+    let uu____1700 = FStar_List.hd c.FStar_Syntax_Syntax.comp_univs  in
+    (uu____1700, (c.FStar_Syntax_Syntax.result_typ), wp)
   
 let (is_named_tot :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
@@ -484,8 +485,8 @@ let (is_named_tot :
     | FStar_Syntax_Syntax.Comp c1 ->
         FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name
           FStar_Parser_Const.effect_Tot_lid
-    | FStar_Syntax_Syntax.Total uu____1702 -> true
-    | FStar_Syntax_Syntax.GTotal uu____1712 -> false
+    | FStar_Syntax_Syntax.Total uu____1714 -> true
+    | FStar_Syntax_Syntax.GTotal uu____1724 -> false
   
 let (is_total_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
@@ -495,22 +496,22 @@ let (is_total_comp :
       ||
       (FStar_All.pipe_right (comp_flags c)
          (FStar_Util.for_some
-            (fun uu___0_1737  ->
-               match uu___0_1737 with
+            (fun uu___0_1749  ->
+               match uu___0_1749 with
                | FStar_Syntax_Syntax.TOTAL  -> true
                | FStar_Syntax_Syntax.RETURN  -> true
-               | uu____1741 -> false)))
+               | uu____1753 -> false)))
   
 let (is_partial_return :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c  ->
     FStar_All.pipe_right (comp_flags c)
       (FStar_Util.for_some
-         (fun uu___1_1758  ->
-            match uu___1_1758 with
+         (fun uu___1_1770  ->
+            match uu___1_1770 with
             | FStar_Syntax_Syntax.RETURN  -> true
             | FStar_Syntax_Syntax.PARTIAL_RETURN  -> true
-            | uu____1762 -> false))
+            | uu____1774 -> false))
   
 let (is_tot_or_gtot_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
@@ -529,18 +530,18 @@ let (is_pure_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____1794 -> true
-    | FStar_Syntax_Syntax.GTotal uu____1804 -> false
+    | FStar_Syntax_Syntax.Total uu____1806 -> true
+    | FStar_Syntax_Syntax.GTotal uu____1816 -> false
     | FStar_Syntax_Syntax.Comp ct ->
         ((is_total_comp c) ||
            (is_pure_effect ct.FStar_Syntax_Syntax.effect_name))
           ||
           (FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
              (FStar_Util.for_some
-                (fun uu___2_1819  ->
-                   match uu___2_1819 with
+                (fun uu___2_1831  ->
+                   match uu___2_1831 with
                    | FStar_Syntax_Syntax.LEMMA  -> true
-                   | uu____1822 -> false)))
+                   | uu____1834 -> false)))
   
 let (is_ghost_effect : FStar_Ident.lident -> Prims.bool) =
   fun l  ->
@@ -561,12 +562,12 @@ let (is_pure_or_ghost_effect : FStar_Ident.lident -> Prims.bool) =
   fun l  -> (is_pure_effect l) || (is_ghost_effect l) 
 let (is_pure_or_ghost_function : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____1863 =
-      let uu____1864 = FStar_Syntax_Subst.compress t  in
-      uu____1864.FStar_Syntax_Syntax.n  in
-    match uu____1863 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____1868,c) -> is_pure_or_ghost_comp c
-    | uu____1890 -> true
+    let uu____1875 =
+      let uu____1876 = FStar_Syntax_Subst.compress t  in
+      uu____1876.FStar_Syntax_Syntax.n  in
+    match uu____1875 with
+    | FStar_Syntax_Syntax.Tm_arrow (uu____1880,c) -> is_pure_or_ghost_comp c
+    | uu____1902 -> true
   
 let (is_lemma_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
@@ -575,30 +576,30 @@ let (is_lemma_comp :
     | FStar_Syntax_Syntax.Comp ct ->
         FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
           FStar_Parser_Const.effect_Lemma_lid
-    | uu____1905 -> false
+    | uu____1917 -> false
   
 let (is_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____1914 =
-      let uu____1915 = FStar_Syntax_Subst.compress t  in
-      uu____1915.FStar_Syntax_Syntax.n  in
-    match uu____1914 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____1919,c) -> is_lemma_comp c
-    | uu____1941 -> false
+    let uu____1926 =
+      let uu____1927 = FStar_Syntax_Subst.compress t  in
+      uu____1927.FStar_Syntax_Syntax.n  in
+    match uu____1926 with
+    | FStar_Syntax_Syntax.Tm_arrow (uu____1931,c) -> is_lemma_comp c
+    | uu____1953 -> false
   
 let rec (head_of : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let uu____1949 =
-      let uu____1950 = FStar_Syntax_Subst.compress t  in
-      uu____1950.FStar_Syntax_Syntax.n  in
-    match uu____1949 with
-    | FStar_Syntax_Syntax.Tm_app (t1,uu____1954) -> head_of t1
-    | FStar_Syntax_Syntax.Tm_match (t1,uu____1980) -> head_of t1
-    | FStar_Syntax_Syntax.Tm_abs (uu____2017,t1,uu____2019) -> head_of t1
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____2045,uu____2046) ->
+    let uu____1961 =
+      let uu____1962 = FStar_Syntax_Subst.compress t  in
+      uu____1962.FStar_Syntax_Syntax.n  in
+    match uu____1961 with
+    | FStar_Syntax_Syntax.Tm_app (t1,uu____1966) -> head_of t1
+    | FStar_Syntax_Syntax.Tm_match (t1,uu____1992) -> head_of t1
+    | FStar_Syntax_Syntax.Tm_abs (uu____2029,t1,uu____2031) -> head_of t1
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____2057,uu____2058) ->
         head_of t1
-    | FStar_Syntax_Syntax.Tm_meta (t1,uu____2088) -> head_of t1
-    | uu____2093 -> t
+    | FStar_Syntax_Syntax.Tm_meta (t1,uu____2100) -> head_of t1
+    | uu____2105 -> t
   
 let (head_and_args :
   FStar_Syntax_Syntax.term ->
@@ -611,7 +612,7 @@ let (head_and_args :
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_app (head,args) -> (head, args)
-    | uu____2171 -> (t1, [])
+    | uu____2183 -> (t1, [])
   
 let rec (head_and_args' :
   FStar_Syntax_Syntax.term ->
@@ -623,18 +624,18 @@ let rec (head_and_args' :
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_app (head,args) ->
-        let uu____2253 = head_and_args' head  in
-        (match uu____2253 with
+        let uu____2265 = head_and_args' head  in
+        (match uu____2265 with
          | (head1,args') -> (head1, (FStar_List.append args' args)))
-    | uu____2322 -> (t1, [])
+    | uu____2334 -> (t1, [])
   
 let (un_uinst : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_uinst (t2,uu____2349) ->
+    | FStar_Syntax_Syntax.Tm_uinst (t2,uu____2361) ->
         FStar_Syntax_Subst.compress t2
-    | uu____2354 -> t1
+    | uu____2366 -> t1
   
 let (is_ml_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
@@ -646,11 +647,11 @@ let (is_ml_comp :
           ||
           (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
              (FStar_Util.for_some
-                (fun uu___3_2372  ->
-                   match uu___3_2372 with
+                (fun uu___3_2384  ->
+                   match uu___3_2384 with
                    | FStar_Syntax_Syntax.MLEFFECT  -> true
-                   | uu____2375 -> false)))
-    | uu____2377 -> false
+                   | uu____2387 -> false)))
+    | uu____2389 -> false
   
 let (comp_result :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -658,8 +659,8 @@ let (comp_result :
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (t,uu____2394) -> t
-    | FStar_Syntax_Syntax.GTotal (t,uu____2404) -> t
+    | FStar_Syntax_Syntax.Total (t,uu____2406) -> t
+    | FStar_Syntax_Syntax.GTotal (t,uu____2416) -> t
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.result_typ
   
 let (set_result_typ :
@@ -670,23 +671,23 @@ let (set_result_typ :
   fun c  ->
     fun t  ->
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total uu____2433 ->
+      | FStar_Syntax_Syntax.Total uu____2445 ->
           FStar_Syntax_Syntax.mk_Total t
-      | FStar_Syntax_Syntax.GTotal uu____2442 ->
+      | FStar_Syntax_Syntax.GTotal uu____2454 ->
           FStar_Syntax_Syntax.mk_GTotal t
       | FStar_Syntax_Syntax.Comp ct ->
           FStar_Syntax_Syntax.mk_Comp
-            (let uu___366_2454 = ct  in
+            (let uu___364_2466 = ct  in
              {
                FStar_Syntax_Syntax.comp_univs =
-                 (uu___366_2454.FStar_Syntax_Syntax.comp_univs);
+                 (uu___364_2466.FStar_Syntax_Syntax.comp_univs);
                FStar_Syntax_Syntax.effect_name =
-                 (uu___366_2454.FStar_Syntax_Syntax.effect_name);
+                 (uu___364_2466.FStar_Syntax_Syntax.effect_name);
                FStar_Syntax_Syntax.result_typ = t;
                FStar_Syntax_Syntax.effect_args =
-                 (uu___366_2454.FStar_Syntax_Syntax.effect_args);
+                 (uu___364_2466.FStar_Syntax_Syntax.effect_args);
                FStar_Syntax_Syntax.flags =
-                 (uu___366_2454.FStar_Syntax_Syntax.flags)
+                 (uu___364_2466.FStar_Syntax_Syntax.flags)
              })
   
 let (is_trivial_wp :
@@ -694,18 +695,18 @@ let (is_trivial_wp :
   fun c  ->
     FStar_All.pipe_right (comp_flags c)
       (FStar_Util.for_some
-         (fun uu___4_2470  ->
-            match uu___4_2470 with
+         (fun uu___4_2482  ->
+            match uu___4_2482 with
             | FStar_Syntax_Syntax.TOTAL  -> true
             | FStar_Syntax_Syntax.RETURN  -> true
-            | uu____2474 -> false))
+            | uu____2486 -> false))
   
 let (comp_effect_args : FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.args)
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____2482 -> []
-    | FStar_Syntax_Syntax.GTotal uu____2499 -> []
+    | FStar_Syntax_Syntax.Total uu____2494 -> []
+    | FStar_Syntax_Syntax.GTotal uu____2511 -> []
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.effect_args
   
 let (primops : FStar_Ident.lident Prims.list) =
@@ -735,15 +736,15 @@ let (is_primop :
     match f.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         is_primop_lid (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-    | uu____2543 -> false
+    | uu____2555 -> false
   
 let rec (unascribe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun e  ->
     let e1 = FStar_Syntax_Subst.compress e  in
     match e1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____2553,uu____2554) ->
+    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____2565,uu____2566) ->
         unascribe e2
-    | uu____2595 -> e1
+    | uu____2607 -> e1
   
 let rec (ascribe :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -756,9 +757,9 @@ let rec (ascribe :
   fun t  ->
     fun k  ->
       match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_ascribed (t',uu____2648,uu____2649) ->
+      | FStar_Syntax_Syntax.Tm_ascribed (t',uu____2660,uu____2661) ->
           ascribe t' k
-      | uu____2690 ->
+      | uu____2702 ->
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (t, k, FStar_Pervasives_Native.None))
@@ -767,35 +768,35 @@ let rec (ascribe :
 let (unfold_lazy : FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term)
   =
   fun i  ->
-    let uu____2717 =
-      let uu____2726 = FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser  in
-      FStar_Util.must uu____2726  in
-    uu____2717 i.FStar_Syntax_Syntax.lkind i
+    let uu____2729 =
+      let uu____2738 = FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser  in
+      FStar_Util.must uu____2738  in
+    uu____2729 i.FStar_Syntax_Syntax.lkind i
   
 let rec (unlazy : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let uu____2782 =
-      let uu____2783 = FStar_Syntax_Subst.compress t  in
-      uu____2783.FStar_Syntax_Syntax.n  in
-    match uu____2782 with
+    let uu____2794 =
+      let uu____2795 = FStar_Syntax_Subst.compress t  in
+      uu____2795.FStar_Syntax_Syntax.n  in
+    match uu____2794 with
     | FStar_Syntax_Syntax.Tm_lazy i ->
-        let uu____2787 = unfold_lazy i  in
-        FStar_All.pipe_left unlazy uu____2787
-    | uu____2788 -> t
+        let uu____2799 = unfold_lazy i  in
+        FStar_All.pipe_left unlazy uu____2799
+    | uu____2800 -> t
   
 let (unlazy_emb : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let uu____2795 =
-      let uu____2796 = FStar_Syntax_Subst.compress t  in
-      uu____2796.FStar_Syntax_Syntax.n  in
-    match uu____2795 with
+    let uu____2807 =
+      let uu____2808 = FStar_Syntax_Subst.compress t  in
+      uu____2808.FStar_Syntax_Syntax.n  in
+    match uu____2807 with
     | FStar_Syntax_Syntax.Tm_lazy i ->
         (match i.FStar_Syntax_Syntax.lkind with
-         | FStar_Syntax_Syntax.Lazy_embedding uu____2800 ->
-             let uu____2809 = unfold_lazy i  in
-             FStar_All.pipe_left unlazy uu____2809
-         | uu____2810 -> t)
-    | uu____2811 -> t
+         | FStar_Syntax_Syntax.Lazy_embedding uu____2812 ->
+             let uu____2821 = unfold_lazy i  in
+             FStar_All.pipe_left unlazy uu____2821
+         | uu____2822 -> t)
+    | uu____2823 -> t
   
 let (eq_lazy_kind :
   FStar_Syntax_Syntax.lazy_kind ->
@@ -823,24 +824,24 @@ let (eq_lazy_kind :
           -> true
       | (FStar_Syntax_Syntax.Lazy_uvar ,FStar_Syntax_Syntax.Lazy_uvar ) ->
           true
-      | uu____2836 -> false
+      | uu____2848 -> false
   
 let unlazy_as_t :
-  'uuuuuu2849 .
-    FStar_Syntax_Syntax.lazy_kind -> FStar_Syntax_Syntax.term -> 'uuuuuu2849
+  'uuuuuu2861 .
+    FStar_Syntax_Syntax.lazy_kind -> FStar_Syntax_Syntax.term -> 'uuuuuu2861
   =
   fun k  ->
     fun t  ->
-      let uu____2860 =
-        let uu____2861 = FStar_Syntax_Subst.compress t  in
-        uu____2861.FStar_Syntax_Syntax.n  in
-      match uu____2860 with
+      let uu____2872 =
+        let uu____2873 = FStar_Syntax_Subst.compress t  in
+        uu____2873.FStar_Syntax_Syntax.n  in
+      match uu____2872 with
       | FStar_Syntax_Syntax.Tm_lazy
           { FStar_Syntax_Syntax.blob = v; FStar_Syntax_Syntax.lkind = k';
-            FStar_Syntax_Syntax.ltyp = uu____2866;
-            FStar_Syntax_Syntax.rng = uu____2867;_}
+            FStar_Syntax_Syntax.ltyp = uu____2878;
+            FStar_Syntax_Syntax.rng = uu____2879;_}
           when eq_lazy_kind k k' -> FStar_Dyn.undyn v
-      | uu____2870 -> failwith "Not a Tm_lazy of the expected kind"
+      | uu____2882 -> failwith "Not a Tm_lazy of the expected kind"
   
 let mk_lazy :
   'a .
@@ -859,9 +860,9 @@ let mk_lazy :
             | FStar_Pervasives_Native.Some r1 -> r1
             | FStar_Pervasives_Native.None  -> FStar_Range.dummyRange  in
           let i =
-            let uu____2911 = FStar_Dyn.mkdyn t  in
+            let uu____2923 = FStar_Dyn.mkdyn t  in
             {
-              FStar_Syntax_Syntax.blob = uu____2911;
+              FStar_Syntax_Syntax.blob = uu____2923;
               FStar_Syntax_Syntax.lkind = k;
               FStar_Syntax_Syntax.ltyp = typ;
               FStar_Syntax_Syntax.rng = rng
@@ -874,9 +875,9 @@ let (canon_app :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun t  ->
-    let uu____2924 =
-      let uu____2939 = unascribe t  in head_and_args' uu____2939  in
-    match uu____2924 with
+    let uu____2936 =
+      let uu____2951 = unascribe t  in head_and_args' uu____2951  in
+    match uu____2936 with
     | (hd,args) ->
         FStar_Syntax_Syntax.mk_Tm_app hd args FStar_Pervasives_Native.None
           t.FStar_Syntax_Syntax.pos
@@ -887,15 +888,15 @@ type eq_result =
   | Unknown 
 let (uu___is_Equal : eq_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Equal  -> true | uu____2973 -> false
+    match projectee with | Equal  -> true | uu____2985 -> false
   
 let (uu___is_NotEqual : eq_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NotEqual  -> true | uu____2984 -> false
+    match projectee with | NotEqual  -> true | uu____2996 -> false
   
 let (uu___is_Unknown : eq_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Unknown  -> true | uu____2995 -> false
+    match projectee with | Unknown  -> true | uu____3007 -> false
   
 let (injectives : Prims.string Prims.list) =
   ["FStar.Int8.int_to_t";
@@ -919,10 +920,10 @@ let (eq_inj : eq_result -> eq_result -> eq_result) =
     fun g  ->
       match (f, g) with
       | (Equal ,Equal ) -> Equal
-      | (NotEqual ,uu____3045) -> NotEqual
-      | (uu____3046,NotEqual ) -> NotEqual
-      | (Unknown ,uu____3047) -> Unknown
-      | (uu____3048,Unknown ) -> Unknown
+      | (NotEqual ,uu____3057) -> NotEqual
+      | (uu____3058,NotEqual ) -> NotEqual
+      | (Unknown ,uu____3059) -> Unknown
+      | (uu____3060,Unknown ) -> Unknown
   
 let rec (eq_tm :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> eq_result) =
@@ -930,44 +931,44 @@ let rec (eq_tm :
     fun t2  ->
       let t11 = canon_app t1  in
       let t21 = canon_app t2  in
-      let equal_if uu___5_3157 = if uu___5_3157 then Equal else Unknown  in
-      let equal_iff uu___6_3168 = if uu___6_3168 then Equal else NotEqual  in
-      let eq_and f g = match f with | Equal  -> g () | uu____3189 -> Unknown
+      let equal_if uu___5_3169 = if uu___5_3169 then Equal else Unknown  in
+      let equal_iff uu___6_3180 = if uu___6_3180 then Equal else NotEqual  in
+      let eq_and f g = match f with | Equal  -> g () | uu____3201 -> Unknown
          in
       let equal_data f1 args1 f2 args2 =
-        let uu____3211 = FStar_Syntax_Syntax.fv_eq f1 f2  in
-        if uu____3211
+        let uu____3223 = FStar_Syntax_Syntax.fv_eq f1 f2  in
+        if uu____3223
         then
-          let uu____3215 = FStar_List.zip args1 args2  in
+          let uu____3227 = FStar_List.zip args1 args2  in
           FStar_All.pipe_left
             (FStar_List.fold_left
                (fun acc  ->
-                  fun uu____3292  ->
-                    match uu____3292 with
+                  fun uu____3304  ->
+                    match uu____3304 with
                     | ((a1,q1),(a2,q2)) ->
-                        let uu____3333 = eq_tm a1 a2  in
-                        eq_inj acc uu____3333) Equal) uu____3215
+                        let uu____3345 = eq_tm a1 a2  in
+                        eq_inj acc uu____3345) Equal) uu____3227
         else NotEqual  in
       let heads_and_args_in_case_both_data =
-        let uu____3347 =
-          let uu____3364 = FStar_All.pipe_right t11 unmeta  in
-          FStar_All.pipe_right uu____3364 head_and_args  in
-        match uu____3347 with
+        let uu____3359 =
+          let uu____3376 = FStar_All.pipe_right t11 unmeta  in
+          FStar_All.pipe_right uu____3376 head_and_args  in
+        match uu____3359 with
         | (head1,args1) ->
-            let uu____3417 =
-              let uu____3434 = FStar_All.pipe_right t21 unmeta  in
-              FStar_All.pipe_right uu____3434 head_and_args  in
-            (match uu____3417 with
+            let uu____3429 =
+              let uu____3446 = FStar_All.pipe_right t21 unmeta  in
+              FStar_All.pipe_right uu____3446 head_and_args  in
+            (match uu____3429 with
              | (head2,args2) ->
-                 let uu____3487 =
-                   let uu____3492 =
-                     let uu____3493 = un_uinst head1  in
-                     uu____3493.FStar_Syntax_Syntax.n  in
-                   let uu____3496 =
-                     let uu____3497 = un_uinst head2  in
-                     uu____3497.FStar_Syntax_Syntax.n  in
-                   (uu____3492, uu____3496)  in
-                 (match uu____3487 with
+                 let uu____3499 =
+                   let uu____3504 =
+                     let uu____3505 = un_uinst head1  in
+                     uu____3505.FStar_Syntax_Syntax.n  in
+                   let uu____3508 =
+                     let uu____3509 = un_uinst head2  in
+                     uu____3509.FStar_Syntax_Syntax.n  in
+                   (uu____3504, uu____3508)  in
+                 (match uu____3499 with
                   | (FStar_Syntax_Syntax.Tm_fvar
                      f,FStar_Syntax_Syntax.Tm_fvar g) when
                       (f.FStar_Syntax_Syntax.fv_qual =
@@ -978,111 +979,112 @@ let rec (eq_tm :
                            (FStar_Pervasives_Native.Some
                               FStar_Syntax_Syntax.Data_ctor))
                       -> FStar_Pervasives_Native.Some (f, args1, g, args2)
-                  | uu____3524 -> FStar_Pervasives_Native.None))
+                  | uu____3536 -> FStar_Pervasives_Native.None))
          in
-      let uu____3537 =
-        let uu____3542 =
-          let uu____3543 = unmeta t11  in uu____3543.FStar_Syntax_Syntax.n
+      let uu____3549 =
+        let uu____3554 =
+          let uu____3555 = unmeta t11  in uu____3555.FStar_Syntax_Syntax.n
            in
-        let uu____3546 =
-          let uu____3547 = unmeta t21  in uu____3547.FStar_Syntax_Syntax.n
+        let uu____3558 =
+          let uu____3559 = unmeta t21  in uu____3559.FStar_Syntax_Syntax.n
            in
-        (uu____3542, uu____3546)  in
-      match uu____3537 with
+        (uu____3554, uu____3558)  in
+      match uu____3549 with
       | (FStar_Syntax_Syntax.Tm_bvar bv1,FStar_Syntax_Syntax.Tm_bvar bv2) ->
           equal_if
             (bv1.FStar_Syntax_Syntax.index = bv2.FStar_Syntax_Syntax.index)
-      | (FStar_Syntax_Syntax.Tm_lazy uu____3553,uu____3554) ->
-          let uu____3555 = unlazy t11  in eq_tm uu____3555 t21
-      | (uu____3556,FStar_Syntax_Syntax.Tm_lazy uu____3557) ->
-          let uu____3558 = unlazy t21  in eq_tm t11 uu____3558
+      | (FStar_Syntax_Syntax.Tm_lazy uu____3565,uu____3566) ->
+          let uu____3567 = unlazy t11  in eq_tm uu____3567 t21
+      | (uu____3568,FStar_Syntax_Syntax.Tm_lazy uu____3569) ->
+          let uu____3570 = unlazy t21  in eq_tm t11 uu____3570
       | (FStar_Syntax_Syntax.Tm_name a,FStar_Syntax_Syntax.Tm_name b) ->
-          equal_if (FStar_Syntax_Syntax.bv_eq a b)
-      | uu____3561 when
+          let uu____3573 = FStar_Syntax_Syntax.bv_eq a b  in
+          equal_if uu____3573
+      | uu____3575 when
           FStar_All.pipe_right heads_and_args_in_case_both_data
             FStar_Util.is_some
           ->
-          let uu____3585 =
+          let uu____3599 =
             FStar_All.pipe_right heads_and_args_in_case_both_data
               FStar_Util.must
              in
-          FStar_All.pipe_right uu____3585
-            (fun uu____3633  ->
-               match uu____3633 with
+          FStar_All.pipe_right uu____3599
+            (fun uu____3647  ->
+               match uu____3647 with
                | (f,args1,g,args2) -> equal_data f args1 g args2)
       | (FStar_Syntax_Syntax.Tm_fvar f,FStar_Syntax_Syntax.Tm_fvar g) ->
-          let uu____3648 = FStar_Syntax_Syntax.fv_eq f g  in
-          equal_if uu____3648
+          let uu____3662 = FStar_Syntax_Syntax.fv_eq f g  in
+          equal_if uu____3662
       | (FStar_Syntax_Syntax.Tm_uinst (f,us),FStar_Syntax_Syntax.Tm_uinst
          (g,vs)) ->
-          let uu____3662 = eq_tm f g  in
-          eq_and uu____3662
-            (fun uu____3665  ->
-               let uu____3666 = eq_univs_list us vs  in equal_if uu____3666)
+          let uu____3676 = eq_tm f g  in
+          eq_and uu____3676
+            (fun uu____3679  ->
+               let uu____3680 = eq_univs_list us vs  in equal_if uu____3680)
       | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
-         uu____3668),uu____3669) -> Unknown
-      | (uu____3670,FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
-         uu____3671)) -> Unknown
+         uu____3682),uu____3683) -> Unknown
+      | (uu____3684,FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
+         uu____3685)) -> Unknown
       | (FStar_Syntax_Syntax.Tm_constant c,FStar_Syntax_Syntax.Tm_constant d)
           ->
-          let uu____3674 = FStar_Const.eq_const c d  in equal_iff uu____3674
+          let uu____3688 = FStar_Const.eq_const c d  in equal_iff uu____3688
       | (FStar_Syntax_Syntax.Tm_uvar
-         (u1,([],uu____3677)),FStar_Syntax_Syntax.Tm_uvar
-         (u2,([],uu____3679))) ->
-          let uu____3708 =
+         (u1,([],uu____3691)),FStar_Syntax_Syntax.Tm_uvar
+         (u2,([],uu____3693))) ->
+          let uu____3722 =
             FStar_Syntax_Unionfind.equiv u1.FStar_Syntax_Syntax.ctx_uvar_head
               u2.FStar_Syntax_Syntax.ctx_uvar_head
              in
-          equal_if uu____3708
+          equal_if uu____3722
       | (FStar_Syntax_Syntax.Tm_app (h1,args1),FStar_Syntax_Syntax.Tm_app
          (h2,args2)) ->
-          let uu____3762 =
-            let uu____3767 =
-              let uu____3768 = un_uinst h1  in
-              uu____3768.FStar_Syntax_Syntax.n  in
-            let uu____3771 =
-              let uu____3772 = un_uinst h2  in
-              uu____3772.FStar_Syntax_Syntax.n  in
-            (uu____3767, uu____3771)  in
-          (match uu____3762 with
+          let uu____3776 =
+            let uu____3781 =
+              let uu____3782 = un_uinst h1  in
+              uu____3782.FStar_Syntax_Syntax.n  in
+            let uu____3785 =
+              let uu____3786 = un_uinst h2  in
+              uu____3786.FStar_Syntax_Syntax.n  in
+            (uu____3781, uu____3785)  in
+          (match uu____3776 with
            | (FStar_Syntax_Syntax.Tm_fvar f1,FStar_Syntax_Syntax.Tm_fvar f2)
                when
                (FStar_Syntax_Syntax.fv_eq f1 f2) &&
-                 (let uu____3778 =
-                    let uu____3780 = FStar_Syntax_Syntax.lid_of_fv f1  in
-                    FStar_Ident.string_of_lid uu____3780  in
-                  FStar_List.mem uu____3778 injectives)
+                 (let uu____3792 =
+                    let uu____3794 = FStar_Syntax_Syntax.lid_of_fv f1  in
+                    FStar_Ident.string_of_lid uu____3794  in
+                  FStar_List.mem uu____3792 injectives)
                -> equal_data f1 args1 f2 args2
-           | uu____3782 ->
-               let uu____3787 = eq_tm h1 h2  in
-               eq_and uu____3787 (fun uu____3789  -> eq_args args1 args2))
+           | uu____3796 ->
+               let uu____3801 = eq_tm h1 h2  in
+               eq_and uu____3801 (fun uu____3803  -> eq_args args1 args2))
       | (FStar_Syntax_Syntax.Tm_match (t12,bs1),FStar_Syntax_Syntax.Tm_match
          (t22,bs2)) ->
           if (FStar_List.length bs1) = (FStar_List.length bs2)
           then
-            let uu____3895 = FStar_List.zip bs1 bs2  in
-            let uu____3958 = eq_tm t12 t22  in
+            let uu____3909 = FStar_List.zip bs1 bs2  in
+            let uu____3972 = eq_tm t12 t22  in
             FStar_List.fold_right
-              (fun uu____3995  ->
+              (fun uu____4009  ->
                  fun a  ->
-                   match uu____3995 with
+                   match uu____4009 with
                    | (b1,b2) ->
-                       eq_and a (fun uu____4088  -> branch_matches b1 b2))
-              uu____3895 uu____3958
+                       eq_and a (fun uu____4102  -> branch_matches b1 b2))
+              uu____3909 uu____3972
           else Unknown
       | (FStar_Syntax_Syntax.Tm_type u,FStar_Syntax_Syntax.Tm_type v) ->
-          let uu____4093 = eq_univs u v  in equal_if uu____4093
+          let uu____4107 = eq_univs u v  in equal_if uu____4107
       | (FStar_Syntax_Syntax.Tm_quoted (t12,q1),FStar_Syntax_Syntax.Tm_quoted
          (t22,q2)) ->
-          let uu____4107 = eq_quoteinfo q1 q2  in
-          eq_and uu____4107 (fun uu____4109  -> eq_tm t12 t22)
+          let uu____4121 = eq_quoteinfo q1 q2  in
+          eq_and uu____4121 (fun uu____4123  -> eq_tm t12 t22)
       | (FStar_Syntax_Syntax.Tm_refine
          (t12,phi1),FStar_Syntax_Syntax.Tm_refine (t22,phi2)) ->
-          let uu____4122 =
+          let uu____4136 =
             eq_tm t12.FStar_Syntax_Syntax.sort t22.FStar_Syntax_Syntax.sort
              in
-          eq_and uu____4122 (fun uu____4124  -> eq_tm phi1 phi2)
-      | uu____4125 -> Unknown
+          eq_and uu____4136 (fun uu____4138  -> eq_tm phi1 phi2)
+      | uu____4139 -> Unknown
 
 and (eq_quoteinfo :
   FStar_Syntax_Syntax.quoteinfo -> FStar_Syntax_Syntax.quoteinfo -> eq_result)
@@ -1105,20 +1107,23 @@ and (eq_antiquotes :
     fun a2  ->
       match (a1, a2) with
       | ([],[]) -> Equal
-      | ([],uu____4197) -> NotEqual
-      | (uu____4228,[]) -> NotEqual
+      | ([],uu____4211) -> NotEqual
+      | (uu____4242,[]) -> NotEqual
       | ((x1,t1)::a11,(x2,t2)::a21) ->
-          if Prims.op_Negation (FStar_Syntax_Syntax.bv_eq x1 x2)
+          let uu____4331 =
+            let uu____4333 = FStar_Syntax_Syntax.bv_eq x1 x2  in
+            Prims.op_Negation uu____4333  in
+          if uu____4331
           then NotEqual
           else
-            (let uu____4320 = eq_tm t1 t2  in
-             match uu____4320 with
+            (let uu____4338 = eq_tm t1 t2  in
+             match uu____4338 with
              | NotEqual  -> NotEqual
              | Unknown  ->
-                 let uu____4321 = eq_antiquotes a11 a21  in
-                 (match uu____4321 with
+                 let uu____4339 = eq_antiquotes a11 a21  in
+                 (match uu____4339 with
                   | NotEqual  -> NotEqual
-                  | uu____4322 -> Unknown)
+                  | uu____4340 -> Unknown)
              | Equal  -> eq_antiquotes a11 a21)
 
 and (branch_matches :
@@ -1139,25 +1144,25 @@ and (branch_matches :
             true
         | (FStar_Pervasives_Native.Some x,FStar_Pervasives_Native.Some y) ->
             f x y
-        | (uu____4406,uu____4407) -> false  in
-      let uu____4417 = b1  in
-      match uu____4417 with
+        | (uu____4424,uu____4425) -> false  in
+      let uu____4435 = b1  in
+      match uu____4435 with
       | (p1,w1,t1) ->
-          let uu____4451 = b2  in
-          (match uu____4451 with
+          let uu____4469 = b2  in
+          (match uu____4469 with
            | (p2,w2,t2) ->
-               let uu____4485 = FStar_Syntax_Syntax.eq_pat p1 p2  in
-               if uu____4485
+               let uu____4503 = FStar_Syntax_Syntax.eq_pat p1 p2  in
+               if uu____4503
                then
-                 let uu____4488 =
-                   (let uu____4492 = eq_tm t1 t2  in uu____4492 = Equal) &&
+                 let uu____4506 =
+                   (let uu____4510 = eq_tm t1 t2  in uu____4510 = Equal) &&
                      (related_by
                         (fun t11  ->
                            fun t21  ->
-                             let uu____4501 = eq_tm t11 t21  in
-                             uu____4501 = Equal) w1 w2)
+                             let uu____4519 = eq_tm t11 t21  in
+                             uu____4519 = Equal) w1 w2)
                     in
-                 (if uu____4488 then Equal else Unknown)
+                 (if uu____4506 then Equal else Unknown)
                else Unknown)
 
 and (eq_args :
@@ -1166,12 +1171,12 @@ and (eq_args :
     fun a2  ->
       match (a1, a2) with
       | ([],[]) -> Equal
-      | ((a,uu____4566)::a11,(b,uu____4569)::b1) ->
-          let uu____4643 = eq_tm a b  in
-          (match uu____4643 with
+      | ((a,uu____4584)::a11,(b,uu____4587)::b1) ->
+          let uu____4661 = eq_tm a b  in
+          (match uu____4661 with
            | Equal  -> eq_args a11 b1
-           | uu____4644 -> Unknown)
-      | uu____4645 -> Unknown
+           | uu____4662 -> Unknown)
+      | uu____4663 -> Unknown
 
 and (eq_univs_list :
   FStar_Syntax_Syntax.universes ->
@@ -1192,8 +1197,8 @@ let (eq_aqual :
       match (a1, a2) with
       | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.None ) ->
           Equal
-      | (FStar_Pervasives_Native.None ,uu____4700) -> NotEqual
-      | (uu____4707,FStar_Pervasives_Native.None ) -> NotEqual
+      | (FStar_Pervasives_Native.None ,uu____4718) -> NotEqual
+      | (uu____4725,FStar_Pervasives_Native.None ) -> NotEqual
       | (FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
          b1),FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit b2))
           when b1 = b2 -> Equal
@@ -1203,87 +1208,87 @@ let (eq_aqual :
       | (FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality
          ),FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality )) ->
           Equal
-      | uu____4737 -> NotEqual
+      | uu____4755 -> NotEqual
   
 let rec (unrefine : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_refine (x,uu____4754) ->
+    | FStar_Syntax_Syntax.Tm_refine (x,uu____4772) ->
         unrefine x.FStar_Syntax_Syntax.sort
-    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____4760,uu____4761) ->
+    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____4778,uu____4779) ->
         unrefine t2
-    | uu____4802 -> t1
+    | uu____4820 -> t1
   
 let rec (is_uvar : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____4810 =
-      let uu____4811 = FStar_Syntax_Subst.compress t  in
-      uu____4811.FStar_Syntax_Syntax.n  in
-    match uu____4810 with
-    | FStar_Syntax_Syntax.Tm_uvar uu____4815 -> true
-    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____4830) -> is_uvar t1
-    | FStar_Syntax_Syntax.Tm_app uu____4835 ->
-        let uu____4852 =
-          let uu____4853 = FStar_All.pipe_right t head_and_args  in
-          FStar_All.pipe_right uu____4853 FStar_Pervasives_Native.fst  in
-        FStar_All.pipe_right uu____4852 is_uvar
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____4916,uu____4917) ->
+    let uu____4828 =
+      let uu____4829 = FStar_Syntax_Subst.compress t  in
+      uu____4829.FStar_Syntax_Syntax.n  in
+    match uu____4828 with
+    | FStar_Syntax_Syntax.Tm_uvar uu____4833 -> true
+    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____4848) -> is_uvar t1
+    | FStar_Syntax_Syntax.Tm_app uu____4853 ->
+        let uu____4870 =
+          let uu____4871 = FStar_All.pipe_right t head_and_args  in
+          FStar_All.pipe_right uu____4871 FStar_Pervasives_Native.fst  in
+        FStar_All.pipe_right uu____4870 is_uvar
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____4934,uu____4935) ->
         is_uvar t1
-    | uu____4958 -> false
+    | uu____4976 -> false
   
 let rec (is_unit : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____4967 =
-      let uu____4968 = unrefine t  in uu____4968.FStar_Syntax_Syntax.n  in
-    match uu____4967 with
+    let uu____4985 =
+      let uu____4986 = unrefine t  in uu____4986.FStar_Syntax_Syntax.n  in
+    match uu____4985 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         ((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.unit_lid) ||
            (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid))
           ||
           (FStar_Syntax_Syntax.fv_eq_lid fv
              FStar_Parser_Const.auto_squash_lid)
-    | FStar_Syntax_Syntax.Tm_app (head,uu____4974) -> is_unit head
-    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____5000) -> is_unit t1
-    | uu____5005 -> false
+    | FStar_Syntax_Syntax.Tm_app (head,uu____4992) -> is_unit head
+    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____5018) -> is_unit t1
+    | uu____5023 -> false
   
 let (is_eqtype_no_unrefine : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____5014 =
-      let uu____5015 = FStar_Syntax_Subst.compress t  in
-      uu____5015.FStar_Syntax_Syntax.n  in
-    match uu____5014 with
+    let uu____5032 =
+      let uu____5033 = FStar_Syntax_Subst.compress t  in
+      uu____5033.FStar_Syntax_Syntax.n  in
+    match uu____5032 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.eqtype_lid
-    | uu____5020 -> false
+    | uu____5038 -> false
   
 let (is_fun : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e  ->
-    let uu____5029 =
-      let uu____5030 = FStar_Syntax_Subst.compress e  in
-      uu____5030.FStar_Syntax_Syntax.n  in
-    match uu____5029 with
-    | FStar_Syntax_Syntax.Tm_abs uu____5034 -> true
-    | uu____5054 -> false
+    let uu____5047 =
+      let uu____5048 = FStar_Syntax_Subst.compress e  in
+      uu____5048.FStar_Syntax_Syntax.n  in
+    match uu____5047 with
+    | FStar_Syntax_Syntax.Tm_abs uu____5052 -> true
+    | uu____5072 -> false
   
 let (is_function_typ : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____5063 =
-      let uu____5064 = FStar_Syntax_Subst.compress t  in
-      uu____5064.FStar_Syntax_Syntax.n  in
-    match uu____5063 with
-    | FStar_Syntax_Syntax.Tm_arrow uu____5068 -> true
-    | uu____5084 -> false
+    let uu____5081 =
+      let uu____5082 = FStar_Syntax_Subst.compress t  in
+      uu____5082.FStar_Syntax_Syntax.n  in
+    match uu____5081 with
+    | FStar_Syntax_Syntax.Tm_arrow uu____5086 -> true
+    | uu____5102 -> false
   
 let rec (pre_typ : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_refine (x,uu____5094) ->
+    | FStar_Syntax_Syntax.Tm_refine (x,uu____5112) ->
         pre_typ x.FStar_Syntax_Syntax.sort
-    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____5100,uu____5101) ->
+    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____5118,uu____5119) ->
         pre_typ t2
-    | uu____5142 -> t1
+    | uu____5160 -> t1
   
 let (destruct :
   FStar_Syntax_Syntax.term ->
@@ -1295,46 +1300,46 @@ let (destruct :
   fun typ  ->
     fun lid  ->
       let typ1 = FStar_Syntax_Subst.compress typ  in
-      let uu____5167 =
-        let uu____5168 = un_uinst typ1  in uu____5168.FStar_Syntax_Syntax.n
+      let uu____5185 =
+        let uu____5186 = un_uinst typ1  in uu____5186.FStar_Syntax_Syntax.n
          in
-      match uu____5167 with
+      match uu____5185 with
       | FStar_Syntax_Syntax.Tm_app (head,args) ->
           let head1 = un_uinst head  in
           (match head1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_fvar tc when
                FStar_Syntax_Syntax.fv_eq_lid tc lid ->
                FStar_Pervasives_Native.Some args
-           | uu____5233 -> FStar_Pervasives_Native.None)
+           | uu____5251 -> FStar_Pervasives_Native.None)
       | FStar_Syntax_Syntax.Tm_fvar tc when
           FStar_Syntax_Syntax.fv_eq_lid tc lid ->
           FStar_Pervasives_Native.Some []
-      | uu____5263 -> FStar_Pervasives_Native.None
+      | uu____5281 -> FStar_Pervasives_Native.None
   
 let (lids_of_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Ident.lident Prims.list) =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_let (uu____5284,lids) -> lids
-    | FStar_Syntax_Syntax.Sig_splice (lids,uu____5291) -> lids
-    | FStar_Syntax_Syntax.Sig_bundle (uu____5296,lids) -> lids
+    | FStar_Syntax_Syntax.Sig_let (uu____5302,lids) -> lids
+    | FStar_Syntax_Syntax.Sig_splice (lids,uu____5309) -> lids
+    | FStar_Syntax_Syntax.Sig_bundle (uu____5314,lids) -> lids
     | FStar_Syntax_Syntax.Sig_inductive_typ
-        (lid,uu____5307,uu____5308,uu____5309,uu____5310,uu____5311) -> 
+        (lid,uu____5325,uu____5326,uu____5327,uu____5328,uu____5329) -> 
         [lid]
     | FStar_Syntax_Syntax.Sig_effect_abbrev
-        (lid,uu____5321,uu____5322,uu____5323,uu____5324) -> [lid]
+        (lid,uu____5339,uu____5340,uu____5341,uu____5342) -> [lid]
     | FStar_Syntax_Syntax.Sig_datacon
-        (lid,uu____5330,uu____5331,uu____5332,uu____5333,uu____5334) -> 
+        (lid,uu____5348,uu____5349,uu____5350,uu____5351,uu____5352) -> 
         [lid]
-    | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____5342,uu____5343) ->
+    | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____5360,uu____5361) ->
         [lid]
-    | FStar_Syntax_Syntax.Sig_assume (lid,uu____5345,uu____5346) -> [lid]
+    | FStar_Syntax_Syntax.Sig_assume (lid,uu____5363,uu____5364) -> [lid]
     | FStar_Syntax_Syntax.Sig_new_effect n -> [n.FStar_Syntax_Syntax.mname]
-    | FStar_Syntax_Syntax.Sig_sub_effect uu____5348 -> []
-    | FStar_Syntax_Syntax.Sig_pragma uu____5349 -> []
-    | FStar_Syntax_Syntax.Sig_main uu____5350 -> []
-    | FStar_Syntax_Syntax.Sig_fail uu____5351 -> []
-    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____5364 -> []
+    | FStar_Syntax_Syntax.Sig_sub_effect uu____5366 -> []
+    | FStar_Syntax_Syntax.Sig_pragma uu____5367 -> []
+    | FStar_Syntax_Syntax.Sig_main uu____5368 -> []
+    | FStar_Syntax_Syntax.Sig_fail uu____5369 -> []
+    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____5382 -> []
   
 let (lid_of_sigelt :
   FStar_Syntax_Syntax.sigelt ->
@@ -1343,7 +1348,7 @@ let (lid_of_sigelt :
   fun se  ->
     match lids_of_sigelt se with
     | l::[] -> FStar_Pervasives_Native.Some l
-    | uu____5388 -> FStar_Pervasives_Native.None
+    | uu____5406 -> FStar_Pervasives_Native.None
   
 let (quals_of_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.qualifier Prims.list) =
@@ -1354,24 +1359,24 @@ let (range_of_lbname :
   (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
     FStar_Range.range)
   =
-  fun uu___7_5414  ->
-    match uu___7_5414 with
+  fun uu___7_5432  ->
+    match uu___7_5432 with
     | FStar_Util.Inl x -> FStar_Syntax_Syntax.range_of_bv x
     | FStar_Util.Inr fv ->
         FStar_Ident.range_of_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
   
 let range_of_arg :
-  'uuuuuu5428 'uuuuuu5429 .
-    ('uuuuuu5428 FStar_Syntax_Syntax.syntax * 'uuuuuu5429) ->
+  'uuuuuu5446 'uuuuuu5447 .
+    ('uuuuuu5446 FStar_Syntax_Syntax.syntax * 'uuuuuu5447) ->
       FStar_Range.range
   =
-  fun uu____5440  ->
-    match uu____5440 with | (hd,uu____5448) -> hd.FStar_Syntax_Syntax.pos
+  fun uu____5458  ->
+    match uu____5458 with | (hd,uu____5466) -> hd.FStar_Syntax_Syntax.pos
   
 let range_of_args :
-  'uuuuuu5462 'uuuuuu5463 .
-    ('uuuuuu5462 FStar_Syntax_Syntax.syntax * 'uuuuuu5463) Prims.list ->
+  'uuuuuu5480 'uuuuuu5481 .
+    ('uuuuuu5480 FStar_Syntax_Syntax.syntax * 'uuuuuu5481) Prims.list ->
       FStar_Range.range -> FStar_Range.range
   =
   fun args  ->
@@ -1391,7 +1396,7 @@ let (mk_app :
     fun args  ->
       match args with
       | [] -> f
-      | uu____5561 ->
+      | uu____5579 ->
           let r = range_of_args args f.FStar_Syntax_Syntax.pos  in
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (f, args))
             FStar_Pervasives_Native.None r
@@ -1404,15 +1409,15 @@ let (mk_app_binders :
   =
   fun f  ->
     fun bs  ->
-      let uu____5620 =
+      let uu____5638 =
         FStar_List.map
-          (fun uu____5647  ->
-             match uu____5647 with
+          (fun uu____5665  ->
+             match uu____5665 with
              | (bv,aq) ->
-                 let uu____5666 = FStar_Syntax_Syntax.bv_to_name bv  in
-                 (uu____5666, aq)) bs
+                 let uu____5684 = FStar_Syntax_Syntax.bv_to_name bv  in
+                 (uu____5684, aq)) bs
          in
-      mk_app f uu____5620
+      mk_app f uu____5638
   
 let (field_projector_prefix : Prims.string) = "__proj__" 
 let (field_projector_sep : Prims.string) = "__item__" 
@@ -1429,17 +1434,25 @@ let (mk_field_projector_name_from_ident :
   FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident) =
   fun lid  ->
     fun i  ->
-      let itext = i.FStar_Ident.idText  in
+      let itext = FStar_Ident.text_of_id i  in
       let newi =
         if field_projector_contains_constructor itext
         then i
         else
-          FStar_Ident.mk_ident
-            ((mk_field_projector_name_from_string
-                (lid.FStar_Ident.ident).FStar_Ident.idText itext),
-              (i.FStar_Ident.idRange))
+          (let uu____5735 =
+             let uu____5741 =
+               let uu____5743 =
+                 let uu____5745 = FStar_Ident.ident_of_lid lid  in
+                 FStar_Ident.text_of_id uu____5745  in
+               mk_field_projector_name_from_string uu____5743 itext  in
+             let uu____5746 = FStar_Ident.range_of_id i  in
+             (uu____5741, uu____5746)  in
+           FStar_Ident.mk_ident uu____5735)
          in
-      FStar_Ident.lid_of_ids (FStar_List.append lid.FStar_Ident.ns [newi])
+      let uu____5748 =
+        let uu____5749 = FStar_Ident.ns_of_lid lid  in
+        FStar_List.append uu____5749 [newi]  in
+      FStar_Ident.lid_of_ids uu____5748
   
 let (mk_field_projector_name :
   FStar_Ident.lident ->
@@ -1449,16 +1462,16 @@ let (mk_field_projector_name :
     fun x  ->
       fun i  ->
         let nm =
-          let uu____5737 = FStar_Syntax_Syntax.is_null_bv x  in
-          if uu____5737
+          let uu____5771 = FStar_Syntax_Syntax.is_null_bv x  in
+          if uu____5771
           then
-            let uu____5740 =
-              let uu____5746 =
-                let uu____5748 = FStar_Util.string_of_int i  in
-                Prims.op_Hat "_" uu____5748  in
-              let uu____5751 = FStar_Syntax_Syntax.range_of_bv x  in
-              (uu____5746, uu____5751)  in
-            FStar_Ident.mk_ident uu____5740
+            let uu____5774 =
+              let uu____5780 =
+                let uu____5782 = FStar_Util.string_of_int i  in
+                Prims.op_Hat "_" uu____5782  in
+              let uu____5785 = FStar_Syntax_Syntax.range_of_bv x  in
+              (uu____5780, uu____5785)  in
+            FStar_Ident.mk_ident uu____5774
           else x.FStar_Syntax_Syntax.ppname  in
         mk_field_projector_name_from_ident lid nm
   
@@ -1466,23 +1479,23 @@ let (ses_of_sigbundle :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt Prims.list) =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_bundle (ses,uu____5766) -> ses
-    | uu____5775 -> failwith "ses_of_sigbundle: not a Sig_bundle"
+    | FStar_Syntax_Syntax.Sig_bundle (ses,uu____5800) -> ses
+    | uu____5809 -> failwith "ses_of_sigbundle: not a Sig_bundle"
   
 let (set_uvar : FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> unit)
   =
   fun uv  ->
     fun t  ->
-      let uu____5790 = FStar_Syntax_Unionfind.find uv  in
-      match uu____5790 with
-      | FStar_Pervasives_Native.Some uu____5793 ->
-          let uu____5794 =
-            let uu____5796 =
-              let uu____5798 = FStar_Syntax_Unionfind.uvar_id uv  in
-              FStar_All.pipe_left FStar_Util.string_of_int uu____5798  in
-            FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu____5796  in
-          failwith uu____5794
-      | uu____5803 -> FStar_Syntax_Unionfind.change uv t
+      let uu____5824 = FStar_Syntax_Unionfind.find uv  in
+      match uu____5824 with
+      | FStar_Pervasives_Native.Some uu____5827 ->
+          let uu____5828 =
+            let uu____5830 =
+              let uu____5832 = FStar_Syntax_Unionfind.uvar_id uv  in
+              FStar_All.pipe_left FStar_Util.string_of_int uu____5832  in
+            FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu____5830  in
+          failwith uu____5828
+      | uu____5837 -> FStar_Syntax_Unionfind.change uv t
   
 let (qualifier_equal :
   FStar_Syntax_Syntax.qualifier ->
@@ -1497,34 +1510,44 @@ let (qualifier_equal :
       | (FStar_Syntax_Syntax.Projector
          (l1a,l1b),FStar_Syntax_Syntax.Projector (l2a,l2b)) ->
           (FStar_Ident.lid_equals l1a l2a) &&
-            (l1b.FStar_Ident.idText = l2b.FStar_Ident.idText)
+            (let uu____5861 = FStar_Ident.text_of_id l1b  in
+             let uu____5863 = FStar_Ident.text_of_id l2b  in
+             uu____5861 = uu____5863)
       | (FStar_Syntax_Syntax.RecordType
          (ns1,f1),FStar_Syntax_Syntax.RecordType (ns2,f2)) ->
           ((((FStar_List.length ns1) = (FStar_List.length ns2)) &&
               (FStar_List.forall2
                  (fun x1  ->
-                    fun x2  -> x1.FStar_Ident.idText = x2.FStar_Ident.idText)
-                 f1 f2))
+                    fun x2  ->
+                      let uu____5892 = FStar_Ident.text_of_id x1  in
+                      let uu____5894 = FStar_Ident.text_of_id x2  in
+                      uu____5892 = uu____5894) f1 f2))
              && ((FStar_List.length f1) = (FStar_List.length f2)))
             &&
             (FStar_List.forall2
                (fun x1  ->
-                  fun x2  -> x1.FStar_Ident.idText = x2.FStar_Ident.idText)
-               f1 f2)
+                  fun x2  ->
+                    let uu____5903 = FStar_Ident.text_of_id x1  in
+                    let uu____5905 = FStar_Ident.text_of_id x2  in
+                    uu____5903 = uu____5905) f1 f2)
       | (FStar_Syntax_Syntax.RecordConstructor
          (ns1,f1),FStar_Syntax_Syntax.RecordConstructor (ns2,f2)) ->
           ((((FStar_List.length ns1) = (FStar_List.length ns2)) &&
               (FStar_List.forall2
                  (fun x1  ->
-                    fun x2  -> x1.FStar_Ident.idText = x2.FStar_Ident.idText)
-                 f1 f2))
+                    fun x2  ->
+                      let uu____5934 = FStar_Ident.text_of_id x1  in
+                      let uu____5936 = FStar_Ident.text_of_id x2  in
+                      uu____5934 = uu____5936) f1 f2))
              && ((FStar_List.length f1) = (FStar_List.length f2)))
             &&
             (FStar_List.forall2
                (fun x1  ->
-                  fun x2  -> x1.FStar_Ident.idText = x2.FStar_Ident.idText)
-               f1 f2)
-      | uu____5886 -> q1 = q2
+                  fun x2  ->
+                    let uu____5945 = FStar_Ident.text_of_id x1  in
+                    let uu____5947 = FStar_Ident.text_of_id x2  in
+                    uu____5945 = uu____5947) f1 f2)
+      | uu____5950 -> q1 = q2
   
 let (abs :
   FStar_Syntax_Syntax.binders ->
@@ -1539,53 +1562,53 @@ let (abs :
           match lopt1 with
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some rc ->
-              let uu____5932 =
-                let uu___994_5933 = rc  in
-                let uu____5934 =
+              let uu____5996 =
+                let uu___992_5997 = rc  in
+                let uu____5998 =
                   FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                     (FStar_Syntax_Subst.close bs)
                    in
                 {
                   FStar_Syntax_Syntax.residual_effect =
-                    (uu___994_5933.FStar_Syntax_Syntax.residual_effect);
-                  FStar_Syntax_Syntax.residual_typ = uu____5934;
+                    (uu___992_5997.FStar_Syntax_Syntax.residual_effect);
+                  FStar_Syntax_Syntax.residual_typ = uu____5998;
                   FStar_Syntax_Syntax.residual_flags =
-                    (uu___994_5933.FStar_Syntax_Syntax.residual_flags)
+                    (uu___992_5997.FStar_Syntax_Syntax.residual_flags)
                 }  in
-              FStar_Pervasives_Native.Some uu____5932
+              FStar_Pervasives_Native.Some uu____5996
            in
         match bs with
         | [] -> t
-        | uu____5951 ->
+        | uu____6015 ->
             let body =
-              let uu____5953 = FStar_Syntax_Subst.close bs t  in
-              FStar_Syntax_Subst.compress uu____5953  in
+              let uu____6017 = FStar_Syntax_Subst.close bs t  in
+              FStar_Syntax_Subst.compress uu____6017  in
             (match body.FStar_Syntax_Syntax.n with
              | FStar_Syntax_Syntax.Tm_abs (bs',t1,lopt') ->
-                 let uu____5983 =
-                   let uu____5990 =
-                     let uu____5991 =
-                       let uu____6010 =
-                         let uu____6019 = FStar_Syntax_Subst.close_binders bs
+                 let uu____6047 =
+                   let uu____6054 =
+                     let uu____6055 =
+                       let uu____6074 =
+                         let uu____6083 = FStar_Syntax_Subst.close_binders bs
                             in
-                         FStar_List.append uu____6019 bs'  in
-                       let uu____6034 = close_lopt lopt'  in
-                       (uu____6010, t1, uu____6034)  in
-                     FStar_Syntax_Syntax.Tm_abs uu____5991  in
-                   FStar_Syntax_Syntax.mk uu____5990  in
-                 uu____5983 FStar_Pervasives_Native.None
+                         FStar_List.append uu____6083 bs'  in
+                       let uu____6098 = close_lopt lopt'  in
+                       (uu____6074, t1, uu____6098)  in
+                     FStar_Syntax_Syntax.Tm_abs uu____6055  in
+                   FStar_Syntax_Syntax.mk uu____6054  in
+                 uu____6047 FStar_Pervasives_Native.None
                    t1.FStar_Syntax_Syntax.pos
-             | uu____6049 ->
-                 let uu____6050 =
-                   let uu____6057 =
-                     let uu____6058 =
-                       let uu____6077 = FStar_Syntax_Subst.close_binders bs
+             | uu____6113 ->
+                 let uu____6114 =
+                   let uu____6121 =
+                     let uu____6122 =
+                       let uu____6141 = FStar_Syntax_Subst.close_binders bs
                           in
-                       let uu____6086 = close_lopt lopt  in
-                       (uu____6077, body, uu____6086)  in
-                     FStar_Syntax_Syntax.Tm_abs uu____6058  in
-                   FStar_Syntax_Syntax.mk uu____6057  in
-                 uu____6050 FStar_Pervasives_Native.None
+                       let uu____6150 = close_lopt lopt  in
+                       (uu____6141, body, uu____6150)  in
+                     FStar_Syntax_Syntax.Tm_abs uu____6122  in
+                   FStar_Syntax_Syntax.mk uu____6121  in
+                 uu____6114 FStar_Pervasives_Native.None
                    t.FStar_Syntax_Syntax.pos)
   
 let (arrow :
@@ -1598,16 +1621,16 @@ let (arrow :
     fun c  ->
       match bs with
       | [] -> comp_result c
-      | uu____6142 ->
-          let uu____6151 =
-            let uu____6158 =
-              let uu____6159 =
-                let uu____6174 = FStar_Syntax_Subst.close_binders bs  in
-                let uu____6183 = FStar_Syntax_Subst.close_comp bs c  in
-                (uu____6174, uu____6183)  in
-              FStar_Syntax_Syntax.Tm_arrow uu____6159  in
-            FStar_Syntax_Syntax.mk uu____6158  in
-          uu____6151 FStar_Pervasives_Native.None c.FStar_Syntax_Syntax.pos
+      | uu____6206 ->
+          let uu____6215 =
+            let uu____6222 =
+              let uu____6223 =
+                let uu____6238 = FStar_Syntax_Subst.close_binders bs  in
+                let uu____6247 = FStar_Syntax_Subst.close_comp bs c  in
+                (uu____6238, uu____6247)  in
+              FStar_Syntax_Syntax.Tm_arrow uu____6223  in
+            FStar_Syntax_Syntax.mk uu____6222  in
+          uu____6215 FStar_Pervasives_Native.None c.FStar_Syntax_Syntax.pos
   
 let (flat_arrow :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -1618,25 +1641,25 @@ let (flat_arrow :
   fun bs  ->
     fun c  ->
       let t = arrow bs c  in
-      let uu____6232 =
-        let uu____6233 = FStar_Syntax_Subst.compress t  in
-        uu____6233.FStar_Syntax_Syntax.n  in
-      match uu____6232 with
+      let uu____6296 =
+        let uu____6297 = FStar_Syntax_Subst.compress t  in
+        uu____6297.FStar_Syntax_Syntax.n  in
+      match uu____6296 with
       | FStar_Syntax_Syntax.Tm_arrow (bs1,c1) ->
           (match c1.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Total (tres,uu____6263) ->
-               let uu____6272 =
-                 let uu____6273 = FStar_Syntax_Subst.compress tres  in
-                 uu____6273.FStar_Syntax_Syntax.n  in
-               (match uu____6272 with
+           | FStar_Syntax_Syntax.Total (tres,uu____6327) ->
+               let uu____6336 =
+                 let uu____6337 = FStar_Syntax_Subst.compress tres  in
+                 uu____6337.FStar_Syntax_Syntax.n  in
+               (match uu____6336 with
                 | FStar_Syntax_Syntax.Tm_arrow (bs',c') ->
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_arrow
                          ((FStar_List.append bs1 bs'), c'))
                       FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
-                | uu____6316 -> t)
-           | uu____6317 -> t)
-      | uu____6318 -> t
+                | uu____6380 -> t)
+           | uu____6381 -> t)
+      | uu____6382 -> t
   
 let (refine :
   FStar_Syntax_Syntax.bv ->
@@ -1645,21 +1668,21 @@ let (refine :
   =
   fun b  ->
     fun t  ->
-      let uu____6336 =
-        let uu____6337 = FStar_Syntax_Syntax.range_of_bv b  in
-        FStar_Range.union_ranges uu____6337 t.FStar_Syntax_Syntax.pos  in
-      let uu____6338 =
-        let uu____6345 =
-          let uu____6346 =
-            let uu____6353 =
-              let uu____6356 =
-                let uu____6357 = FStar_Syntax_Syntax.mk_binder b  in
-                [uu____6357]  in
-              FStar_Syntax_Subst.close uu____6356 t  in
-            (b, uu____6353)  in
-          FStar_Syntax_Syntax.Tm_refine uu____6346  in
-        FStar_Syntax_Syntax.mk uu____6345  in
-      uu____6338 FStar_Pervasives_Native.None uu____6336
+      let uu____6400 =
+        let uu____6401 = FStar_Syntax_Syntax.range_of_bv b  in
+        FStar_Range.union_ranges uu____6401 t.FStar_Syntax_Syntax.pos  in
+      let uu____6402 =
+        let uu____6409 =
+          let uu____6410 =
+            let uu____6417 =
+              let uu____6420 =
+                let uu____6421 = FStar_Syntax_Syntax.mk_binder b  in
+                [uu____6421]  in
+              FStar_Syntax_Subst.close uu____6420 t  in
+            (b, uu____6417)  in
+          FStar_Syntax_Syntax.Tm_refine uu____6410  in
+        FStar_Syntax_Syntax.mk uu____6409  in
+      uu____6402 FStar_Pervasives_Native.None uu____6400
   
 let (branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch) =
   fun b  -> FStar_Syntax_Subst.close_branch b 
@@ -1672,45 +1695,45 @@ let rec (arrow_formals_comp_ln :
     let k1 = FStar_Syntax_Subst.compress k  in
     match k1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        let uu____6437 = is_total_comp c  in
-        if uu____6437
+        let uu____6501 = is_total_comp c  in
+        if uu____6501
         then
-          let uu____6452 = arrow_formals_comp_ln (comp_result c)  in
-          (match uu____6452 with
+          let uu____6516 = arrow_formals_comp_ln (comp_result c)  in
+          (match uu____6516 with
            | (bs',k2) -> ((FStar_List.append bs bs'), k2))
         else (bs, c)
     | FStar_Syntax_Syntax.Tm_refine
-        ({ FStar_Syntax_Syntax.ppname = uu____6519;
-           FStar_Syntax_Syntax.index = uu____6520;
-           FStar_Syntax_Syntax.sort = s;_},uu____6522)
+        ({ FStar_Syntax_Syntax.ppname = uu____6583;
+           FStar_Syntax_Syntax.index = uu____6584;
+           FStar_Syntax_Syntax.sort = s;_},uu____6586)
         ->
         let rec aux s1 k2 =
-          let uu____6553 =
-            let uu____6554 = FStar_Syntax_Subst.compress s1  in
-            uu____6554.FStar_Syntax_Syntax.n  in
-          match uu____6553 with
-          | FStar_Syntax_Syntax.Tm_arrow uu____6569 ->
+          let uu____6617 =
+            let uu____6618 = FStar_Syntax_Subst.compress s1  in
+            uu____6618.FStar_Syntax_Syntax.n  in
+          match uu____6617 with
+          | FStar_Syntax_Syntax.Tm_arrow uu____6633 ->
               arrow_formals_comp_ln s1
           | FStar_Syntax_Syntax.Tm_refine
-              ({ FStar_Syntax_Syntax.ppname = uu____6584;
-                 FStar_Syntax_Syntax.index = uu____6585;
-                 FStar_Syntax_Syntax.sort = s2;_},uu____6587)
+              ({ FStar_Syntax_Syntax.ppname = uu____6648;
+                 FStar_Syntax_Syntax.index = uu____6649;
+                 FStar_Syntax_Syntax.sort = s2;_},uu____6651)
               -> aux s2 k2
-          | uu____6595 ->
-              let uu____6596 = FStar_Syntax_Syntax.mk_Total k2  in
-              ([], uu____6596)
+          | uu____6659 ->
+              let uu____6660 = FStar_Syntax_Syntax.mk_Total k2  in
+              ([], uu____6660)
            in
         aux s k1
-    | uu____6611 ->
-        let uu____6612 = FStar_Syntax_Syntax.mk_Total k1  in ([], uu____6612)
+    | uu____6675 ->
+        let uu____6676 = FStar_Syntax_Syntax.mk_Total k1  in ([], uu____6676)
   
 let (arrow_formals_comp :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp))
   =
   fun k  ->
-    let uu____6637 = arrow_formals_comp_ln k  in
-    match uu____6637 with | (bs,c) -> FStar_Syntax_Subst.open_comp bs c
+    let uu____6701 = arrow_formals_comp_ln k  in
+    match uu____6701 with | (bs,c) -> FStar_Syntax_Subst.open_comp bs c
   
 let (arrow_formals_ln :
   FStar_Syntax_Syntax.term ->
@@ -1719,8 +1742,8 @@ let (arrow_formals_ln :
       FStar_Syntax_Syntax.syntax))
   =
   fun k  ->
-    let uu____6692 = arrow_formals_comp_ln k  in
-    match uu____6692 with | (bs,c) -> (bs, (comp_result c))
+    let uu____6756 = arrow_formals_comp_ln k  in
+    match uu____6756 with | (bs,c) -> (bs, (comp_result c))
   
 let (arrow_formals :
   FStar_Syntax_Syntax.term ->
@@ -1728,8 +1751,8 @@ let (arrow_formals :
       FStar_Syntax_Syntax.syntax))
   =
   fun k  ->
-    let uu____6759 = arrow_formals_comp k  in
-    match uu____6759 with | (bs,c) -> (bs, (comp_result c))
+    let uu____6823 = arrow_formals_comp k  in
+    match uu____6823 with | (bs,c) -> (bs, (comp_result c))
   
 let (let_rec_arity :
   FStar_Syntax_Syntax.letbinding ->
@@ -1740,56 +1763,56 @@ let (let_rec_arity :
       let k1 = FStar_Syntax_Subst.compress k  in
       match k1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____6861 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____6861 with
+          let uu____6925 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____6925 with
            | (bs1,c1) ->
                let ct = comp_to_comp_typ c1  in
-               let uu____6885 =
+               let uu____6949 =
                  FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
                    (FStar_Util.find_opt
-                      (fun uu___8_6894  ->
-                         match uu___8_6894 with
-                         | FStar_Syntax_Syntax.DECREASES uu____6896 -> true
-                         | uu____6900 -> false))
+                      (fun uu___8_6958  ->
+                         match uu___8_6958 with
+                         | FStar_Syntax_Syntax.DECREASES uu____6960 -> true
+                         | uu____6964 -> false))
                   in
-               (match uu____6885 with
+               (match uu____6949 with
                 | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
                     d) -> (bs1, (FStar_Pervasives_Native.Some d))
-                | uu____6935 ->
-                    let uu____6938 = is_total_comp c1  in
-                    if uu____6938
+                | uu____6999 ->
+                    let uu____7002 = is_total_comp c1  in
+                    if uu____7002
                     then
-                      let uu____6957 = arrow_until_decreases (comp_result c1)
+                      let uu____7021 = arrow_until_decreases (comp_result c1)
                          in
-                      (match uu____6957 with
+                      (match uu____7021 with
                        | (bs',d) -> ((FStar_List.append bs1 bs'), d))
                     else (bs1, FStar_Pervasives_Native.None)))
       | FStar_Syntax_Syntax.Tm_refine
-          ({ FStar_Syntax_Syntax.ppname = uu____7050;
-             FStar_Syntax_Syntax.index = uu____7051;
-             FStar_Syntax_Syntax.sort = k2;_},uu____7053)
+          ({ FStar_Syntax_Syntax.ppname = uu____7114;
+             FStar_Syntax_Syntax.index = uu____7115;
+             FStar_Syntax_Syntax.sort = k2;_},uu____7117)
           -> arrow_until_decreases k2
-      | uu____7061 -> ([], FStar_Pervasives_Native.None)  in
-    let uu____7082 = arrow_until_decreases lb.FStar_Syntax_Syntax.lbtyp  in
-    match uu____7082 with
+      | uu____7125 -> ([], FStar_Pervasives_Native.None)  in
+    let uu____7146 = arrow_until_decreases lb.FStar_Syntax_Syntax.lbtyp  in
+    match uu____7146 with
     | (bs,dopt) ->
         let n_univs = FStar_List.length lb.FStar_Syntax_Syntax.lbunivs  in
-        let uu____7136 =
+        let uu____7200 =
           FStar_Util.map_opt dopt
             (fun d  ->
                let d_bvs = FStar_Syntax_Free.names d  in
-               let uu____7157 =
-                 FStar_Common.tabulate n_univs (fun uu____7163  -> false)  in
-               let uu____7166 =
+               let uu____7221 =
+                 FStar_Common.tabulate n_univs (fun uu____7227  -> false)  in
+               let uu____7230 =
                  FStar_All.pipe_right bs
                    (FStar_List.map
-                      (fun uu____7191  ->
-                         match uu____7191 with
-                         | (x,uu____7200) -> FStar_Util.set_mem x d_bvs))
+                      (fun uu____7255  ->
+                         match uu____7255 with
+                         | (x,uu____7264) -> FStar_Util.set_mem x d_bvs))
                   in
-               FStar_List.append uu____7157 uu____7166)
+               FStar_List.append uu____7221 uu____7230)
            in
-        ((n_univs + (FStar_List.length bs)), uu____7136)
+        ((n_univs + (FStar_List.length bs)), uu____7200)
   
 let (abs_formals :
   FStar_Syntax_Syntax.term ->
@@ -1800,46 +1823,46 @@ let (abs_formals :
     let subst_lcomp_opt s l =
       match l with
       | FStar_Pervasives_Native.Some rc ->
-          let uu____7256 =
-            let uu___1121_7257 = rc  in
-            let uu____7258 =
+          let uu____7320 =
+            let uu___1119_7321 = rc  in
+            let uu____7322 =
               FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                 (FStar_Syntax_Subst.subst s)
                in
             {
               FStar_Syntax_Syntax.residual_effect =
-                (uu___1121_7257.FStar_Syntax_Syntax.residual_effect);
-              FStar_Syntax_Syntax.residual_typ = uu____7258;
+                (uu___1119_7321.FStar_Syntax_Syntax.residual_effect);
+              FStar_Syntax_Syntax.residual_typ = uu____7322;
               FStar_Syntax_Syntax.residual_flags =
-                (uu___1121_7257.FStar_Syntax_Syntax.residual_flags)
+                (uu___1119_7321.FStar_Syntax_Syntax.residual_flags)
             }  in
-          FStar_Pervasives_Native.Some uu____7256
-      | uu____7267 -> l  in
+          FStar_Pervasives_Native.Some uu____7320
+      | uu____7331 -> l  in
     let rec aux t1 abs_body_lcomp =
-      let uu____7301 =
-        let uu____7302 =
-          let uu____7305 = FStar_Syntax_Subst.compress t1  in
-          FStar_All.pipe_left unascribe uu____7305  in
-        uu____7302.FStar_Syntax_Syntax.n  in
-      match uu____7301 with
+      let uu____7365 =
+        let uu____7366 =
+          let uu____7369 = FStar_Syntax_Subst.compress t1  in
+          FStar_All.pipe_left unascribe uu____7369  in
+        uu____7366.FStar_Syntax_Syntax.n  in
+      match uu____7365 with
       | FStar_Syntax_Syntax.Tm_abs (bs,t2,what) ->
-          let uu____7351 = aux t2 what  in
-          (match uu____7351 with
+          let uu____7415 = aux t2 what  in
+          (match uu____7415 with
            | (bs',t3,what1) -> ((FStar_List.append bs bs'), t3, what1))
-      | uu____7423 -> ([], t1, abs_body_lcomp)  in
-    let uu____7440 = aux t FStar_Pervasives_Native.None  in
-    match uu____7440 with
+      | uu____7487 -> ([], t1, abs_body_lcomp)  in
+    let uu____7504 = aux t FStar_Pervasives_Native.None  in
+    match uu____7504 with
     | (bs,t1,abs_body_lcomp) ->
-        let uu____7488 = FStar_Syntax_Subst.open_term' bs t1  in
-        (match uu____7488 with
+        let uu____7552 = FStar_Syntax_Subst.open_term' bs t1  in
+        (match uu____7552 with
          | (bs1,t2,opening) ->
              let abs_body_lcomp1 = subst_lcomp_opt opening abs_body_lcomp  in
              (bs1, t2, abs_body_lcomp1))
   
 let (remove_inacc : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let no_acc uu____7522 =
-      match uu____7522 with
+    let no_acc uu____7586 =
+      match uu____7586 with
       | (b,aq) ->
           let aq1 =
             match aq with
@@ -1847,23 +1870,23 @@ let (remove_inacc : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
                 (true )) ->
                 FStar_Pervasives_Native.Some
                   (FStar_Syntax_Syntax.Implicit false)
-            | uu____7536 -> aq  in
+            | uu____7600 -> aq  in
           (b, aq1)
        in
-    let uu____7541 = arrow_formals_comp_ln t  in
-    match uu____7541 with
+    let uu____7605 = arrow_formals_comp_ln t  in
+    match uu____7605 with
     | (bs,c) ->
         (match bs with
          | [] -> t
-         | uu____7578 ->
-             let uu____7587 =
-               let uu____7594 =
-                 let uu____7595 =
-                   let uu____7610 = FStar_List.map no_acc bs  in
-                   (uu____7610, c)  in
-                 FStar_Syntax_Syntax.Tm_arrow uu____7595  in
-               FStar_Syntax_Syntax.mk uu____7594  in
-             uu____7587 FStar_Pervasives_Native.None
+         | uu____7642 ->
+             let uu____7651 =
+               let uu____7658 =
+                 let uu____7659 =
+                   let uu____7674 = FStar_List.map no_acc bs  in
+                   (uu____7674, c)  in
+                 FStar_Syntax_Syntax.Tm_arrow uu____7659  in
+               FStar_Syntax_Syntax.mk uu____7658  in
+             uu____7651 FStar_Pervasives_Native.None
                t.FStar_Syntax_Syntax.pos)
   
 let (mk_letbinding :
@@ -1912,14 +1935,14 @@ let (close_univs_and_mk_letbinding :
                 fun pos  ->
                   let def1 =
                     match (recs, univ_vars) with
-                    | (FStar_Pervasives_Native.None ,uu____7781) -> def
-                    | (uu____7792,[]) -> def
-                    | (FStar_Pervasives_Native.Some fvs,uu____7804) ->
+                    | (FStar_Pervasives_Native.None ,uu____7845) -> def
+                    | (uu____7856,[]) -> def
+                    | (FStar_Pervasives_Native.Some fvs,uu____7868) ->
                         let universes =
                           FStar_All.pipe_right univ_vars
                             (FStar_List.map
-                               (fun uu____7820  ->
-                                  FStar_Syntax_Syntax.U_name uu____7820))
+                               (fun uu____7884  ->
+                                  FStar_Syntax_Syntax.U_name uu____7884))
                            in
                         let inst =
                           FStar_All.pipe_right fvs
@@ -1950,28 +1973,31 @@ let (open_univ_vars_binders_and_comp :
       fun c  ->
         match binders with
         | [] ->
-            let uu____7902 = FStar_Syntax_Subst.open_univ_vars_comp uvs c  in
-            (match uu____7902 with | (uvs1,c1) -> (uvs1, [], c1))
-        | uu____7937 ->
+            let uu____7966 = FStar_Syntax_Subst.open_univ_vars_comp uvs c  in
+            (match uu____7966 with | (uvs1,c1) -> (uvs1, [], c1))
+        | uu____8001 ->
             let t' = arrow binders c  in
-            let uu____7949 = FStar_Syntax_Subst.open_univ_vars uvs t'  in
-            (match uu____7949 with
+            let uu____8013 = FStar_Syntax_Subst.open_univ_vars uvs t'  in
+            (match uu____8013 with
              | (uvs1,t'1) ->
-                 let uu____7970 =
-                   let uu____7971 = FStar_Syntax_Subst.compress t'1  in
-                   uu____7971.FStar_Syntax_Syntax.n  in
-                 (match uu____7970 with
+                 let uu____8034 =
+                   let uu____8035 = FStar_Syntax_Subst.compress t'1  in
+                   uu____8035.FStar_Syntax_Syntax.n  in
+                 (match uu____8034 with
                   | FStar_Syntax_Syntax.Tm_arrow (binders1,c1) ->
                       (uvs1, binders1, c1)
-                  | uu____8020 -> failwith "Impossible"))
+                  | uu____8084 -> failwith "Impossible"))
   
 let (is_tuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
-        FStar_Parser_Const.is_tuple_constructor_string
-          ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-    | uu____8045 -> false
+        let uu____8109 =
+          FStar_Ident.string_of_lid
+            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+           in
+        FStar_Parser_Const.is_tuple_constructor_string uu____8109
+    | uu____8111 -> false
   
 let (is_dtuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t  ->
@@ -1979,7 +2005,7 @@ let (is_dtuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Parser_Const.is_dtuple_constructor_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-    | uu____8056 -> false
+    | uu____8122 -> false
   
 let (is_lid_equality : FStar_Ident.lident -> Prims.bool) =
   fun x  -> FStar_Ident.lid_equals x FStar_Parser_Const.eq2_lid 
@@ -2004,27 +2030,27 @@ let (is_constructor :
   FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool) =
   fun t  ->
     fun lid  ->
-      let uu____8119 =
-        let uu____8120 = pre_typ t  in uu____8120.FStar_Syntax_Syntax.n  in
-      match uu____8119 with
+      let uu____8185 =
+        let uu____8186 = pre_typ t  in uu____8186.FStar_Syntax_Syntax.n  in
+      match uu____8185 with
       | FStar_Syntax_Syntax.Tm_fvar tc ->
           FStar_Ident.lid_equals
             (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v lid
-      | uu____8125 -> false
+      | uu____8191 -> false
   
 let rec (is_constructed_typ :
   FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool) =
   fun t  ->
     fun lid  ->
-      let uu____8139 =
-        let uu____8140 = pre_typ t  in uu____8140.FStar_Syntax_Syntax.n  in
-      match uu____8139 with
-      | FStar_Syntax_Syntax.Tm_fvar uu____8144 -> is_constructor t lid
-      | FStar_Syntax_Syntax.Tm_app (t1,uu____8146) ->
+      let uu____8205 =
+        let uu____8206 = pre_typ t  in uu____8206.FStar_Syntax_Syntax.n  in
+      match uu____8205 with
+      | FStar_Syntax_Syntax.Tm_fvar uu____8210 -> is_constructor t lid
+      | FStar_Syntax_Syntax.Tm_app (t1,uu____8212) ->
           is_constructed_typ t1 lid
-      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____8172) ->
+      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____8238) ->
           is_constructed_typ t1 lid
-      | uu____8177 -> false
+      | uu____8243 -> false
   
 let rec (get_tycon :
   FStar_Syntax_Syntax.term ->
@@ -2033,36 +2059,36 @@ let rec (get_tycon :
   fun t  ->
     let t1 = pre_typ t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_bvar uu____8190 ->
+    | FStar_Syntax_Syntax.Tm_bvar uu____8256 ->
         FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_name uu____8191 ->
+    | FStar_Syntax_Syntax.Tm_name uu____8257 ->
         FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_fvar uu____8192 ->
+    | FStar_Syntax_Syntax.Tm_fvar uu____8258 ->
         FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_app (t2,uu____8194) -> get_tycon t2
-    | uu____8219 -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.Tm_app (t2,uu____8260) -> get_tycon t2
+    | uu____8285 -> FStar_Pervasives_Native.None
   
 let (is_fstar_tactics_by_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____8227 =
-      let uu____8228 = un_uinst t  in uu____8228.FStar_Syntax_Syntax.n  in
-    match uu____8227 with
+    let uu____8293 =
+      let uu____8294 = un_uinst t  in uu____8294.FStar_Syntax_Syntax.n  in
+    match uu____8293 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.by_tactic_lid
-    | uu____8233 -> false
+    | uu____8299 -> false
   
 let (is_builtin_tactic : FStar_Ident.lident -> Prims.bool) =
   fun md  ->
     let path = FStar_Ident.path_of_lid md  in
     if (FStar_List.length path) > (Prims.of_int (2))
     then
-      let uu____8247 =
-        let uu____8251 = FStar_List.splitAt (Prims.of_int (2)) path  in
-        FStar_Pervasives_Native.fst uu____8251  in
-      match uu____8247 with
+      let uu____8313 =
+        let uu____8317 = FStar_List.splitAt (Prims.of_int (2)) path  in
+        FStar_Pervasives_Native.fst uu____8317  in
+      match uu____8313 with
       | "FStar"::"Tactics"::[] -> true
       | "FStar"::"Reflection"::[] -> true
-      | uu____8283 -> false
+      | uu____8349 -> false
     else false
   
 let (ktype : FStar_Syntax_Syntax.term) =
@@ -2077,40 +2103,40 @@ let (ktype0 : FStar_Syntax_Syntax.term) =
   
 let (type_u :
   unit -> (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.universe)) =
-  fun uu____8302  ->
+  fun uu____8368  ->
     let u =
-      let uu____8308 = FStar_Syntax_Unionfind.univ_fresh ()  in
+      let uu____8374 = FStar_Syntax_Unionfind.univ_fresh ()  in
       FStar_All.pipe_left
-        (fun uu____8325  -> FStar_Syntax_Syntax.U_unif uu____8325) uu____8308
+        (fun uu____8391  -> FStar_Syntax_Syntax.U_unif uu____8391) uu____8374
        in
-    let uu____8326 =
+    let uu____8392 =
       FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
         FStar_Pervasives_Native.None FStar_Range.dummyRange
        in
-    (uu____8326, u)
+    (uu____8392, u)
   
 let (attr_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun a  ->
     fun a'  ->
-      let uu____8339 = eq_tm a a'  in
-      match uu____8339 with | Equal  -> true | uu____8342 -> false
+      let uu____8405 = eq_tm a a'  in
+      match uu____8405 with | Equal  -> true | uu____8408 -> false
   
 let (attr_substitute : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
-  let uu____8347 =
-    let uu____8354 =
-      let uu____8355 =
-        let uu____8356 =
+  let uu____8413 =
+    let uu____8420 =
+      let uu____8421 =
+        let uu____8422 =
           FStar_Ident.lid_of_path ["FStar"; "Pervasives"; "Substitute"]
             FStar_Range.dummyRange
            in
-        FStar_Syntax_Syntax.lid_as_fv uu____8356
+        FStar_Syntax_Syntax.lid_as_fv uu____8422
           FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
          in
-      FStar_Syntax_Syntax.Tm_fvar uu____8355  in
-    FStar_Syntax_Syntax.mk uu____8354  in
-  uu____8347 FStar_Pervasives_Native.None FStar_Range.dummyRange 
+      FStar_Syntax_Syntax.Tm_fvar uu____8421  in
+    FStar_Syntax_Syntax.mk uu____8420  in
+  uu____8413 FStar_Pervasives_Native.None FStar_Range.dummyRange 
 let (exp_true_bool : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool true))
@@ -2196,25 +2222,25 @@ let (mk_conj_opt :
       match phi1 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.Some phi2
       | FStar_Pervasives_Native.Some phi11 ->
-          let uu____8469 =
-            let uu____8472 =
+          let uu____8535 =
+            let uu____8538 =
               FStar_Range.union_ranges phi11.FStar_Syntax_Syntax.pos
                 phi2.FStar_Syntax_Syntax.pos
                in
-            let uu____8473 =
-              let uu____8480 =
-                let uu____8481 =
-                  let uu____8498 =
-                    let uu____8509 = FStar_Syntax_Syntax.as_arg phi11  in
-                    let uu____8518 =
-                      let uu____8529 = FStar_Syntax_Syntax.as_arg phi2  in
-                      [uu____8529]  in
-                    uu____8509 :: uu____8518  in
-                  (tand, uu____8498)  in
-                FStar_Syntax_Syntax.Tm_app uu____8481  in
-              FStar_Syntax_Syntax.mk uu____8480  in
-            uu____8473 FStar_Pervasives_Native.None uu____8472  in
-          FStar_Pervasives_Native.Some uu____8469
+            let uu____8539 =
+              let uu____8546 =
+                let uu____8547 =
+                  let uu____8564 =
+                    let uu____8575 = FStar_Syntax_Syntax.as_arg phi11  in
+                    let uu____8584 =
+                      let uu____8595 = FStar_Syntax_Syntax.as_arg phi2  in
+                      [uu____8595]  in
+                    uu____8575 :: uu____8584  in
+                  (tand, uu____8564)  in
+                FStar_Syntax_Syntax.Tm_app uu____8547  in
+              FStar_Syntax_Syntax.mk uu____8546  in
+            uu____8539 FStar_Pervasives_Native.None uu____8538  in
+          FStar_Pervasives_Native.Some uu____8535
   
 let (mk_binop :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2225,39 +2251,39 @@ let (mk_binop :
   fun op_t  ->
     fun phi1  ->
       fun phi2  ->
-        let uu____8606 =
+        let uu____8672 =
           FStar_Range.union_ranges phi1.FStar_Syntax_Syntax.pos
             phi2.FStar_Syntax_Syntax.pos
            in
-        let uu____8607 =
-          let uu____8614 =
-            let uu____8615 =
-              let uu____8632 =
-                let uu____8643 = FStar_Syntax_Syntax.as_arg phi1  in
-                let uu____8652 =
-                  let uu____8663 = FStar_Syntax_Syntax.as_arg phi2  in
-                  [uu____8663]  in
-                uu____8643 :: uu____8652  in
-              (op_t, uu____8632)  in
-            FStar_Syntax_Syntax.Tm_app uu____8615  in
-          FStar_Syntax_Syntax.mk uu____8614  in
-        uu____8607 FStar_Pervasives_Native.None uu____8606
+        let uu____8673 =
+          let uu____8680 =
+            let uu____8681 =
+              let uu____8698 =
+                let uu____8709 = FStar_Syntax_Syntax.as_arg phi1  in
+                let uu____8718 =
+                  let uu____8729 = FStar_Syntax_Syntax.as_arg phi2  in
+                  [uu____8729]  in
+                uu____8709 :: uu____8718  in
+              (op_t, uu____8698)  in
+            FStar_Syntax_Syntax.Tm_app uu____8681  in
+          FStar_Syntax_Syntax.mk uu____8680  in
+        uu____8673 FStar_Pervasives_Native.None uu____8672
   
 let (mk_neg :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun phi  ->
-    let uu____8720 =
-      let uu____8727 =
-        let uu____8728 =
-          let uu____8745 =
-            let uu____8756 = FStar_Syntax_Syntax.as_arg phi  in [uu____8756]
+    let uu____8786 =
+      let uu____8793 =
+        let uu____8794 =
+          let uu____8811 =
+            let uu____8822 = FStar_Syntax_Syntax.as_arg phi  in [uu____8822]
              in
-          (t_not, uu____8745)  in
-        FStar_Syntax_Syntax.Tm_app uu____8728  in
-      FStar_Syntax_Syntax.mk uu____8727  in
-    uu____8720 FStar_Pervasives_Native.None phi.FStar_Syntax_Syntax.pos
+          (t_not, uu____8811)  in
+        FStar_Syntax_Syntax.Tm_app uu____8794  in
+      FStar_Syntax_Syntax.mk uu____8793  in
+    uu____8786 FStar_Pervasives_Native.None phi.FStar_Syntax_Syntax.pos
   
 let (mk_conj :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2304,44 +2330,44 @@ let (b2t :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun e  ->
-    let uu____8953 =
-      let uu____8960 =
-        let uu____8961 =
-          let uu____8978 =
-            let uu____8989 = FStar_Syntax_Syntax.as_arg e  in [uu____8989]
+    let uu____9019 =
+      let uu____9026 =
+        let uu____9027 =
+          let uu____9044 =
+            let uu____9055 = FStar_Syntax_Syntax.as_arg e  in [uu____9055]
              in
-          (b2t_v, uu____8978)  in
-        FStar_Syntax_Syntax.Tm_app uu____8961  in
-      FStar_Syntax_Syntax.mk uu____8960  in
-    uu____8953 FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+          (b2t_v, uu____9044)  in
+        FStar_Syntax_Syntax.Tm_app uu____9027  in
+      FStar_Syntax_Syntax.mk uu____9026  in
+    uu____9019 FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
   
 let (unb2t :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
   =
   fun e  ->
-    let uu____9036 = head_and_args e  in
-    match uu____9036 with
+    let uu____9102 = head_and_args e  in
+    match uu____9102 with
     | (hd,args) ->
-        let uu____9081 =
-          let uu____9096 =
-            let uu____9097 = FStar_Syntax_Subst.compress hd  in
-            uu____9097.FStar_Syntax_Syntax.n  in
-          (uu____9096, args)  in
-        (match uu____9081 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(e1,uu____9114)::[]) when
+        let uu____9147 =
+          let uu____9162 =
+            let uu____9163 = FStar_Syntax_Subst.compress hd  in
+            uu____9163.FStar_Syntax_Syntax.n  in
+          (uu____9162, args)  in
+        (match uu____9147 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(e1,uu____9180)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.b2t_lid ->
              FStar_Pervasives_Native.Some e1
-         | uu____9149 -> FStar_Pervasives_Native.None)
+         | uu____9215 -> FStar_Pervasives_Native.None)
   
 let (is_t_true : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____9171 =
-      let uu____9172 = unmeta t  in uu____9172.FStar_Syntax_Syntax.n  in
-    match uu____9171 with
+    let uu____9237 =
+      let uu____9238 = unmeta t  in uu____9238.FStar_Syntax_Syntax.n  in
+    match uu____9237 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.true_lid
-    | uu____9177 -> false
+    | uu____9243 -> false
   
 let (mk_conj_simp :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2350,12 +2376,12 @@ let (mk_conj_simp :
   =
   fun t1  ->
     fun t2  ->
-      let uu____9200 = is_t_true t1  in
-      if uu____9200
+      let uu____9266 = is_t_true t1  in
+      if uu____9266
       then t2
       else
-        (let uu____9207 = is_t_true t2  in
-         if uu____9207 then t1 else mk_conj t1 t2)
+        (let uu____9273 = is_t_true t2  in
+         if uu____9273 then t1 else mk_conj t1 t2)
   
 let (mk_disj_simp :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2364,12 +2390,12 @@ let (mk_disj_simp :
   =
   fun t1  ->
     fun t2  ->
-      let uu____9235 = is_t_true t1  in
-      if uu____9235
+      let uu____9301 = is_t_true t1  in
+      if uu____9301
       then t_true
       else
-        (let uu____9242 = is_t_true t2  in
-         if uu____9242 then t_true else mk_disj t1 t2)
+        (let uu____9308 = is_t_true t2  in
+         if uu____9308 then t_true else mk_disj t1 t2)
   
 let (teq : FStar_Syntax_Syntax.term) = fvar_const FStar_Parser_Const.eq2_lid 
 let (mk_untyped_eq2 :
@@ -2379,23 +2405,23 @@ let (mk_untyped_eq2 :
   =
   fun e1  ->
     fun e2  ->
-      let uu____9271 =
+      let uu____9337 =
         FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
           e2.FStar_Syntax_Syntax.pos
          in
-      let uu____9272 =
-        let uu____9279 =
-          let uu____9280 =
-            let uu____9297 =
-              let uu____9308 = FStar_Syntax_Syntax.as_arg e1  in
-              let uu____9317 =
-                let uu____9328 = FStar_Syntax_Syntax.as_arg e2  in
-                [uu____9328]  in
-              uu____9308 :: uu____9317  in
-            (teq, uu____9297)  in
-          FStar_Syntax_Syntax.Tm_app uu____9280  in
-        FStar_Syntax_Syntax.mk uu____9279  in
-      uu____9272 FStar_Pervasives_Native.None uu____9271
+      let uu____9338 =
+        let uu____9345 =
+          let uu____9346 =
+            let uu____9363 =
+              let uu____9374 = FStar_Syntax_Syntax.as_arg e1  in
+              let uu____9383 =
+                let uu____9394 = FStar_Syntax_Syntax.as_arg e2  in
+                [uu____9394]  in
+              uu____9374 :: uu____9383  in
+            (teq, uu____9363)  in
+          FStar_Syntax_Syntax.Tm_app uu____9346  in
+        FStar_Syntax_Syntax.mk uu____9345  in
+      uu____9338 FStar_Pervasives_Native.None uu____9337
   
 let (mk_eq2 :
   FStar_Syntax_Syntax.universe ->
@@ -2408,26 +2434,26 @@ let (mk_eq2 :
       fun e1  ->
         fun e2  ->
           let eq_inst = FStar_Syntax_Syntax.mk_Tm_uinst teq [u]  in
-          let uu____9395 =
+          let uu____9461 =
             FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
               e2.FStar_Syntax_Syntax.pos
              in
-          let uu____9396 =
-            let uu____9403 =
-              let uu____9404 =
-                let uu____9421 =
-                  let uu____9432 = FStar_Syntax_Syntax.iarg t  in
-                  let uu____9441 =
-                    let uu____9452 = FStar_Syntax_Syntax.as_arg e1  in
-                    let uu____9461 =
-                      let uu____9472 = FStar_Syntax_Syntax.as_arg e2  in
-                      [uu____9472]  in
-                    uu____9452 :: uu____9461  in
-                  uu____9432 :: uu____9441  in
-                (eq_inst, uu____9421)  in
-              FStar_Syntax_Syntax.Tm_app uu____9404  in
-            FStar_Syntax_Syntax.mk uu____9403  in
-          uu____9396 FStar_Pervasives_Native.None uu____9395
+          let uu____9462 =
+            let uu____9469 =
+              let uu____9470 =
+                let uu____9487 =
+                  let uu____9498 = FStar_Syntax_Syntax.iarg t  in
+                  let uu____9507 =
+                    let uu____9518 = FStar_Syntax_Syntax.as_arg e1  in
+                    let uu____9527 =
+                      let uu____9538 = FStar_Syntax_Syntax.as_arg e2  in
+                      [uu____9538]  in
+                    uu____9518 :: uu____9527  in
+                  uu____9498 :: uu____9507  in
+                (eq_inst, uu____9487)  in
+              FStar_Syntax_Syntax.Tm_app uu____9470  in
+            FStar_Syntax_Syntax.mk uu____9469  in
+          uu____9462 FStar_Pervasives_Native.None uu____9461
   
 let (mk_has_type :
   FStar_Syntax_Syntax.term ->
@@ -2446,22 +2472,22 @@ let (mk_has_type :
                  [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]))
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        let uu____9549 =
-          let uu____9556 =
-            let uu____9557 =
-              let uu____9574 =
-                let uu____9585 = FStar_Syntax_Syntax.iarg t  in
-                let uu____9594 =
-                  let uu____9605 = FStar_Syntax_Syntax.as_arg x  in
-                  let uu____9614 =
-                    let uu____9625 = FStar_Syntax_Syntax.as_arg t'  in
-                    [uu____9625]  in
-                  uu____9605 :: uu____9614  in
-                uu____9585 :: uu____9594  in
-              (t_has_type1, uu____9574)  in
-            FStar_Syntax_Syntax.Tm_app uu____9557  in
-          FStar_Syntax_Syntax.mk uu____9556  in
-        uu____9549 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____9615 =
+          let uu____9622 =
+            let uu____9623 =
+              let uu____9640 =
+                let uu____9651 = FStar_Syntax_Syntax.iarg t  in
+                let uu____9660 =
+                  let uu____9671 = FStar_Syntax_Syntax.as_arg x  in
+                  let uu____9680 =
+                    let uu____9691 = FStar_Syntax_Syntax.as_arg t'  in
+                    [uu____9691]  in
+                  uu____9671 :: uu____9680  in
+                uu____9651 :: uu____9660  in
+              (t_has_type1, uu____9640)  in
+            FStar_Syntax_Syntax.Tm_app uu____9623  in
+          FStar_Syntax_Syntax.mk uu____9622  in
+        uu____9615 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (mk_with_type :
   FStar_Syntax_Syntax.universe ->
@@ -2481,35 +2507,35 @@ let (mk_with_type :
             (FStar_Syntax_Syntax.Tm_uinst (t_with_type, [u]))
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        let uu____9702 =
-          let uu____9709 =
-            let uu____9710 =
-              let uu____9727 =
-                let uu____9738 = FStar_Syntax_Syntax.iarg t  in
-                let uu____9747 =
-                  let uu____9758 = FStar_Syntax_Syntax.as_arg e  in
-                  [uu____9758]  in
-                uu____9738 :: uu____9747  in
-              (t_with_type1, uu____9727)  in
-            FStar_Syntax_Syntax.Tm_app uu____9710  in
-          FStar_Syntax_Syntax.mk uu____9709  in
-        uu____9702 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____9768 =
+          let uu____9775 =
+            let uu____9776 =
+              let uu____9793 =
+                let uu____9804 = FStar_Syntax_Syntax.iarg t  in
+                let uu____9813 =
+                  let uu____9824 = FStar_Syntax_Syntax.as_arg e  in
+                  [uu____9824]  in
+                uu____9804 :: uu____9813  in
+              (t_with_type1, uu____9793)  in
+            FStar_Syntax_Syntax.Tm_app uu____9776  in
+          FStar_Syntax_Syntax.mk uu____9775  in
+        uu____9768 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (lex_t : FStar_Syntax_Syntax.term) =
   fvar_const FStar_Parser_Const.lex_t_lid 
 let (lex_top : FStar_Syntax_Syntax.term) =
-  let uu____9805 =
-    let uu____9812 =
-      let uu____9813 =
-        let uu____9820 =
+  let uu____9871 =
+    let uu____9878 =
+      let uu____9879 =
+        let uu____9886 =
           FStar_Syntax_Syntax.fvar FStar_Parser_Const.lextop_lid
             FStar_Syntax_Syntax.delta_constant
             (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
            in
-        (uu____9820, [FStar_Syntax_Syntax.U_zero])  in
-      FStar_Syntax_Syntax.Tm_uinst uu____9813  in
-    FStar_Syntax_Syntax.mk uu____9812  in
-  uu____9805 FStar_Pervasives_Native.None FStar_Range.dummyRange 
+        (uu____9886, [FStar_Syntax_Syntax.U_zero])  in
+      FStar_Syntax_Syntax.Tm_uinst uu____9879  in
+    FStar_Syntax_Syntax.mk uu____9878  in
+  uu____9871 FStar_Pervasives_Native.None FStar_Range.dummyRange 
 let (lex_pair : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.lexcons_lid
     FStar_Syntax_Syntax.delta_constant
@@ -2570,28 +2596,28 @@ let (mk_forall_aux :
   fun fa  ->
     fun x  ->
       fun body  ->
-        let uu____9903 =
-          let uu____9910 =
-            let uu____9911 =
-              let uu____9928 =
-                let uu____9939 =
+        let uu____9969 =
+          let uu____9976 =
+            let uu____9977 =
+              let uu____9994 =
+                let uu____10005 =
                   FStar_Syntax_Syntax.iarg x.FStar_Syntax_Syntax.sort  in
-                let uu____9948 =
-                  let uu____9959 =
-                    let uu____9968 =
-                      let uu____9969 =
-                        let uu____9970 = FStar_Syntax_Syntax.mk_binder x  in
-                        [uu____9970]  in
-                      abs uu____9969 body
+                let uu____10014 =
+                  let uu____10025 =
+                    let uu____10034 =
+                      let uu____10035 =
+                        let uu____10036 = FStar_Syntax_Syntax.mk_binder x  in
+                        [uu____10036]  in
+                      abs uu____10035 body
                         (FStar_Pervasives_Native.Some (residual_tot ktype0))
                        in
-                    FStar_Syntax_Syntax.as_arg uu____9968  in
-                  [uu____9959]  in
-                uu____9939 :: uu____9948  in
-              (fa, uu____9928)  in
-            FStar_Syntax_Syntax.Tm_app uu____9911  in
-          FStar_Syntax_Syntax.mk uu____9910  in
-        uu____9903 FStar_Pervasives_Native.None FStar_Range.dummyRange
+                    FStar_Syntax_Syntax.as_arg uu____10034  in
+                  [uu____10025]  in
+                uu____10005 :: uu____10014  in
+              (fa, uu____9994)  in
+            FStar_Syntax_Syntax.Tm_app uu____9977  in
+          FStar_Syntax_Syntax.mk uu____9976  in
+        uu____9969 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (mk_forall_no_univ :
   FStar_Syntax_Syntax.bv ->
@@ -2618,8 +2644,8 @@ let (close_forall_no_univs :
       FStar_List.fold_right
         (fun b  ->
            fun f1  ->
-             let uu____10097 = FStar_Syntax_Syntax.is_null_binder b  in
-             if uu____10097
+             let uu____10163 = FStar_Syntax_Syntax.is_null_binder b  in
+             if uu____10163
              then f1
              else mk_forall_no_univ (FStar_Pervasives_Native.fst b) f1) bs f
   
@@ -2627,8 +2653,8 @@ let (is_wild_pat :
   FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t -> Prims.bool) =
   fun p  ->
     match p.FStar_Syntax_Syntax.v with
-    | FStar_Syntax_Syntax.Pat_wild uu____10116 -> true
-    | uu____10118 -> false
+    | FStar_Syntax_Syntax.Pat_wild uu____10182 -> true
+    | uu____10184 -> false
   
 let (if_then_else :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2640,28 +2666,28 @@ let (if_then_else :
     fun t1  ->
       fun t2  ->
         let then_branch =
-          let uu____10165 =
+          let uu____10231 =
             FStar_Syntax_Syntax.withinfo
               (FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool true))
               t1.FStar_Syntax_Syntax.pos
              in
-          (uu____10165, FStar_Pervasives_Native.None, t1)  in
+          (uu____10231, FStar_Pervasives_Native.None, t1)  in
         let else_branch =
-          let uu____10194 =
+          let uu____10260 =
             FStar_Syntax_Syntax.withinfo
               (FStar_Syntax_Syntax.Pat_constant
                  (FStar_Const.Const_bool false)) t2.FStar_Syntax_Syntax.pos
              in
-          (uu____10194, FStar_Pervasives_Native.None, t2)  in
-        let uu____10208 =
-          let uu____10209 =
+          (uu____10260, FStar_Pervasives_Native.None, t2)  in
+        let uu____10274 =
+          let uu____10275 =
             FStar_Range.union_ranges t1.FStar_Syntax_Syntax.pos
               t2.FStar_Syntax_Syntax.pos
              in
-          FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu____10209  in
+          FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu____10275  in
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_match (b, [then_branch; else_branch]))
-          FStar_Pervasives_Native.None uu____10208
+          FStar_Pervasives_Native.None uu____10274
   
 let (mk_squash :
   FStar_Syntax_Syntax.universe ->
@@ -2675,10 +2701,10 @@ let (mk_squash :
           (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
           FStar_Pervasives_Native.None
          in
-      let uu____10285 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
-      let uu____10288 =
-        let uu____10299 = FStar_Syntax_Syntax.as_arg p  in [uu____10299]  in
-      mk_app uu____10285 uu____10288
+      let uu____10351 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
+      let uu____10354 =
+        let uu____10365 = FStar_Syntax_Syntax.as_arg p  in [uu____10365]  in
+      mk_app uu____10351 uu____10354
   
 let (mk_auto_squash :
   FStar_Syntax_Syntax.universe ->
@@ -2692,10 +2718,10 @@ let (mk_auto_squash :
           (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (2)))
           FStar_Pervasives_Native.None
          in
-      let uu____10339 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
-      let uu____10342 =
-        let uu____10353 = FStar_Syntax_Syntax.as_arg p  in [uu____10353]  in
-      mk_app uu____10339 uu____10342
+      let uu____10405 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
+      let uu____10408 =
+        let uu____10419 = FStar_Syntax_Syntax.as_arg p  in [uu____10419]  in
+      mk_app uu____10405 uu____10408
   
 let (un_squash :
   FStar_Syntax_Syntax.term ->
@@ -2703,18 +2729,18 @@ let (un_squash :
       FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____10388 = head_and_args t  in
-    match uu____10388 with
+    let uu____10454 = head_and_args t  in
+    match uu____10454 with
     | (head,args) ->
         let head1 = unascribe head  in
         let head2 = un_uinst head1  in
-        let uu____10437 =
-          let uu____10452 =
-            let uu____10453 = FStar_Syntax_Subst.compress head2  in
-            uu____10453.FStar_Syntax_Syntax.n  in
-          (uu____10452, args)  in
-        (match uu____10437 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(p,uu____10472)::[]) when
+        let uu____10503 =
+          let uu____10518 =
+            let uu____10519 = FStar_Syntax_Subst.compress head2  in
+            uu____10519.FStar_Syntax_Syntax.n  in
+          (uu____10518, args)  in
+        (match uu____10503 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(p,uu____10538)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid
              -> FStar_Pervasives_Native.Some p
          | (FStar_Syntax_Syntax.Tm_refine (b,p),[]) ->
@@ -2723,27 +2749,27 @@ let (un_squash :
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.unit_lid
                   ->
-                  let uu____10538 =
-                    let uu____10543 =
-                      let uu____10544 = FStar_Syntax_Syntax.mk_binder b  in
-                      [uu____10544]  in
-                    FStar_Syntax_Subst.open_term uu____10543 p  in
-                  (match uu____10538 with
+                  let uu____10604 =
+                    let uu____10609 =
+                      let uu____10610 = FStar_Syntax_Syntax.mk_binder b  in
+                      [uu____10610]  in
+                    FStar_Syntax_Subst.open_term uu____10609 p  in
+                  (match uu____10604 with
                    | (bs,p1) ->
                        let b1 =
                          match bs with
                          | b1::[] -> b1
-                         | uu____10601 -> failwith "impossible"  in
-                       let uu____10609 =
-                         let uu____10611 = FStar_Syntax_Free.names p1  in
+                         | uu____10667 -> failwith "impossible"  in
+                       let uu____10675 =
+                         let uu____10677 = FStar_Syntax_Free.names p1  in
                          FStar_Util.set_mem (FStar_Pervasives_Native.fst b1)
-                           uu____10611
+                           uu____10677
                           in
-                       if uu____10609
+                       if uu____10675
                        then FStar_Pervasives_Native.None
                        else FStar_Pervasives_Native.Some p1)
-              | uu____10627 -> FStar_Pervasives_Native.None)
-         | uu____10630 -> FStar_Pervasives_Native.None)
+              | uu____10693 -> FStar_Pervasives_Native.None)
+         | uu____10696 -> FStar_Pervasives_Native.None)
   
 let (is_squash :
   FStar_Syntax_Syntax.term ->
@@ -2751,23 +2777,23 @@ let (is_squash :
       FStar_Syntax_Syntax.syntax) FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____10661 = head_and_args t  in
-    match uu____10661 with
+    let uu____10727 = head_and_args t  in
+    match uu____10727 with
     | (head,args) ->
-        let uu____10712 =
-          let uu____10727 =
-            let uu____10728 = FStar_Syntax_Subst.compress head  in
-            uu____10728.FStar_Syntax_Syntax.n  in
-          (uu____10727, args)  in
-        (match uu____10712 with
+        let uu____10778 =
+          let uu____10793 =
+            let uu____10794 = FStar_Syntax_Subst.compress head  in
+            uu____10794.FStar_Syntax_Syntax.n  in
+          (uu____10793, args)  in
+        (match uu____10778 with
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-               FStar_Syntax_Syntax.pos = uu____10750;
-               FStar_Syntax_Syntax.vars = uu____10751;_},u::[]),(t1,uu____10754)::[])
+               FStar_Syntax_Syntax.pos = uu____10816;
+               FStar_Syntax_Syntax.vars = uu____10817;_},u::[]),(t1,uu____10820)::[])
              when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
-         | uu____10801 -> FStar_Pervasives_Native.None)
+         | uu____10867 -> FStar_Pervasives_Native.None)
   
 let (is_auto_squash :
   FStar_Syntax_Syntax.term ->
@@ -2775,35 +2801,35 @@ let (is_auto_squash :
       FStar_Syntax_Syntax.syntax) FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____10836 = head_and_args t  in
-    match uu____10836 with
+    let uu____10902 = head_and_args t  in
+    match uu____10902 with
     | (head,args) ->
-        let uu____10887 =
-          let uu____10902 =
-            let uu____10903 = FStar_Syntax_Subst.compress head  in
-            uu____10903.FStar_Syntax_Syntax.n  in
-          (uu____10902, args)  in
-        (match uu____10887 with
+        let uu____10953 =
+          let uu____10968 =
+            let uu____10969 = FStar_Syntax_Subst.compress head  in
+            uu____10969.FStar_Syntax_Syntax.n  in
+          (uu____10968, args)  in
+        (match uu____10953 with
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-               FStar_Syntax_Syntax.pos = uu____10925;
-               FStar_Syntax_Syntax.vars = uu____10926;_},u::[]),(t1,uu____10929)::[])
+               FStar_Syntax_Syntax.pos = uu____10991;
+               FStar_Syntax_Syntax.vars = uu____10992;_},u::[]),(t1,uu____10995)::[])
              when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Parser_Const.auto_squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
-         | uu____10976 -> FStar_Pervasives_Native.None)
+         | uu____11042 -> FStar_Pervasives_Native.None)
   
 let (is_sub_singleton : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____11004 =
-      let uu____11021 = unmeta t  in head_and_args uu____11021  in
-    match uu____11004 with
-    | (head,uu____11024) ->
-        let uu____11049 =
-          let uu____11050 = un_uinst head  in
-          uu____11050.FStar_Syntax_Syntax.n  in
-        (match uu____11049 with
+    let uu____11070 =
+      let uu____11087 = unmeta t  in head_and_args uu____11087  in
+    match uu____11070 with
+    | (head,uu____11090) ->
+        let uu____11115 =
+          let uu____11116 = un_uinst head  in
+          uu____11116.FStar_Syntax_Syntax.n  in
+        (match uu____11115 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              (((((((((((((((((FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.squash_lid)
@@ -2858,7 +2884,7 @@ let (is_sub_singleton : FStar_Syntax_Syntax.term -> Prims.bool) =
                ||
                (FStar_Syntax_Syntax.fv_eq_lid fv
                   FStar_Parser_Const.precedes_lid)
-         | uu____11055 -> false)
+         | uu____11121 -> false)
   
 let (arrow_one_ln :
   FStar_Syntax_Syntax.typ ->
@@ -2866,22 +2892,22 @@ let (arrow_one_ln :
       FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____11075 =
-      let uu____11076 = FStar_Syntax_Subst.compress t  in
-      uu____11076.FStar_Syntax_Syntax.n  in
-    match uu____11075 with
+    let uu____11141 =
+      let uu____11142 = FStar_Syntax_Subst.compress t  in
+      uu____11142.FStar_Syntax_Syntax.n  in
+    match uu____11141 with
     | FStar_Syntax_Syntax.Tm_arrow ([],c) ->
         failwith "fatal: empty binders on arrow?"
     | FStar_Syntax_Syntax.Tm_arrow (b::[],c) ->
         FStar_Pervasives_Native.Some (b, c)
     | FStar_Syntax_Syntax.Tm_arrow (b::bs,c) ->
-        let uu____11182 =
-          let uu____11187 =
-            let uu____11188 = arrow bs c  in
-            FStar_Syntax_Syntax.mk_Total uu____11188  in
-          (b, uu____11187)  in
-        FStar_Pervasives_Native.Some uu____11182
-    | uu____11193 -> FStar_Pervasives_Native.None
+        let uu____11248 =
+          let uu____11253 =
+            let uu____11254 = arrow bs c  in
+            FStar_Syntax_Syntax.mk_Total uu____11254  in
+          (b, uu____11253)  in
+        FStar_Pervasives_Native.Some uu____11248
+    | uu____11259 -> FStar_Pervasives_Native.None
   
 let (arrow_one :
   FStar_Syntax_Syntax.typ ->
@@ -2889,18 +2915,18 @@ let (arrow_one :
       FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____11216 = arrow_one_ln t  in
-    FStar_Util.bind_opt uu____11216
-      (fun uu____11244  ->
-         match uu____11244 with
+    let uu____11282 = arrow_one_ln t  in
+    FStar_Util.bind_opt uu____11282
+      (fun uu____11310  ->
+         match uu____11310 with
          | (b,c) ->
-             let uu____11263 = FStar_Syntax_Subst.open_comp [b] c  in
-             (match uu____11263 with
+             let uu____11329 = FStar_Syntax_Subst.open_comp [b] c  in
+             (match uu____11329 with
               | (bs,c1) ->
                   let b1 =
                     match bs with
                     | b1::[] -> b1
-                    | uu____11326 ->
+                    | uu____11392 ->
                         failwith
                           "impossible: open_comp returned different amount of binders"
                      in
@@ -2910,8 +2936,8 @@ let (is_free_in :
   FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun bv  ->
     fun t  ->
-      let uu____11363 = FStar_Syntax_Free.names t  in
-      FStar_Util.set_mem bv uu____11363
+      let uu____11429 = FStar_Syntax_Free.names t  in
+      FStar_Util.set_mem bv uu____11429
   
 type qpats = FStar_Syntax_Syntax.args Prims.list
 type connective =
@@ -2920,7 +2946,7 @@ type connective =
   | BaseConn of (FStar_Ident.lident * FStar_Syntax_Syntax.args) 
 let (uu___is_QAll : connective -> Prims.bool) =
   fun projectee  ->
-    match projectee with | QAll _0 -> true | uu____11415 -> false
+    match projectee with | QAll _0 -> true | uu____11481 -> false
   
 let (__proj__QAll__item___0 :
   connective ->
@@ -2928,7 +2954,7 @@ let (__proj__QAll__item___0 :
   = fun projectee  -> match projectee with | QAll _0 -> _0 
 let (uu___is_QEx : connective -> Prims.bool) =
   fun projectee  ->
-    match projectee with | QEx _0 -> true | uu____11458 -> false
+    match projectee with | QEx _0 -> true | uu____11524 -> false
   
 let (__proj__QEx__item___0 :
   connective ->
@@ -2936,7 +2962,7 @@ let (__proj__QEx__item___0 :
   = fun projectee  -> match projectee with | QEx _0 -> _0 
 let (uu___is_BaseConn : connective -> Prims.bool) =
   fun projectee  ->
-    match projectee with | BaseConn _0 -> true | uu____11499 -> false
+    match projectee with | BaseConn _0 -> true | uu____11565 -> false
   
 let (__proj__BaseConn__item___0 :
   connective -> (FStar_Ident.lident * FStar_Syntax_Syntax.args)) =
@@ -2983,26 +3009,26 @@ let (destruct_typ_as_formula :
       let f2 = FStar_Syntax_Subst.compress f1  in
       match f2.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta
-          (t,FStar_Syntax_Syntax.Meta_monadic uu____11885) ->
+          (t,FStar_Syntax_Syntax.Meta_monadic uu____11951) ->
           unmeta_monadic t
       | FStar_Syntax_Syntax.Tm_meta
-          (t,FStar_Syntax_Syntax.Meta_monadic_lift uu____11897) ->
+          (t,FStar_Syntax_Syntax.Meta_monadic_lift uu____11963) ->
           unmeta_monadic t
-      | uu____11910 -> f2  in
+      | uu____11976 -> f2  in
     let lookup_arity_lid table target_lid args =
       let arg_len = FStar_List.length args  in
-      let aux uu____11979 =
-        match uu____11979 with
+      let aux uu____12045 =
+        match uu____12045 with
         | (arity,lids) ->
             if arg_len = arity
             then
               FStar_Util.find_map lids
-                (fun uu____12017  ->
-                   match uu____12017 with
+                (fun uu____12083  ->
+                   match uu____12083 with
                    | (lid,out_lid) ->
-                       let uu____12026 =
+                       let uu____12092 =
                          FStar_Ident.lid_equals target_lid lid  in
-                       if uu____12026
+                       if uu____12092
                        then
                          FStar_Pervasives_Native.Some
                            (BaseConn (out_lid, args))
@@ -3011,43 +3037,43 @@ let (destruct_typ_as_formula :
          in
       FStar_Util.find_map table aux  in
     let destruct_base_conn t =
-      let uu____12053 = head_and_args t  in
-      match uu____12053 with
+      let uu____12119 = head_and_args t  in
+      match uu____12119 with
       | (hd,args) ->
-          let uu____12098 =
-            let uu____12099 = un_uinst hd  in
-            uu____12099.FStar_Syntax_Syntax.n  in
-          (match uu____12098 with
+          let uu____12164 =
+            let uu____12165 = un_uinst hd  in
+            uu____12165.FStar_Syntax_Syntax.n  in
+          (match uu____12164 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                lookup_arity_lid destruct_base_table
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v args
-           | uu____12105 -> FStar_Pervasives_Native.None)
+           | uu____12171 -> FStar_Pervasives_Native.None)
        in
     let destruct_sq_base_conn t =
-      let uu____12114 = un_squash t  in
-      FStar_Util.bind_opt uu____12114
+      let uu____12180 = un_squash t  in
+      FStar_Util.bind_opt uu____12180
         (fun t1  ->
-           let uu____12130 = head_and_args' t1  in
-           match uu____12130 with
+           let uu____12196 = head_and_args' t1  in
+           match uu____12196 with
            | (hd,args) ->
-               let uu____12169 =
-                 let uu____12170 = un_uinst hd  in
-                 uu____12170.FStar_Syntax_Syntax.n  in
-               (match uu____12169 with
+               let uu____12235 =
+                 let uu____12236 = un_uinst hd  in
+                 uu____12236.FStar_Syntax_Syntax.n  in
+               (match uu____12235 with
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     lookup_arity_lid destruct_sq_base_table
                       (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                       args
-                | uu____12176 -> FStar_Pervasives_Native.None))
+                | uu____12242 -> FStar_Pervasives_Native.None))
        in
     let patterns t =
       let t1 = FStar_Syntax_Subst.compress t  in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta
-          (t2,FStar_Syntax_Syntax.Meta_pattern (uu____12217,pats)) ->
-          let uu____12255 = FStar_Syntax_Subst.compress t2  in
-          (pats, uu____12255)
-      | uu____12268 -> ([], t1)  in
+          (t2,FStar_Syntax_Syntax.Meta_pattern (uu____12283,pats)) ->
+          let uu____12321 = FStar_Syntax_Subst.compress t2  in
+          (pats, uu____12321)
+      | uu____12334 -> ([], t1)  in
     let destruct_q_conn t =
       let is_q fa fv =
         if fa
@@ -3055,228 +3081,228 @@ let (destruct_typ_as_formula :
         else is_exists (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
          in
       let flat t1 =
-        let uu____12335 = head_and_args t1  in
-        match uu____12335 with
+        let uu____12401 = head_and_args t1  in
+        match uu____12401 with
         | (t2,args) ->
-            let uu____12390 = un_uinst t2  in
-            let uu____12391 =
+            let uu____12456 = un_uinst t2  in
+            let uu____12457 =
               FStar_All.pipe_right args
                 (FStar_List.map
-                   (fun uu____12432  ->
-                      match uu____12432 with
+                   (fun uu____12498  ->
+                      match uu____12498 with
                       | (t3,imp) ->
-                          let uu____12451 = unascribe t3  in
-                          (uu____12451, imp)))
+                          let uu____12517 = unascribe t3  in
+                          (uu____12517, imp)))
                in
-            (uu____12390, uu____12391)
+            (uu____12456, uu____12457)
          in
       let rec aux qopt out t1 =
-        let uu____12502 = let uu____12526 = flat t1  in (qopt, uu____12526)
+        let uu____12568 = let uu____12592 = flat t1  in (qopt, uu____12592)
            in
-        match uu____12502 with
+        match uu____12568 with
         | (FStar_Pervasives_Native.Some
            fa,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-                 FStar_Syntax_Syntax.pos = uu____12566;
-                 FStar_Syntax_Syntax.vars = uu____12567;_},({
+                 FStar_Syntax_Syntax.pos = uu____12632;
+                 FStar_Syntax_Syntax.vars = uu____12633;_},({
                                                               FStar_Syntax_Syntax.n
                                                                 =
                                                                 FStar_Syntax_Syntax.Tm_abs
-                                                                (b::[],t2,uu____12570);
+                                                                (b::[],t2,uu____12636);
                                                               FStar_Syntax_Syntax.pos
-                                                                = uu____12571;
+                                                                = uu____12637;
                                                               FStar_Syntax_Syntax.vars
-                                                                = uu____12572;_},uu____12573)::[]))
+                                                                = uu____12638;_},uu____12639)::[]))
             when is_q fa tc -> aux qopt (b :: out) t2
         | (FStar_Pervasives_Native.Some
            fa,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-                 FStar_Syntax_Syntax.pos = uu____12675;
-                 FStar_Syntax_Syntax.vars = uu____12676;_},uu____12677::
+                 FStar_Syntax_Syntax.pos = uu____12741;
+                 FStar_Syntax_Syntax.vars = uu____12742;_},uu____12743::
                ({
                   FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                    (b::[],t2,uu____12680);
-                  FStar_Syntax_Syntax.pos = uu____12681;
-                  FStar_Syntax_Syntax.vars = uu____12682;_},uu____12683)::[]))
+                    (b::[],t2,uu____12746);
+                  FStar_Syntax_Syntax.pos = uu____12747;
+                  FStar_Syntax_Syntax.vars = uu____12748;_},uu____12749)::[]))
             when is_q fa tc -> aux qopt (b :: out) t2
         | (FStar_Pervasives_Native.None
            ,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-               FStar_Syntax_Syntax.pos = uu____12800;
-               FStar_Syntax_Syntax.vars = uu____12801;_},({
+               FStar_Syntax_Syntax.pos = uu____12866;
+               FStar_Syntax_Syntax.vars = uu____12867;_},({
                                                             FStar_Syntax_Syntax.n
                                                               =
                                                               FStar_Syntax_Syntax.Tm_abs
-                                                              (b::[],t2,uu____12804);
+                                                              (b::[],t2,uu____12870);
                                                             FStar_Syntax_Syntax.pos
-                                                              = uu____12805;
+                                                              = uu____12871;
                                                             FStar_Syntax_Syntax.vars
-                                                              = uu____12806;_},uu____12807)::[]))
+                                                              = uu____12872;_},uu____12873)::[]))
             when
             is_qlid (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v ->
-            let uu____12900 =
-              let uu____12904 =
+            let uu____12966 =
+              let uu____12970 =
                 is_forall
                   (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                  in
-              FStar_Pervasives_Native.Some uu____12904  in
-            aux uu____12900 (b :: out) t2
+              FStar_Pervasives_Native.Some uu____12970  in
+            aux uu____12966 (b :: out) t2
         | (FStar_Pervasives_Native.None
            ,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-               FStar_Syntax_Syntax.pos = uu____12914;
-               FStar_Syntax_Syntax.vars = uu____12915;_},uu____12916::
+               FStar_Syntax_Syntax.pos = uu____12980;
+               FStar_Syntax_Syntax.vars = uu____12981;_},uu____12982::
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                  (b::[],t2,uu____12919);
-                FStar_Syntax_Syntax.pos = uu____12920;
-                FStar_Syntax_Syntax.vars = uu____12921;_},uu____12922)::[]))
+                  (b::[],t2,uu____12985);
+                FStar_Syntax_Syntax.pos = uu____12986;
+                FStar_Syntax_Syntax.vars = uu____12987;_},uu____12988)::[]))
             when
             is_qlid (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v ->
-            let uu____13031 =
-              let uu____13035 =
+            let uu____13097 =
+              let uu____13101 =
                 is_forall
                   (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                  in
-              FStar_Pervasives_Native.Some uu____13035  in
-            aux uu____13031 (b :: out) t2
-        | (FStar_Pervasives_Native.Some b,uu____13045) ->
+              FStar_Pervasives_Native.Some uu____13101  in
+            aux uu____13097 (b :: out) t2
+        | (FStar_Pervasives_Native.Some b,uu____13111) ->
             let bs = FStar_List.rev out  in
-            let uu____13098 = FStar_Syntax_Subst.open_term bs t1  in
-            (match uu____13098 with
+            let uu____13164 = FStar_Syntax_Subst.open_term bs t1  in
+            (match uu____13164 with
              | (bs1,t2) ->
-                 let uu____13107 = patterns t2  in
-                 (match uu____13107 with
+                 let uu____13173 = patterns t2  in
+                 (match uu____13173 with
                   | (pats,body) ->
                       if b
                       then
                         FStar_Pervasives_Native.Some (QAll (bs1, pats, body))
                       else
                         FStar_Pervasives_Native.Some (QEx (bs1, pats, body))))
-        | uu____13157 -> FStar_Pervasives_Native.None  in
+        | uu____13223 -> FStar_Pervasives_Native.None  in
       aux FStar_Pervasives_Native.None [] t  in
     let rec destruct_sq_forall t =
-      let uu____13212 = un_squash t  in
-      FStar_Util.bind_opt uu____13212
+      let uu____13278 = un_squash t  in
+      FStar_Util.bind_opt uu____13278
         (fun t1  ->
-           let uu____13227 = arrow_one t1  in
-           match uu____13227 with
+           let uu____13293 = arrow_one t1  in
+           match uu____13293 with
            | FStar_Pervasives_Native.Some (b,c) ->
-               let uu____13242 =
-                 let uu____13244 = is_tot_or_gtot_comp c  in
-                 Prims.op_Negation uu____13244  in
-               if uu____13242
+               let uu____13308 =
+                 let uu____13310 = is_tot_or_gtot_comp c  in
+                 Prims.op_Negation uu____13310  in
+               if uu____13308
                then FStar_Pervasives_Native.None
                else
                  (let q =
-                    let uu____13254 = comp_to_comp_typ_nouniv c  in
-                    uu____13254.FStar_Syntax_Syntax.result_typ  in
-                  let uu____13255 =
+                    let uu____13320 = comp_to_comp_typ_nouniv c  in
+                    uu____13320.FStar_Syntax_Syntax.result_typ  in
+                  let uu____13321 =
                     is_free_in (FStar_Pervasives_Native.fst b) q  in
-                  if uu____13255
+                  if uu____13321
                   then
-                    let uu____13262 = patterns q  in
-                    match uu____13262 with
+                    let uu____13328 = patterns q  in
+                    match uu____13328 with
                     | (pats,q1) ->
                         FStar_All.pipe_left maybe_collect
                           (FStar_Pervasives_Native.Some
                              (QAll ([b], pats, q1)))
                   else
-                    (let uu____13325 =
-                       let uu____13326 =
-                         let uu____13331 =
-                           let uu____13332 =
+                    (let uu____13391 =
+                       let uu____13392 =
+                         let uu____13397 =
+                           let uu____13398 =
                              FStar_Syntax_Syntax.as_arg
                                (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                               in
-                           let uu____13343 =
-                             let uu____13354 = FStar_Syntax_Syntax.as_arg q
+                           let uu____13409 =
+                             let uu____13420 = FStar_Syntax_Syntax.as_arg q
                                 in
-                             [uu____13354]  in
-                           uu____13332 :: uu____13343  in
-                         (FStar_Parser_Const.imp_lid, uu____13331)  in
-                       BaseConn uu____13326  in
-                     FStar_Pervasives_Native.Some uu____13325))
-           | uu____13387 -> FStar_Pervasives_Native.None)
+                             [uu____13420]  in
+                           uu____13398 :: uu____13409  in
+                         (FStar_Parser_Const.imp_lid, uu____13397)  in
+                       BaseConn uu____13392  in
+                     FStar_Pervasives_Native.Some uu____13391))
+           | uu____13453 -> FStar_Pervasives_Native.None)
     
     and destruct_sq_exists t =
-      let uu____13395 = un_squash t  in
-      FStar_Util.bind_opt uu____13395
+      let uu____13461 = un_squash t  in
+      FStar_Util.bind_opt uu____13461
         (fun t1  ->
-           let uu____13426 = head_and_args' t1  in
-           match uu____13426 with
+           let uu____13492 = head_and_args' t1  in
+           match uu____13492 with
            | (hd,args) ->
-               let uu____13465 =
-                 let uu____13480 =
-                   let uu____13481 = un_uinst hd  in
-                   uu____13481.FStar_Syntax_Syntax.n  in
-                 (uu____13480, args)  in
-               (match uu____13465 with
+               let uu____13531 =
+                 let uu____13546 =
+                   let uu____13547 = un_uinst hd  in
+                   uu____13547.FStar_Syntax_Syntax.n  in
+                 (uu____13546, args)  in
+               (match uu____13531 with
                 | (FStar_Syntax_Syntax.Tm_fvar
-                   fv,(a1,uu____13498)::(a2,uu____13500)::[]) when
+                   fv,(a1,uu____13564)::(a2,uu____13566)::[]) when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.dtuple2_lid
                     ->
-                    let uu____13551 =
-                      let uu____13552 = FStar_Syntax_Subst.compress a2  in
-                      uu____13552.FStar_Syntax_Syntax.n  in
-                    (match uu____13551 with
-                     | FStar_Syntax_Syntax.Tm_abs (b::[],q,uu____13559) ->
-                         let uu____13594 = FStar_Syntax_Subst.open_term [b] q
+                    let uu____13617 =
+                      let uu____13618 = FStar_Syntax_Subst.compress a2  in
+                      uu____13618.FStar_Syntax_Syntax.n  in
+                    (match uu____13617 with
+                     | FStar_Syntax_Syntax.Tm_abs (b::[],q,uu____13625) ->
+                         let uu____13660 = FStar_Syntax_Subst.open_term [b] q
                             in
-                         (match uu____13594 with
+                         (match uu____13660 with
                           | (bs,q1) ->
                               let b1 =
                                 match bs with
                                 | b1::[] -> b1
-                                | uu____13647 -> failwith "impossible"  in
-                              let uu____13655 = patterns q1  in
-                              (match uu____13655 with
+                                | uu____13713 -> failwith "impossible"  in
+                              let uu____13721 = patterns q1  in
+                              (match uu____13721 with
                                | (pats,q2) ->
                                    FStar_All.pipe_left maybe_collect
                                      (FStar_Pervasives_Native.Some
                                         (QEx ([b1], pats, q2)))))
-                     | uu____13716 -> FStar_Pervasives_Native.None)
-                | uu____13717 -> FStar_Pervasives_Native.None))
+                     | uu____13782 -> FStar_Pervasives_Native.None)
+                | uu____13783 -> FStar_Pervasives_Native.None))
     
     and maybe_collect f1 =
       match f1 with
       | FStar_Pervasives_Native.Some (QAll (bs,pats,phi)) ->
-          let uu____13740 = destruct_sq_forall phi  in
-          (match uu____13740 with
+          let uu____13806 = destruct_sq_forall phi  in
+          (match uu____13806 with
            | FStar_Pervasives_Native.Some (QAll (bs',pats',psi)) ->
                FStar_All.pipe_left
-                 (fun uu____13750  ->
-                    FStar_Pervasives_Native.Some uu____13750)
+                 (fun uu____13816  ->
+                    FStar_Pervasives_Native.Some uu____13816)
                  (QAll
                     ((FStar_List.append bs bs'),
                       (FStar_List.append pats pats'), psi))
-           | uu____13757 -> f1)
+           | uu____13823 -> f1)
       | FStar_Pervasives_Native.Some (QEx (bs,pats,phi)) ->
-          let uu____13763 = destruct_sq_exists phi  in
-          (match uu____13763 with
+          let uu____13829 = destruct_sq_exists phi  in
+          (match uu____13829 with
            | FStar_Pervasives_Native.Some (QEx (bs',pats',psi)) ->
                FStar_All.pipe_left
-                 (fun uu____13773  ->
-                    FStar_Pervasives_Native.Some uu____13773)
+                 (fun uu____13839  ->
+                    FStar_Pervasives_Native.Some uu____13839)
                  (QEx
                     ((FStar_List.append bs bs'),
                       (FStar_List.append pats pats'), psi))
-           | uu____13780 -> f1)
-      | uu____13783 -> f1
+           | uu____13846 -> f1)
+      | uu____13849 -> f1
      in
     let phi = unmeta_monadic f  in
-    let uu____13787 = destruct_base_conn phi  in
-    FStar_Util.catch_opt uu____13787
-      (fun uu____13792  ->
-         let uu____13793 = destruct_q_conn phi  in
-         FStar_Util.catch_opt uu____13793
-           (fun uu____13798  ->
-              let uu____13799 = destruct_sq_base_conn phi  in
-              FStar_Util.catch_opt uu____13799
-                (fun uu____13804  ->
-                   let uu____13805 = destruct_sq_forall phi  in
-                   FStar_Util.catch_opt uu____13805
-                     (fun uu____13810  ->
-                        let uu____13811 = destruct_sq_exists phi  in
-                        FStar_Util.catch_opt uu____13811
-                          (fun uu____13815  -> FStar_Pervasives_Native.None)))))
+    let uu____13853 = destruct_base_conn phi  in
+    FStar_Util.catch_opt uu____13853
+      (fun uu____13858  ->
+         let uu____13859 = destruct_q_conn phi  in
+         FStar_Util.catch_opt uu____13859
+           (fun uu____13864  ->
+              let uu____13865 = destruct_sq_base_conn phi  in
+              FStar_Util.catch_opt uu____13865
+                (fun uu____13870  ->
+                   let uu____13871 = destruct_sq_forall phi  in
+                   FStar_Util.catch_opt uu____13871
+                     (fun uu____13876  ->
+                        let uu____13877 = destruct_sq_exists phi  in
+                        FStar_Util.catch_opt uu____13877
+                          (fun uu____13881  -> FStar_Pervasives_Native.None)))))
   
 let (action_as_lb :
   FStar_Ident.lident ->
@@ -3287,25 +3313,25 @@ let (action_as_lb :
     fun a  ->
       fun pos  ->
         let lb =
-          let uu____13833 =
-            let uu____13838 =
+          let uu____13899 =
+            let uu____13904 =
               FStar_Syntax_Syntax.lid_as_fv a.FStar_Syntax_Syntax.action_name
                 FStar_Syntax_Syntax.delta_equational
                 FStar_Pervasives_Native.None
                in
-            FStar_Util.Inr uu____13838  in
-          let uu____13839 =
-            let uu____13840 =
+            FStar_Util.Inr uu____13904  in
+          let uu____13905 =
+            let uu____13906 =
               FStar_Syntax_Syntax.mk_Total a.FStar_Syntax_Syntax.action_typ
                in
-            arrow a.FStar_Syntax_Syntax.action_params uu____13840  in
-          let uu____13843 =
+            arrow a.FStar_Syntax_Syntax.action_params uu____13906  in
+          let uu____13909 =
             abs a.FStar_Syntax_Syntax.action_params
               a.FStar_Syntax_Syntax.action_defn FStar_Pervasives_Native.None
              in
           close_univs_and_mk_letbinding FStar_Pervasives_Native.None
-            uu____13833 a.FStar_Syntax_Syntax.action_univs uu____13839
-            FStar_Parser_Const.effect_Tot_lid uu____13843 [] pos
+            uu____13899 a.FStar_Syntax_Syntax.action_univs uu____13905
+            FStar_Parser_Const.effect_Tot_lid uu____13909 [] pos
            in
         {
           FStar_Syntax_Syntax.sigel =
@@ -3331,16 +3357,16 @@ let (mk_reify :
         (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_reify)
         FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
        in
-    let uu____13869 =
-      let uu____13876 =
-        let uu____13877 =
-          let uu____13894 =
-            let uu____13905 = FStar_Syntax_Syntax.as_arg t  in [uu____13905]
+    let uu____13935 =
+      let uu____13942 =
+        let uu____13943 =
+          let uu____13960 =
+            let uu____13971 = FStar_Syntax_Syntax.as_arg t  in [uu____13971]
              in
-          (reify_, uu____13894)  in
-        FStar_Syntax_Syntax.Tm_app uu____13877  in
-      FStar_Syntax_Syntax.mk uu____13876  in
-    uu____13869 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+          (reify_, uu____13960)  in
+        FStar_Syntax_Syntax.Tm_app uu____13943  in
+      FStar_Syntax_Syntax.mk uu____13942  in
+    uu____13935 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
   
 let (mk_reflect :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -3348,64 +3374,64 @@ let (mk_reflect :
   =
   fun t  ->
     let reflect_ =
-      let uu____13957 =
-        let uu____13964 =
-          let uu____13965 =
-            let uu____13966 = FStar_Ident.lid_of_str "Bogus.Effect"  in
-            FStar_Const.Const_reflect uu____13966  in
-          FStar_Syntax_Syntax.Tm_constant uu____13965  in
-        FStar_Syntax_Syntax.mk uu____13964  in
-      uu____13957 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos  in
-    let uu____13968 =
-      let uu____13975 =
-        let uu____13976 =
-          let uu____13993 =
-            let uu____14004 = FStar_Syntax_Syntax.as_arg t  in [uu____14004]
+      let uu____14023 =
+        let uu____14030 =
+          let uu____14031 =
+            let uu____14032 = FStar_Ident.lid_of_str "Bogus.Effect"  in
+            FStar_Const.Const_reflect uu____14032  in
+          FStar_Syntax_Syntax.Tm_constant uu____14031  in
+        FStar_Syntax_Syntax.mk uu____14030  in
+      uu____14023 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos  in
+    let uu____14034 =
+      let uu____14041 =
+        let uu____14042 =
+          let uu____14059 =
+            let uu____14070 = FStar_Syntax_Syntax.as_arg t  in [uu____14070]
              in
-          (reflect_, uu____13993)  in
-        FStar_Syntax_Syntax.Tm_app uu____13976  in
-      FStar_Syntax_Syntax.mk uu____13975  in
-    uu____13968 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+          (reflect_, uu____14059)  in
+        FStar_Syntax_Syntax.Tm_app uu____14042  in
+      FStar_Syntax_Syntax.mk uu____14041  in
+    uu____14034 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
   
 let rec (delta_qualifier :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth) =
   fun t  ->
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____14048 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_delayed uu____14114 -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_lazy i ->
-        let uu____14065 = unfold_lazy i  in delta_qualifier uu____14065
+        let uu____14131 = unfold_lazy i  in delta_qualifier uu____14131
     | FStar_Syntax_Syntax.Tm_fvar fv -> fv.FStar_Syntax_Syntax.fv_delta
-    | FStar_Syntax_Syntax.Tm_bvar uu____14067 ->
+    | FStar_Syntax_Syntax.Tm_bvar uu____14133 ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_name uu____14068 ->
+    | FStar_Syntax_Syntax.Tm_name uu____14134 ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_match uu____14069 ->
+    | FStar_Syntax_Syntax.Tm_match uu____14135 ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_uvar uu____14092 ->
+    | FStar_Syntax_Syntax.Tm_uvar uu____14158 ->
         FStar_Syntax_Syntax.delta_equational
     | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_type uu____14105 ->
+    | FStar_Syntax_Syntax.Tm_type uu____14171 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_quoted uu____14106 ->
+    | FStar_Syntax_Syntax.Tm_quoted uu____14172 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_constant uu____14113 ->
+    | FStar_Syntax_Syntax.Tm_constant uu____14179 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_arrow uu____14114 ->
+    | FStar_Syntax_Syntax.Tm_arrow uu____14180 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_uinst (t2,uu____14130) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_uinst (t2,uu____14196) -> delta_qualifier t2
     | FStar_Syntax_Syntax.Tm_refine
-        ({ FStar_Syntax_Syntax.ppname = uu____14135;
-           FStar_Syntax_Syntax.index = uu____14136;
-           FStar_Syntax_Syntax.sort = t2;_},uu____14138)
+        ({ FStar_Syntax_Syntax.ppname = uu____14201;
+           FStar_Syntax_Syntax.index = uu____14202;
+           FStar_Syntax_Syntax.sort = t2;_},uu____14204)
         -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_meta (t2,uu____14147) -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____14153,uu____14154) ->
+    | FStar_Syntax_Syntax.Tm_meta (t2,uu____14213) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____14219,uu____14220) ->
         delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_app (t2,uu____14196) -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_abs (uu____14221,t2,uu____14223) ->
+    | FStar_Syntax_Syntax.Tm_app (t2,uu____14262) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_abs (uu____14287,t2,uu____14289) ->
         delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_let (uu____14248,t2) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_let (uu____14314,t2) -> delta_qualifier t2
   
 let rec (incr_delta_depth :
   FStar_Syntax_Syntax.delta_depth -> FStar_Syntax_Syntax.delta_depth) =
@@ -3420,28 +3446,28 @@ let rec (incr_delta_depth :
 let (incr_delta_qualifier :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth) =
   fun t  ->
-    let uu____14287 = delta_qualifier t  in incr_delta_depth uu____14287
+    let uu____14353 = delta_qualifier t  in incr_delta_depth uu____14353
   
 let (is_unknown : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____14295 =
-      let uu____14296 = FStar_Syntax_Subst.compress t  in
-      uu____14296.FStar_Syntax_Syntax.n  in
-    match uu____14295 with
+    let uu____14361 =
+      let uu____14362 = FStar_Syntax_Subst.compress t  in
+      uu____14362.FStar_Syntax_Syntax.n  in
+    match uu____14361 with
     | FStar_Syntax_Syntax.Tm_unknown  -> true
-    | uu____14301 -> false
+    | uu____14367 -> false
   
 let rec apply_last :
-  'uuuuuu14310 .
-    ('uuuuuu14310 -> 'uuuuuu14310) ->
-      'uuuuuu14310 Prims.list -> 'uuuuuu14310 Prims.list
+  'uuuuuu14376 .
+    ('uuuuuu14376 -> 'uuuuuu14376) ->
+      'uuuuuu14376 Prims.list -> 'uuuuuu14376 Prims.list
   =
   fun f  ->
     fun l  ->
       match l with
       | [] -> failwith "apply_last: got empty list"
-      | a::[] -> let uu____14336 = f a  in [uu____14336]
-      | x::xs -> let uu____14341 = apply_last f xs  in x :: uu____14341
+      | a::[] -> let uu____14402 = f a  in [uu____14402]
+      | x::xs -> let uu____14407 = apply_last f xs  in x :: uu____14407
   
 let (dm4f_lid :
   FStar_Syntax_Syntax.eff_decl -> Prims.string -> FStar_Ident.lident) =
@@ -3465,52 +3491,52 @@ let (mk_list :
     fun rng  ->
       fun l  ->
         let ctor l1 =
-          let uu____14396 =
-            let uu____14403 =
-              let uu____14404 =
+          let uu____14462 =
+            let uu____14469 =
+              let uu____14470 =
                 FStar_Syntax_Syntax.lid_as_fv l1
                   FStar_Syntax_Syntax.delta_constant
                   (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
                  in
-              FStar_Syntax_Syntax.Tm_fvar uu____14404  in
-            FStar_Syntax_Syntax.mk uu____14403  in
-          uu____14396 FStar_Pervasives_Native.None rng  in
+              FStar_Syntax_Syntax.Tm_fvar uu____14470  in
+            FStar_Syntax_Syntax.mk uu____14469  in
+          uu____14462 FStar_Pervasives_Native.None rng  in
         let cons args pos =
-          let uu____14418 =
-            let uu____14423 =
-              let uu____14424 = ctor FStar_Parser_Const.cons_lid  in
-              FStar_Syntax_Syntax.mk_Tm_uinst uu____14424
+          let uu____14484 =
+            let uu____14489 =
+              let uu____14490 = ctor FStar_Parser_Const.cons_lid  in
+              FStar_Syntax_Syntax.mk_Tm_uinst uu____14490
                 [FStar_Syntax_Syntax.U_zero]
                in
-            FStar_Syntax_Syntax.mk_Tm_app uu____14423 args  in
-          uu____14418 FStar_Pervasives_Native.None pos  in
+            FStar_Syntax_Syntax.mk_Tm_app uu____14489 args  in
+          uu____14484 FStar_Pervasives_Native.None pos  in
         let nil args pos =
-          let uu____14438 =
-            let uu____14443 =
-              let uu____14444 = ctor FStar_Parser_Const.nil_lid  in
-              FStar_Syntax_Syntax.mk_Tm_uinst uu____14444
+          let uu____14504 =
+            let uu____14509 =
+              let uu____14510 = ctor FStar_Parser_Const.nil_lid  in
+              FStar_Syntax_Syntax.mk_Tm_uinst uu____14510
                 [FStar_Syntax_Syntax.U_zero]
                in
-            FStar_Syntax_Syntax.mk_Tm_app uu____14443 args  in
-          uu____14438 FStar_Pervasives_Native.None pos  in
-        let uu____14445 =
-          let uu____14446 =
-            let uu____14447 = FStar_Syntax_Syntax.iarg typ  in [uu____14447]
+            FStar_Syntax_Syntax.mk_Tm_app uu____14509 args  in
+          uu____14504 FStar_Pervasives_Native.None pos  in
+        let uu____14511 =
+          let uu____14512 =
+            let uu____14513 = FStar_Syntax_Syntax.iarg typ  in [uu____14513]
              in
-          nil uu____14446 rng  in
+          nil uu____14512 rng  in
         FStar_List.fold_right
           (fun t  ->
              fun a  ->
-               let uu____14481 =
-                 let uu____14482 = FStar_Syntax_Syntax.iarg typ  in
-                 let uu____14491 =
-                   let uu____14502 = FStar_Syntax_Syntax.as_arg t  in
-                   let uu____14511 =
-                     let uu____14522 = FStar_Syntax_Syntax.as_arg a  in
-                     [uu____14522]  in
-                   uu____14502 :: uu____14511  in
-                 uu____14482 :: uu____14491  in
-               cons uu____14481 t.FStar_Syntax_Syntax.pos) l uu____14445
+               let uu____14547 =
+                 let uu____14548 = FStar_Syntax_Syntax.iarg typ  in
+                 let uu____14557 =
+                   let uu____14568 = FStar_Syntax_Syntax.as_arg t  in
+                   let uu____14577 =
+                     let uu____14588 = FStar_Syntax_Syntax.as_arg a  in
+                     [uu____14588]  in
+                   uu____14568 :: uu____14577  in
+                 uu____14548 :: uu____14557  in
+               cons uu____14547 t.FStar_Syntax_Syntax.pos) l uu____14511
   
 let rec eqlist :
   'a .
@@ -3522,7 +3548,7 @@ let rec eqlist :
         match (xs, ys) with
         | ([],[]) -> true
         | (x::xs1,y::ys1) -> (eq x y) && (eqlist eq xs1 ys1)
-        | uu____14631 -> false
+        | uu____14697 -> false
   
 let eqsum :
   'a 'b .
@@ -3537,7 +3563,7 @@ let eqsum :
           match (x, y) with
           | (FStar_Util.Inl x1,FStar_Util.Inl y1) -> e1 x1 y1
           | (FStar_Util.Inr x1,FStar_Util.Inr y1) -> e2 x1 y1
-          | uu____14745 -> false
+          | uu____14811 -> false
   
 let eqprod :
   'a 'b .
@@ -3562,7 +3588,7 @@ let eqopt :
         match (x, y) with
         | (FStar_Pervasives_Native.Some x1,FStar_Pervasives_Native.Some y1)
             -> e x1 y1
-        | uu____14911 -> false
+        | uu____14977 -> false
   
 let (debug_term_eq : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref false 
 let (check : Prims.string -> Prims.bool -> Prims.bool) =
@@ -3571,8 +3597,8 @@ let (check : Prims.string -> Prims.bool -> Prims.bool) =
       if cond
       then true
       else
-        ((let uu____14949 = FStar_ST.op_Bang debug_term_eq  in
-          if uu____14949
+        ((let uu____15015 = FStar_ST.op_Bang debug_term_eq  in
+          if uu____15015
           then FStar_Util.print1 ">>> term_eq failing: %s\n" msg
           else ());
          false)
@@ -3585,34 +3611,34 @@ let rec (term_eq_dbg :
   fun dbg  ->
     fun t1  ->
       fun t2  ->
-        let t11 = let uu____15153 = unmeta_safe t1  in canon_app uu____15153
+        let t11 = let uu____15219 = unmeta_safe t1  in canon_app uu____15219
            in
-        let t21 = let uu____15159 = unmeta_safe t2  in canon_app uu____15159
+        let t21 = let uu____15225 = unmeta_safe t2  in canon_app uu____15225
            in
-        let uu____15162 =
-          let uu____15167 =
-            let uu____15168 =
-              let uu____15171 = un_uinst t11  in
-              FStar_Syntax_Subst.compress uu____15171  in
-            uu____15168.FStar_Syntax_Syntax.n  in
-          let uu____15172 =
-            let uu____15173 =
-              let uu____15176 = un_uinst t21  in
-              FStar_Syntax_Subst.compress uu____15176  in
-            uu____15173.FStar_Syntax_Syntax.n  in
-          (uu____15167, uu____15172)  in
-        match uu____15162 with
-        | (FStar_Syntax_Syntax.Tm_uinst uu____15178,uu____15179) ->
+        let uu____15228 =
+          let uu____15233 =
+            let uu____15234 =
+              let uu____15237 = un_uinst t11  in
+              FStar_Syntax_Subst.compress uu____15237  in
+            uu____15234.FStar_Syntax_Syntax.n  in
+          let uu____15238 =
+            let uu____15239 =
+              let uu____15242 = un_uinst t21  in
+              FStar_Syntax_Subst.compress uu____15242  in
+            uu____15239.FStar_Syntax_Syntax.n  in
+          (uu____15233, uu____15238)  in
+        match uu____15228 with
+        | (FStar_Syntax_Syntax.Tm_uinst uu____15244,uu____15245) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____15188,FStar_Syntax_Syntax.Tm_uinst uu____15189) ->
+        | (uu____15254,FStar_Syntax_Syntax.Tm_uinst uu____15255) ->
             failwith "term_eq: impossible, should have been removed"
-        | (FStar_Syntax_Syntax.Tm_delayed uu____15198,uu____15199) ->
+        | (FStar_Syntax_Syntax.Tm_delayed uu____15264,uu____15265) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____15216,FStar_Syntax_Syntax.Tm_delayed uu____15217) ->
+        | (uu____15282,FStar_Syntax_Syntax.Tm_delayed uu____15283) ->
             failwith "term_eq: impossible, should have been removed"
-        | (FStar_Syntax_Syntax.Tm_ascribed uu____15234,uu____15235) ->
+        | (FStar_Syntax_Syntax.Tm_ascribed uu____15300,uu____15301) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____15264,FStar_Syntax_Syntax.Tm_ascribed uu____15265) ->
+        | (uu____15330,FStar_Syntax_Syntax.Tm_ascribed uu____15331) ->
             failwith "term_eq: impossible, should have been removed"
         | (FStar_Syntax_Syntax.Tm_bvar x,FStar_Syntax_Syntax.Tm_bvar y) ->
             check "bvar"
@@ -3621,152 +3647,152 @@ let rec (term_eq_dbg :
             check "name"
               (x.FStar_Syntax_Syntax.index = y.FStar_Syntax_Syntax.index)
         | (FStar_Syntax_Syntax.Tm_fvar x,FStar_Syntax_Syntax.Tm_fvar y) ->
-            let uu____15304 = FStar_Syntax_Syntax.fv_eq x y  in
-            check "fvar" uu____15304
+            let uu____15370 = FStar_Syntax_Syntax.fv_eq x y  in
+            check "fvar" uu____15370
         | (FStar_Syntax_Syntax.Tm_constant c1,FStar_Syntax_Syntax.Tm_constant
            c2) ->
-            let uu____15309 = FStar_Const.eq_const c1 c2  in
-            check "const" uu____15309
+            let uu____15375 = FStar_Const.eq_const c1 c2  in
+            check "const" uu____15375
         | (FStar_Syntax_Syntax.Tm_type
-           uu____15312,FStar_Syntax_Syntax.Tm_type uu____15313) -> true
+           uu____15378,FStar_Syntax_Syntax.Tm_type uu____15379) -> true
         | (FStar_Syntax_Syntax.Tm_abs (b1,t12,k1),FStar_Syntax_Syntax.Tm_abs
            (b2,t22,k2)) ->
-            (let uu____15371 = eqlist (binder_eq_dbg dbg) b1 b2  in
-             check "abs binders" uu____15371) &&
-              (let uu____15381 = term_eq_dbg dbg t12 t22  in
-               check "abs bodies" uu____15381)
+            (let uu____15437 = eqlist (binder_eq_dbg dbg) b1 b2  in
+             check "abs binders" uu____15437) &&
+              (let uu____15447 = term_eq_dbg dbg t12 t22  in
+               check "abs bodies" uu____15447)
         | (FStar_Syntax_Syntax.Tm_arrow (b1,c1),FStar_Syntax_Syntax.Tm_arrow
            (b2,c2)) ->
-            (let uu____15430 = eqlist (binder_eq_dbg dbg) b1 b2  in
-             check "arrow binders" uu____15430) &&
-              (let uu____15440 = comp_eq_dbg dbg c1 c2  in
-               check "arrow comp" uu____15440)
+            (let uu____15496 = eqlist (binder_eq_dbg dbg) b1 b2  in
+             check "arrow binders" uu____15496) &&
+              (let uu____15506 = comp_eq_dbg dbg c1 c2  in
+               check "arrow comp" uu____15506)
         | (FStar_Syntax_Syntax.Tm_refine
            (b1,t12),FStar_Syntax_Syntax.Tm_refine (b2,t22)) ->
-            (let uu____15457 =
+            (let uu____15523 =
                term_eq_dbg dbg b1.FStar_Syntax_Syntax.sort
                  b2.FStar_Syntax_Syntax.sort
                 in
-             check "refine bv sort" uu____15457) &&
-              (let uu____15461 = term_eq_dbg dbg t12 t22  in
-               check "refine formula" uu____15461)
+             check "refine bv sort" uu____15523) &&
+              (let uu____15527 = term_eq_dbg dbg t12 t22  in
+               check "refine formula" uu____15527)
         | (FStar_Syntax_Syntax.Tm_app (f1,a1),FStar_Syntax_Syntax.Tm_app
            (f2,a2)) ->
-            (let uu____15518 = term_eq_dbg dbg f1 f2  in
-             check "app head" uu____15518) &&
-              (let uu____15522 = eqlist (arg_eq_dbg dbg) a1 a2  in
-               check "app args" uu____15522)
+            (let uu____15584 = term_eq_dbg dbg f1 f2  in
+             check "app head" uu____15584) &&
+              (let uu____15588 = eqlist (arg_eq_dbg dbg) a1 a2  in
+               check "app args" uu____15588)
         | (FStar_Syntax_Syntax.Tm_match
            (t12,bs1),FStar_Syntax_Syntax.Tm_match (t22,bs2)) ->
-            (let uu____15611 = term_eq_dbg dbg t12 t22  in
-             check "match head" uu____15611) &&
-              (let uu____15615 = eqlist (branch_eq_dbg dbg) bs1 bs2  in
-               check "match branches" uu____15615)
-        | (FStar_Syntax_Syntax.Tm_lazy uu____15632,uu____15633) ->
-            let uu____15634 =
-              let uu____15636 = unlazy t11  in
-              term_eq_dbg dbg uu____15636 t21  in
-            check "lazy_l" uu____15634
-        | (uu____15638,FStar_Syntax_Syntax.Tm_lazy uu____15639) ->
-            let uu____15640 =
-              let uu____15642 = unlazy t21  in
-              term_eq_dbg dbg t11 uu____15642  in
-            check "lazy_r" uu____15640
+            (let uu____15677 = term_eq_dbg dbg t12 t22  in
+             check "match head" uu____15677) &&
+              (let uu____15681 = eqlist (branch_eq_dbg dbg) bs1 bs2  in
+               check "match branches" uu____15681)
+        | (FStar_Syntax_Syntax.Tm_lazy uu____15698,uu____15699) ->
+            let uu____15700 =
+              let uu____15702 = unlazy t11  in
+              term_eq_dbg dbg uu____15702 t21  in
+            check "lazy_l" uu____15700
+        | (uu____15704,FStar_Syntax_Syntax.Tm_lazy uu____15705) ->
+            let uu____15706 =
+              let uu____15708 = unlazy t21  in
+              term_eq_dbg dbg t11 uu____15708  in
+            check "lazy_r" uu____15706
         | (FStar_Syntax_Syntax.Tm_let
            ((b1,lbs1),t12),FStar_Syntax_Syntax.Tm_let ((b2,lbs2),t22)) ->
             ((check "let flag" (b1 = b2)) &&
-               (let uu____15687 = eqlist (letbinding_eq_dbg dbg) lbs1 lbs2
+               (let uu____15753 = eqlist (letbinding_eq_dbg dbg) lbs1 lbs2
                    in
-                check "let lbs" uu____15687))
+                check "let lbs" uu____15753))
               &&
-              (let uu____15691 = term_eq_dbg dbg t12 t22  in
-               check "let body" uu____15691)
+              (let uu____15757 = term_eq_dbg dbg t12 t22  in
+               check "let body" uu____15757)
         | (FStar_Syntax_Syntax.Tm_uvar
-           (u1,uu____15695),FStar_Syntax_Syntax.Tm_uvar (u2,uu____15697)) ->
+           (u1,uu____15761),FStar_Syntax_Syntax.Tm_uvar (u2,uu____15763)) ->
             check "uvar"
               (u1.FStar_Syntax_Syntax.ctx_uvar_head =
                  u2.FStar_Syntax_Syntax.ctx_uvar_head)
         | (FStar_Syntax_Syntax.Tm_quoted
            (qt1,qi1),FStar_Syntax_Syntax.Tm_quoted (qt2,qi2)) ->
-            (let uu____15755 =
-               let uu____15757 = eq_quoteinfo qi1 qi2  in uu____15757 = Equal
+            (let uu____15821 =
+               let uu____15823 = eq_quoteinfo qi1 qi2  in uu____15823 = Equal
                 in
-             check "tm_quoted qi" uu____15755) &&
-              (let uu____15760 = term_eq_dbg dbg qt1 qt2  in
-               check "tm_quoted payload" uu____15760)
+             check "tm_quoted qi" uu____15821) &&
+              (let uu____15826 = term_eq_dbg dbg qt1 qt2  in
+               check "tm_quoted payload" uu____15826)
         | (FStar_Syntax_Syntax.Tm_meta (t12,m1),FStar_Syntax_Syntax.Tm_meta
            (t22,m2)) ->
             (match (m1, m2) with
              | (FStar_Syntax_Syntax.Meta_monadic
                 (n1,ty1),FStar_Syntax_Syntax.Meta_monadic (n2,ty2)) ->
-                 (let uu____15790 = FStar_Ident.lid_equals n1 n2  in
-                  check "meta_monadic lid" uu____15790) &&
-                   (let uu____15794 = term_eq_dbg dbg ty1 ty2  in
-                    check "meta_monadic type" uu____15794)
+                 (let uu____15856 = FStar_Ident.lid_equals n1 n2  in
+                  check "meta_monadic lid" uu____15856) &&
+                   (let uu____15860 = term_eq_dbg dbg ty1 ty2  in
+                    check "meta_monadic type" uu____15860)
              | (FStar_Syntax_Syntax.Meta_monadic_lift
                 (s1,t13,ty1),FStar_Syntax_Syntax.Meta_monadic_lift
                 (s2,t23,ty2)) ->
-                 ((let uu____15813 = FStar_Ident.lid_equals s1 s2  in
-                   check "meta_monadic_lift src" uu____15813) &&
-                    (let uu____15817 = FStar_Ident.lid_equals t13 t23  in
-                     check "meta_monadic_lift tgt" uu____15817))
+                 ((let uu____15879 = FStar_Ident.lid_equals s1 s2  in
+                   check "meta_monadic_lift src" uu____15879) &&
+                    (let uu____15883 = FStar_Ident.lid_equals t13 t23  in
+                     check "meta_monadic_lift tgt" uu____15883))
                    &&
-                   (let uu____15821 = term_eq_dbg dbg ty1 ty2  in
-                    check "meta_monadic_lift type" uu____15821)
-             | uu____15824 -> fail "metas")
-        | (FStar_Syntax_Syntax.Tm_unknown ,uu____15830) -> fail "unk"
-        | (uu____15832,FStar_Syntax_Syntax.Tm_unknown ) -> fail "unk"
-        | (FStar_Syntax_Syntax.Tm_bvar uu____15834,uu____15835) ->
+                   (let uu____15887 = term_eq_dbg dbg ty1 ty2  in
+                    check "meta_monadic_lift type" uu____15887)
+             | uu____15890 -> fail "metas")
+        | (FStar_Syntax_Syntax.Tm_unknown ,uu____15896) -> fail "unk"
+        | (uu____15898,FStar_Syntax_Syntax.Tm_unknown ) -> fail "unk"
+        | (FStar_Syntax_Syntax.Tm_bvar uu____15900,uu____15901) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_name uu____15837,uu____15838) ->
+        | (FStar_Syntax_Syntax.Tm_name uu____15903,uu____15904) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_fvar uu____15840,uu____15841) ->
+        | (FStar_Syntax_Syntax.Tm_fvar uu____15906,uu____15907) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_constant uu____15843,uu____15844) ->
+        | (FStar_Syntax_Syntax.Tm_constant uu____15909,uu____15910) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_type uu____15846,uu____15847) ->
+        | (FStar_Syntax_Syntax.Tm_type uu____15912,uu____15913) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_abs uu____15849,uu____15850) ->
+        | (FStar_Syntax_Syntax.Tm_abs uu____15915,uu____15916) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_arrow uu____15870,uu____15871) ->
+        | (FStar_Syntax_Syntax.Tm_arrow uu____15936,uu____15937) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_refine uu____15887,uu____15888) ->
+        | (FStar_Syntax_Syntax.Tm_refine uu____15953,uu____15954) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_app uu____15896,uu____15897) ->
+        | (FStar_Syntax_Syntax.Tm_app uu____15962,uu____15963) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_match uu____15915,uu____15916) ->
+        | (FStar_Syntax_Syntax.Tm_match uu____15981,uu____15982) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_let uu____15940,uu____15941) ->
+        | (FStar_Syntax_Syntax.Tm_let uu____16006,uu____16007) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_uvar uu____15956,uu____15957) ->
+        | (FStar_Syntax_Syntax.Tm_uvar uu____16022,uu____16023) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_meta uu____15971,uu____15972) ->
+        | (FStar_Syntax_Syntax.Tm_meta uu____16037,uu____16038) ->
             fail "bottom"
-        | (uu____15980,FStar_Syntax_Syntax.Tm_bvar uu____15981) ->
+        | (uu____16046,FStar_Syntax_Syntax.Tm_bvar uu____16047) ->
             fail "bottom"
-        | (uu____15983,FStar_Syntax_Syntax.Tm_name uu____15984) ->
+        | (uu____16049,FStar_Syntax_Syntax.Tm_name uu____16050) ->
             fail "bottom"
-        | (uu____15986,FStar_Syntax_Syntax.Tm_fvar uu____15987) ->
+        | (uu____16052,FStar_Syntax_Syntax.Tm_fvar uu____16053) ->
             fail "bottom"
-        | (uu____15989,FStar_Syntax_Syntax.Tm_constant uu____15990) ->
+        | (uu____16055,FStar_Syntax_Syntax.Tm_constant uu____16056) ->
             fail "bottom"
-        | (uu____15992,FStar_Syntax_Syntax.Tm_type uu____15993) ->
+        | (uu____16058,FStar_Syntax_Syntax.Tm_type uu____16059) ->
             fail "bottom"
-        | (uu____15995,FStar_Syntax_Syntax.Tm_abs uu____15996) ->
+        | (uu____16061,FStar_Syntax_Syntax.Tm_abs uu____16062) ->
             fail "bottom"
-        | (uu____16016,FStar_Syntax_Syntax.Tm_arrow uu____16017) ->
+        | (uu____16082,FStar_Syntax_Syntax.Tm_arrow uu____16083) ->
             fail "bottom"
-        | (uu____16033,FStar_Syntax_Syntax.Tm_refine uu____16034) ->
+        | (uu____16099,FStar_Syntax_Syntax.Tm_refine uu____16100) ->
             fail "bottom"
-        | (uu____16042,FStar_Syntax_Syntax.Tm_app uu____16043) ->
+        | (uu____16108,FStar_Syntax_Syntax.Tm_app uu____16109) ->
             fail "bottom"
-        | (uu____16061,FStar_Syntax_Syntax.Tm_match uu____16062) ->
+        | (uu____16127,FStar_Syntax_Syntax.Tm_match uu____16128) ->
             fail "bottom"
-        | (uu____16086,FStar_Syntax_Syntax.Tm_let uu____16087) ->
+        | (uu____16152,FStar_Syntax_Syntax.Tm_let uu____16153) ->
             fail "bottom"
-        | (uu____16102,FStar_Syntax_Syntax.Tm_uvar uu____16103) ->
+        | (uu____16168,FStar_Syntax_Syntax.Tm_uvar uu____16169) ->
             fail "bottom"
-        | (uu____16117,FStar_Syntax_Syntax.Tm_meta uu____16118) ->
+        | (uu____16183,FStar_Syntax_Syntax.Tm_meta uu____16184) ->
             fail "bottom"
 
 and (arg_eq_dbg :
@@ -3783,13 +3809,13 @@ and (arg_eq_dbg :
         eqprod
           (fun t1  ->
              fun t2  ->
-               let uu____16153 = term_eq_dbg dbg t1 t2  in
-               check "arg tm" uu____16153)
+               let uu____16219 = term_eq_dbg dbg t1 t2  in
+               check "arg tm" uu____16219)
           (fun q1  ->
              fun q2  ->
-               let uu____16165 =
-                 let uu____16167 = eq_aqual q1 q2  in uu____16167 = Equal  in
-               check "arg qual" uu____16165) a1 a2
+               let uu____16231 =
+                 let uu____16233 = eq_aqual q1 q2  in uu____16233 = Equal  in
+               check "arg qual" uu____16231) a1 a2
 
 and (binder_eq_dbg :
   Prims.bool ->
@@ -3804,16 +3830,16 @@ and (binder_eq_dbg :
         eqprod
           (fun b11  ->
              fun b21  ->
-               let uu____16192 =
+               let uu____16258 =
                  term_eq_dbg dbg b11.FStar_Syntax_Syntax.sort
                    b21.FStar_Syntax_Syntax.sort
                   in
-               check "binder sort" uu____16192)
+               check "binder sort" uu____16258)
           (fun q1  ->
              fun q2  ->
-               let uu____16204 =
-                 let uu____16206 = eq_aqual q1 q2  in uu____16206 = Equal  in
-               check "binder qual" uu____16204) b1 b2
+               let uu____16270 =
+                 let uu____16272 = eq_aqual q1 q2  in uu____16272 = Equal  in
+               check "binder qual" uu____16270) b1 b2
 
 and (comp_eq_dbg :
   Prims.bool ->
@@ -3825,16 +3851,16 @@ and (comp_eq_dbg :
       fun c2  ->
         let c11 = comp_to_comp_typ_nouniv c1  in
         let c21 = comp_to_comp_typ_nouniv c2  in
-        ((let uu____16220 =
+        ((let uu____16286 =
             FStar_Ident.lid_equals c11.FStar_Syntax_Syntax.effect_name
               c21.FStar_Syntax_Syntax.effect_name
              in
-          check "comp eff" uu____16220) &&
-           (let uu____16224 =
+          check "comp eff" uu____16286) &&
+           (let uu____16290 =
               term_eq_dbg dbg c11.FStar_Syntax_Syntax.result_typ
                 c21.FStar_Syntax_Syntax.result_typ
                in
-            check "comp result typ" uu____16224))
+            check "comp result typ" uu____16290))
           && true
 
 and (eq_flags_dbg :
@@ -3854,23 +3880,23 @@ and (branch_eq_dbg :
         FStar_Syntax_Syntax.syntax) -> Prims.bool)
   =
   fun dbg  ->
-    fun uu____16234  ->
-      fun uu____16235  ->
-        match (uu____16234, uu____16235) with
+    fun uu____16300  ->
+      fun uu____16301  ->
+        match (uu____16300, uu____16301) with
         | ((p1,w1,t1),(p2,w2,t2)) ->
-            ((let uu____16362 = FStar_Syntax_Syntax.eq_pat p1 p2  in
-              check "branch pat" uu____16362) &&
-               (let uu____16366 = term_eq_dbg dbg t1 t2  in
-                check "branch body" uu____16366))
+            ((let uu____16428 = FStar_Syntax_Syntax.eq_pat p1 p2  in
+              check "branch pat" uu____16428) &&
+               (let uu____16432 = term_eq_dbg dbg t1 t2  in
+                check "branch body" uu____16432))
               &&
-              (let uu____16370 =
+              (let uu____16436 =
                  match (w1, w2) with
                  | (FStar_Pervasives_Native.Some
                     x,FStar_Pervasives_Native.Some y) -> term_eq_dbg dbg x y
                  | (FStar_Pervasives_Native.None
                     ,FStar_Pervasives_Native.None ) -> true
-                 | uu____16412 -> false  in
-               check "branch when" uu____16370)
+                 | uu____16478 -> false  in
+               check "branch when" uu____16436)
 
 and (letbinding_eq_dbg :
   Prims.bool ->
@@ -3880,85 +3906,85 @@ and (letbinding_eq_dbg :
   fun dbg  ->
     fun lb1  ->
       fun lb2  ->
-        ((let uu____16433 =
+        ((let uu____16499 =
             eqsum (fun bv1  -> fun bv2  -> true) FStar_Syntax_Syntax.fv_eq
               lb1.FStar_Syntax_Syntax.lbname lb2.FStar_Syntax_Syntax.lbname
              in
-          check "lb bv" uu____16433) &&
-           (let uu____16442 =
+          check "lb bv" uu____16499) &&
+           (let uu____16508 =
               term_eq_dbg dbg lb1.FStar_Syntax_Syntax.lbtyp
                 lb2.FStar_Syntax_Syntax.lbtyp
                in
-            check "lb typ" uu____16442))
+            check "lb typ" uu____16508))
           &&
-          (let uu____16446 =
+          (let uu____16512 =
              term_eq_dbg dbg lb1.FStar_Syntax_Syntax.lbdef
                lb2.FStar_Syntax_Syntax.lbdef
               in
-           check "lb def" uu____16446)
+           check "lb def" uu____16512)
 
 let (term_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t1  ->
     fun t2  ->
       let r =
-        let uu____16463 = FStar_ST.op_Bang debug_term_eq  in
-        term_eq_dbg uu____16463 t1 t2  in
+        let uu____16529 = FStar_ST.op_Bang debug_term_eq  in
+        term_eq_dbg uu____16529 t1 t2  in
       FStar_ST.op_Colon_Equals debug_term_eq false; r
   
 let rec (sizeof : FStar_Syntax_Syntax.term -> Prims.int) =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____16517 ->
-        let uu____16532 =
-          let uu____16534 = FStar_Syntax_Subst.compress t  in
-          sizeof uu____16534  in
-        Prims.int_one + uu____16532
+    | FStar_Syntax_Syntax.Tm_delayed uu____16583 ->
+        let uu____16598 =
+          let uu____16600 = FStar_Syntax_Subst.compress t  in
+          sizeof uu____16600  in
+        Prims.int_one + uu____16598
     | FStar_Syntax_Syntax.Tm_bvar bv ->
-        let uu____16537 = sizeof bv.FStar_Syntax_Syntax.sort  in
-        Prims.int_one + uu____16537
+        let uu____16603 = sizeof bv.FStar_Syntax_Syntax.sort  in
+        Prims.int_one + uu____16603
     | FStar_Syntax_Syntax.Tm_name bv ->
-        let uu____16541 = sizeof bv.FStar_Syntax_Syntax.sort  in
-        Prims.int_one + uu____16541
+        let uu____16607 = sizeof bv.FStar_Syntax_Syntax.sort  in
+        Prims.int_one + uu____16607
     | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
-        let uu____16550 = sizeof t1  in (FStar_List.length us) + uu____16550
-    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____16554) ->
-        let uu____16579 = sizeof t1  in
-        let uu____16581 =
+        let uu____16616 = sizeof t1  in (FStar_List.length us) + uu____16616
+    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____16620) ->
+        let uu____16645 = sizeof t1  in
+        let uu____16647 =
           FStar_List.fold_left
             (fun acc  ->
-               fun uu____16596  ->
-                 match uu____16596 with
-                 | (bv,uu____16606) ->
-                     let uu____16611 = sizeof bv.FStar_Syntax_Syntax.sort  in
-                     acc + uu____16611) Prims.int_zero bs
+               fun uu____16662  ->
+                 match uu____16662 with
+                 | (bv,uu____16672) ->
+                     let uu____16677 = sizeof bv.FStar_Syntax_Syntax.sort  in
+                     acc + uu____16677) Prims.int_zero bs
            in
-        uu____16579 + uu____16581
+        uu____16645 + uu____16647
     | FStar_Syntax_Syntax.Tm_app (hd,args) ->
-        let uu____16640 = sizeof hd  in
-        let uu____16642 =
+        let uu____16706 = sizeof hd  in
+        let uu____16708 =
           FStar_List.fold_left
             (fun acc  ->
-               fun uu____16657  ->
-                 match uu____16657 with
-                 | (arg,uu____16667) ->
-                     let uu____16672 = sizeof arg  in acc + uu____16672)
+               fun uu____16723  ->
+                 match uu____16723 with
+                 | (arg,uu____16733) ->
+                     let uu____16738 = sizeof arg  in acc + uu____16738)
             Prims.int_zero args
            in
-        uu____16640 + uu____16642
-    | uu____16675 -> Prims.int_one
+        uu____16706 + uu____16708
+    | uu____16741 -> Prims.int_one
   
 let (is_fvar : FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.bool)
   =
   fun lid  ->
     fun t  ->
-      let uu____16689 =
-        let uu____16690 = un_uinst t  in uu____16690.FStar_Syntax_Syntax.n
+      let uu____16755 =
+        let uu____16756 = un_uinst t  in uu____16756.FStar_Syntax_Syntax.n
          in
-      match uu____16689 with
+      match uu____16755 with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           FStar_Syntax_Syntax.fv_eq_lid fv lid
-      | uu____16695 -> false
+      | uu____16761 -> false
   
 let (is_synth_by_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  -> is_fvar FStar_Parser_Const.synth_lid t 
@@ -3975,17 +4001,17 @@ let (get_attribute :
     fun attrs  ->
       FStar_List.tryPick
         (fun t  ->
-           let uu____16756 = head_and_args t  in
-           match uu____16756 with
+           let uu____16822 = head_and_args t  in
+           match uu____16822 with
            | (head,args) ->
-               let uu____16811 =
-                 let uu____16812 = FStar_Syntax_Subst.compress head  in
-                 uu____16812.FStar_Syntax_Syntax.n  in
-               (match uu____16811 with
+               let uu____16877 =
+                 let uu____16878 = FStar_Syntax_Subst.compress head  in
+                 uu____16878.FStar_Syntax_Syntax.n  in
+               (match uu____16877 with
                 | FStar_Syntax_Syntax.Tm_fvar fv when
                     FStar_Syntax_Syntax.fv_eq_lid fv attr ->
                     FStar_Pervasives_Native.Some args
-                | uu____16838 -> FStar_Pervasives_Native.None)) attrs
+                | uu____16904 -> FStar_Pervasives_Native.None)) attrs
   
 let (remove_attr :
   FStar_Ident.lident ->
@@ -3996,7 +4022,7 @@ let (remove_attr :
     fun attrs  ->
       FStar_List.filter
         (fun a  ->
-           let uu____16871 = is_fvar attr a  in Prims.op_Negation uu____16871)
+           let uu____16937 = is_fvar attr a  in Prims.op_Negation uu____16937)
         attrs
   
 let (process_pragma :
@@ -4004,8 +4030,8 @@ let (process_pragma :
   fun p  ->
     fun r  ->
       let set_options s =
-        let uu____16892 = FStar_Options.set_options s  in
-        match uu____16892 with
+        let uu____16958 = FStar_Options.set_options s  in
+        match uu____16958 with
         | FStar_Getopt.Success  -> ()
         | FStar_Getopt.Help  ->
             FStar_Errors.raise_error
@@ -4021,9 +4047,9 @@ let (process_pragma :
       | FStar_Syntax_Syntax.LightOff  -> FStar_Options.set_ml_ish ()
       | FStar_Syntax_Syntax.SetOptions o -> set_options o
       | FStar_Syntax_Syntax.ResetOptions sopt ->
-          ((let uu____16906 = FStar_Options.restore_cmd_line_options false
+          ((let uu____16972 = FStar_Options.restore_cmd_line_options false
                in
-            FStar_All.pipe_right uu____16906 (fun uu____16908  -> ()));
+            FStar_All.pipe_right uu____16972 (fun uu____16974  -> ()));
            (match sopt with
             | FStar_Pervasives_Native.None  -> ()
             | FStar_Pervasives_Native.Some s -> set_options s))
@@ -4034,8 +4060,8 @@ let (process_pragma :
             | FStar_Pervasives_Native.Some s -> set_options s))
       | FStar_Syntax_Syntax.RestartSolver  -> ()
       | FStar_Syntax_Syntax.PopOptions  ->
-          let uu____16922 = FStar_Options.internal_pop ()  in
-          if uu____16922
+          let uu____16988 = FStar_Options.internal_pop ()  in
+          if uu____16988
           then ()
           else
             FStar_Errors.raise_error
@@ -4049,153 +4075,153 @@ let rec (unbound_variables :
   fun tm  ->
     let t = FStar_Syntax_Subst.compress tm  in
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____16954 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_delayed uu____17020 -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_name x -> []
-    | FStar_Syntax_Syntax.Tm_uvar uu____16973 -> []
+    | FStar_Syntax_Syntax.Tm_uvar uu____17039 -> []
     | FStar_Syntax_Syntax.Tm_type u -> []
     | FStar_Syntax_Syntax.Tm_bvar x -> [x]
-    | FStar_Syntax_Syntax.Tm_fvar uu____16988 -> []
-    | FStar_Syntax_Syntax.Tm_constant uu____16989 -> []
-    | FStar_Syntax_Syntax.Tm_lazy uu____16990 -> []
+    | FStar_Syntax_Syntax.Tm_fvar uu____17054 -> []
+    | FStar_Syntax_Syntax.Tm_constant uu____17055 -> []
+    | FStar_Syntax_Syntax.Tm_lazy uu____17056 -> []
     | FStar_Syntax_Syntax.Tm_unknown  -> []
     | FStar_Syntax_Syntax.Tm_uinst (t1,us) -> unbound_variables t1
-    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____16999) ->
-        let uu____17024 = FStar_Syntax_Subst.open_term bs t1  in
-        (match uu____17024 with
+    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____17065) ->
+        let uu____17090 = FStar_Syntax_Subst.open_term bs t1  in
+        (match uu____17090 with
          | (bs1,t2) ->
-             let uu____17033 =
+             let uu____17099 =
                FStar_List.collect
-                 (fun uu____17045  ->
-                    match uu____17045 with
-                    | (b,uu____17055) ->
+                 (fun uu____17111  ->
+                    match uu____17111 with
+                    | (b,uu____17121) ->
                         unbound_variables b.FStar_Syntax_Syntax.sort) bs1
                 in
-             let uu____17060 = unbound_variables t2  in
-             FStar_List.append uu____17033 uu____17060)
+             let uu____17126 = unbound_variables t2  in
+             FStar_List.append uu____17099 uu____17126)
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        let uu____17085 = FStar_Syntax_Subst.open_comp bs c  in
-        (match uu____17085 with
+        let uu____17151 = FStar_Syntax_Subst.open_comp bs c  in
+        (match uu____17151 with
          | (bs1,c1) ->
-             let uu____17094 =
+             let uu____17160 =
                FStar_List.collect
-                 (fun uu____17106  ->
-                    match uu____17106 with
-                    | (b,uu____17116) ->
+                 (fun uu____17172  ->
+                    match uu____17172 with
+                    | (b,uu____17182) ->
                         unbound_variables b.FStar_Syntax_Syntax.sort) bs1
                 in
-             let uu____17121 = unbound_variables_comp c1  in
-             FStar_List.append uu____17094 uu____17121)
+             let uu____17187 = unbound_variables_comp c1  in
+             FStar_List.append uu____17160 uu____17187)
     | FStar_Syntax_Syntax.Tm_refine (b,t1) ->
-        let uu____17130 =
+        let uu____17196 =
           FStar_Syntax_Subst.open_term [(b, FStar_Pervasives_Native.None)] t1
            in
-        (match uu____17130 with
+        (match uu____17196 with
          | (bs,t2) ->
-             let uu____17153 =
+             let uu____17219 =
                FStar_List.collect
-                 (fun uu____17165  ->
-                    match uu____17165 with
-                    | (b1,uu____17175) ->
+                 (fun uu____17231  ->
+                    match uu____17231 with
+                    | (b1,uu____17241) ->
                         unbound_variables b1.FStar_Syntax_Syntax.sort) bs
                 in
-             let uu____17180 = unbound_variables t2  in
-             FStar_List.append uu____17153 uu____17180)
+             let uu____17246 = unbound_variables t2  in
+             FStar_List.append uu____17219 uu____17246)
     | FStar_Syntax_Syntax.Tm_app (t1,args) ->
-        let uu____17209 =
+        let uu____17275 =
           FStar_List.collect
-            (fun uu____17223  ->
-               match uu____17223 with
-               | (x,uu____17235) -> unbound_variables x) args
+            (fun uu____17289  ->
+               match uu____17289 with
+               | (x,uu____17301) -> unbound_variables x) args
            in
-        let uu____17244 = unbound_variables t1  in
-        FStar_List.append uu____17209 uu____17244
+        let uu____17310 = unbound_variables t1  in
+        FStar_List.append uu____17275 uu____17310
     | FStar_Syntax_Syntax.Tm_match (t1,pats) ->
-        let uu____17285 = unbound_variables t1  in
-        let uu____17288 =
+        let uu____17351 = unbound_variables t1  in
+        let uu____17354 =
           FStar_All.pipe_right pats
             (FStar_List.collect
                (fun br  ->
-                  let uu____17303 = FStar_Syntax_Subst.open_branch br  in
-                  match uu____17303 with
+                  let uu____17369 = FStar_Syntax_Subst.open_branch br  in
+                  match uu____17369 with
                   | (p,wopt,t2) ->
-                      let uu____17325 = unbound_variables t2  in
-                      let uu____17328 =
+                      let uu____17391 = unbound_variables t2  in
+                      let uu____17394 =
                         match wopt with
                         | FStar_Pervasives_Native.None  -> []
                         | FStar_Pervasives_Native.Some t3 ->
                             unbound_variables t3
                          in
-                      FStar_List.append uu____17325 uu____17328))
+                      FStar_List.append uu____17391 uu____17394))
            in
-        FStar_List.append uu____17285 uu____17288
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,uu____17342) ->
-        let uu____17383 = unbound_variables t1  in
-        let uu____17386 =
-          let uu____17389 =
+        FStar_List.append uu____17351 uu____17354
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,uu____17408) ->
+        let uu____17449 = unbound_variables t1  in
+        let uu____17452 =
+          let uu____17455 =
             match FStar_Pervasives_Native.fst asc with
             | FStar_Util.Inl t2 -> unbound_variables t2
             | FStar_Util.Inr c2 -> unbound_variables_comp c2  in
-          let uu____17420 =
+          let uu____17486 =
             match FStar_Pervasives_Native.snd asc with
             | FStar_Pervasives_Native.None  -> []
             | FStar_Pervasives_Native.Some tac -> unbound_variables tac  in
-          FStar_List.append uu____17389 uu____17420  in
-        FStar_List.append uu____17383 uu____17386
+          FStar_List.append uu____17455 uu____17486  in
+        FStar_List.append uu____17449 uu____17452
     | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),t1) ->
-        let uu____17461 = unbound_variables lb.FStar_Syntax_Syntax.lbtyp  in
-        let uu____17464 =
-          let uu____17467 = unbound_variables lb.FStar_Syntax_Syntax.lbdef
+        let uu____17527 = unbound_variables lb.FStar_Syntax_Syntax.lbtyp  in
+        let uu____17530 =
+          let uu____17533 = unbound_variables lb.FStar_Syntax_Syntax.lbdef
              in
-          let uu____17470 =
+          let uu____17536 =
             match lb.FStar_Syntax_Syntax.lbname with
-            | FStar_Util.Inr uu____17475 -> unbound_variables t1
+            | FStar_Util.Inr uu____17541 -> unbound_variables t1
             | FStar_Util.Inl bv ->
-                let uu____17477 =
+                let uu____17543 =
                   FStar_Syntax_Subst.open_term
                     [(bv, FStar_Pervasives_Native.None)] t1
                    in
-                (match uu____17477 with
-                 | (uu____17498,t2) -> unbound_variables t2)
+                (match uu____17543 with
+                 | (uu____17564,t2) -> unbound_variables t2)
              in
-          FStar_List.append uu____17467 uu____17470  in
-        FStar_List.append uu____17461 uu____17464
-    | FStar_Syntax_Syntax.Tm_let ((uu____17500,lbs),t1) ->
-        let uu____17520 = FStar_Syntax_Subst.open_let_rec lbs t1  in
-        (match uu____17520 with
+          FStar_List.append uu____17533 uu____17536  in
+        FStar_List.append uu____17527 uu____17530
+    | FStar_Syntax_Syntax.Tm_let ((uu____17566,lbs),t1) ->
+        let uu____17586 = FStar_Syntax_Subst.open_let_rec lbs t1  in
+        (match uu____17586 with
          | (lbs1,t2) ->
-             let uu____17535 = unbound_variables t2  in
-             let uu____17538 =
+             let uu____17601 = unbound_variables t2  in
+             let uu____17604 =
                FStar_List.collect
                  (fun lb  ->
-                    let uu____17545 =
+                    let uu____17611 =
                       unbound_variables lb.FStar_Syntax_Syntax.lbtyp  in
-                    let uu____17548 =
+                    let uu____17614 =
                       unbound_variables lb.FStar_Syntax_Syntax.lbdef  in
-                    FStar_List.append uu____17545 uu____17548) lbs1
+                    FStar_List.append uu____17611 uu____17614) lbs1
                 in
-             FStar_List.append uu____17535 uu____17538)
+             FStar_List.append uu____17601 uu____17604)
     | FStar_Syntax_Syntax.Tm_quoted (tm1,qi) ->
         (match qi.FStar_Syntax_Syntax.qkind with
          | FStar_Syntax_Syntax.Quote_static  -> []
          | FStar_Syntax_Syntax.Quote_dynamic  -> unbound_variables tm1)
     | FStar_Syntax_Syntax.Tm_meta (t1,m) ->
-        let uu____17565 = unbound_variables t1  in
-        let uu____17568 =
+        let uu____17631 = unbound_variables t1  in
+        let uu____17634 =
           match m with
-          | FStar_Syntax_Syntax.Meta_pattern (uu____17573,args) ->
+          | FStar_Syntax_Syntax.Meta_pattern (uu____17639,args) ->
               FStar_List.collect
                 (FStar_List.collect
-                   (fun uu____17628  ->
-                      match uu____17628 with
-                      | (a,uu____17640) -> unbound_variables a)) args
+                   (fun uu____17694  ->
+                      match uu____17694 with
+                      | (a,uu____17706) -> unbound_variables a)) args
           | FStar_Syntax_Syntax.Meta_monadic_lift
-              (uu____17649,uu____17650,t') -> unbound_variables t'
-          | FStar_Syntax_Syntax.Meta_monadic (uu____17656,t') ->
+              (uu____17715,uu____17716,t') -> unbound_variables t'
+          | FStar_Syntax_Syntax.Meta_monadic (uu____17722,t') ->
               unbound_variables t'
-          | FStar_Syntax_Syntax.Meta_labeled uu____17662 -> []
-          | FStar_Syntax_Syntax.Meta_desugared uu____17671 -> []
-          | FStar_Syntax_Syntax.Meta_named uu____17672 -> []  in
-        FStar_List.append uu____17565 uu____17568
+          | FStar_Syntax_Syntax.Meta_labeled uu____17728 -> []
+          | FStar_Syntax_Syntax.Meta_desugared uu____17737 -> []
+          | FStar_Syntax_Syntax.Meta_named uu____17738 -> []  in
+        FStar_List.append uu____17631 uu____17634
 
 and (unbound_variables_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -4203,19 +4229,19 @@ and (unbound_variables_comp :
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.GTotal (t,uu____17679) -> unbound_variables t
-    | FStar_Syntax_Syntax.Total (t,uu____17689) -> unbound_variables t
+    | FStar_Syntax_Syntax.GTotal (t,uu____17745) -> unbound_variables t
+    | FStar_Syntax_Syntax.Total (t,uu____17755) -> unbound_variables t
     | FStar_Syntax_Syntax.Comp ct ->
-        let uu____17699 = unbound_variables ct.FStar_Syntax_Syntax.result_typ
+        let uu____17765 = unbound_variables ct.FStar_Syntax_Syntax.result_typ
            in
-        let uu____17702 =
+        let uu____17768 =
           FStar_List.collect
-            (fun uu____17716  ->
-               match uu____17716 with
-               | (a,uu____17728) -> unbound_variables a)
+            (fun uu____17782  ->
+               match uu____17782 with
+               | (a,uu____17794) -> unbound_variables a)
             ct.FStar_Syntax_Syntax.effect_args
            in
-        FStar_List.append uu____17699 uu____17702
+        FStar_List.append uu____17765 uu____17768
 
 let (extract_attr' :
   FStar_Ident.lid ->
@@ -4229,18 +4255,18 @@ let (extract_attr' :
         match attrs1 with
         | [] -> FStar_Pervasives_Native.None
         | h::t ->
-            let uu____17843 = head_and_args h  in
-            (match uu____17843 with
+            let uu____17909 = head_and_args h  in
+            (match uu____17909 with
              | (head,args) ->
-                 let uu____17904 =
-                   let uu____17905 = FStar_Syntax_Subst.compress head  in
-                   uu____17905.FStar_Syntax_Syntax.n  in
-                 (match uu____17904 with
+                 let uu____17970 =
+                   let uu____17971 = FStar_Syntax_Subst.compress head  in
+                   uu____17971.FStar_Syntax_Syntax.n  in
+                 (match uu____17970 with
                   | FStar_Syntax_Syntax.Tm_fvar fv when
                       FStar_Syntax_Syntax.fv_eq_lid fv attr_lid ->
                       let attrs' = FStar_List.rev_acc acc t  in
                       FStar_Pervasives_Native.Some (attrs', args)
-                  | uu____17958 -> aux (h :: acc) t))
+                  | uu____18024 -> aux (h :: acc) t))
          in
       aux [] attrs
   
@@ -4252,114 +4278,114 @@ let (extract_attr :
   =
   fun attr_lid  ->
     fun se  ->
-      let uu____17982 =
+      let uu____18048 =
         extract_attr' attr_lid se.FStar_Syntax_Syntax.sigattrs  in
-      match uu____17982 with
+      match uu____18048 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (attrs',t) ->
           FStar_Pervasives_Native.Some
-            ((let uu___2476_18024 = se  in
+            ((let uu___2474_18090 = se  in
               {
                 FStar_Syntax_Syntax.sigel =
-                  (uu___2476_18024.FStar_Syntax_Syntax.sigel);
+                  (uu___2474_18090.FStar_Syntax_Syntax.sigel);
                 FStar_Syntax_Syntax.sigrng =
-                  (uu___2476_18024.FStar_Syntax_Syntax.sigrng);
+                  (uu___2474_18090.FStar_Syntax_Syntax.sigrng);
                 FStar_Syntax_Syntax.sigquals =
-                  (uu___2476_18024.FStar_Syntax_Syntax.sigquals);
+                  (uu___2474_18090.FStar_Syntax_Syntax.sigquals);
                 FStar_Syntax_Syntax.sigmeta =
-                  (uu___2476_18024.FStar_Syntax_Syntax.sigmeta);
+                  (uu___2474_18090.FStar_Syntax_Syntax.sigmeta);
                 FStar_Syntax_Syntax.sigattrs = attrs';
                 FStar_Syntax_Syntax.sigopts =
-                  (uu___2476_18024.FStar_Syntax_Syntax.sigopts)
+                  (uu___2474_18090.FStar_Syntax_Syntax.sigopts)
               }), t)
   
 let (is_smt_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____18032 =
-      let uu____18033 = FStar_Syntax_Subst.compress t  in
-      uu____18033.FStar_Syntax_Syntax.n  in
-    match uu____18032 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____18037,c) ->
+    let uu____18098 =
+      let uu____18099 = FStar_Syntax_Subst.compress t  in
+      uu____18099.FStar_Syntax_Syntax.n  in
+    match uu____18098 with
+    | FStar_Syntax_Syntax.Tm_arrow (uu____18103,c) ->
         (match c.FStar_Syntax_Syntax.n with
          | FStar_Syntax_Syntax.Comp ct when
              FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                FStar_Parser_Const.effect_Lemma_lid
              ->
              (match ct.FStar_Syntax_Syntax.effect_args with
-              | _req::_ens::(pats,uu____18065)::uu____18066 ->
+              | _req::_ens::(pats,uu____18131)::uu____18132 ->
                   let pats' = unmeta pats  in
-                  let uu____18126 = head_and_args pats'  in
-                  (match uu____18126 with
-                   | (head,uu____18145) ->
-                       let uu____18170 =
-                         let uu____18171 = un_uinst head  in
-                         uu____18171.FStar_Syntax_Syntax.n  in
-                       (match uu____18170 with
+                  let uu____18192 = head_and_args pats'  in
+                  (match uu____18192 with
+                   | (head,uu____18211) ->
+                       let uu____18236 =
+                         let uu____18237 = un_uinst head  in
+                         uu____18237.FStar_Syntax_Syntax.n  in
+                       (match uu____18236 with
                         | FStar_Syntax_Syntax.Tm_fvar fv ->
                             FStar_Syntax_Syntax.fv_eq_lid fv
                               FStar_Parser_Const.cons_lid
-                        | uu____18176 -> false))
-              | uu____18178 -> false)
-         | uu____18190 -> false)
-    | uu____18192 -> false
+                        | uu____18242 -> false))
+              | uu____18244 -> false)
+         | uu____18256 -> false)
+    | uu____18258 -> false
   
 let rec (list_elements :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term Prims.list FStar_Pervasives_Native.option)
   =
   fun e  ->
-    let uu____18208 =
-      let uu____18225 = unmeta e  in head_and_args uu____18225  in
-    match uu____18208 with
+    let uu____18274 =
+      let uu____18291 = unmeta e  in head_and_args uu____18291  in
+    match uu____18274 with
     | (head,args) ->
-        let uu____18256 =
-          let uu____18271 =
-            let uu____18272 = un_uinst head  in
-            uu____18272.FStar_Syntax_Syntax.n  in
-          (uu____18271, args)  in
-        (match uu____18256 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,uu____18290) when
+        let uu____18322 =
+          let uu____18337 =
+            let uu____18338 = un_uinst head  in
+            uu____18338.FStar_Syntax_Syntax.n  in
+          (uu____18337, args)  in
+        (match uu____18322 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv,uu____18356) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid ->
              FStar_Pervasives_Native.Some []
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,uu____18314::(hd,uu____18316)::(tl,uu____18318)::[]) when
+            fv,uu____18380::(hd,uu____18382)::(tl,uu____18384)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid ->
-             let uu____18385 =
-               let uu____18388 =
-                 let uu____18391 = list_elements tl  in
-                 FStar_Util.must uu____18391  in
-               hd :: uu____18388  in
-             FStar_Pervasives_Native.Some uu____18385
-         | uu____18400 -> FStar_Pervasives_Native.None)
+             let uu____18451 =
+               let uu____18454 =
+                 let uu____18457 = list_elements tl  in
+                 FStar_Util.must uu____18457  in
+               hd :: uu____18454  in
+             FStar_Pervasives_Native.Some uu____18451
+         | uu____18466 -> FStar_Pervasives_Native.None)
   
 let (unthunk_lemma_post :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun t  ->
-    let uu____18429 =
-      let uu____18430 = FStar_Syntax_Subst.compress t  in
-      uu____18430.FStar_Syntax_Syntax.n  in
-    match uu____18429 with
-    | FStar_Syntax_Syntax.Tm_abs (b::[],e,uu____18437) ->
-        let uu____18472 = FStar_Syntax_Subst.open_term [b] e  in
-        (match uu____18472 with
+    let uu____18495 =
+      let uu____18496 = FStar_Syntax_Subst.compress t  in
+      uu____18496.FStar_Syntax_Syntax.n  in
+    match uu____18495 with
+    | FStar_Syntax_Syntax.Tm_abs (b::[],e,uu____18503) ->
+        let uu____18538 = FStar_Syntax_Subst.open_term [b] e  in
+        (match uu____18538 with
          | (bs,e1) ->
              let b1 = FStar_List.hd bs  in
-             let uu____18506 = is_free_in (FStar_Pervasives_Native.fst b1) e1
+             let uu____18572 = is_free_in (FStar_Pervasives_Native.fst b1) e1
                 in
-             if uu____18506
+             if uu____18572
              then
-               let uu____18513 =
-                 let uu____18524 = FStar_Syntax_Syntax.as_arg exp_unit  in
-                 [uu____18524]  in
-               mk_app t uu____18513
+               let uu____18579 =
+                 let uu____18590 = FStar_Syntax_Syntax.as_arg exp_unit  in
+                 [uu____18590]  in
+               mk_app t uu____18579
              else e1)
-    | uu____18551 ->
-        let uu____18552 =
-          let uu____18563 = FStar_Syntax_Syntax.as_arg exp_unit  in
-          [uu____18563]  in
-        mk_app t uu____18552
+    | uu____18617 ->
+        let uu____18618 =
+          let uu____18629 = FStar_Syntax_Syntax.as_arg exp_unit  in
+          [uu____18629]  in
+        mk_app t uu____18618
   
 let (smt_lemma_as_forall :
   FStar_Syntax_Syntax.term ->
@@ -4369,8 +4395,8 @@ let (smt_lemma_as_forall :
   fun t  ->
     fun universe_of_binders  ->
       let list_elements1 e =
-        let uu____18618 = list_elements e  in
-        match uu____18618 with
+        let uu____18684 = list_elements e  in
+        match uu____18684 with
         | FStar_Pervasives_Native.Some l -> l
         | FStar_Pervasives_Native.None  ->
             (FStar_Errors.log_issue e.FStar_Syntax_Syntax.pos
@@ -4379,125 +4405,125 @@ let (smt_lemma_as_forall :
              [])
          in
       let one_pat p =
-        let uu____18653 =
-          let uu____18670 = unmeta p  in
-          FStar_All.pipe_right uu____18670 head_and_args  in
-        match uu____18653 with
+        let uu____18719 =
+          let uu____18736 = unmeta p  in
+          FStar_All.pipe_right uu____18736 head_and_args  in
+        match uu____18719 with
         | (head,args) ->
-            let uu____18721 =
-              let uu____18736 =
-                let uu____18737 = un_uinst head  in
-                uu____18737.FStar_Syntax_Syntax.n  in
-              (uu____18736, args)  in
-            (match uu____18721 with
+            let uu____18787 =
+              let uu____18802 =
+                let uu____18803 = un_uinst head  in
+                uu____18803.FStar_Syntax_Syntax.n  in
+              (uu____18802, args)  in
+            (match uu____18787 with
              | (FStar_Syntax_Syntax.Tm_fvar
-                fv,(uu____18759,uu____18760)::arg::[]) when
+                fv,(uu____18825,uu____18826)::arg::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpat_lid
                  -> arg
-             | uu____18812 ->
-                 let uu____18827 =
-                   let uu____18833 =
-                     let uu____18835 = tts p  in
+             | uu____18878 ->
+                 let uu____18893 =
+                   let uu____18899 =
+                     let uu____18901 = tts p  in
                      FStar_Util.format1
                        "Not an atomic SMT pattern: %s; patterns on lemmas must be a list of simple SMTPat's or a single SMTPatOr containing a list of lists of patterns"
-                       uu____18835
+                       uu____18901
                       in
-                   (FStar_Errors.Error_IllSMTPat, uu____18833)  in
-                 FStar_Errors.raise_error uu____18827
+                   (FStar_Errors.Error_IllSMTPat, uu____18899)  in
+                 FStar_Errors.raise_error uu____18893
                    p.FStar_Syntax_Syntax.pos)
          in
       let lemma_pats p =
         let elts = list_elements1 p  in
         let smt_pat_or t1 =
-          let uu____18878 =
-            let uu____18895 = unmeta t1  in
-            FStar_All.pipe_right uu____18895 head_and_args  in
-          match uu____18878 with
+          let uu____18944 =
+            let uu____18961 = unmeta t1  in
+            FStar_All.pipe_right uu____18961 head_and_args  in
+          match uu____18944 with
           | (head,args) ->
-              let uu____18942 =
-                let uu____18957 =
-                  let uu____18958 = un_uinst head  in
-                  uu____18958.FStar_Syntax_Syntax.n  in
-                (uu____18957, args)  in
-              (match uu____18942 with
-               | (FStar_Syntax_Syntax.Tm_fvar fv,(e,uu____18977)::[]) when
+              let uu____19008 =
+                let uu____19023 =
+                  let uu____19024 = un_uinst head  in
+                  uu____19024.FStar_Syntax_Syntax.n  in
+                (uu____19023, args)  in
+              (match uu____19008 with
+               | (FStar_Syntax_Syntax.Tm_fvar fv,(e,uu____19043)::[]) when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.smtpatOr_lid
                    -> FStar_Pervasives_Native.Some e
-               | uu____19014 -> FStar_Pervasives_Native.None)
+               | uu____19080 -> FStar_Pervasives_Native.None)
            in
         match elts with
         | t1::[] ->
-            let uu____19044 = smt_pat_or t1  in
-            (match uu____19044 with
+            let uu____19110 = smt_pat_or t1  in
+            (match uu____19110 with
              | FStar_Pervasives_Native.Some e ->
-                 let uu____19066 = list_elements1 e  in
-                 FStar_All.pipe_right uu____19066
+                 let uu____19132 = list_elements1 e  in
+                 FStar_All.pipe_right uu____19132
                    (FStar_List.map
                       (fun branch1  ->
-                         let uu____19096 = list_elements1 branch1  in
-                         FStar_All.pipe_right uu____19096
+                         let uu____19162 = list_elements1 branch1  in
+                         FStar_All.pipe_right uu____19162
                            (FStar_List.map one_pat)))
-             | uu____19125 ->
-                 let uu____19130 =
+             | uu____19191 ->
+                 let uu____19196 =
                    FStar_All.pipe_right elts (FStar_List.map one_pat)  in
-                 [uu____19130])
-        | uu____19185 ->
-            let uu____19188 =
+                 [uu____19196])
+        | uu____19251 ->
+            let uu____19254 =
               FStar_All.pipe_right elts (FStar_List.map one_pat)  in
-            [uu____19188]
+            [uu____19254]
          in
-      let uu____19243 =
-        let uu____19276 =
-          let uu____19277 = FStar_Syntax_Subst.compress t  in
-          uu____19277.FStar_Syntax_Syntax.n  in
-        match uu____19276 with
+      let uu____19309 =
+        let uu____19342 =
+          let uu____19343 = FStar_Syntax_Subst.compress t  in
+          uu____19343.FStar_Syntax_Syntax.n  in
+        match uu____19342 with
         | FStar_Syntax_Syntax.Tm_arrow (binders,c) ->
-            let uu____19334 = FStar_Syntax_Subst.open_comp binders c  in
-            (match uu____19334 with
+            let uu____19400 = FStar_Syntax_Subst.open_comp binders c  in
+            (match uu____19400 with
              | (binders1,c1) ->
                  (match c1.FStar_Syntax_Syntax.n with
                   | FStar_Syntax_Syntax.Comp
-                      { FStar_Syntax_Syntax.comp_univs = uu____19405;
-                        FStar_Syntax_Syntax.effect_name = uu____19406;
-                        FStar_Syntax_Syntax.result_typ = uu____19407;
+                      { FStar_Syntax_Syntax.comp_univs = uu____19471;
+                        FStar_Syntax_Syntax.effect_name = uu____19472;
+                        FStar_Syntax_Syntax.result_typ = uu____19473;
                         FStar_Syntax_Syntax.effect_args =
-                          (pre,uu____19409)::(post,uu____19411)::(pats,uu____19413)::[];
-                        FStar_Syntax_Syntax.flags = uu____19414;_}
+                          (pre,uu____19475)::(post,uu____19477)::(pats,uu____19479)::[];
+                        FStar_Syntax_Syntax.flags = uu____19480;_}
                       ->
-                      let uu____19475 = lemma_pats pats  in
-                      (binders1, pre, post, uu____19475)
-                  | uu____19512 -> failwith "impos"))
-        | uu____19546 -> failwith "Impos"  in
-      match uu____19243 with
+                      let uu____19541 = lemma_pats pats  in
+                      (binders1, pre, post, uu____19541)
+                  | uu____19578 -> failwith "impos"))
+        | uu____19612 -> failwith "Impos"  in
+      match uu____19309 with
       | (binders,pre,post,patterns) ->
           let post1 = unthunk_lemma_post post  in
           let body =
-            let uu____19638 =
-              let uu____19645 =
-                let uu____19646 =
-                  let uu____19653 = mk_imp pre post1  in
-                  let uu____19656 =
-                    let uu____19657 =
-                      let uu____19678 =
+            let uu____19704 =
+              let uu____19711 =
+                let uu____19712 =
+                  let uu____19719 = mk_imp pre post1  in
+                  let uu____19722 =
+                    let uu____19723 =
+                      let uu____19744 =
                         FStar_Syntax_Syntax.binders_to_names binders  in
-                      (uu____19678, patterns)  in
-                    FStar_Syntax_Syntax.Meta_pattern uu____19657  in
-                  (uu____19653, uu____19656)  in
-                FStar_Syntax_Syntax.Tm_meta uu____19646  in
-              FStar_Syntax_Syntax.mk uu____19645  in
-            uu____19638 FStar_Pervasives_Native.None
+                      (uu____19744, patterns)  in
+                    FStar_Syntax_Syntax.Meta_pattern uu____19723  in
+                  (uu____19719, uu____19722)  in
+                FStar_Syntax_Syntax.Tm_meta uu____19712  in
+              FStar_Syntax_Syntax.mk uu____19711  in
+            uu____19704 FStar_Pervasives_Native.None
               t.FStar_Syntax_Syntax.pos
              in
           let quant =
-            let uu____19702 = universe_of_binders binders  in
+            let uu____19768 = universe_of_binders binders  in
             FStar_List.fold_right2
               (fun b  ->
                  fun u  ->
                    fun out  ->
                      mk_forall u (FStar_Pervasives_Native.fst b) out) binders
-              uu____19702 body
+              uu____19768 body
              in
           quant
   
@@ -4506,19 +4532,19 @@ let (eff_decl_of_new_effect :
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_new_effect ne -> ne
-    | uu____19732 -> failwith "eff_decl_of_new_effect: not a Sig_new_effect"
+    | uu____19798 -> failwith "eff_decl_of_new_effect: not a Sig_new_effect"
   
 let (is_layered : FStar_Syntax_Syntax.eff_decl -> Prims.bool) =
   fun ed  ->
     match ed.FStar_Syntax_Syntax.combinators with
-    | FStar_Syntax_Syntax.Layered_eff uu____19743 -> true
-    | uu____19745 -> false
+    | FStar_Syntax_Syntax.Layered_eff uu____19809 -> true
+    | uu____19811 -> false
   
 let (is_dm4f : FStar_Syntax_Syntax.eff_decl -> Prims.bool) =
   fun ed  ->
     match ed.FStar_Syntax_Syntax.combinators with
-    | FStar_Syntax_Syntax.DM4F_eff uu____19756 -> true
-    | uu____19758 -> false
+    | FStar_Syntax_Syntax.DM4F_eff uu____19822 -> true
+    | uu____19824 -> false
   
 let (apply_wp_eff_combinators :
   (FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme) ->
@@ -4527,30 +4553,30 @@ let (apply_wp_eff_combinators :
   =
   fun f  ->
     fun combs  ->
-      let uu____19776 = f combs.FStar_Syntax_Syntax.ret_wp  in
-      let uu____19777 = f combs.FStar_Syntax_Syntax.bind_wp  in
-      let uu____19778 = f combs.FStar_Syntax_Syntax.stronger  in
-      let uu____19779 = f combs.FStar_Syntax_Syntax.if_then_else  in
-      let uu____19780 = f combs.FStar_Syntax_Syntax.ite_wp  in
-      let uu____19781 = f combs.FStar_Syntax_Syntax.close_wp  in
-      let uu____19782 = f combs.FStar_Syntax_Syntax.trivial  in
-      let uu____19783 =
+      let uu____19842 = f combs.FStar_Syntax_Syntax.ret_wp  in
+      let uu____19843 = f combs.FStar_Syntax_Syntax.bind_wp  in
+      let uu____19844 = f combs.FStar_Syntax_Syntax.stronger  in
+      let uu____19845 = f combs.FStar_Syntax_Syntax.if_then_else  in
+      let uu____19846 = f combs.FStar_Syntax_Syntax.ite_wp  in
+      let uu____19847 = f combs.FStar_Syntax_Syntax.close_wp  in
+      let uu____19848 = f combs.FStar_Syntax_Syntax.trivial  in
+      let uu____19849 =
         FStar_Util.map_option f combs.FStar_Syntax_Syntax.repr  in
-      let uu____19786 =
+      let uu____19852 =
         FStar_Util.map_option f combs.FStar_Syntax_Syntax.return_repr  in
-      let uu____19789 =
+      let uu____19855 =
         FStar_Util.map_option f combs.FStar_Syntax_Syntax.bind_repr  in
       {
-        FStar_Syntax_Syntax.ret_wp = uu____19776;
-        FStar_Syntax_Syntax.bind_wp = uu____19777;
-        FStar_Syntax_Syntax.stronger = uu____19778;
-        FStar_Syntax_Syntax.if_then_else = uu____19779;
-        FStar_Syntax_Syntax.ite_wp = uu____19780;
-        FStar_Syntax_Syntax.close_wp = uu____19781;
-        FStar_Syntax_Syntax.trivial = uu____19782;
-        FStar_Syntax_Syntax.repr = uu____19783;
-        FStar_Syntax_Syntax.return_repr = uu____19786;
-        FStar_Syntax_Syntax.bind_repr = uu____19789
+        FStar_Syntax_Syntax.ret_wp = uu____19842;
+        FStar_Syntax_Syntax.bind_wp = uu____19843;
+        FStar_Syntax_Syntax.stronger = uu____19844;
+        FStar_Syntax_Syntax.if_then_else = uu____19845;
+        FStar_Syntax_Syntax.ite_wp = uu____19846;
+        FStar_Syntax_Syntax.close_wp = uu____19847;
+        FStar_Syntax_Syntax.trivial = uu____19848;
+        FStar_Syntax_Syntax.repr = uu____19849;
+        FStar_Syntax_Syntax.return_repr = uu____19852;
+        FStar_Syntax_Syntax.bind_repr = uu____19855
       }
   
 let (apply_layered_eff_combinators :
@@ -4560,26 +4586,26 @@ let (apply_layered_eff_combinators :
   =
   fun f  ->
     fun combs  ->
-      let map_tuple uu____19821 =
-        match uu____19821 with
+      let map_tuple uu____19887 =
+        match uu____19887 with
         | (ts1,ts2) ->
-            let uu____19832 = f ts1  in
-            let uu____19833 = f ts2  in (uu____19832, uu____19833)
+            let uu____19898 = f ts1  in
+            let uu____19899 = f ts2  in (uu____19898, uu____19899)
          in
-      let uu____19834 = map_tuple combs.FStar_Syntax_Syntax.l_repr  in
-      let uu____19839 = map_tuple combs.FStar_Syntax_Syntax.l_return  in
-      let uu____19844 = map_tuple combs.FStar_Syntax_Syntax.l_bind  in
-      let uu____19849 = map_tuple combs.FStar_Syntax_Syntax.l_subcomp  in
-      let uu____19854 = map_tuple combs.FStar_Syntax_Syntax.l_if_then_else
+      let uu____19900 = map_tuple combs.FStar_Syntax_Syntax.l_repr  in
+      let uu____19905 = map_tuple combs.FStar_Syntax_Syntax.l_return  in
+      let uu____19910 = map_tuple combs.FStar_Syntax_Syntax.l_bind  in
+      let uu____19915 = map_tuple combs.FStar_Syntax_Syntax.l_subcomp  in
+      let uu____19920 = map_tuple combs.FStar_Syntax_Syntax.l_if_then_else
          in
       {
         FStar_Syntax_Syntax.l_base_effect =
           (combs.FStar_Syntax_Syntax.l_base_effect);
-        FStar_Syntax_Syntax.l_repr = uu____19834;
-        FStar_Syntax_Syntax.l_return = uu____19839;
-        FStar_Syntax_Syntax.l_bind = uu____19844;
-        FStar_Syntax_Syntax.l_subcomp = uu____19849;
-        FStar_Syntax_Syntax.l_if_then_else = uu____19854
+        FStar_Syntax_Syntax.l_repr = uu____19900;
+        FStar_Syntax_Syntax.l_return = uu____19905;
+        FStar_Syntax_Syntax.l_bind = uu____19910;
+        FStar_Syntax_Syntax.l_subcomp = uu____19915;
+        FStar_Syntax_Syntax.l_if_then_else = uu____19920
       }
   
 let (apply_eff_combinators :
@@ -4591,14 +4617,14 @@ let (apply_eff_combinators :
     fun combs  ->
       match combs with
       | FStar_Syntax_Syntax.Primitive_eff combs1 ->
-          let uu____19876 = apply_wp_eff_combinators f combs1  in
-          FStar_Syntax_Syntax.Primitive_eff uu____19876
+          let uu____19942 = apply_wp_eff_combinators f combs1  in
+          FStar_Syntax_Syntax.Primitive_eff uu____19942
       | FStar_Syntax_Syntax.DM4F_eff combs1 ->
-          let uu____19878 = apply_wp_eff_combinators f combs1  in
-          FStar_Syntax_Syntax.DM4F_eff uu____19878
+          let uu____19944 = apply_wp_eff_combinators f combs1  in
+          FStar_Syntax_Syntax.DM4F_eff uu____19944
       | FStar_Syntax_Syntax.Layered_eff combs1 ->
-          let uu____19880 = apply_layered_eff_combinators f combs1  in
-          FStar_Syntax_Syntax.Layered_eff uu____19880
+          let uu____19946 = apply_layered_eff_combinators f combs1  in
+          FStar_Syntax_Syntax.Layered_eff uu____19946
   
 let (get_wp_close_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4610,7 +4636,7 @@ let (get_wp_close_combinator :
         FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.close_wp)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.close_wp)
-    | uu____19895 -> FStar_Pervasives_Native.None
+    | uu____19961 -> FStar_Pervasives_Native.None
   
 let (get_eff_repr :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4622,12 +4648,12 @@ let (get_eff_repr :
         combs.FStar_Syntax_Syntax.repr
     | FStar_Syntax_Syntax.DM4F_eff combs -> combs.FStar_Syntax_Syntax.repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____19909 =
+        let uu____19975 =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_repr
             FStar_Pervasives_Native.fst
            in
-        FStar_All.pipe_right uu____19909
-          (fun uu____19916  -> FStar_Pervasives_Native.Some uu____19916)
+        FStar_All.pipe_right uu____19975
+          (fun uu____19982  -> FStar_Pervasives_Native.Some uu____19982)
   
 let (get_bind_vc_combinator :
   FStar_Syntax_Syntax.eff_decl -> FStar_Syntax_Syntax.tscheme) =
@@ -4662,12 +4688,12 @@ let (get_bind_repr :
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         combs.FStar_Syntax_Syntax.bind_repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____19956 =
+        let uu____20022 =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_bind
             FStar_Pervasives_Native.fst
            in
-        FStar_All.pipe_right uu____19956
-          (fun uu____19963  -> FStar_Pervasives_Native.Some uu____19963)
+        FStar_All.pipe_right uu____20022
+          (fun uu____20029  -> FStar_Pervasives_Native.Some uu____20029)
   
 let (get_return_repr :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4680,12 +4706,12 @@ let (get_return_repr :
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         combs.FStar_Syntax_Syntax.return_repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____19977 =
+        let uu____20043 =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_return
             FStar_Pervasives_Native.fst
            in
-        FStar_All.pipe_right uu____19977
-          (fun uu____19984  -> FStar_Pervasives_Native.Some uu____19984)
+        FStar_All.pipe_right uu____20043
+          (fun uu____20050  -> FStar_Pervasives_Native.Some uu____20050)
   
 let (get_wp_trivial_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4695,11 +4721,11 @@ let (get_wp_trivial_combinator :
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.trivial
-          (fun uu____19998  -> FStar_Pervasives_Native.Some uu____19998)
+          (fun uu____20064  -> FStar_Pervasives_Native.Some uu____20064)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.trivial
-          (fun uu____20002  -> FStar_Pervasives_Native.Some uu____20002)
-    | uu____20003 -> FStar_Pervasives_Native.None
+          (fun uu____20068  -> FStar_Pervasives_Native.Some uu____20068)
+    | uu____20069 -> FStar_Pervasives_Native.None
   
 let (get_layered_if_then_else_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4708,13 +4734,13 @@ let (get_layered_if_then_else_combinator :
   fun ed  ->
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____20015 =
+        let uu____20081 =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_if_then_else
             FStar_Pervasives_Native.fst
            in
-        FStar_All.pipe_right uu____20015
-          (fun uu____20022  -> FStar_Pervasives_Native.Some uu____20022)
-    | uu____20023 -> FStar_Pervasives_Native.None
+        FStar_All.pipe_right uu____20081
+          (fun uu____20088  -> FStar_Pervasives_Native.Some uu____20088)
+    | uu____20089 -> FStar_Pervasives_Native.None
   
 let (get_wp_if_then_else_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4724,11 +4750,11 @@ let (get_wp_if_then_else_combinator :
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.if_then_else
-          (fun uu____20037  -> FStar_Pervasives_Native.Some uu____20037)
+          (fun uu____20103  -> FStar_Pervasives_Native.Some uu____20103)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.if_then_else
-          (fun uu____20041  -> FStar_Pervasives_Native.Some uu____20041)
-    | uu____20042 -> FStar_Pervasives_Native.None
+          (fun uu____20107  -> FStar_Pervasives_Native.Some uu____20107)
+    | uu____20108 -> FStar_Pervasives_Native.None
   
 let (get_wp_ite_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4738,11 +4764,11 @@ let (get_wp_ite_combinator :
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.ite_wp
-          (fun uu____20056  -> FStar_Pervasives_Native.Some uu____20056)
+          (fun uu____20122  -> FStar_Pervasives_Native.Some uu____20122)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.ite_wp
-          (fun uu____20060  -> FStar_Pervasives_Native.Some uu____20060)
-    | uu____20061 -> FStar_Pervasives_Native.None
+          (fun uu____20126  -> FStar_Pervasives_Native.Some uu____20126)
+    | uu____20127 -> FStar_Pervasives_Native.None
   
 let (get_stronger_vc_combinator :
   FStar_Syntax_Syntax.eff_decl -> FStar_Syntax_Syntax.tscheme) =
@@ -4762,17 +4788,17 @@ let (get_stronger_repr :
   =
   fun ed  ->
     match ed.FStar_Syntax_Syntax.combinators with
-    | FStar_Syntax_Syntax.Primitive_eff uu____20085 ->
+    | FStar_Syntax_Syntax.Primitive_eff uu____20151 ->
         FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.DM4F_eff uu____20086 ->
+    | FStar_Syntax_Syntax.DM4F_eff uu____20152 ->
         FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____20088 =
+        let uu____20154 =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_subcomp
             FStar_Pervasives_Native.fst
            in
-        FStar_All.pipe_right uu____20088
-          (fun uu____20095  -> FStar_Pervasives_Native.Some uu____20095)
+        FStar_All.pipe_right uu____20154
+          (fun uu____20161  -> FStar_Pervasives_Native.Some uu____20161)
   
 let (get_layered_effect_base :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4782,6 +4808,6 @@ let (get_layered_effect_base :
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Layered_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_base_effect
-          (fun uu____20109  -> FStar_Pervasives_Native.Some uu____20109)
-    | uu____20110 -> FStar_Pervasives_Native.None
+          (fun uu____20175  -> FStar_Pervasives_Native.Some uu____20175)
+    | uu____20176 -> FStar_Pervasives_Native.None
   

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -2924,19 +2924,20 @@ let (split_env :
         match uu____5903 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (bv',e') ->
-            if FStar_Syntax_Syntax.bv_eq bvar bv'
+            let uu____5938 = FStar_Syntax_Syntax.bv_eq bvar bv'  in
+            if uu____5938
             then FStar_Pervasives_Native.Some (e', bv', [])
             else
-              (let uu____5961 = aux e'  in
-               FStar_Util.map_opt uu____5961
-                 (fun uu____5992  ->
-                    match uu____5992 with
+              (let uu____5963 = aux e'  in
+               FStar_Util.map_opt uu____5963
+                 (fun uu____5994  ->
+                    match uu____5994 with
                     | (e'',bv,bvs) -> (e'', bv, (bv' :: bvs))))
          in
-      let uu____6018 = aux e  in
-      FStar_Util.map_opt uu____6018
-        (fun uu____6049  ->
-           match uu____6049 with
+      let uu____6020 = aux e  in
+      FStar_Util.map_opt uu____6020
+        (fun uu____6051  ->
+           match uu____6051 with
            | (e',bv,bvs) -> (e', bv, (FStar_List.rev bvs)))
   
 let (push_bvs :
@@ -2958,41 +2959,41 @@ let (subst_goal :
   fun b1  ->
     fun b2  ->
       fun g  ->
-        let uu____6126 =
-          let uu____6137 = FStar_Tactics_Types.goal_env g  in
-          split_env b1 uu____6137  in
-        match uu____6126 with
+        let uu____6128 =
+          let uu____6139 = FStar_Tactics_Types.goal_env g  in
+          split_env b1 uu____6139  in
+        match uu____6128 with
         | FStar_Pervasives_Native.Some (e0,b11,bvs) ->
             let bs =
               FStar_List.map FStar_Syntax_Syntax.mk_binder (b11 :: bvs)  in
             let t = FStar_Tactics_Types.goal_type g  in
-            let uu____6177 =
-              let uu____6190 = FStar_Syntax_Subst.close_binders bs  in
-              let uu____6199 = FStar_Syntax_Subst.close bs t  in
-              (uu____6190, uu____6199)  in
-            (match uu____6177 with
+            let uu____6179 =
+              let uu____6192 = FStar_Syntax_Subst.close_binders bs  in
+              let uu____6201 = FStar_Syntax_Subst.close bs t  in
+              (uu____6192, uu____6201)  in
+            (match uu____6179 with
              | (bs',t') ->
                  let bs'1 =
-                   let uu____6243 = FStar_Syntax_Syntax.mk_binder b2  in
-                   let uu____6250 = FStar_List.tail bs'  in uu____6243 ::
-                     uu____6250
+                   let uu____6245 = FStar_Syntax_Syntax.mk_binder b2  in
+                   let uu____6252 = FStar_List.tail bs'  in uu____6245 ::
+                     uu____6252
                     in
-                 let uu____6271 = FStar_Syntax_Subst.open_term bs'1 t'  in
-                 (match uu____6271 with
+                 let uu____6273 = FStar_Syntax_Subst.open_term bs'1 t'  in
+                 (match uu____6273 with
                   | (bs'',t'') ->
                       let b21 =
-                        let uu____6287 = FStar_List.hd bs''  in
-                        FStar_Pervasives_Native.fst uu____6287  in
+                        let uu____6289 = FStar_List.hd bs''  in
+                        FStar_Pervasives_Native.fst uu____6289  in
                       let new_env =
-                        let uu____6303 =
+                        let uu____6305 =
                           FStar_List.map FStar_Pervasives_Native.fst bs''  in
-                        push_bvs e0 uu____6303  in
-                      let uu____6314 =
+                        push_bvs e0 uu____6305  in
+                      let uu____6316 =
                         FStar_Tactics_Monad.new_uvar "subst_goal" new_env t''
                          in
-                      FStar_Tactics_Monad.bind uu____6314
-                        (fun uu____6338  ->
-                           match uu____6338 with
+                      FStar_Tactics_Monad.bind uu____6316
+                        (fun uu____6340  ->
+                           match uu____6340 with
                            | (uvt,uv) ->
                                let goal' =
                                  FStar_Tactics_Types.mk_goal new_env uv
@@ -3001,28 +3002,28 @@ let (subst_goal :
                                    g.FStar_Tactics_Types.label
                                   in
                                let sol =
-                                 let uu____6357 =
+                                 let uu____6359 =
                                    FStar_Syntax_Util.abs bs'' uvt
                                      FStar_Pervasives_Native.None
                                     in
-                                 let uu____6360 =
+                                 let uu____6362 =
                                    FStar_List.map
-                                     (fun uu____6381  ->
-                                        match uu____6381 with
+                                     (fun uu____6383  ->
+                                        match uu____6383 with
                                         | (bv,q) ->
-                                            let uu____6394 =
+                                            let uu____6396 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 bv
                                                in
                                             FStar_Syntax_Syntax.as_arg
-                                              uu____6394) bs
+                                              uu____6396) bs
                                     in
-                                 FStar_Syntax_Util.mk_app uu____6357
-                                   uu____6360
+                                 FStar_Syntax_Util.mk_app uu____6359
+                                   uu____6362
                                   in
-                               let uu____6395 = set_solution g sol  in
-                               FStar_Tactics_Monad.bind uu____6395
-                                 (fun uu____6405  ->
+                               let uu____6397 = set_solution g sol  in
+                               FStar_Tactics_Monad.bind uu____6397
+                                 (fun uu____6407  ->
                                     FStar_Tactics_Monad.ret
                                       (FStar_Pervasives_Native.Some
                                          (b21, goal'))))))
@@ -3031,41 +3032,41 @@ let (subst_goal :
   
 let (rewrite : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun h  ->
-    let uu____6444 =
+    let uu____6446 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun goal  ->
-           let uu____6452 = h  in
-           match uu____6452 with
-           | (bv,uu____6456) ->
+           let uu____6454 = h  in
+           match uu____6454 with
+           | (bv,uu____6458) ->
                FStar_Tactics_Monad.mlog
-                 (fun uu____6464  ->
-                    let uu____6465 = FStar_Syntax_Print.bv_to_string bv  in
-                    let uu____6467 =
+                 (fun uu____6466  ->
+                    let uu____6467 = FStar_Syntax_Print.bv_to_string bv  in
+                    let uu____6469 =
                       FStar_Syntax_Print.term_to_string
                         bv.FStar_Syntax_Syntax.sort
                        in
-                    FStar_Util.print2 "+++Rewrite %s : %s\n" uu____6465
-                      uu____6467)
-                 (fun uu____6472  ->
-                    let uu____6473 =
-                      let uu____6484 = FStar_Tactics_Types.goal_env goal  in
-                      split_env bv uu____6484  in
-                    match uu____6473 with
+                    FStar_Util.print2 "+++Rewrite %s : %s\n" uu____6467
+                      uu____6469)
+                 (fun uu____6474  ->
+                    let uu____6475 =
+                      let uu____6486 = FStar_Tactics_Types.goal_env goal  in
+                      split_env bv uu____6486  in
+                    match uu____6475 with
                     | FStar_Pervasives_Native.None  ->
                         FStar_Tactics_Monad.fail
                           "binder not found in environment"
                     | FStar_Pervasives_Native.Some (e0,bv1,bvs) ->
-                        let uu____6511 =
-                          let uu____6518 =
+                        let uu____6513 =
+                          let uu____6520 =
                             whnf e0 bv1.FStar_Syntax_Syntax.sort  in
-                          destruct_eq uu____6518  in
-                        (match uu____6511 with
+                          destruct_eq uu____6520  in
+                        (match uu____6513 with
                          | FStar_Pervasives_Native.Some (x,e) ->
-                             let uu____6527 =
-                               let uu____6528 = FStar_Syntax_Subst.compress x
+                             let uu____6529 =
+                               let uu____6530 = FStar_Syntax_Subst.compress x
                                   in
-                               uu____6528.FStar_Syntax_Syntax.n  in
-                             (match uu____6527 with
+                               uu____6530.FStar_Syntax_Syntax.n  in
+                             (match uu____6529 with
                               | FStar_Syntax_Syntax.Tm_name x1 ->
                                   let s = [FStar_Syntax_Syntax.NT (x1, e)]
                                      in
@@ -3075,47 +3076,47 @@ let (rewrite : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                                     FStar_List.map
                                       FStar_Syntax_Syntax.mk_binder bvs
                                      in
-                                  let uu____6555 =
-                                    let uu____6560 =
+                                  let uu____6557 =
+                                    let uu____6562 =
                                       FStar_Syntax_Subst.close_binders bs  in
-                                    let uu____6561 =
+                                    let uu____6563 =
                                       FStar_Syntax_Subst.close bs t  in
-                                    (uu____6560, uu____6561)  in
-                                  (match uu____6555 with
+                                    (uu____6562, uu____6563)  in
+                                  (match uu____6557 with
                                    | (bs',t') ->
-                                       let uu____6566 =
-                                         let uu____6571 =
+                                       let uu____6568 =
+                                         let uu____6573 =
                                            FStar_Syntax_Subst.subst_binders s
                                              bs'
                                             in
-                                         let uu____6572 =
+                                         let uu____6574 =
                                            FStar_Syntax_Subst.subst s t  in
-                                         (uu____6571, uu____6572)  in
-                                       (match uu____6566 with
+                                         (uu____6573, uu____6574)  in
+                                       (match uu____6568 with
                                         | (bs'1,t'1) ->
-                                            let uu____6577 =
+                                            let uu____6579 =
                                               FStar_Syntax_Subst.open_term
                                                 bs'1 t'1
                                                in
-                                            (match uu____6577 with
+                                            (match uu____6579 with
                                              | (bs'',t'') ->
                                                  let new_env =
-                                                   let uu____6587 =
-                                                     let uu____6590 =
+                                                   let uu____6589 =
+                                                     let uu____6592 =
                                                        FStar_List.map
                                                          FStar_Pervasives_Native.fst
                                                          bs''
                                                         in
-                                                     bv1 :: uu____6590  in
-                                                   push_bvs e0 uu____6587  in
-                                                 let uu____6601 =
+                                                     bv1 :: uu____6592  in
+                                                   push_bvs e0 uu____6589  in
+                                                 let uu____6603 =
                                                    FStar_Tactics_Monad.new_uvar
                                                      "rewrite" new_env t''
                                                     in
                                                  FStar_Tactics_Monad.bind
-                                                   uu____6601
-                                                   (fun uu____6619  ->
-                                                      match uu____6619 with
+                                                   uu____6603
+                                                   (fun uu____6621  ->
+                                                      match uu____6621 with
                                                       | (uvt,uv) ->
                                                           let goal' =
                                                             FStar_Tactics_Types.mk_goal
@@ -3125,51 +3126,51 @@ let (rewrite : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                                                               goal.FStar_Tactics_Types.label
                                                              in
                                                           let sol =
-                                                            let uu____6632 =
+                                                            let uu____6634 =
                                                               FStar_Syntax_Util.abs
                                                                 bs'' uvt
                                                                 FStar_Pervasives_Native.None
                                                                in
-                                                            let uu____6635 =
+                                                            let uu____6637 =
                                                               FStar_List.map
                                                                 (fun
-                                                                   uu____6656
+                                                                   uu____6658
                                                                     ->
-                                                                   match uu____6656
+                                                                   match uu____6658
                                                                    with
                                                                    | 
-                                                                   (bv2,uu____6664)
+                                                                   (bv2,uu____6666)
                                                                     ->
-                                                                    let uu____6669
+                                                                    let uu____6671
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     bv2  in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu____6669)
+                                                                    uu____6671)
                                                                 bs
                                                                in
                                                             FStar_Syntax_Util.mk_app
-                                                              uu____6632
-                                                              uu____6635
+                                                              uu____6634
+                                                              uu____6637
                                                              in
-                                                          let uu____6670 =
+                                                          let uu____6672 =
                                                             set_solution goal
                                                               sol
                                                              in
                                                           FStar_Tactics_Monad.bind
-                                                            uu____6670
-                                                            (fun uu____6674 
+                                                            uu____6672
+                                                            (fun uu____6676 
                                                                ->
                                                                FStar_Tactics_Monad.replace_cur
                                                                  goal')))))
-                              | uu____6675 ->
+                              | uu____6677 ->
                                   FStar_Tactics_Monad.fail
                                     "Not an equality hypothesis with a variable on the LHS")
-                         | uu____6677 ->
+                         | uu____6679 ->
                              FStar_Tactics_Monad.fail
                                "Not an equality hypothesis")))
        in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rewrite") uu____6444
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rewrite") uu____6446
   
 let (rename_to :
   FStar_Syntax_Syntax.binder ->
@@ -3177,134 +3178,137 @@ let (rename_to :
   =
   fun b  ->
     fun s  ->
-      let uu____6707 =
+      let uu____6709 =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
           (fun goal  ->
-             let uu____6729 = b  in
-             match uu____6729 with
+             let uu____6731 = b  in
+             match uu____6731 with
              | (bv,q) ->
                  let bv' =
-                   let uu____6745 =
-                     let uu___897_6746 = bv  in
-                     let uu____6747 =
-                       FStar_Ident.mk_ident
-                         (s,
-                           ((bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange))
-                        in
+                   let uu____6747 =
+                     let uu___897_6748 = bv  in
+                     let uu____6749 =
+                       let uu____6750 =
+                         let uu____6756 =
+                           FStar_Ident.range_of_id
+                             bv.FStar_Syntax_Syntax.ppname
+                            in
+                         (s, uu____6756)  in
+                       FStar_Ident.mk_ident uu____6750  in
                      {
-                       FStar_Syntax_Syntax.ppname = uu____6747;
+                       FStar_Syntax_Syntax.ppname = uu____6749;
                        FStar_Syntax_Syntax.index =
-                         (uu___897_6746.FStar_Syntax_Syntax.index);
+                         (uu___897_6748.FStar_Syntax_Syntax.index);
                        FStar_Syntax_Syntax.sort =
-                         (uu___897_6746.FStar_Syntax_Syntax.sort)
+                         (uu___897_6748.FStar_Syntax_Syntax.sort)
                      }  in
-                   FStar_Syntax_Syntax.freshen_bv uu____6745  in
-                 let uu____6749 = subst_goal bv bv' goal  in
-                 FStar_Tactics_Monad.bind uu____6749
-                   (fun uu___4_6771  ->
-                      match uu___4_6771 with
+                   FStar_Syntax_Syntax.freshen_bv uu____6747  in
+                 let uu____6758 = subst_goal bv bv' goal  in
+                 FStar_Tactics_Monad.bind uu____6758
+                   (fun uu___4_6780  ->
+                      match uu___4_6780 with
                       | FStar_Pervasives_Native.None  ->
                           FStar_Tactics_Monad.fail
                             "binder not found in environment"
                       | FStar_Pervasives_Native.Some (bv'1,goal1) ->
-                          let uu____6803 =
+                          let uu____6812 =
                             FStar_Tactics_Monad.replace_cur goal1  in
-                          FStar_Tactics_Monad.bind uu____6803
-                            (fun uu____6813  ->
+                          FStar_Tactics_Monad.bind uu____6812
+                            (fun uu____6822  ->
                                FStar_Tactics_Monad.ret (bv'1, q))))
          in
       FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rename_to")
-        uu____6707
+        uu____6709
   
 let (binder_retype :
   FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun b  ->
-    let uu____6849 =
+    let uu____6858 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun goal  ->
-           let uu____6858 = b  in
-           match uu____6858 with
-           | (bv,uu____6862) ->
-               let uu____6867 =
-                 let uu____6878 = FStar_Tactics_Types.goal_env goal  in
-                 split_env bv uu____6878  in
-               (match uu____6867 with
+           let uu____6867 = b  in
+           match uu____6867 with
+           | (bv,uu____6871) ->
+               let uu____6876 =
+                 let uu____6887 = FStar_Tactics_Types.goal_env goal  in
+                 split_env bv uu____6887  in
+               (match uu____6876 with
                 | FStar_Pervasives_Native.None  ->
                     FStar_Tactics_Monad.fail
                       "binder is not present in environment"
                 | FStar_Pervasives_Native.Some (e0,bv1,bvs) ->
-                    let uu____6905 = FStar_Syntax_Util.type_u ()  in
-                    (match uu____6905 with
+                    let uu____6914 = FStar_Syntax_Util.type_u ()  in
+                    (match uu____6914 with
                      | (ty,u) ->
-                         let uu____6914 =
+                         let uu____6923 =
                            FStar_Tactics_Monad.new_uvar "binder_retype" e0 ty
                             in
-                         FStar_Tactics_Monad.bind uu____6914
-                           (fun uu____6933  ->
-                              match uu____6933 with
+                         FStar_Tactics_Monad.bind uu____6923
+                           (fun uu____6942  ->
+                              match uu____6942 with
                               | (t',u_t') ->
                                   let bv'' =
-                                    let uu___924_6943 = bv1  in
+                                    let uu___924_6952 = bv1  in
                                     {
                                       FStar_Syntax_Syntax.ppname =
-                                        (uu___924_6943.FStar_Syntax_Syntax.ppname);
+                                        (uu___924_6952.FStar_Syntax_Syntax.ppname);
                                       FStar_Syntax_Syntax.index =
-                                        (uu___924_6943.FStar_Syntax_Syntax.index);
+                                        (uu___924_6952.FStar_Syntax_Syntax.index);
                                       FStar_Syntax_Syntax.sort = t'
                                     }  in
                                   let s =
-                                    let uu____6947 =
-                                      let uu____6948 =
-                                        let uu____6955 =
+                                    let uu____6956 =
+                                      let uu____6957 =
+                                        let uu____6964 =
                                           FStar_Syntax_Syntax.bv_to_name bv''
                                            in
-                                        (bv1, uu____6955)  in
-                                      FStar_Syntax_Syntax.NT uu____6948  in
-                                    [uu____6947]  in
+                                        (bv1, uu____6964)  in
+                                      FStar_Syntax_Syntax.NT uu____6957  in
+                                    [uu____6956]  in
                                   let bvs1 =
                                     FStar_List.map
                                       (fun b1  ->
-                                         let uu___929_6967 = b1  in
-                                         let uu____6968 =
+                                         let uu___929_6976 = b1  in
+                                         let uu____6977 =
                                            FStar_Syntax_Subst.subst s
                                              b1.FStar_Syntax_Syntax.sort
                                             in
                                          {
                                            FStar_Syntax_Syntax.ppname =
-                                             (uu___929_6967.FStar_Syntax_Syntax.ppname);
+                                             (uu___929_6976.FStar_Syntax_Syntax.ppname);
                                            FStar_Syntax_Syntax.index =
-                                             (uu___929_6967.FStar_Syntax_Syntax.index);
+                                             (uu___929_6976.FStar_Syntax_Syntax.index);
                                            FStar_Syntax_Syntax.sort =
-                                             uu____6968
+                                             uu____6977
                                          }) bvs
                                      in
                                   let env' = push_bvs e0 (bv'' :: bvs1)  in
                                   FStar_Tactics_Monad.bind
                                     FStar_Tactics_Monad.dismiss
-                                    (fun uu____6975  ->
+                                    (fun uu____6984  ->
                                        let new_goal =
-                                         let uu____6977 =
+                                         let uu____6986 =
                                            FStar_Tactics_Types.goal_with_env
                                              goal env'
                                             in
-                                         let uu____6978 =
-                                           let uu____6979 =
+                                         let uu____6987 =
+                                           let uu____6988 =
                                              FStar_Tactics_Types.goal_type
                                                goal
                                               in
                                            FStar_Syntax_Subst.subst s
-                                             uu____6979
+                                             uu____6988
                                             in
                                          FStar_Tactics_Types.goal_with_type
-                                           uu____6977 uu____6978
+                                           uu____6986 uu____6987
                                           in
-                                       let uu____6980 =
+                                       let uu____6989 =
                                          FStar_Tactics_Monad.add_goals
                                            [new_goal]
                                           in
-                                       FStar_Tactics_Monad.bind uu____6980
-                                         (fun uu____6985  ->
-                                            let uu____6986 =
+                                       FStar_Tactics_Monad.bind uu____6989
+                                         (fun uu____6994  ->
+                                            let uu____6995 =
                                               FStar_Syntax_Util.mk_eq2
                                                 (FStar_Syntax_Syntax.U_succ u)
                                                 ty
@@ -3313,10 +3317,10 @@ let (binder_retype :
                                                in
                                             FStar_Tactics_Monad.add_irrelevant_goal
                                               goal "binder_retype equation"
-                                              e0 uu____6986))))))
+                                              e0 uu____6995))))))
        in
     FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "binder_retype")
-      uu____6849
+      uu____6858
   
 let (norm_binder_type :
   FStar_Syntax_Embeddings.norm_step Prims.list ->
@@ -3324,89 +3328,89 @@ let (norm_binder_type :
   =
   fun s  ->
     fun b  ->
-      let uu____7012 =
+      let uu____7021 =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
           (fun goal  ->
-             let uu____7021 = b  in
-             match uu____7021 with
-             | (bv,uu____7025) ->
-                 let uu____7030 =
-                   let uu____7041 = FStar_Tactics_Types.goal_env goal  in
-                   split_env bv uu____7041  in
-                 (match uu____7030 with
+             let uu____7030 = b  in
+             match uu____7030 with
+             | (bv,uu____7034) ->
+                 let uu____7039 =
+                   let uu____7050 = FStar_Tactics_Types.goal_env goal  in
+                   split_env bv uu____7050  in
+                 (match uu____7039 with
                   | FStar_Pervasives_Native.None  ->
                       FStar_Tactics_Monad.fail
                         "binder is not present in environment"
                   | FStar_Pervasives_Native.Some (e0,bv1,bvs) ->
                       let steps =
-                        let uu____7071 =
+                        let uu____7080 =
                           FStar_TypeChecker_Normalize.tr_norm_steps s  in
                         FStar_List.append
                           [FStar_TypeChecker_Env.Reify;
-                          FStar_TypeChecker_Env.UnfoldTac] uu____7071
+                          FStar_TypeChecker_Env.UnfoldTac] uu____7080
                          in
                       let sort' =
                         normalize steps e0 bv1.FStar_Syntax_Syntax.sort  in
                       let bv' =
-                        let uu___950_7076 = bv1  in
+                        let uu___950_7085 = bv1  in
                         {
                           FStar_Syntax_Syntax.ppname =
-                            (uu___950_7076.FStar_Syntax_Syntax.ppname);
+                            (uu___950_7085.FStar_Syntax_Syntax.ppname);
                           FStar_Syntax_Syntax.index =
-                            (uu___950_7076.FStar_Syntax_Syntax.index);
+                            (uu___950_7085.FStar_Syntax_Syntax.index);
                           FStar_Syntax_Syntax.sort = sort'
                         }  in
                       let env' = push_bvs e0 (bv' :: bvs)  in
-                      let uu____7078 =
+                      let uu____7087 =
                         FStar_Tactics_Types.goal_with_env goal env'  in
-                      FStar_Tactics_Monad.replace_cur uu____7078))
+                      FStar_Tactics_Monad.replace_cur uu____7087))
          in
       FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "norm_binder_type")
-        uu____7012
+        uu____7021
   
 let (revert : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7091  ->
+  fun uu____7100  ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal  ->
-         let uu____7097 =
-           let uu____7104 = FStar_Tactics_Types.goal_env goal  in
-           FStar_TypeChecker_Env.pop_bv uu____7104  in
-         match uu____7097 with
+         let uu____7106 =
+           let uu____7113 = FStar_Tactics_Types.goal_env goal  in
+           FStar_TypeChecker_Env.pop_bv uu____7113  in
+         match uu____7106 with
          | FStar_Pervasives_Native.None  ->
              FStar_Tactics_Monad.fail "Cannot revert; empty context"
          | FStar_Pervasives_Native.Some (x,env') ->
              let typ' =
-               let uu____7121 =
-                 let uu____7124 = FStar_Tactics_Types.goal_type goal  in
-                 FStar_Syntax_Syntax.mk_Total uu____7124  in
+               let uu____7130 =
+                 let uu____7133 = FStar_Tactics_Types.goal_type goal  in
+                 FStar_Syntax_Syntax.mk_Total uu____7133  in
                FStar_Syntax_Util.arrow [(x, FStar_Pervasives_Native.None)]
-                 uu____7121
+                 uu____7130
                 in
-             let uu____7139 = FStar_Tactics_Monad.new_uvar "revert" env' typ'
+             let uu____7148 = FStar_Tactics_Monad.new_uvar "revert" env' typ'
                 in
-             FStar_Tactics_Monad.bind uu____7139
-               (fun uu____7155  ->
-                  match uu____7155 with
+             FStar_Tactics_Monad.bind uu____7148
+               (fun uu____7164  ->
+                  match uu____7164 with
                   | (r,u_r) ->
-                      let uu____7164 =
-                        let uu____7167 =
-                          let uu____7168 =
-                            let uu____7169 =
+                      let uu____7173 =
+                        let uu____7176 =
+                          let uu____7177 =
+                            let uu____7178 =
                               FStar_Tactics_Types.goal_type goal  in
-                            uu____7169.FStar_Syntax_Syntax.pos  in
-                          let uu____7172 =
-                            let uu____7177 =
-                              let uu____7178 =
-                                let uu____7187 =
+                            uu____7178.FStar_Syntax_Syntax.pos  in
+                          let uu____7181 =
+                            let uu____7186 =
+                              let uu____7187 =
+                                let uu____7196 =
                                   FStar_Syntax_Syntax.bv_to_name x  in
-                                FStar_Syntax_Syntax.as_arg uu____7187  in
-                              [uu____7178]  in
-                            FStar_Syntax_Syntax.mk_Tm_app r uu____7177  in
-                          uu____7172 FStar_Pervasives_Native.None uu____7168
+                                FStar_Syntax_Syntax.as_arg uu____7196  in
+                              [uu____7187]  in
+                            FStar_Syntax_Syntax.mk_Tm_app r uu____7186  in
+                          uu____7181 FStar_Pervasives_Native.None uu____7177
                            in
-                        set_solution goal uu____7167  in
-                      FStar_Tactics_Monad.bind uu____7164
-                        (fun uu____7206  ->
+                        set_solution goal uu____7176  in
+                      FStar_Tactics_Monad.bind uu____7173
+                        (fun uu____7215  ->
                            let g =
                              FStar_Tactics_Types.mk_goal env' u_r
                                goal.FStar_Tactics_Types.opts
@@ -3419,8 +3423,8 @@ let (free_in :
   FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun bv  ->
     fun t  ->
-      let uu____7220 = FStar_Syntax_Free.names t  in
-      FStar_Util.set_mem bv uu____7220
+      let uu____7229 = FStar_Syntax_Free.names t  in
+      FStar_Util.set_mem bv uu____7229
   
 let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun b  ->
@@ -3428,22 +3432,22 @@ let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal  ->
          FStar_Tactics_Monad.mlog
-           (fun uu____7241  ->
-              let uu____7242 = FStar_Syntax_Print.binder_to_string b  in
-              let uu____7244 =
-                let uu____7246 =
-                  let uu____7248 =
-                    let uu____7257 = FStar_Tactics_Types.goal_env goal  in
-                    FStar_TypeChecker_Env.all_binders uu____7257  in
-                  FStar_All.pipe_right uu____7248 FStar_List.length  in
-                FStar_All.pipe_right uu____7246 FStar_Util.string_of_int  in
+           (fun uu____7250  ->
+              let uu____7251 = FStar_Syntax_Print.binder_to_string b  in
+              let uu____7253 =
+                let uu____7255 =
+                  let uu____7257 =
+                    let uu____7266 = FStar_Tactics_Types.goal_env goal  in
+                    FStar_TypeChecker_Env.all_binders uu____7266  in
+                  FStar_All.pipe_right uu____7257 FStar_List.length  in
+                FStar_All.pipe_right uu____7255 FStar_Util.string_of_int  in
               FStar_Util.print2 "Clear of (%s), env has %s binders\n"
-                uu____7242 uu____7244)
-           (fun uu____7278  ->
-              let uu____7279 =
-                let uu____7290 = FStar_Tactics_Types.goal_env goal  in
-                split_env bv uu____7290  in
-              match uu____7279 with
+                uu____7251 uu____7253)
+           (fun uu____7287  ->
+              let uu____7288 =
+                let uu____7299 = FStar_Tactics_Types.goal_env goal  in
+                split_env bv uu____7299  in
+              match uu____7288 with
               | FStar_Pervasives_Native.None  ->
                   FStar_Tactics_Monad.fail
                     "Cannot clear; binder not in environment"
@@ -3452,46 +3456,46 @@ let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                     match bvs1 with
                     | [] -> FStar_Tactics_Monad.ret ()
                     | bv'::bvs2 ->
-                        let uu____7335 =
+                        let uu____7344 =
                           free_in bv1 bv'.FStar_Syntax_Syntax.sort  in
-                        if uu____7335
+                        if uu____7344
                         then
-                          let uu____7340 =
-                            let uu____7342 =
+                          let uu____7349 =
+                            let uu____7351 =
                               FStar_Syntax_Print.bv_to_string bv'  in
                             FStar_Util.format1
                               "Cannot clear; binder present in the type of %s"
-                              uu____7342
+                              uu____7351
                              in
-                          FStar_Tactics_Monad.fail uu____7340
+                          FStar_Tactics_Monad.fail uu____7349
                         else check bvs2
                      in
-                  let uu____7347 =
-                    let uu____7349 = FStar_Tactics_Types.goal_type goal  in
-                    free_in bv1 uu____7349  in
-                  if uu____7347
+                  let uu____7356 =
+                    let uu____7358 = FStar_Tactics_Types.goal_type goal  in
+                    free_in bv1 uu____7358  in
+                  if uu____7356
                   then
                     FStar_Tactics_Monad.fail
                       "Cannot clear; binder present in goal"
                   else
-                    (let uu____7356 = check bvs  in
-                     FStar_Tactics_Monad.bind uu____7356
-                       (fun uu____7362  ->
+                    (let uu____7365 = check bvs  in
+                     FStar_Tactics_Monad.bind uu____7365
+                       (fun uu____7371  ->
                           let env' = push_bvs e' bvs  in
-                          let uu____7364 =
-                            let uu____7371 =
+                          let uu____7373 =
+                            let uu____7380 =
                               FStar_Tactics_Types.goal_type goal  in
                             FStar_Tactics_Monad.new_uvar "clear.witness" env'
-                              uu____7371
+                              uu____7380
                              in
-                          FStar_Tactics_Monad.bind uu____7364
-                            (fun uu____7381  ->
-                               match uu____7381 with
+                          FStar_Tactics_Monad.bind uu____7373
+                            (fun uu____7390  ->
+                               match uu____7390 with
                                | (ut,uvar_ut) ->
-                                   let uu____7390 = set_solution goal ut  in
-                                   FStar_Tactics_Monad.bind uu____7390
-                                     (fun uu____7395  ->
-                                        let uu____7396 =
+                                   let uu____7399 = set_solution goal ut  in
+                                   FStar_Tactics_Monad.bind uu____7399
+                                     (fun uu____7404  ->
+                                        let uu____7405 =
                                           FStar_Tactics_Types.mk_goal env'
                                             uvar_ut
                                             goal.FStar_Tactics_Types.opts
@@ -3499,21 +3503,21 @@ let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                                             goal.FStar_Tactics_Types.label
                                            in
                                         FStar_Tactics_Monad.replace_cur
-                                          uu____7396))))))
+                                          uu____7405))))))
   
 let (clear_top : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7404  ->
+  fun uu____7413  ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal  ->
-         let uu____7410 =
-           let uu____7417 = FStar_Tactics_Types.goal_env goal  in
-           FStar_TypeChecker_Env.pop_bv uu____7417  in
-         match uu____7410 with
+         let uu____7419 =
+           let uu____7426 = FStar_Tactics_Types.goal_env goal  in
+           FStar_TypeChecker_Env.pop_bv uu____7426  in
+         match uu____7419 with
          | FStar_Pervasives_Native.None  ->
              FStar_Tactics_Monad.fail "Cannot clear; empty context"
-         | FStar_Pervasives_Native.Some (x,uu____7426) ->
-             let uu____7431 = FStar_Syntax_Syntax.mk_binder x  in
-             clear uu____7431)
+         | FStar_Pervasives_Native.Some (x,uu____7435) ->
+             let uu____7440 = FStar_Syntax_Syntax.mk_binder x  in
+             clear uu____7440)
   
 let (prune : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun s  ->
@@ -3521,8 +3525,8 @@ let (prune : Prims.string -> unit FStar_Tactics_Monad.tac) =
       (fun g  ->
          let ctx = FStar_Tactics_Types.goal_env g  in
          let ctx' =
-           let uu____7451 = FStar_Ident.path_of_text s  in
-           FStar_TypeChecker_Env.rem_proof_ns ctx uu____7451  in
+           let uu____7460 = FStar_Ident.path_of_text s  in
+           FStar_TypeChecker_Env.rem_proof_ns ctx uu____7460  in
          let g' = FStar_Tactics_Types.goal_with_env g ctx'  in
          FStar_Tactics_Monad.replace_cur g')
   
@@ -3532,8 +3536,8 @@ let (addns : Prims.string -> unit FStar_Tactics_Monad.tac) =
       (fun g  ->
          let ctx = FStar_Tactics_Types.goal_env g  in
          let ctx' =
-           let uu____7472 = FStar_Ident.path_of_text s  in
-           FStar_TypeChecker_Env.add_proof_ns ctx uu____7472  in
+           let uu____7481 = FStar_Ident.path_of_text s  in
+           FStar_TypeChecker_Env.add_proof_ns ctx uu____7481  in
          let g' = FStar_Tactics_Types.goal_with_env g ctx'  in
          FStar_Tactics_Monad.replace_cur g')
   
@@ -3545,123 +3549,123 @@ let (_trefl :
     fun r  ->
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g  ->
-           let uu____7492 =
-             let uu____7496 = FStar_Tactics_Types.goal_env g  in
-             do_unify uu____7496 l r  in
-           FStar_Tactics_Monad.bind uu____7492
+           let uu____7501 =
+             let uu____7505 = FStar_Tactics_Types.goal_env g  in
+             do_unify uu____7505 l r  in
+           FStar_Tactics_Monad.bind uu____7501
              (fun b  ->
                 if b
                 then solve' g FStar_Syntax_Util.exp_unit
                 else
                   (let l1 =
-                     let uu____7507 = FStar_Tactics_Types.goal_env g  in
+                     let uu____7516 = FStar_Tactics_Types.goal_env g  in
                      FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant;
                        FStar_TypeChecker_Env.Primops;
-                       FStar_TypeChecker_Env.UnfoldTac] uu____7507 l
+                       FStar_TypeChecker_Env.UnfoldTac] uu____7516 l
                       in
                    let r1 =
-                     let uu____7509 = FStar_Tactics_Types.goal_env g  in
+                     let uu____7518 = FStar_Tactics_Types.goal_env g  in
                      FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant;
                        FStar_TypeChecker_Env.Primops;
-                       FStar_TypeChecker_Env.UnfoldTac] uu____7509 r
+                       FStar_TypeChecker_Env.UnfoldTac] uu____7518 r
                       in
-                   let uu____7510 =
-                     let uu____7514 = FStar_Tactics_Types.goal_env g  in
-                     do_unify uu____7514 l1 r1  in
-                   FStar_Tactics_Monad.bind uu____7510
+                   let uu____7519 =
+                     let uu____7523 = FStar_Tactics_Types.goal_env g  in
+                     do_unify uu____7523 l1 r1  in
+                   FStar_Tactics_Monad.bind uu____7519
                      (fun b1  ->
                         if b1
                         then solve' g FStar_Syntax_Util.exp_unit
                         else
-                          (let uu____7524 =
-                             let uu____7531 =
-                               let uu____7537 =
+                          (let uu____7533 =
+                             let uu____7540 =
+                               let uu____7546 =
                                  FStar_Tactics_Types.goal_env g  in
-                               tts uu____7537  in
+                               tts uu____7546  in
                              FStar_TypeChecker_Err.print_discrepancy
-                               uu____7531 l1 r1
+                               uu____7540 l1 r1
                               in
-                           match uu____7524 with
+                           match uu____7533 with
                            | (ls,rs) ->
                                fail2 "not a trivial equality ((%s) vs (%s))"
                                  ls rs)))))
   
 let (trefl : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7554  ->
-    let uu____7557 =
+  fun uu____7563  ->
+    let uu____7566 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g  ->
-           let uu____7565 =
-             let uu____7572 =
-               let uu____7573 = FStar_Tactics_Types.goal_env g  in
-               let uu____7574 = FStar_Tactics_Types.goal_type g  in
-               whnf uu____7573 uu____7574  in
-             destruct_eq uu____7572  in
-           match uu____7565 with
+           let uu____7574 =
+             let uu____7581 =
+               let uu____7582 = FStar_Tactics_Types.goal_env g  in
+               let uu____7583 = FStar_Tactics_Types.goal_type g  in
+               whnf uu____7582 uu____7583  in
+             destruct_eq uu____7581  in
+           match uu____7574 with
            | FStar_Pervasives_Native.Some (l,r) -> _trefl l r
            | FStar_Pervasives_Native.None  ->
-               let uu____7587 =
-                 let uu____7589 = FStar_Tactics_Types.goal_env g  in
-                 let uu____7590 = FStar_Tactics_Types.goal_type g  in
-                 tts uu____7589 uu____7590  in
-               fail1 "not an equality (%s)" uu____7587)
+               let uu____7596 =
+                 let uu____7598 = FStar_Tactics_Types.goal_env g  in
+                 let uu____7599 = FStar_Tactics_Types.goal_type g  in
+                 tts uu____7598 uu____7599  in
+               fail1 "not an equality (%s)" uu____7596)
        in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "trefl") uu____7557
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "trefl") uu____7566
   
 let (dup : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7604  ->
+  fun uu____7613  ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g  ->
          let env1 = FStar_Tactics_Types.goal_env g  in
-         let uu____7612 =
-           let uu____7619 = FStar_Tactics_Types.goal_type g  in
-           FStar_Tactics_Monad.new_uvar "dup" env1 uu____7619  in
-         FStar_Tactics_Monad.bind uu____7612
-           (fun uu____7629  ->
-              match uu____7629 with
+         let uu____7621 =
+           let uu____7628 = FStar_Tactics_Types.goal_type g  in
+           FStar_Tactics_Monad.new_uvar "dup" env1 uu____7628  in
+         FStar_Tactics_Monad.bind uu____7621
+           (fun uu____7638  ->
+              match uu____7638 with
               | (u,u_uvar) ->
                   let g' =
-                    let uu___1036_7639 = g  in
+                    let uu___1036_7648 = g  in
                     {
                       FStar_Tactics_Types.goal_main_env =
-                        (uu___1036_7639.FStar_Tactics_Types.goal_main_env);
+                        (uu___1036_7648.FStar_Tactics_Types.goal_main_env);
                       FStar_Tactics_Types.goal_ctx_uvar = u_uvar;
                       FStar_Tactics_Types.opts =
-                        (uu___1036_7639.FStar_Tactics_Types.opts);
+                        (uu___1036_7648.FStar_Tactics_Types.opts);
                       FStar_Tactics_Types.is_guard =
-                        (uu___1036_7639.FStar_Tactics_Types.is_guard);
+                        (uu___1036_7648.FStar_Tactics_Types.is_guard);
                       FStar_Tactics_Types.label =
-                        (uu___1036_7639.FStar_Tactics_Types.label)
+                        (uu___1036_7648.FStar_Tactics_Types.label)
                     }  in
                   FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                    (fun uu____7643  ->
+                    (fun uu____7652  ->
                        let t_eq =
-                         let uu____7645 =
-                           let uu____7646 = FStar_Tactics_Types.goal_type g
+                         let uu____7654 =
+                           let uu____7655 = FStar_Tactics_Types.goal_type g
                               in
                            env1.FStar_TypeChecker_Env.universe_of env1
-                             uu____7646
+                             uu____7655
                             in
-                         let uu____7647 = FStar_Tactics_Types.goal_type g  in
-                         let uu____7648 = FStar_Tactics_Types.goal_witness g
+                         let uu____7656 = FStar_Tactics_Types.goal_type g  in
+                         let uu____7657 = FStar_Tactics_Types.goal_witness g
                             in
-                         FStar_Syntax_Util.mk_eq2 uu____7645 uu____7647 u
-                           uu____7648
+                         FStar_Syntax_Util.mk_eq2 uu____7654 uu____7656 u
+                           uu____7657
                           in
-                       let uu____7649 =
+                       let uu____7658 =
                          FStar_Tactics_Monad.add_irrelevant_goal g
                            "dup equation" env1 t_eq
                           in
-                       FStar_Tactics_Monad.bind uu____7649
-                         (fun uu____7655  ->
-                            let uu____7656 =
+                       FStar_Tactics_Monad.bind uu____7658
+                         (fun uu____7664  ->
+                            let uu____7665 =
                               FStar_Tactics_Monad.add_goals [g']  in
-                            FStar_Tactics_Monad.bind uu____7656
-                              (fun uu____7660  -> FStar_Tactics_Monad.ret ())))))
+                            FStar_Tactics_Monad.bind uu____7665
+                              (fun uu____7669  -> FStar_Tactics_Monad.ret ())))))
   
 let longest_prefix :
   'a .
@@ -3675,11 +3679,11 @@ let longest_prefix :
         let rec aux acc l11 l21 =
           match (l11, l21) with
           | (x::xs,y::ys) ->
-              let uu____7786 = f x y  in
-              if uu____7786 then aux (x :: acc) xs ys else (acc, xs, ys)
-          | uu____7809 -> (acc, l11, l21)  in
-        let uu____7824 = aux [] l1 l2  in
-        match uu____7824 with | (pr,t1,t2) -> ((FStar_List.rev pr), t1, t2)
+              let uu____7795 = f x y  in
+              if uu____7795 then aux (x :: acc) xs ys else (acc, xs, ys)
+          | uu____7818 -> (acc, l11, l21)  in
+        let uu____7833 = aux [] l1 l2  in
+        match uu____7833 with | (pr,t1,t2) -> ((FStar_List.rev pr), t1, t2)
   
 let (join_goals :
   FStar_Tactics_Types.goal ->
@@ -3695,13 +3699,13 @@ let (join_goals :
                FStar_Syntax_Util.mk_forall_no_univ
                  (FStar_Pervasives_Native.fst b) f1) bs f
          in
-      let uu____7930 = FStar_Tactics_Types.get_phi g1  in
-      match uu____7930 with
+      let uu____7939 = FStar_Tactics_Types.get_phi g1  in
+      match uu____7939 with
       | FStar_Pervasives_Native.None  ->
           FStar_Tactics_Monad.fail "goal 1 is not irrelevant"
       | FStar_Pervasives_Native.Some phi1 ->
-          let uu____7937 = FStar_Tactics_Types.get_phi g2  in
-          (match uu____7937 with
+          let uu____7946 = FStar_Tactics_Types.get_phi g2  in
+          (match uu____7946 with
            | FStar_Pervasives_Native.None  ->
                FStar_Tactics_Monad.fail "goal 2 is not irrelevant"
            | FStar_Pervasives_Native.Some phi2 ->
@@ -3711,233 +3715,233 @@ let (join_goals :
                let gamma2 =
                  (g2.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma
                   in
-               let uu____7950 =
+               let uu____7959 =
                  longest_prefix FStar_Syntax_Syntax.eq_binding
                    (FStar_List.rev gamma1) (FStar_List.rev gamma2)
                   in
-               (match uu____7950 with
+               (match uu____7959 with
                 | (gamma,r1,r2) ->
                     let t1 =
-                      let uu____7981 =
+                      let uu____7990 =
                         FStar_TypeChecker_Env.binders_of_bindings
                           (FStar_List.rev r1)
                          in
-                      close_forall_no_univs uu____7981 phi1  in
+                      close_forall_no_univs uu____7990 phi1  in
                     let t2 =
-                      let uu____7991 =
+                      let uu____8000 =
                         FStar_TypeChecker_Env.binders_of_bindings
                           (FStar_List.rev r2)
                          in
-                      close_forall_no_univs uu____7991 phi2  in
-                    let uu____8000 =
+                      close_forall_no_univs uu____8000 phi2  in
+                    let uu____8009 =
                       set_solution g1 FStar_Syntax_Util.exp_unit  in
-                    FStar_Tactics_Monad.bind uu____8000
-                      (fun uu____8005  ->
-                         let uu____8006 =
+                    FStar_Tactics_Monad.bind uu____8009
+                      (fun uu____8014  ->
+                         let uu____8015 =
                            set_solution g2 FStar_Syntax_Util.exp_unit  in
-                         FStar_Tactics_Monad.bind uu____8006
-                           (fun uu____8013  ->
+                         FStar_Tactics_Monad.bind uu____8015
+                           (fun uu____8022  ->
                               let ng = FStar_Syntax_Util.mk_conj t1 t2  in
                               let nenv =
-                                let uu___1088_8018 =
+                                let uu___1088_8027 =
                                   FStar_Tactics_Types.goal_env g1  in
-                                let uu____8019 =
+                                let uu____8028 =
                                   FStar_Util.smap_create (Prims.of_int (100))
                                    in
                                 {
                                   FStar_TypeChecker_Env.solver =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.solver);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.solver);
                                   FStar_TypeChecker_Env.range =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.range);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.range);
                                   FStar_TypeChecker_Env.curmodule =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.curmodule);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.curmodule);
                                   FStar_TypeChecker_Env.gamma =
                                     (FStar_List.rev gamma);
                                   FStar_TypeChecker_Env.gamma_sig =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.gamma_sig);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.gamma_sig);
                                   FStar_TypeChecker_Env.gamma_cache =
-                                    uu____8019;
+                                    uu____8028;
                                   FStar_TypeChecker_Env.modules =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.modules);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.modules);
                                   FStar_TypeChecker_Env.expected_typ =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.expected_typ);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.expected_typ);
                                   FStar_TypeChecker_Env.sigtab =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.sigtab);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.sigtab);
                                   FStar_TypeChecker_Env.attrtab =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.attrtab);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.attrtab);
                                   FStar_TypeChecker_Env.instantiate_imp =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.instantiate_imp);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.instantiate_imp);
                                   FStar_TypeChecker_Env.effects =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.effects);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.effects);
                                   FStar_TypeChecker_Env.generalize =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.generalize);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.generalize);
                                   FStar_TypeChecker_Env.letrecs =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.letrecs);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.letrecs);
                                   FStar_TypeChecker_Env.top_level =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.top_level);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.top_level);
                                   FStar_TypeChecker_Env.check_uvars =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.check_uvars);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.check_uvars);
                                   FStar_TypeChecker_Env.use_eq =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.use_eq);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.use_eq);
                                   FStar_TypeChecker_Env.use_eq_strict =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.use_eq_strict);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.use_eq_strict);
                                   FStar_TypeChecker_Env.is_iface =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.is_iface);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.is_iface);
                                   FStar_TypeChecker_Env.admit =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.admit);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.admit);
                                   FStar_TypeChecker_Env.lax =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.lax);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.lax);
                                   FStar_TypeChecker_Env.lax_universes =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.lax_universes);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.lax_universes);
                                   FStar_TypeChecker_Env.phase1 =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.phase1);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.phase1);
                                   FStar_TypeChecker_Env.failhard =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.failhard);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.failhard);
                                   FStar_TypeChecker_Env.nosynth =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.nosynth);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.nosynth);
                                   FStar_TypeChecker_Env.uvar_subtyping =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.uvar_subtyping);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.tc_term =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.tc_term);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.type_of =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.type_of);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.type_of);
                                   FStar_TypeChecker_Env.universe_of =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.universe_of);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.universe_of);
                                   FStar_TypeChecker_Env.check_type_of =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.check_type_of);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.check_type_of);
                                   FStar_TypeChecker_Env.use_bv_sorts =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.use_bv_sorts);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.use_bv_sorts);
                                   FStar_TypeChecker_Env.qtbl_name_and_index =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.qtbl_name_and_index);
                                   FStar_TypeChecker_Env.normalized_eff_names
                                     =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.normalized_eff_names);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.normalized_eff_names);
                                   FStar_TypeChecker_Env.fv_delta_depths =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.fv_delta_depths);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.fv_delta_depths);
                                   FStar_TypeChecker_Env.proof_ns =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.proof_ns);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.proof_ns);
                                   FStar_TypeChecker_Env.synth_hook =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.synth_hook);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.synth_hook);
                                   FStar_TypeChecker_Env.try_solve_implicits_hook
                                     =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                   FStar_TypeChecker_Env.splice =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.splice);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.splice);
                                   FStar_TypeChecker_Env.mpreprocess =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.mpreprocess);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.mpreprocess);
                                   FStar_TypeChecker_Env.postprocess =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.postprocess);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.postprocess);
                                   FStar_TypeChecker_Env.is_native_tactic =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.is_native_tactic);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.is_native_tactic);
                                   FStar_TypeChecker_Env.identifier_info =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.identifier_info);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.identifier_info);
                                   FStar_TypeChecker_Env.tc_hooks =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.tc_hooks);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.tc_hooks);
                                   FStar_TypeChecker_Env.dsenv =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.dsenv);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.dsenv);
                                   FStar_TypeChecker_Env.nbe =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.nbe);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.nbe);
                                   FStar_TypeChecker_Env.strict_args_tab =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.strict_args_tab);
+                                    (uu___1088_8027.FStar_TypeChecker_Env.strict_args_tab);
                                   FStar_TypeChecker_Env.erasable_types_tab =
-                                    (uu___1088_8018.FStar_TypeChecker_Env.erasable_types_tab)
+                                    (uu___1088_8027.FStar_TypeChecker_Env.erasable_types_tab)
                                 }  in
-                              let uu____8023 =
+                              let uu____8032 =
                                 FStar_Tactics_Monad.mk_irrelevant_goal
                                   "joined" nenv ng
                                   g1.FStar_Tactics_Types.opts
                                   g1.FStar_Tactics_Types.label
                                  in
-                              FStar_Tactics_Monad.bind uu____8023
+                              FStar_Tactics_Monad.bind uu____8032
                                 (fun goal  ->
                                    FStar_Tactics_Monad.mlog
-                                     (fun uu____8033  ->
-                                        let uu____8034 =
+                                     (fun uu____8042  ->
+                                        let uu____8043 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             g1
                                            in
-                                        let uu____8036 =
+                                        let uu____8045 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             g2
                                            in
-                                        let uu____8038 =
+                                        let uu____8047 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             goal
                                            in
                                         FStar_Util.print3
                                           "join_goals of\n(%s)\nand\n(%s)\n= (%s)\n"
-                                          uu____8034 uu____8036 uu____8038)
-                                     (fun uu____8042  ->
+                                          uu____8043 uu____8045 uu____8047)
+                                     (fun uu____8051  ->
                                         FStar_Tactics_Monad.ret goal))))))
   
 let (join : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____8050  ->
+  fun uu____8059  ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps  ->
          match ps.FStar_Tactics_Types.goals with
          | g1::g2::gs ->
-             let uu____8066 =
+             let uu____8075 =
                FStar_Tactics_Monad.set
-                 (let uu___1103_8071 = ps  in
+                 (let uu___1103_8080 = ps  in
                   {
                     FStar_Tactics_Types.main_context =
-                      (uu___1103_8071.FStar_Tactics_Types.main_context);
+                      (uu___1103_8080.FStar_Tactics_Types.main_context);
                     FStar_Tactics_Types.all_implicits =
-                      (uu___1103_8071.FStar_Tactics_Types.all_implicits);
+                      (uu___1103_8080.FStar_Tactics_Types.all_implicits);
                     FStar_Tactics_Types.goals = gs;
                     FStar_Tactics_Types.smt_goals =
-                      (uu___1103_8071.FStar_Tactics_Types.smt_goals);
+                      (uu___1103_8080.FStar_Tactics_Types.smt_goals);
                     FStar_Tactics_Types.depth =
-                      (uu___1103_8071.FStar_Tactics_Types.depth);
+                      (uu___1103_8080.FStar_Tactics_Types.depth);
                     FStar_Tactics_Types.__dump =
-                      (uu___1103_8071.FStar_Tactics_Types.__dump);
+                      (uu___1103_8080.FStar_Tactics_Types.__dump);
                     FStar_Tactics_Types.psc =
-                      (uu___1103_8071.FStar_Tactics_Types.psc);
+                      (uu___1103_8080.FStar_Tactics_Types.psc);
                     FStar_Tactics_Types.entry_range =
-                      (uu___1103_8071.FStar_Tactics_Types.entry_range);
+                      (uu___1103_8080.FStar_Tactics_Types.entry_range);
                     FStar_Tactics_Types.guard_policy =
-                      (uu___1103_8071.FStar_Tactics_Types.guard_policy);
+                      (uu___1103_8080.FStar_Tactics_Types.guard_policy);
                     FStar_Tactics_Types.freshness =
-                      (uu___1103_8071.FStar_Tactics_Types.freshness);
+                      (uu___1103_8080.FStar_Tactics_Types.freshness);
                     FStar_Tactics_Types.tac_verb_dbg =
-                      (uu___1103_8071.FStar_Tactics_Types.tac_verb_dbg);
+                      (uu___1103_8080.FStar_Tactics_Types.tac_verb_dbg);
                     FStar_Tactics_Types.local_state =
-                      (uu___1103_8071.FStar_Tactics_Types.local_state)
+                      (uu___1103_8080.FStar_Tactics_Types.local_state)
                   })
                 in
-             FStar_Tactics_Monad.bind uu____8066
-               (fun uu____8074  ->
-                  let uu____8075 = join_goals g1 g2  in
-                  FStar_Tactics_Monad.bind uu____8075
+             FStar_Tactics_Monad.bind uu____8075
+               (fun uu____8083  ->
+                  let uu____8084 = join_goals g1 g2  in
+                  FStar_Tactics_Monad.bind uu____8084
                     (fun g12  -> FStar_Tactics_Monad.add_goals [g12]))
-         | uu____8080 -> FStar_Tactics_Monad.fail "join: less than 2 goals")
+         | uu____8089 -> FStar_Tactics_Monad.fail "join: less than 2 goals")
   
 let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun s  ->
-    let uu____8096 =
+    let uu____8105 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g  ->
            FStar_Options.push ();
-           (let uu____8109 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts
+           (let uu____8118 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts
                in
-            FStar_Options.set uu____8109);
+            FStar_Options.set uu____8118);
            (let res = FStar_Options.set_options s  in
             let opts' = FStar_Options.peek ()  in
             FStar_Options.pop ();
             (match res with
              | FStar_Getopt.Success  ->
                  let g' =
-                   let uu___1114_8116 = g  in
+                   let uu___1114_8125 = g  in
                    {
                      FStar_Tactics_Types.goal_main_env =
-                       (uu___1114_8116.FStar_Tactics_Types.goal_main_env);
+                       (uu___1114_8125.FStar_Tactics_Types.goal_main_env);
                      FStar_Tactics_Types.goal_ctx_uvar =
-                       (uu___1114_8116.FStar_Tactics_Types.goal_ctx_uvar);
+                       (uu___1114_8125.FStar_Tactics_Types.goal_ctx_uvar);
                      FStar_Tactics_Types.opts = opts';
                      FStar_Tactics_Types.is_guard =
-                       (uu___1114_8116.FStar_Tactics_Types.is_guard);
+                       (uu___1114_8125.FStar_Tactics_Types.is_guard);
                      FStar_Tactics_Types.label =
-                       (uu___1114_8116.FStar_Tactics_Types.label)
+                       (uu___1114_8125.FStar_Tactics_Types.label)
                    }  in
                  FStar_Tactics_Monad.replace_cur g'
              | FStar_Getopt.Error err ->
@@ -3946,25 +3950,25 @@ let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
                  fail1 "Setting options `%s` failed (got `Help`?)" s)))
        in
     FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "set_options")
-      uu____8096
+      uu____8105
   
 let (top_env : unit -> env FStar_Tactics_Monad.tac) =
-  fun uu____8133  ->
+  fun uu____8142  ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps  ->
          FStar_All.pipe_left FStar_Tactics_Monad.ret
            ps.FStar_Tactics_Types.main_context)
   
 let (lax_on : unit -> Prims.bool FStar_Tactics_Monad.tac) =
-  fun uu____8148  ->
+  fun uu____8157  ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g  ->
-         let uu____8156 =
+         let uu____8165 =
            (FStar_Options.lax ()) ||
-             (let uu____8159 = FStar_Tactics_Types.goal_env g  in
-              uu____8159.FStar_TypeChecker_Env.lax)
+             (let uu____8168 = FStar_Tactics_Types.goal_env g  in
+              uu____8168.FStar_TypeChecker_Env.lax)
             in
-         FStar_Tactics_Monad.ret uu____8156)
+         FStar_Tactics_Monad.ret uu____8165)
   
 let (unquote :
   FStar_Reflection_Data.typ ->
@@ -3973,44 +3977,44 @@ let (unquote :
   =
   fun ty  ->
     fun tm  ->
-      let uu____8176 =
+      let uu____8185 =
         FStar_Tactics_Monad.mlog
-          (fun uu____8181  ->
-             let uu____8182 = FStar_Syntax_Print.term_to_string tm  in
-             FStar_Util.print1 "unquote: tm = %s\n" uu____8182)
-          (fun uu____8186  ->
+          (fun uu____8190  ->
+             let uu____8191 = FStar_Syntax_Print.term_to_string tm  in
+             FStar_Util.print1 "unquote: tm = %s\n" uu____8191)
+          (fun uu____8195  ->
              FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
                (fun goal  ->
                   let env1 =
-                    let uu____8192 = FStar_Tactics_Types.goal_env goal  in
-                    FStar_TypeChecker_Env.set_expected_typ uu____8192 ty  in
-                  let uu____8193 = __tc_ghost env1 tm  in
-                  FStar_Tactics_Monad.bind uu____8193
-                    (fun uu____8212  ->
-                       match uu____8212 with
+                    let uu____8201 = FStar_Tactics_Types.goal_env goal  in
+                    FStar_TypeChecker_Env.set_expected_typ uu____8201 ty  in
+                  let uu____8202 = __tc_ghost env1 tm  in
+                  FStar_Tactics_Monad.bind uu____8202
+                    (fun uu____8221  ->
+                       match uu____8221 with
                        | (tm1,typ,guard) ->
                            FStar_Tactics_Monad.mlog
-                             (fun uu____8226  ->
-                                let uu____8227 =
+                             (fun uu____8235  ->
+                                let uu____8236 =
                                   FStar_Syntax_Print.term_to_string tm1  in
                                 FStar_Util.print1 "unquote: tm' = %s\n"
-                                  uu____8227)
-                             (fun uu____8231  ->
+                                  uu____8236)
+                             (fun uu____8240  ->
                                 FStar_Tactics_Monad.mlog
-                                  (fun uu____8234  ->
-                                     let uu____8235 =
+                                  (fun uu____8243  ->
+                                     let uu____8244 =
                                        FStar_Syntax_Print.term_to_string typ
                                         in
                                      FStar_Util.print1 "unquote: typ = %s\n"
-                                       uu____8235)
-                                  (fun uu____8240  ->
-                                     let uu____8241 =
+                                       uu____8244)
+                                  (fun uu____8249  ->
+                                     let uu____8250 =
                                        proc_guard "unquote" env1 guard  in
-                                     FStar_Tactics_Monad.bind uu____8241
-                                       (fun uu____8246  ->
+                                     FStar_Tactics_Monad.bind uu____8250
+                                       (fun uu____8255  ->
                                           FStar_Tactics_Monad.ret tm1))))))
          in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unquote") uu____8176
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unquote") uu____8185
   
 let (uvar_env :
   env ->
@@ -4019,154 +4023,154 @@ let (uvar_env :
   =
   fun env1  ->
     fun ty  ->
-      let uu____8271 =
+      let uu____8280 =
         match ty with
         | FStar_Pervasives_Native.Some ty1 -> FStar_Tactics_Monad.ret ty1
         | FStar_Pervasives_Native.None  ->
-            let uu____8277 =
-              let uu____8284 =
-                let uu____8285 = FStar_Syntax_Util.type_u ()  in
-                FStar_All.pipe_left FStar_Pervasives_Native.fst uu____8285
+            let uu____8286 =
+              let uu____8293 =
+                let uu____8294 = FStar_Syntax_Util.type_u ()  in
+                FStar_All.pipe_left FStar_Pervasives_Native.fst uu____8294
                  in
-              FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu____8284  in
-            FStar_Tactics_Monad.bind uu____8277
-              (fun uu____8302  ->
-                 match uu____8302 with
+              FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu____8293  in
+            FStar_Tactics_Monad.bind uu____8286
+              (fun uu____8311  ->
+                 match uu____8311 with
                  | (typ,uvar_typ) -> FStar_Tactics_Monad.ret typ)
          in
-      FStar_Tactics_Monad.bind uu____8271
+      FStar_Tactics_Monad.bind uu____8280
         (fun typ  ->
-           let uu____8314 = FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ
+           let uu____8323 = FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ
               in
-           FStar_Tactics_Monad.bind uu____8314
-             (fun uu____8329  ->
-                match uu____8329 with
+           FStar_Tactics_Monad.bind uu____8323
+             (fun uu____8338  ->
+                match uu____8338 with
                 | (t,uvar_t) -> FStar_Tactics_Monad.ret t))
   
 let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun t  ->
-    let uu____8348 =
+    let uu____8357 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps  ->
            let env1 = ps.FStar_Tactics_Types.main_context  in
            let opts =
              match ps.FStar_Tactics_Types.goals with
-             | g::uu____8367 -> g.FStar_Tactics_Types.opts
-             | uu____8370 -> FStar_Options.peek ()  in
-           let uu____8373 = FStar_Syntax_Util.head_and_args t  in
-           match uu____8373 with
+             | g::uu____8376 -> g.FStar_Tactics_Types.opts
+             | uu____8379 -> FStar_Options.peek ()  in
+           let uu____8382 = FStar_Syntax_Util.head_and_args t  in
+           match uu____8382 with
            | ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                  (ctx_uvar,uu____8393);
-                FStar_Syntax_Syntax.pos = uu____8394;
-                FStar_Syntax_Syntax.vars = uu____8395;_},uu____8396)
+                  (ctx_uvar,uu____8402);
+                FStar_Syntax_Syntax.pos = uu____8403;
+                FStar_Syntax_Syntax.vars = uu____8404;_},uu____8405)
                ->
                let env2 =
-                 let uu___1168_8438 = env1  in
+                 let uu___1168_8447 = env1  in
                  {
                    FStar_TypeChecker_Env.solver =
-                     (uu___1168_8438.FStar_TypeChecker_Env.solver);
+                     (uu___1168_8447.FStar_TypeChecker_Env.solver);
                    FStar_TypeChecker_Env.range =
-                     (uu___1168_8438.FStar_TypeChecker_Env.range);
+                     (uu___1168_8447.FStar_TypeChecker_Env.range);
                    FStar_TypeChecker_Env.curmodule =
-                     (uu___1168_8438.FStar_TypeChecker_Env.curmodule);
+                     (uu___1168_8447.FStar_TypeChecker_Env.curmodule);
                    FStar_TypeChecker_Env.gamma =
                      (ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_gamma);
                    FStar_TypeChecker_Env.gamma_sig =
-                     (uu___1168_8438.FStar_TypeChecker_Env.gamma_sig);
+                     (uu___1168_8447.FStar_TypeChecker_Env.gamma_sig);
                    FStar_TypeChecker_Env.gamma_cache =
-                     (uu___1168_8438.FStar_TypeChecker_Env.gamma_cache);
+                     (uu___1168_8447.FStar_TypeChecker_Env.gamma_cache);
                    FStar_TypeChecker_Env.modules =
-                     (uu___1168_8438.FStar_TypeChecker_Env.modules);
+                     (uu___1168_8447.FStar_TypeChecker_Env.modules);
                    FStar_TypeChecker_Env.expected_typ =
-                     (uu___1168_8438.FStar_TypeChecker_Env.expected_typ);
+                     (uu___1168_8447.FStar_TypeChecker_Env.expected_typ);
                    FStar_TypeChecker_Env.sigtab =
-                     (uu___1168_8438.FStar_TypeChecker_Env.sigtab);
+                     (uu___1168_8447.FStar_TypeChecker_Env.sigtab);
                    FStar_TypeChecker_Env.attrtab =
-                     (uu___1168_8438.FStar_TypeChecker_Env.attrtab);
+                     (uu___1168_8447.FStar_TypeChecker_Env.attrtab);
                    FStar_TypeChecker_Env.instantiate_imp =
-                     (uu___1168_8438.FStar_TypeChecker_Env.instantiate_imp);
+                     (uu___1168_8447.FStar_TypeChecker_Env.instantiate_imp);
                    FStar_TypeChecker_Env.effects =
-                     (uu___1168_8438.FStar_TypeChecker_Env.effects);
+                     (uu___1168_8447.FStar_TypeChecker_Env.effects);
                    FStar_TypeChecker_Env.generalize =
-                     (uu___1168_8438.FStar_TypeChecker_Env.generalize);
+                     (uu___1168_8447.FStar_TypeChecker_Env.generalize);
                    FStar_TypeChecker_Env.letrecs =
-                     (uu___1168_8438.FStar_TypeChecker_Env.letrecs);
+                     (uu___1168_8447.FStar_TypeChecker_Env.letrecs);
                    FStar_TypeChecker_Env.top_level =
-                     (uu___1168_8438.FStar_TypeChecker_Env.top_level);
+                     (uu___1168_8447.FStar_TypeChecker_Env.top_level);
                    FStar_TypeChecker_Env.check_uvars =
-                     (uu___1168_8438.FStar_TypeChecker_Env.check_uvars);
+                     (uu___1168_8447.FStar_TypeChecker_Env.check_uvars);
                    FStar_TypeChecker_Env.use_eq =
-                     (uu___1168_8438.FStar_TypeChecker_Env.use_eq);
+                     (uu___1168_8447.FStar_TypeChecker_Env.use_eq);
                    FStar_TypeChecker_Env.use_eq_strict =
-                     (uu___1168_8438.FStar_TypeChecker_Env.use_eq_strict);
+                     (uu___1168_8447.FStar_TypeChecker_Env.use_eq_strict);
                    FStar_TypeChecker_Env.is_iface =
-                     (uu___1168_8438.FStar_TypeChecker_Env.is_iface);
+                     (uu___1168_8447.FStar_TypeChecker_Env.is_iface);
                    FStar_TypeChecker_Env.admit =
-                     (uu___1168_8438.FStar_TypeChecker_Env.admit);
+                     (uu___1168_8447.FStar_TypeChecker_Env.admit);
                    FStar_TypeChecker_Env.lax =
-                     (uu___1168_8438.FStar_TypeChecker_Env.lax);
+                     (uu___1168_8447.FStar_TypeChecker_Env.lax);
                    FStar_TypeChecker_Env.lax_universes =
-                     (uu___1168_8438.FStar_TypeChecker_Env.lax_universes);
+                     (uu___1168_8447.FStar_TypeChecker_Env.lax_universes);
                    FStar_TypeChecker_Env.phase1 =
-                     (uu___1168_8438.FStar_TypeChecker_Env.phase1);
+                     (uu___1168_8447.FStar_TypeChecker_Env.phase1);
                    FStar_TypeChecker_Env.failhard =
-                     (uu___1168_8438.FStar_TypeChecker_Env.failhard);
+                     (uu___1168_8447.FStar_TypeChecker_Env.failhard);
                    FStar_TypeChecker_Env.nosynth =
-                     (uu___1168_8438.FStar_TypeChecker_Env.nosynth);
+                     (uu___1168_8447.FStar_TypeChecker_Env.nosynth);
                    FStar_TypeChecker_Env.uvar_subtyping =
-                     (uu___1168_8438.FStar_TypeChecker_Env.uvar_subtyping);
+                     (uu___1168_8447.FStar_TypeChecker_Env.uvar_subtyping);
                    FStar_TypeChecker_Env.tc_term =
-                     (uu___1168_8438.FStar_TypeChecker_Env.tc_term);
+                     (uu___1168_8447.FStar_TypeChecker_Env.tc_term);
                    FStar_TypeChecker_Env.type_of =
-                     (uu___1168_8438.FStar_TypeChecker_Env.type_of);
+                     (uu___1168_8447.FStar_TypeChecker_Env.type_of);
                    FStar_TypeChecker_Env.universe_of =
-                     (uu___1168_8438.FStar_TypeChecker_Env.universe_of);
+                     (uu___1168_8447.FStar_TypeChecker_Env.universe_of);
                    FStar_TypeChecker_Env.check_type_of =
-                     (uu___1168_8438.FStar_TypeChecker_Env.check_type_of);
+                     (uu___1168_8447.FStar_TypeChecker_Env.check_type_of);
                    FStar_TypeChecker_Env.use_bv_sorts =
-                     (uu___1168_8438.FStar_TypeChecker_Env.use_bv_sorts);
+                     (uu___1168_8447.FStar_TypeChecker_Env.use_bv_sorts);
                    FStar_TypeChecker_Env.qtbl_name_and_index =
-                     (uu___1168_8438.FStar_TypeChecker_Env.qtbl_name_and_index);
+                     (uu___1168_8447.FStar_TypeChecker_Env.qtbl_name_and_index);
                    FStar_TypeChecker_Env.normalized_eff_names =
-                     (uu___1168_8438.FStar_TypeChecker_Env.normalized_eff_names);
+                     (uu___1168_8447.FStar_TypeChecker_Env.normalized_eff_names);
                    FStar_TypeChecker_Env.fv_delta_depths =
-                     (uu___1168_8438.FStar_TypeChecker_Env.fv_delta_depths);
+                     (uu___1168_8447.FStar_TypeChecker_Env.fv_delta_depths);
                    FStar_TypeChecker_Env.proof_ns =
-                     (uu___1168_8438.FStar_TypeChecker_Env.proof_ns);
+                     (uu___1168_8447.FStar_TypeChecker_Env.proof_ns);
                    FStar_TypeChecker_Env.synth_hook =
-                     (uu___1168_8438.FStar_TypeChecker_Env.synth_hook);
+                     (uu___1168_8447.FStar_TypeChecker_Env.synth_hook);
                    FStar_TypeChecker_Env.try_solve_implicits_hook =
-                     (uu___1168_8438.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                     (uu___1168_8447.FStar_TypeChecker_Env.try_solve_implicits_hook);
                    FStar_TypeChecker_Env.splice =
-                     (uu___1168_8438.FStar_TypeChecker_Env.splice);
+                     (uu___1168_8447.FStar_TypeChecker_Env.splice);
                    FStar_TypeChecker_Env.mpreprocess =
-                     (uu___1168_8438.FStar_TypeChecker_Env.mpreprocess);
+                     (uu___1168_8447.FStar_TypeChecker_Env.mpreprocess);
                    FStar_TypeChecker_Env.postprocess =
-                     (uu___1168_8438.FStar_TypeChecker_Env.postprocess);
+                     (uu___1168_8447.FStar_TypeChecker_Env.postprocess);
                    FStar_TypeChecker_Env.is_native_tactic =
-                     (uu___1168_8438.FStar_TypeChecker_Env.is_native_tactic);
+                     (uu___1168_8447.FStar_TypeChecker_Env.is_native_tactic);
                    FStar_TypeChecker_Env.identifier_info =
-                     (uu___1168_8438.FStar_TypeChecker_Env.identifier_info);
+                     (uu___1168_8447.FStar_TypeChecker_Env.identifier_info);
                    FStar_TypeChecker_Env.tc_hooks =
-                     (uu___1168_8438.FStar_TypeChecker_Env.tc_hooks);
+                     (uu___1168_8447.FStar_TypeChecker_Env.tc_hooks);
                    FStar_TypeChecker_Env.dsenv =
-                     (uu___1168_8438.FStar_TypeChecker_Env.dsenv);
+                     (uu___1168_8447.FStar_TypeChecker_Env.dsenv);
                    FStar_TypeChecker_Env.nbe =
-                     (uu___1168_8438.FStar_TypeChecker_Env.nbe);
+                     (uu___1168_8447.FStar_TypeChecker_Env.nbe);
                    FStar_TypeChecker_Env.strict_args_tab =
-                     (uu___1168_8438.FStar_TypeChecker_Env.strict_args_tab);
+                     (uu___1168_8447.FStar_TypeChecker_Env.strict_args_tab);
                    FStar_TypeChecker_Env.erasable_types_tab =
-                     (uu___1168_8438.FStar_TypeChecker_Env.erasable_types_tab)
+                     (uu___1168_8447.FStar_TypeChecker_Env.erasable_types_tab)
                  }  in
                let g =
                  FStar_Tactics_Types.mk_goal env2 ctx_uvar opts false ""  in
-               let uu____8442 =
-                 let uu____8445 = bnorm_goal g  in [uu____8445]  in
-               FStar_Tactics_Monad.add_goals uu____8442
-           | uu____8446 -> FStar_Tactics_Monad.fail "not a uvar")
+               let uu____8451 =
+                 let uu____8454 = bnorm_goal g  in [uu____8454]  in
+               FStar_Tactics_Monad.add_goals uu____8451
+           | uu____8455 -> FStar_Tactics_Monad.fail "not a uvar")
        in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unshelve") uu____8348
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unshelve") uu____8357
   
 let (tac_and :
   Prims.bool FStar_Tactics_Monad.tac ->
@@ -4177,18 +4181,18 @@ let (tac_and :
       let comp =
         FStar_Tactics_Monad.bind t1
           (fun b  ->
-             let uu____8508 = if b then t2 else FStar_Tactics_Monad.ret false
+             let uu____8517 = if b then t2 else FStar_Tactics_Monad.ret false
                 in
-             FStar_Tactics_Monad.bind uu____8508
+             FStar_Tactics_Monad.bind uu____8517
                (fun b'  ->
                   if b'
                   then FStar_Tactics_Monad.ret b'
                   else FStar_Tactics_Monad.fail ""))
          in
-      let uu____8534 = trytac comp  in
-      FStar_Tactics_Monad.bind uu____8534
-        (fun uu___5_8546  ->
-           match uu___5_8546 with
+      let uu____8543 = trytac comp  in
+      FStar_Tactics_Monad.bind uu____8543
+        (fun uu___5_8555  ->
+           match uu___5_8555 with
            | FStar_Pervasives_Native.Some (true ) ->
                FStar_Tactics_Monad.ret true
            | FStar_Pervasives_Native.Some (false ) -> failwith "impossible"
@@ -4202,35 +4206,35 @@ let (unify_env :
   fun e  ->
     fun t1  ->
       fun t2  ->
-        let uu____8588 =
+        let uu____8597 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps  ->
-               let uu____8596 = __tc e t1  in
-               FStar_Tactics_Monad.bind uu____8596
-                 (fun uu____8617  ->
-                    match uu____8617 with
+               let uu____8605 = __tc e t1  in
+               FStar_Tactics_Monad.bind uu____8605
+                 (fun uu____8626  ->
+                    match uu____8626 with
                     | (t11,ty1,g1) ->
-                        let uu____8630 = __tc e t2  in
-                        FStar_Tactics_Monad.bind uu____8630
-                          (fun uu____8651  ->
-                             match uu____8651 with
+                        let uu____8639 = __tc e t2  in
+                        FStar_Tactics_Monad.bind uu____8639
+                          (fun uu____8660  ->
+                             match uu____8660 with
                              | (t21,ty2,g2) ->
-                                 let uu____8664 =
+                                 let uu____8673 =
                                    proc_guard "unify_env g1" e g1  in
-                                 FStar_Tactics_Monad.bind uu____8664
-                                   (fun uu____8671  ->
-                                      let uu____8672 =
+                                 FStar_Tactics_Monad.bind uu____8673
+                                   (fun uu____8680  ->
+                                      let uu____8681 =
                                         proc_guard "unify_env g2" e g2  in
-                                      FStar_Tactics_Monad.bind uu____8672
-                                        (fun uu____8680  ->
-                                           let uu____8681 =
+                                      FStar_Tactics_Monad.bind uu____8681
+                                        (fun uu____8689  ->
+                                           let uu____8690 =
                                              do_unify e ty1 ty2  in
-                                           let uu____8685 =
+                                           let uu____8694 =
                                              do_unify e t11 t21  in
-                                           tac_and uu____8681 uu____8685)))))
+                                           tac_and uu____8690 uu____8694)))))
            in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unify_env")
-          uu____8588
+          uu____8597
   
 let (launch_process :
   Prims.string ->
@@ -4241,9 +4245,9 @@ let (launch_process :
     fun args  ->
       fun input  ->
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.idtac
-          (fun uu____8733  ->
-             let uu____8734 = FStar_Options.unsafe_tactic_exec ()  in
-             if uu____8734
+          (fun uu____8742  ->
+             let uu____8743 = FStar_Options.unsafe_tactic_exec ()  in
+             if uu____8743
              then
                let s =
                  FStar_Util.run_process "tactic_launch" prog args
@@ -4262,50 +4266,50 @@ let (fresh_bv_named :
   fun nm  ->
     fun t  ->
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.idtac
-        (fun uu____8768  ->
-           let uu____8769 =
+        (fun uu____8777  ->
+           let uu____8778 =
              FStar_Syntax_Syntax.gen_bv nm FStar_Pervasives_Native.None t  in
-           FStar_Tactics_Monad.ret uu____8769)
+           FStar_Tactics_Monad.ret uu____8778)
   
 let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
   fun ty  ->
-    let uu____8780 =
+    let uu____8789 =
       FStar_Tactics_Monad.mlog
-        (fun uu____8785  ->
-           let uu____8786 = FStar_Syntax_Print.term_to_string ty  in
-           FStar_Util.print1 "change: ty = %s\n" uu____8786)
-        (fun uu____8790  ->
+        (fun uu____8794  ->
+           let uu____8795 = FStar_Syntax_Print.term_to_string ty  in
+           FStar_Util.print1 "change: ty = %s\n" uu____8795)
+        (fun uu____8799  ->
            FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
              (fun g  ->
-                let uu____8794 =
-                  let uu____8803 = FStar_Tactics_Types.goal_env g  in
-                  __tc uu____8803 ty  in
-                FStar_Tactics_Monad.bind uu____8794
-                  (fun uu____8815  ->
-                     match uu____8815 with
-                     | (ty1,uu____8825,guard) ->
-                         let uu____8827 =
-                           let uu____8830 = FStar_Tactics_Types.goal_env g
+                let uu____8803 =
+                  let uu____8812 = FStar_Tactics_Types.goal_env g  in
+                  __tc uu____8812 ty  in
+                FStar_Tactics_Monad.bind uu____8803
+                  (fun uu____8824  ->
+                     match uu____8824 with
+                     | (ty1,uu____8834,guard) ->
+                         let uu____8836 =
+                           let uu____8839 = FStar_Tactics_Types.goal_env g
                               in
-                           proc_guard "change" uu____8830 guard  in
-                         FStar_Tactics_Monad.bind uu____8827
-                           (fun uu____8834  ->
-                              let uu____8835 =
-                                let uu____8839 =
+                           proc_guard "change" uu____8839 guard  in
+                         FStar_Tactics_Monad.bind uu____8836
+                           (fun uu____8843  ->
+                              let uu____8844 =
+                                let uu____8848 =
                                   FStar_Tactics_Types.goal_env g  in
-                                let uu____8840 =
+                                let uu____8849 =
                                   FStar_Tactics_Types.goal_type g  in
-                                do_unify uu____8839 uu____8840 ty1  in
-                              FStar_Tactics_Monad.bind uu____8835
+                                do_unify uu____8848 uu____8849 ty1  in
+                              FStar_Tactics_Monad.bind uu____8844
                                 (fun bb  ->
                                    if bb
                                    then
-                                     let uu____8849 =
+                                     let uu____8858 =
                                        FStar_Tactics_Types.goal_with_type g
                                          ty1
                                         in
                                      FStar_Tactics_Monad.replace_cur
-                                       uu____8849
+                                       uu____8858
                                    else
                                      (let steps =
                                         [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -4313,35 +4317,35 @@ let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
                                           FStar_Syntax_Syntax.delta_constant;
                                         FStar_TypeChecker_Env.Primops]  in
                                       let ng =
-                                        let uu____8856 =
+                                        let uu____8865 =
                                           FStar_Tactics_Types.goal_env g  in
-                                        let uu____8857 =
+                                        let uu____8866 =
                                           FStar_Tactics_Types.goal_type g  in
-                                        normalize steps uu____8856 uu____8857
+                                        normalize steps uu____8865 uu____8866
                                          in
                                       let nty =
-                                        let uu____8859 =
+                                        let uu____8868 =
                                           FStar_Tactics_Types.goal_env g  in
-                                        normalize steps uu____8859 ty1  in
-                                      let uu____8860 =
-                                        let uu____8864 =
+                                        normalize steps uu____8868 ty1  in
+                                      let uu____8869 =
+                                        let uu____8873 =
                                           FStar_Tactics_Types.goal_env g  in
-                                        do_unify uu____8864 ng nty  in
-                                      FStar_Tactics_Monad.bind uu____8860
+                                        do_unify uu____8873 ng nty  in
+                                      FStar_Tactics_Monad.bind uu____8869
                                         (fun b  ->
                                            if b
                                            then
-                                             let uu____8873 =
+                                             let uu____8882 =
                                                FStar_Tactics_Types.goal_with_type
                                                  g ty1
                                                 in
                                              FStar_Tactics_Monad.replace_cur
-                                               uu____8873
+                                               uu____8882
                                            else
                                              FStar_Tactics_Monad.fail
                                                "not convertible")))))))
        in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "change") uu____8780
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "change") uu____8789
   
 let failwhen :
   'a .
@@ -4358,68 +4362,68 @@ let (t_destruct :
       FStar_Tactics_Monad.tac)
   =
   fun s_tm  ->
-    let uu____8947 =
+    let uu____8956 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g  ->
-           let uu____8965 =
-             let uu____8974 = FStar_Tactics_Types.goal_env g  in
-             __tc uu____8974 s_tm  in
-           FStar_Tactics_Monad.bind uu____8965
-             (fun uu____8992  ->
-                match uu____8992 with
+           let uu____8974 =
+             let uu____8983 = FStar_Tactics_Types.goal_env g  in
+             __tc uu____8983 s_tm  in
+           FStar_Tactics_Monad.bind uu____8974
+             (fun uu____9001  ->
+                match uu____9001 with
                 | (s_tm1,s_ty,guard) ->
-                    let uu____9010 =
-                      let uu____9013 = FStar_Tactics_Types.goal_env g  in
-                      proc_guard "destruct" uu____9013 guard  in
-                    FStar_Tactics_Monad.bind uu____9010
-                      (fun uu____9027  ->
+                    let uu____9019 =
+                      let uu____9022 = FStar_Tactics_Types.goal_env g  in
+                      proc_guard "destruct" uu____9022 guard  in
+                    FStar_Tactics_Monad.bind uu____9019
+                      (fun uu____9036  ->
                          let s_ty1 =
-                           let uu____9029 = FStar_Tactics_Types.goal_env g
+                           let uu____9038 = FStar_Tactics_Types.goal_env g
                               in
                            FStar_TypeChecker_Normalize.normalize
                              [FStar_TypeChecker_Env.UnfoldTac;
                              FStar_TypeChecker_Env.Weak;
                              FStar_TypeChecker_Env.HNF;
                              FStar_TypeChecker_Env.UnfoldUntil
-                               FStar_Syntax_Syntax.delta_constant] uu____9029
+                               FStar_Syntax_Syntax.delta_constant] uu____9038
                              s_ty
                             in
-                         let uu____9030 =
+                         let uu____9039 =
                            FStar_Syntax_Util.head_and_args' s_ty1  in
-                         match uu____9030 with
+                         match uu____9039 with
                          | (h,args) ->
-                             let uu____9075 =
-                               let uu____9082 =
-                                 let uu____9083 =
+                             let uu____9084 =
+                               let uu____9091 =
+                                 let uu____9092 =
                                    FStar_Syntax_Subst.compress h  in
-                                 uu____9083.FStar_Syntax_Syntax.n  in
-                               match uu____9082 with
+                                 uu____9092.FStar_Syntax_Syntax.n  in
+                               match uu____9091 with
                                | FStar_Syntax_Syntax.Tm_fvar fv ->
                                    FStar_Tactics_Monad.ret (fv, [])
                                | FStar_Syntax_Syntax.Tm_uinst
                                    ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_fvar fv;
-                                      FStar_Syntax_Syntax.pos = uu____9098;
-                                      FStar_Syntax_Syntax.vars = uu____9099;_},us)
+                                      FStar_Syntax_Syntax.pos = uu____9107;
+                                      FStar_Syntax_Syntax.vars = uu____9108;_},us)
                                    -> FStar_Tactics_Monad.ret (fv, us)
-                               | uu____9109 ->
+                               | uu____9118 ->
                                    FStar_Tactics_Monad.fail
                                      "type is not an fv"
                                 in
-                             FStar_Tactics_Monad.bind uu____9075
-                               (fun uu____9130  ->
-                                  match uu____9130 with
+                             FStar_Tactics_Monad.bind uu____9084
+                               (fun uu____9139  ->
+                                  match uu____9139 with
                                   | (fv,a_us) ->
                                       let t_lid =
                                         FStar_Syntax_Syntax.lid_of_fv fv  in
-                                      let uu____9146 =
-                                        let uu____9149 =
+                                      let uu____9155 =
+                                        let uu____9158 =
                                           FStar_Tactics_Types.goal_env g  in
                                         FStar_TypeChecker_Env.lookup_sigelt
-                                          uu____9149 t_lid
+                                          uu____9158 t_lid
                                          in
-                                      (match uu____9146 with
+                                      (match uu____9155 with
                                        | FStar_Pervasives_Native.None  ->
                                            FStar_Tactics_Monad.fail
                                              "type not found in environment"
@@ -4434,18 +4438,18 @@ let (t_destruct :
                                                     se.FStar_Syntax_Syntax.sigattrs
                                                     FStar_Parser_Const.erasable_attr
                                                    in
-                                                let uu____9190 =
+                                                let uu____9199 =
                                                   erasable &&
-                                                    (let uu____9193 =
+                                                    (let uu____9202 =
                                                        FStar_Tactics_Types.is_irrelevant
                                                          g
                                                         in
                                                      Prims.op_Negation
-                                                       uu____9193)
+                                                       uu____9202)
                                                    in
-                                                failwhen uu____9190
+                                                failwhen uu____9199
                                                   "cannot destruct erasable type to solve proof-relevant goal"
-                                                  (fun uu____9203  ->
+                                                  (fun uu____9212  ->
                                                      failwhen
                                                        ((FStar_List.length
                                                            a_us)
@@ -4453,29 +4457,29 @@ let (t_destruct :
                                                           (FStar_List.length
                                                              t_us))
                                                        "t_us don't match?"
-                                                       (fun uu____9216  ->
-                                                          let uu____9217 =
+                                                       (fun uu____9225  ->
+                                                          let uu____9226 =
                                                             FStar_Syntax_Subst.open_term
                                                               t_ps t_ty
                                                              in
-                                                          match uu____9217
+                                                          match uu____9226
                                                           with
                                                           | (t_ps1,t_ty1) ->
-                                                              let uu____9232
+                                                              let uu____9241
                                                                 =
                                                                 FStar_Tactics_Monad.mapM
                                                                   (fun c_lid 
                                                                     ->
-                                                                    let uu____9260
+                                                                    let uu____9269
                                                                     =
-                                                                    let uu____9263
+                                                                    let uu____9272
                                                                     =
                                                                     FStar_Tactics_Types.goal_env
                                                                     g  in
                                                                     FStar_TypeChecker_Env.lookup_sigelt
-                                                                    uu____9263
+                                                                    uu____9272
                                                                     c_lid  in
-                                                                    match uu____9260
+                                                                    match uu____9269
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
@@ -4506,7 +4510,7 @@ let (t_destruct :
                                                                     c_us))
                                                                     "t_us don't match?"
                                                                     (fun
-                                                                    uu____9340
+                                                                    uu____9349
                                                                      ->
                                                                     let s =
                                                                     FStar_TypeChecker_Env.mk_univ_subst
@@ -4517,27 +4521,27 @@ let (t_destruct :
                                                                     FStar_Syntax_Subst.subst
                                                                     s c_ty
                                                                      in
-                                                                    let uu____9345
+                                                                    let uu____9354
                                                                     =
                                                                     FStar_TypeChecker_Env.inst_tscheme
                                                                     (c_us,
                                                                     c_ty1)
                                                                      in
-                                                                    match uu____9345
+                                                                    match uu____9354
                                                                     with
                                                                     | 
                                                                     (c_us1,c_ty2)
                                                                     ->
-                                                                    let uu____9368
+                                                                    let uu____9377
                                                                     =
                                                                     FStar_Syntax_Util.arrow_formals_comp
                                                                     c_ty2  in
-                                                                    (match uu____9368
+                                                                    (match uu____9377
                                                                     with
                                                                     | 
                                                                     (bs,comp)
                                                                     ->
-                                                                    let uu____9387
+                                                                    let uu____9396
                                                                     =
                                                                     let rename_bv
                                                                     bv =
@@ -4547,121 +4551,132 @@ let (t_destruct :
                                                                      in
                                                                     let ppname1
                                                                     =
-                                                                    let uu___1295_9410
-                                                                    = ppname
+                                                                    let uu____9419
+                                                                    =
+                                                                    let uu____9425
+                                                                    =
+                                                                    let uu____9427
+                                                                    =
+                                                                    FStar_Ident.text_of_id
+                                                                    ppname
                                                                      in
-                                                                    {
-                                                                    FStar_Ident.idText
-                                                                    =
-                                                                    (Prims.op_Hat
+                                                                    Prims.op_Hat
                                                                     "a"
-                                                                    ppname.FStar_Ident.idText);
-                                                                    FStar_Ident.idRange
+                                                                    uu____9427
+                                                                     in
+                                                                    let uu____9430
                                                                     =
-                                                                    (uu___1295_9410.FStar_Ident.idRange)
-                                                                    }  in
+                                                                    FStar_Ident.range_of_id
+                                                                    ppname
+                                                                     in
+                                                                    (uu____9425,
+                                                                    uu____9430)
+                                                                     in
+                                                                    FStar_Ident.mk_ident
+                                                                    uu____9419
+                                                                     in
                                                                     FStar_Syntax_Syntax.freshen_bv
-                                                                    (let uu___1298_9414
+                                                                    (let uu___1296_9434
                                                                     = bv  in
                                                                     {
                                                                     FStar_Syntax_Syntax.ppname
                                                                     = ppname1;
                                                                     FStar_Syntax_Syntax.index
                                                                     =
-                                                                    (uu___1298_9414.FStar_Syntax_Syntax.index);
+                                                                    (uu___1296_9434.FStar_Syntax_Syntax.index);
                                                                     FStar_Syntax_Syntax.sort
                                                                     =
-                                                                    (uu___1298_9414.FStar_Syntax_Syntax.sort)
+                                                                    (uu___1296_9434.FStar_Syntax_Syntax.sort)
                                                                     })  in
                                                                     let bs' =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9440
+                                                                    uu____9460
                                                                      ->
-                                                                    match uu____9440
+                                                                    match uu____9460
                                                                     with
                                                                     | 
                                                                     (bv,aq)
                                                                     ->
-                                                                    let uu____9459
+                                                                    let uu____9479
                                                                     =
                                                                     rename_bv
                                                                     bv  in
-                                                                    (uu____9459,
+                                                                    (uu____9479,
                                                                     aq)) bs
                                                                      in
                                                                     let subst
                                                                     =
                                                                     FStar_List.map2
                                                                     (fun
-                                                                    uu____9484
+                                                                    uu____9504
                                                                      ->
                                                                     fun
-                                                                    uu____9485
+                                                                    uu____9505
                                                                      ->
                                                                     match 
-                                                                    (uu____9484,
-                                                                    uu____9485)
+                                                                    (uu____9504,
+                                                                    uu____9505)
                                                                     with
                                                                     | 
-                                                                    ((bv,uu____9511),
-                                                                    (bv',uu____9513))
+                                                                    ((bv,uu____9531),
+                                                                    (bv',uu____9533))
                                                                     ->
-                                                                    let uu____9534
+                                                                    let uu____9554
                                                                     =
-                                                                    let uu____9541
+                                                                    let uu____9561
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     bv'  in
                                                                     (bv,
-                                                                    uu____9541)
+                                                                    uu____9561)
                                                                      in
                                                                     FStar_Syntax_Syntax.NT
-                                                                    uu____9534)
+                                                                    uu____9554)
                                                                     bs bs'
                                                                      in
-                                                                    let uu____9546
+                                                                    let uu____9566
                                                                     =
                                                                     FStar_Syntax_Subst.subst_binders
                                                                     subst bs'
                                                                      in
-                                                                    let uu____9555
+                                                                    let uu____9575
                                                                     =
                                                                     FStar_Syntax_Subst.subst_comp
                                                                     subst
                                                                     comp  in
-                                                                    (uu____9546,
-                                                                    uu____9555)
+                                                                    (uu____9566,
+                                                                    uu____9575)
                                                                      in
-                                                                    (match uu____9387
+                                                                    (match uu____9396
                                                                     with
                                                                     | 
                                                                     (bs1,comp1)
                                                                     ->
-                                                                    let uu____9602
+                                                                    let uu____9622
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam
                                                                     bs1  in
-                                                                    (match uu____9602
+                                                                    (match uu____9622
                                                                     with
                                                                     | 
                                                                     (d_ps,bs2)
                                                                     ->
-                                                                    let uu____9675
+                                                                    let uu____9695
                                                                     =
-                                                                    let uu____9677
+                                                                    let uu____9697
                                                                     =
                                                                     FStar_Syntax_Util.is_total_comp
                                                                     comp1  in
                                                                     Prims.op_Negation
-                                                                    uu____9677
+                                                                    uu____9697
                                                                      in
                                                                     failwhen
-                                                                    uu____9675
+                                                                    uu____9695
                                                                     "not total?"
                                                                     (fun
-                                                                    uu____9696
+                                                                    uu____9716
                                                                      ->
                                                                     let mk_pat
                                                                     p =
@@ -4673,25 +4688,25 @@ let (t_destruct :
                                                                     (s_tm1.FStar_Syntax_Syntax.pos)
                                                                     }  in
                                                                     let is_imp
-                                                                    uu___6_9713
+                                                                    uu___6_9733
                                                                     =
-                                                                    match uu___6_9713
+                                                                    match uu___6_9733
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
                                                                     (FStar_Syntax_Syntax.Implicit
-                                                                    uu____9717)
+                                                                    uu____9737)
                                                                     -> true
                                                                     | 
-                                                                    uu____9720
+                                                                    uu____9740
                                                                     -> false
                                                                      in
-                                                                    let uu____9724
+                                                                    let uu____9744
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam
                                                                     args  in
-                                                                    match uu____9724
+                                                                    match uu____9744
                                                                     with
                                                                     | 
                                                                     (a_ps,a_is)
@@ -4703,7 +4718,7 @@ let (t_destruct :
                                                                     d_ps))
                                                                     "params not match?"
                                                                     (fun
-                                                                    uu____9860
+                                                                    uu____9880
                                                                      ->
                                                                     let d_ps_a_ps
                                                                     =
@@ -4714,13 +4729,13 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9922
+                                                                    uu____9942
                                                                      ->
-                                                                    match uu____9922
+                                                                    match uu____9942
                                                                     with
                                                                     | 
-                                                                    ((bv,uu____9942),
-                                                                    (t,uu____9944))
+                                                                    ((bv,uu____9962),
+                                                                    (t,uu____9964))
                                                                     ->
                                                                     FStar_Syntax_Syntax.NT
                                                                     (bv, t))
@@ -4734,13 +4749,13 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____10014
+                                                                    uu____10034
                                                                      ->
-                                                                    match uu____10014
+                                                                    match uu____10034
                                                                     with
                                                                     | 
-                                                                    ((bv,uu____10041),
-                                                                    (t,uu____10043))
+                                                                    ((bv,uu____10061),
+                                                                    (t,uu____10063))
                                                                     ->
                                                                     ((mk_pat
                                                                     (FStar_Syntax_Syntax.Pat_dot_term
@@ -4752,9 +4767,9 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____10102
+                                                                    uu____10122
                                                                      ->
-                                                                    match uu____10102
+                                                                    match uu____10122
                                                                     with
                                                                     | 
                                                                     (bv,aq)
@@ -4788,165 +4803,165 @@ let (t_destruct :
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1
                                                                     s_ty1  in
-                                                                    let uu____10157
+                                                                    let uu____10177
                                                                     =
                                                                     FStar_TypeChecker_TcTerm.tc_pat
-                                                                    (let uu___1357_10181
+                                                                    (let uu___1355_10201
                                                                     = env1
                                                                      in
                                                                     {
                                                                     FStar_TypeChecker_Env.solver
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.solver);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.solver);
                                                                     FStar_TypeChecker_Env.range
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.range);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.range);
                                                                     FStar_TypeChecker_Env.curmodule
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.curmodule);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.curmodule);
                                                                     FStar_TypeChecker_Env.gamma
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.gamma);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.gamma);
                                                                     FStar_TypeChecker_Env.gamma_sig
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.gamma_sig);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.gamma_sig);
                                                                     FStar_TypeChecker_Env.gamma_cache
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.gamma_cache);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.gamma_cache);
                                                                     FStar_TypeChecker_Env.modules
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.modules);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.modules);
                                                                     FStar_TypeChecker_Env.expected_typ
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.expected_typ);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.expected_typ);
                                                                     FStar_TypeChecker_Env.sigtab
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.sigtab);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.sigtab);
                                                                     FStar_TypeChecker_Env.attrtab
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.attrtab);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.attrtab);
                                                                     FStar_TypeChecker_Env.instantiate_imp
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.instantiate_imp);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.instantiate_imp);
                                                                     FStar_TypeChecker_Env.effects
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.effects);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.effects);
                                                                     FStar_TypeChecker_Env.generalize
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.generalize);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.generalize);
                                                                     FStar_TypeChecker_Env.letrecs
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.letrecs);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.letrecs);
                                                                     FStar_TypeChecker_Env.top_level
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.top_level);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.top_level);
                                                                     FStar_TypeChecker_Env.check_uvars
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.check_uvars);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.check_uvars);
                                                                     FStar_TypeChecker_Env.use_eq
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.use_eq);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.use_eq);
                                                                     FStar_TypeChecker_Env.use_eq_strict
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.use_eq_strict);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.use_eq_strict);
                                                                     FStar_TypeChecker_Env.is_iface
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.is_iface);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.admit);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.admit);
                                                                     FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.lax_universes);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.lax_universes);
                                                                     FStar_TypeChecker_Env.phase1
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.phase1);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.phase1);
                                                                     FStar_TypeChecker_Env.failhard
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.failhard);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.failhard);
                                                                     FStar_TypeChecker_Env.nosynth
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.nosynth);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.nosynth);
                                                                     FStar_TypeChecker_Env.uvar_subtyping
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.uvar_subtyping);
                                                                     FStar_TypeChecker_Env.tc_term
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.tc_term);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.tc_term);
                                                                     FStar_TypeChecker_Env.type_of
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.type_of);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.type_of);
                                                                     FStar_TypeChecker_Env.universe_of
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.universe_of);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.universe_of);
                                                                     FStar_TypeChecker_Env.check_type_of
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.check_type_of);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.check_type_of);
                                                                     FStar_TypeChecker_Env.use_bv_sorts
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.use_bv_sorts);
                                                                     FStar_TypeChecker_Env.qtbl_name_and_index
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                     FStar_TypeChecker_Env.normalized_eff_names
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.normalized_eff_names);
                                                                     FStar_TypeChecker_Env.fv_delta_depths
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.fv_delta_depths);
                                                                     FStar_TypeChecker_Env.proof_ns
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.proof_ns);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.proof_ns);
                                                                     FStar_TypeChecker_Env.synth_hook
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.synth_hook);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.synth_hook);
                                                                     FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                     FStar_TypeChecker_Env.splice
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.splice);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.splice);
                                                                     FStar_TypeChecker_Env.mpreprocess
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.mpreprocess);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.mpreprocess);
                                                                     FStar_TypeChecker_Env.postprocess
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.postprocess);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.postprocess);
                                                                     FStar_TypeChecker_Env.is_native_tactic
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.is_native_tactic);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.is_native_tactic);
                                                                     FStar_TypeChecker_Env.identifier_info
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.identifier_info);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.identifier_info);
                                                                     FStar_TypeChecker_Env.tc_hooks
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.tc_hooks);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.tc_hooks);
                                                                     FStar_TypeChecker_Env.dsenv
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.dsenv);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.dsenv);
                                                                     FStar_TypeChecker_Env.nbe
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.nbe);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.nbe);
                                                                     FStar_TypeChecker_Env.strict_args_tab
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.strict_args_tab);
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.strict_args_tab);
                                                                     FStar_TypeChecker_Env.erasable_types_tab
                                                                     =
-                                                                    (uu___1357_10181.FStar_TypeChecker_Env.erasable_types_tab)
+                                                                    (uu___1355_10201.FStar_TypeChecker_Env.erasable_types_tab)
                                                                     }) s_ty1
                                                                     pat  in
-                                                                    match uu____10157
+                                                                    match uu____10177
                                                                     with
                                                                     | 
-                                                                    (uu____10195,uu____10196,uu____10197,uu____10198,pat_t,uu____10200,_guard_pat,_erasable)
+                                                                    (uu____10215,uu____10216,uu____10217,uu____10218,pat_t,uu____10220,_guard_pat,_erasable)
                                                                     ->
                                                                     let eq_b
                                                                     =
-                                                                    let uu____10214
+                                                                    let uu____10234
                                                                     =
-                                                                    let uu____10215
+                                                                    let uu____10235
                                                                     =
                                                                     FStar_Syntax_Util.mk_eq2
                                                                     equ s_ty1
@@ -4954,52 +4969,52 @@ let (t_destruct :
                                                                     pat_t  in
                                                                     FStar_Syntax_Util.mk_squash
                                                                     equ
-                                                                    uu____10215
+                                                                    uu____10235
                                                                      in
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     "breq"
                                                                     FStar_Pervasives_Native.None
-                                                                    uu____10214
+                                                                    uu____10234
                                                                      in
                                                                     let cod1
                                                                     =
-                                                                    let uu____10220
+                                                                    let uu____10240
                                                                     =
-                                                                    let uu____10229
+                                                                    let uu____10249
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     eq_b  in
-                                                                    [uu____10229]
+                                                                    [uu____10249]
                                                                      in
-                                                                    let uu____10248
+                                                                    let uu____10268
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod  in
                                                                     FStar_Syntax_Util.arrow
-                                                                    uu____10220
-                                                                    uu____10248
+                                                                    uu____10240
+                                                                    uu____10268
                                                                      in
                                                                     let nty =
-                                                                    let uu____10254
+                                                                    let uu____10274
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod1  in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs3
-                                                                    uu____10254
+                                                                    uu____10274
                                                                      in
-                                                                    let uu____10257
+                                                                    let uu____10277
                                                                     =
                                                                     FStar_Tactics_Monad.new_uvar
                                                                     "destruct branch"
                                                                     env1 nty
                                                                      in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____10257
+                                                                    uu____10277
                                                                     (fun
-                                                                    uu____10287
+                                                                    uu____10307
                                                                      ->
-                                                                    match uu____10287
+                                                                    match uu____10307
                                                                     with
                                                                     | 
                                                                     (uvt,uv)
@@ -5017,58 +5032,58 @@ let (t_destruct :
                                                                      in
                                                                     let brt1
                                                                     =
-                                                                    let uu____10314
+                                                                    let uu____10334
                                                                     =
-                                                                    let uu____10325
+                                                                    let uu____10345
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     FStar_Syntax_Util.exp_unit
                                                                      in
-                                                                    [uu____10325]
+                                                                    [uu____10345]
                                                                      in
                                                                     FStar_Syntax_Util.mk_app
                                                                     brt
-                                                                    uu____10314
+                                                                    uu____10334
                                                                      in
                                                                     let br =
                                                                     FStar_Syntax_Subst.close_branch
                                                                     (pat,
                                                                     FStar_Pervasives_Native.None,
                                                                     brt1)  in
-                                                                    let uu____10361
+                                                                    let uu____10381
                                                                     =
-                                                                    let uu____10372
+                                                                    let uu____10392
                                                                     =
-                                                                    let uu____10377
+                                                                    let uu____10397
                                                                     =
                                                                     FStar_BigInt.of_int_fs
                                                                     (FStar_List.length
                                                                     bs3)  in
                                                                     (fv1,
-                                                                    uu____10377)
+                                                                    uu____10397)
                                                                      in
                                                                     (g', br,
-                                                                    uu____10372)
+                                                                    uu____10392)
                                                                      in
                                                                     FStar_Tactics_Monad.ret
-                                                                    uu____10361)))))))
+                                                                    uu____10381)))))))
                                                                     | 
-                                                                    uu____10398
+                                                                    uu____10418
                                                                     ->
                                                                     FStar_Tactics_Monad.fail
                                                                     "impossible: not a ctor"))
                                                                   c_lids
                                                                  in
                                                               FStar_Tactics_Monad.bind
-                                                                uu____9232
+                                                                uu____9241
                                                                 (fun goal_brs
                                                                     ->
-                                                                   let uu____10448
+                                                                   let uu____10468
                                                                     =
                                                                     FStar_List.unzip3
                                                                     goal_brs
                                                                      in
-                                                                   match uu____10448
+                                                                   match uu____10468
                                                                    with
                                                                    | 
                                                                    (goals,brs,infos)
@@ -5081,60 +5096,60 @@ let (t_destruct :
                                                                     FStar_Pervasives_Native.None
                                                                     s_tm1.FStar_Syntax_Syntax.pos
                                                                      in
-                                                                    let uu____10521
+                                                                    let uu____10541
                                                                     =
                                                                     solve' g
                                                                     w  in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____10521
+                                                                    uu____10541
                                                                     (fun
-                                                                    uu____10532
+                                                                    uu____10552
                                                                      ->
-                                                                    let uu____10533
+                                                                    let uu____10553
                                                                     =
                                                                     FStar_Tactics_Monad.add_goals
                                                                     goals  in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____10533
+                                                                    uu____10553
                                                                     (fun
-                                                                    uu____10543
+                                                                    uu____10563
                                                                      ->
                                                                     FStar_Tactics_Monad.ret
                                                                     infos)))))
-                                            | uu____10550 ->
+                                            | uu____10570 ->
                                                 FStar_Tactics_Monad.fail
                                                   "not an inductive type"))))))
        in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "destruct") uu____8947
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "destruct") uu____8956
   
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l  ->
     match l with
     | [] -> failwith "last: empty list"
     | x::[] -> x
-    | uu____10599::xs -> last xs
+    | uu____10619::xs -> last xs
   
 let rec init : 'a . 'a Prims.list -> 'a Prims.list =
   fun l  ->
     match l with
     | [] -> failwith "init: empty list"
     | x::[] -> []
-    | x::xs -> let uu____10629 = init xs  in x :: uu____10629
+    | x::xs -> let uu____10649 = init xs  in x :: uu____10649
   
 let rec (inspect :
   FStar_Syntax_Syntax.term ->
     FStar_Reflection_Data.term_view FStar_Tactics_Monad.tac)
   =
   fun t  ->
-    let uu____10642 =
-      let uu____10645 = top_env ()  in
-      FStar_Tactics_Monad.bind uu____10645
+    let uu____10662 =
+      let uu____10665 = top_env ()  in
+      FStar_Tactics_Monad.bind uu____10665
         (fun e  ->
            let t1 = FStar_Syntax_Util.unascribe t  in
            let t2 = FStar_Syntax_Util.un_uinst t1  in
            let t3 = FStar_Syntax_Util.unlazy_emb t2  in
            match t3.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_meta (t4,uu____10661) -> inspect t4
+           | FStar_Syntax_Syntax.Tm_meta (t4,uu____10681) -> inspect t4
            | FStar_Syntax_Syntax.Tm_name bv ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Var bv)
@@ -5147,80 +5162,80 @@ let rec (inspect :
            | FStar_Syntax_Syntax.Tm_app (hd,[]) ->
                failwith "empty arguments on Tm_app"
            | FStar_Syntax_Syntax.Tm_app (hd,args) ->
-               let uu____10727 = last args  in
-               (match uu____10727 with
+               let uu____10747 = last args  in
+               (match uu____10747 with
                 | (a,q) ->
                     let q' = FStar_Reflection_Basic.inspect_aqual q  in
-                    let uu____10757 =
-                      let uu____10758 =
-                        let uu____10763 =
-                          let uu____10764 =
-                            let uu____10769 = init args  in
-                            FStar_Syntax_Syntax.mk_Tm_app hd uu____10769  in
-                          uu____10764 FStar_Pervasives_Native.None
+                    let uu____10777 =
+                      let uu____10778 =
+                        let uu____10783 =
+                          let uu____10784 =
+                            let uu____10789 = init args  in
+                            FStar_Syntax_Syntax.mk_Tm_app hd uu____10789  in
+                          uu____10784 FStar_Pervasives_Native.None
                             t3.FStar_Syntax_Syntax.pos
                            in
-                        (uu____10763, (a, q'))  in
-                      FStar_Reflection_Data.Tv_App uu____10758  in
-                    FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10757)
-           | FStar_Syntax_Syntax.Tm_abs ([],uu____10780,uu____10781) ->
+                        (uu____10783, (a, q'))  in
+                      FStar_Reflection_Data.Tv_App uu____10778  in
+                    FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10777)
+           | FStar_Syntax_Syntax.Tm_abs ([],uu____10800,uu____10801) ->
                failwith "empty arguments on Tm_abs"
            | FStar_Syntax_Syntax.Tm_abs (bs,t4,k) ->
-               let uu____10834 = FStar_Syntax_Subst.open_term bs t4  in
-               (match uu____10834 with
+               let uu____10854 = FStar_Syntax_Subst.open_term bs t4  in
+               (match uu____10854 with
                 | (bs1,t5) ->
                     (match bs1 with
                      | [] -> failwith "impossible"
                      | b::bs2 ->
-                         let uu____10876 =
-                           let uu____10877 =
-                             let uu____10882 = FStar_Syntax_Util.abs bs2 t5 k
+                         let uu____10896 =
+                           let uu____10897 =
+                             let uu____10902 = FStar_Syntax_Util.abs bs2 t5 k
                                 in
-                             (b, uu____10882)  in
-                           FStar_Reflection_Data.Tv_Abs uu____10877  in
+                             (b, uu____10902)  in
+                           FStar_Reflection_Data.Tv_Abs uu____10897  in
                          FStar_All.pipe_left FStar_Tactics_Monad.ret
-                           uu____10876))
-           | FStar_Syntax_Syntax.Tm_type uu____10885 ->
+                           uu____10896))
+           | FStar_Syntax_Syntax.Tm_type uu____10905 ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Type ())
            | FStar_Syntax_Syntax.Tm_arrow ([],k) ->
                failwith "empty binders on arrow"
-           | FStar_Syntax_Syntax.Tm_arrow uu____10910 ->
-               let uu____10925 = FStar_Syntax_Util.arrow_one t3  in
-               (match uu____10925 with
+           | FStar_Syntax_Syntax.Tm_arrow uu____10930 ->
+               let uu____10945 = FStar_Syntax_Util.arrow_one t3  in
+               (match uu____10945 with
                 | FStar_Pervasives_Native.Some (b,c) ->
                     FStar_All.pipe_left FStar_Tactics_Monad.ret
                       (FStar_Reflection_Data.Tv_Arrow (b, c))
                 | FStar_Pervasives_Native.None  -> failwith "impossible")
            | FStar_Syntax_Syntax.Tm_refine (bv,t4) ->
                let b = FStar_Syntax_Syntax.mk_binder bv  in
-               let uu____10956 = FStar_Syntax_Subst.open_term [b] t4  in
-               (match uu____10956 with
+               let uu____10976 = FStar_Syntax_Subst.open_term [b] t4  in
+               (match uu____10976 with
                 | (b',t5) ->
                     let b1 =
                       match b' with
                       | b'1::[] -> b'1
-                      | uu____11009 -> failwith "impossible"  in
+                      | uu____11029 -> failwith "impossible"  in
                     FStar_All.pipe_left FStar_Tactics_Monad.ret
                       (FStar_Reflection_Data.Tv_Refine
                          ((FStar_Pervasives_Native.fst b1), t5)))
            | FStar_Syntax_Syntax.Tm_constant c ->
-               let uu____11022 =
-                 let uu____11023 = FStar_Reflection_Basic.inspect_const c  in
-                 FStar_Reflection_Data.Tv_Const uu____11023  in
-               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11022
+               let uu____11042 =
+                 let uu____11043 = FStar_Reflection_Basic.inspect_const c  in
+                 FStar_Reflection_Data.Tv_Const uu____11043  in
+               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11042
            | FStar_Syntax_Syntax.Tm_uvar (ctx_u,s) ->
-               let uu____11044 =
-                 let uu____11045 =
-                   let uu____11050 =
-                     let uu____11051 =
+               let uu____11064 =
+                 let uu____11065 =
+                   let uu____11070 =
+                     let uu____11071 =
                        FStar_Syntax_Unionfind.uvar_id
                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_head
                         in
-                     FStar_BigInt.of_int_fs uu____11051  in
-                   (uu____11050, (ctx_u, s))  in
-                 FStar_Reflection_Data.Tv_Uvar uu____11045  in
-               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11044
+                     FStar_BigInt.of_int_fs uu____11071  in
+                   (uu____11070, (ctx_u, s))  in
+                 FStar_Reflection_Data.Tv_Uvar uu____11065  in
+               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11064
            | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),t21) ->
                if lb.FStar_Syntax_Syntax.lbunivs <> []
                then
@@ -5228,19 +5243,19 @@ let rec (inspect :
                    FStar_Reflection_Data.Tv_Unknown
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
-                  | FStar_Util.Inr uu____11091 ->
+                  | FStar_Util.Inr uu____11111 ->
                       FStar_All.pipe_left FStar_Tactics_Monad.ret
                         FStar_Reflection_Data.Tv_Unknown
                   | FStar_Util.Inl bv ->
                       let b = FStar_Syntax_Syntax.mk_binder bv  in
-                      let uu____11096 = FStar_Syntax_Subst.open_term [b] t21
+                      let uu____11116 = FStar_Syntax_Subst.open_term [b] t21
                          in
-                      (match uu____11096 with
+                      (match uu____11116 with
                        | (bs,t22) ->
                            let b1 =
                              match bs with
                              | b1::[] -> b1
-                             | uu____11149 ->
+                             | uu____11169 ->
                                  failwith
                                    "impossible: open_term returned different amount of binders"
                               in
@@ -5256,18 +5271,18 @@ let rec (inspect :
                    FStar_Reflection_Data.Tv_Unknown
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
-                  | FStar_Util.Inr uu____11193 ->
+                  | FStar_Util.Inr uu____11213 ->
                       FStar_All.pipe_left FStar_Tactics_Monad.ret
                         FStar_Reflection_Data.Tv_Unknown
                   | FStar_Util.Inl bv ->
-                      let uu____11197 =
+                      let uu____11217 =
                         FStar_Syntax_Subst.open_let_rec [lb] t21  in
-                      (match uu____11197 with
+                      (match uu____11217 with
                        | (lbs,t22) ->
                            (match lbs with
                             | lb1::[] ->
                                 (match lb1.FStar_Syntax_Syntax.lbname with
-                                 | FStar_Util.Inr uu____11217 ->
+                                 | FStar_Util.Inr uu____11237 ->
                                      FStar_Tactics_Monad.ret
                                        FStar_Reflection_Data.Tv_Unknown
                                  | FStar_Util.Inl bv1 ->
@@ -5279,28 +5294,28 @@ let rec (inspect :
                                             bv1,
                                             (lb1.FStar_Syntax_Syntax.lbdef),
                                             t22)))
-                            | uu____11225 ->
+                            | uu____11245 ->
                                 failwith
                                   "impossible: open_term returned different amount of binders")))
            | FStar_Syntax_Syntax.Tm_match (t4,brs) ->
                let rec inspect_pat p =
                  match p.FStar_Syntax_Syntax.v with
                  | FStar_Syntax_Syntax.Pat_constant c ->
-                     let uu____11280 = FStar_Reflection_Basic.inspect_const c
+                     let uu____11300 = FStar_Reflection_Basic.inspect_const c
                         in
-                     FStar_Reflection_Data.Pat_Constant uu____11280
+                     FStar_Reflection_Data.Pat_Constant uu____11300
                  | FStar_Syntax_Syntax.Pat_cons (fv,ps) ->
-                     let uu____11301 =
-                       let uu____11313 =
+                     let uu____11321 =
+                       let uu____11333 =
                          FStar_List.map
-                           (fun uu____11337  ->
-                              match uu____11337 with
+                           (fun uu____11357  ->
+                              match uu____11357 with
                               | (p1,b) ->
-                                  let uu____11358 = inspect_pat p1  in
-                                  (uu____11358, b)) ps
+                                  let uu____11378 = inspect_pat p1  in
+                                  (uu____11378, b)) ps
                           in
-                       (fv, uu____11313)  in
-                     FStar_Reflection_Data.Pat_Cons uu____11301
+                       (fv, uu____11333)  in
+                     FStar_Reflection_Data.Pat_Cons uu____11321
                  | FStar_Syntax_Syntax.Pat_var bv ->
                      FStar_Reflection_Data.Pat_Var bv
                  | FStar_Syntax_Syntax.Pat_wild bv ->
@@ -5312,33 +5327,33 @@ let rec (inspect :
                   in
                let brs2 =
                  FStar_List.map
-                   (fun uu___7_11454  ->
-                      match uu___7_11454 with
-                      | (pat,uu____11476,t5) ->
-                          let uu____11494 = inspect_pat pat  in
-                          (uu____11494, t5)) brs1
+                   (fun uu___7_11474  ->
+                      match uu___7_11474 with
+                      | (pat,uu____11496,t5) ->
+                          let uu____11514 = inspect_pat pat  in
+                          (uu____11514, t5)) brs1
                   in
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Match (t4, brs2))
            | FStar_Syntax_Syntax.Tm_unknown  ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  FStar_Reflection_Data.Tv_Unknown
-           | uu____11503 ->
-               ((let uu____11505 =
-                   let uu____11511 =
-                     let uu____11513 = FStar_Syntax_Print.tag_of_term t3  in
-                     let uu____11515 = term_to_string e t3  in
+           | uu____11523 ->
+               ((let uu____11525 =
+                   let uu____11531 =
+                     let uu____11533 = FStar_Syntax_Print.tag_of_term t3  in
+                     let uu____11535 = term_to_string e t3  in
                      FStar_Util.format2
                        "inspect: outside of expected syntax (%s, %s)\n"
-                       uu____11513 uu____11515
+                       uu____11533 uu____11535
                       in
-                   (FStar_Errors.Warning_CantInspect, uu____11511)  in
+                   (FStar_Errors.Warning_CantInspect, uu____11531)  in
                  FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos
-                   uu____11505);
+                   uu____11525);
                 FStar_All.pipe_left FStar_Tactics_Monad.ret
                   FStar_Reflection_Data.Tv_Unknown))
        in
-    FStar_Tactics_Monad.wrap_err "inspect" uu____10642
+    FStar_Tactics_Monad.wrap_err "inspect" uu____10662
   
 let (pack :
   FStar_Reflection_Data.term_view ->
@@ -5347,80 +5362,80 @@ let (pack :
   fun tv  ->
     match tv with
     | FStar_Reflection_Data.Tv_Var bv ->
-        let uu____11533 = FStar_Syntax_Syntax.bv_to_name bv  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11533
+        let uu____11553 = FStar_Syntax_Syntax.bv_to_name bv  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11553
     | FStar_Reflection_Data.Tv_BVar bv ->
-        let uu____11537 = FStar_Syntax_Syntax.bv_to_tm bv  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11537
+        let uu____11557 = FStar_Syntax_Syntax.bv_to_tm bv  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11557
     | FStar_Reflection_Data.Tv_FVar fv ->
-        let uu____11541 = FStar_Syntax_Syntax.fv_to_tm fv  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11541
+        let uu____11561 = FStar_Syntax_Syntax.fv_to_tm fv  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11561
     | FStar_Reflection_Data.Tv_App (l,(r,q)) ->
         let q' = FStar_Reflection_Basic.pack_aqual q  in
-        let uu____11548 = FStar_Syntax_Util.mk_app l [(r, q')]  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11548
+        let uu____11568 = FStar_Syntax_Util.mk_app l [(r, q')]  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11568
     | FStar_Reflection_Data.Tv_Abs (b,t) ->
-        let uu____11573 =
+        let uu____11593 =
           FStar_Syntax_Util.abs [b] t FStar_Pervasives_Native.None  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11573
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11593
     | FStar_Reflection_Data.Tv_Arrow (b,c) ->
-        let uu____11590 = FStar_Syntax_Util.arrow [b] c  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11590
+        let uu____11610 = FStar_Syntax_Util.arrow [b] c  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11610
     | FStar_Reflection_Data.Tv_Type () ->
         FStar_All.pipe_left FStar_Tactics_Monad.ret FStar_Syntax_Util.ktype
     | FStar_Reflection_Data.Tv_Refine (bv,t) ->
-        let uu____11609 = FStar_Syntax_Util.refine bv t  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11609
+        let uu____11629 = FStar_Syntax_Util.refine bv t  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11629
     | FStar_Reflection_Data.Tv_Const c ->
-        let uu____11613 =
-          let uu____11614 =
-            let uu____11621 =
-              let uu____11622 = FStar_Reflection_Basic.pack_const c  in
-              FStar_Syntax_Syntax.Tm_constant uu____11622  in
-            FStar_Syntax_Syntax.mk uu____11621  in
-          uu____11614 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11613
+        let uu____11633 =
+          let uu____11634 =
+            let uu____11641 =
+              let uu____11642 = FStar_Reflection_Basic.pack_const c  in
+              FStar_Syntax_Syntax.Tm_constant uu____11642  in
+            FStar_Syntax_Syntax.mk uu____11641  in
+          uu____11634 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11633
     | FStar_Reflection_Data.Tv_Uvar (_u,ctx_u_s) ->
-        let uu____11627 =
+        let uu____11647 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar ctx_u_s)
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11627
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11647
     | FStar_Reflection_Data.Tv_Let (false ,attrs,bv,t1,t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             attrs FStar_Range.dummyRange
            in
-        let uu____11641 =
-          let uu____11642 =
-            let uu____11649 =
-              let uu____11650 =
-                let uu____11664 =
-                  let uu____11667 =
-                    let uu____11668 = FStar_Syntax_Syntax.mk_binder bv  in
-                    [uu____11668]  in
-                  FStar_Syntax_Subst.close uu____11667 t2  in
-                ((false, [lb]), uu____11664)  in
-              FStar_Syntax_Syntax.Tm_let uu____11650  in
-            FStar_Syntax_Syntax.mk uu____11649  in
-          uu____11642 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11641
+        let uu____11661 =
+          let uu____11662 =
+            let uu____11669 =
+              let uu____11670 =
+                let uu____11684 =
+                  let uu____11687 =
+                    let uu____11688 = FStar_Syntax_Syntax.mk_binder bv  in
+                    [uu____11688]  in
+                  FStar_Syntax_Subst.close uu____11687 t2  in
+                ((false, [lb]), uu____11684)  in
+              FStar_Syntax_Syntax.Tm_let uu____11670  in
+            FStar_Syntax_Syntax.mk uu____11669  in
+          uu____11662 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11661
     | FStar_Reflection_Data.Tv_Let (true ,attrs,bv,t1,t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             attrs FStar_Range.dummyRange
            in
-        let uu____11713 = FStar_Syntax_Subst.close_let_rec [lb] t2  in
-        (match uu____11713 with
+        let uu____11733 = FStar_Syntax_Subst.close_let_rec [lb] t2  in
+        (match uu____11733 with
          | (lbs,body) ->
-             let uu____11728 =
+             let uu____11748 =
                FStar_Syntax_Syntax.mk
                  (FStar_Syntax_Syntax.Tm_let ((true, lbs), body))
                  FStar_Pervasives_Native.None FStar_Range.dummyRange
                 in
-             FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11728)
+             FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11748)
     | FStar_Reflection_Data.Tv_Match (t,brs) ->
         let wrap v =
           {
@@ -5430,24 +5445,24 @@ let (pack :
         let rec pack_pat p =
           match p with
           | FStar_Reflection_Data.Pat_Constant c ->
-              let uu____11765 =
-                let uu____11766 = FStar_Reflection_Basic.pack_const c  in
-                FStar_Syntax_Syntax.Pat_constant uu____11766  in
-              FStar_All.pipe_left wrap uu____11765
+              let uu____11785 =
+                let uu____11786 = FStar_Reflection_Basic.pack_const c  in
+                FStar_Syntax_Syntax.Pat_constant uu____11786  in
+              FStar_All.pipe_left wrap uu____11785
           | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
-              let uu____11783 =
-                let uu____11784 =
-                  let uu____11798 =
+              let uu____11803 =
+                let uu____11804 =
+                  let uu____11818 =
                     FStar_List.map
-                      (fun uu____11822  ->
-                         match uu____11822 with
+                      (fun uu____11842  ->
+                         match uu____11842 with
                          | (p1,b) ->
-                             let uu____11837 = pack_pat p1  in
-                             (uu____11837, b)) ps
+                             let uu____11857 = pack_pat p1  in
+                             (uu____11857, b)) ps
                      in
-                  (fv, uu____11798)  in
-                FStar_Syntax_Syntax.Pat_cons uu____11784  in
-              FStar_All.pipe_left wrap uu____11783
+                  (fv, uu____11818)  in
+                FStar_Syntax_Syntax.Pat_cons uu____11804  in
+              FStar_All.pipe_left wrap uu____11803
           | FStar_Reflection_Data.Pat_Var bv ->
               FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_Data.Pat_Wild bv ->
@@ -5458,42 +5473,42 @@ let (pack :
            in
         let brs1 =
           FStar_List.map
-            (fun uu___8_11885  ->
-               match uu___8_11885 with
+            (fun uu___8_11905  ->
+               match uu___8_11905 with
                | (pat,t1) ->
-                   let uu____11902 = pack_pat pat  in
-                   (uu____11902, FStar_Pervasives_Native.None, t1)) brs
+                   let uu____11922 = pack_pat pat  in
+                   (uu____11922, FStar_Pervasives_Native.None, t1)) brs
            in
         let brs2 = FStar_List.map FStar_Syntax_Subst.close_branch brs1  in
-        let uu____11950 =
+        let uu____11970 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (t, brs2))
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11950
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11970
     | FStar_Reflection_Data.Tv_AscribedT (e,t,tacopt) ->
-        let uu____11978 =
+        let uu____11998 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inl t), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Pervasives_Native.None
             FStar_Range.dummyRange
            in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11978
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11998
     | FStar_Reflection_Data.Tv_AscribedC (e,c,tacopt) ->
-        let uu____12024 =
+        let uu____12044 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inr c), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Pervasives_Native.None
             FStar_Range.dummyRange
            in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____12024
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____12044
     | FStar_Reflection_Data.Tv_Unknown  ->
-        let uu____12063 =
+        let uu____12083 =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
             FStar_Pervasives_Native.None FStar_Range.dummyRange
            in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____12063
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____12083
   
 let (lget :
   FStar_Reflection_Data.typ ->
@@ -5501,18 +5516,18 @@ let (lget :
   =
   fun ty  ->
     fun k  ->
-      let uu____12083 =
+      let uu____12103 =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
           (fun ps  ->
-             let uu____12089 =
+             let uu____12109 =
                FStar_Util.psmap_try_find ps.FStar_Tactics_Types.local_state k
                 in
-             match uu____12089 with
+             match uu____12109 with
              | FStar_Pervasives_Native.None  ->
                  FStar_Tactics_Monad.fail "not found"
              | FStar_Pervasives_Native.Some t -> unquote ty t)
          in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lget") uu____12083
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lget") uu____12103
   
 let (lset :
   FStar_Reflection_Data.typ ->
@@ -5521,43 +5536,43 @@ let (lset :
   fun _ty  ->
     fun k  ->
       fun t  ->
-        let uu____12123 =
+        let uu____12143 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps  ->
                let ps1 =
-                 let uu___1662_12130 = ps  in
-                 let uu____12131 =
+                 let uu___1660_12150 = ps  in
+                 let uu____12151 =
                    FStar_Util.psmap_add ps.FStar_Tactics_Types.local_state k
                      t
                     in
                  {
                    FStar_Tactics_Types.main_context =
-                     (uu___1662_12130.FStar_Tactics_Types.main_context);
+                     (uu___1660_12150.FStar_Tactics_Types.main_context);
                    FStar_Tactics_Types.all_implicits =
-                     (uu___1662_12130.FStar_Tactics_Types.all_implicits);
+                     (uu___1660_12150.FStar_Tactics_Types.all_implicits);
                    FStar_Tactics_Types.goals =
-                     (uu___1662_12130.FStar_Tactics_Types.goals);
+                     (uu___1660_12150.FStar_Tactics_Types.goals);
                    FStar_Tactics_Types.smt_goals =
-                     (uu___1662_12130.FStar_Tactics_Types.smt_goals);
+                     (uu___1660_12150.FStar_Tactics_Types.smt_goals);
                    FStar_Tactics_Types.depth =
-                     (uu___1662_12130.FStar_Tactics_Types.depth);
+                     (uu___1660_12150.FStar_Tactics_Types.depth);
                    FStar_Tactics_Types.__dump =
-                     (uu___1662_12130.FStar_Tactics_Types.__dump);
+                     (uu___1660_12150.FStar_Tactics_Types.__dump);
                    FStar_Tactics_Types.psc =
-                     (uu___1662_12130.FStar_Tactics_Types.psc);
+                     (uu___1660_12150.FStar_Tactics_Types.psc);
                    FStar_Tactics_Types.entry_range =
-                     (uu___1662_12130.FStar_Tactics_Types.entry_range);
+                     (uu___1660_12150.FStar_Tactics_Types.entry_range);
                    FStar_Tactics_Types.guard_policy =
-                     (uu___1662_12130.FStar_Tactics_Types.guard_policy);
+                     (uu___1660_12150.FStar_Tactics_Types.guard_policy);
                    FStar_Tactics_Types.freshness =
-                     (uu___1662_12130.FStar_Tactics_Types.freshness);
+                     (uu___1660_12150.FStar_Tactics_Types.freshness);
                    FStar_Tactics_Types.tac_verb_dbg =
-                     (uu___1662_12130.FStar_Tactics_Types.tac_verb_dbg);
-                   FStar_Tactics_Types.local_state = uu____12131
+                     (uu___1660_12150.FStar_Tactics_Types.tac_verb_dbg);
+                   FStar_Tactics_Types.local_state = uu____12151
                  }  in
                FStar_Tactics_Monad.set ps1)
            in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lset") uu____12123
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lset") uu____12143
   
 let (goal_of_goal_ty :
   env ->
@@ -5566,221 +5581,221 @@ let (goal_of_goal_ty :
   =
   fun env1  ->
     fun typ  ->
-      let uu____12158 =
+      let uu____12178 =
         FStar_TypeChecker_Env.new_implicit_var_aux "proofstate_of_goal_ty"
           typ.FStar_Syntax_Syntax.pos env1 typ
           FStar_Syntax_Syntax.Allow_untyped FStar_Pervasives_Native.None
          in
-      match uu____12158 with
+      match uu____12178 with
       | (u,ctx_uvars,g_u) ->
-          let uu____12195 = FStar_List.hd ctx_uvars  in
-          (match uu____12195 with
-           | (ctx_uvar,uu____12209) ->
+          let uu____12215 = FStar_List.hd ctx_uvars  in
+          (match uu____12215 with
+           | (ctx_uvar,uu____12229) ->
                let g =
-                 let uu____12211 = FStar_Options.peek ()  in
-                 FStar_Tactics_Types.mk_goal env1 ctx_uvar uu____12211 false
+                 let uu____12231 = FStar_Options.peek ()  in
+                 FStar_Tactics_Types.mk_goal env1 ctx_uvar uu____12231 false
                    ""
                   in
                (g, g_u))
   
 let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
   fun env1  ->
-    let uu____12220 = FStar_TypeChecker_Env.clear_expected_typ env1  in
-    match uu____12220 with
-    | (env2,uu____12228) ->
+    let uu____12240 = FStar_TypeChecker_Env.clear_expected_typ env1  in
+    match uu____12240 with
+    | (env2,uu____12248) ->
         let env3 =
-          let uu___1679_12234 = env2  in
+          let uu___1677_12254 = env2  in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1679_12234.FStar_TypeChecker_Env.solver);
+              (uu___1677_12254.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1679_12234.FStar_TypeChecker_Env.range);
+              (uu___1677_12254.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1679_12234.FStar_TypeChecker_Env.curmodule);
+              (uu___1677_12254.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1679_12234.FStar_TypeChecker_Env.gamma);
+              (uu___1677_12254.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1679_12234.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1677_12254.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1679_12234.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1677_12254.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1679_12234.FStar_TypeChecker_Env.modules);
+              (uu___1677_12254.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1679_12234.FStar_TypeChecker_Env.expected_typ);
+              (uu___1677_12254.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1679_12234.FStar_TypeChecker_Env.sigtab);
+              (uu___1677_12254.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1679_12234.FStar_TypeChecker_Env.attrtab);
+              (uu___1677_12254.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp = false;
             FStar_TypeChecker_Env.effects =
-              (uu___1679_12234.FStar_TypeChecker_Env.effects);
+              (uu___1677_12254.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1679_12234.FStar_TypeChecker_Env.generalize);
+              (uu___1677_12254.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1679_12234.FStar_TypeChecker_Env.letrecs);
+              (uu___1677_12254.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___1679_12234.FStar_TypeChecker_Env.top_level);
+              (uu___1677_12254.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1679_12234.FStar_TypeChecker_Env.check_uvars);
+              (uu___1677_12254.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1679_12234.FStar_TypeChecker_Env.use_eq);
+              (uu___1677_12254.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1679_12234.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1677_12254.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1679_12234.FStar_TypeChecker_Env.is_iface);
+              (uu___1677_12254.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1679_12234.FStar_TypeChecker_Env.admit);
+              (uu___1677_12254.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax =
-              (uu___1679_12234.FStar_TypeChecker_Env.lax);
+              (uu___1677_12254.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___1679_12234.FStar_TypeChecker_Env.lax_universes);
+              (uu___1677_12254.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___1679_12234.FStar_TypeChecker_Env.phase1);
+              (uu___1677_12254.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___1679_12234.FStar_TypeChecker_Env.failhard);
+              (uu___1677_12254.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___1679_12234.FStar_TypeChecker_Env.nosynth);
+              (uu___1677_12254.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1679_12234.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1677_12254.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1679_12234.FStar_TypeChecker_Env.tc_term);
+              (uu___1677_12254.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1679_12234.FStar_TypeChecker_Env.type_of);
+              (uu___1677_12254.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1679_12234.FStar_TypeChecker_Env.universe_of);
+              (uu___1677_12254.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1679_12234.FStar_TypeChecker_Env.check_type_of);
+              (uu___1677_12254.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1679_12234.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1677_12254.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1679_12234.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1677_12254.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1679_12234.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1677_12254.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1679_12234.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1677_12254.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1679_12234.FStar_TypeChecker_Env.proof_ns);
+              (uu___1677_12254.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1679_12234.FStar_TypeChecker_Env.synth_hook);
+              (uu___1677_12254.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1679_12234.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1677_12254.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1679_12234.FStar_TypeChecker_Env.splice);
+              (uu___1677_12254.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1679_12234.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1677_12254.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1679_12234.FStar_TypeChecker_Env.postprocess);
+              (uu___1677_12254.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.is_native_tactic =
-              (uu___1679_12234.FStar_TypeChecker_Env.is_native_tactic);
+              (uu___1677_12254.FStar_TypeChecker_Env.is_native_tactic);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1679_12234.FStar_TypeChecker_Env.identifier_info);
+              (uu___1677_12254.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1679_12234.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1677_12254.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1679_12234.FStar_TypeChecker_Env.dsenv);
+              (uu___1677_12254.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1679_12234.FStar_TypeChecker_Env.nbe);
+              (uu___1677_12254.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1679_12234.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1677_12254.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1679_12234.FStar_TypeChecker_Env.erasable_types_tab)
+              (uu___1677_12254.FStar_TypeChecker_Env.erasable_types_tab)
           }  in
         let env4 =
-          let uu___1682_12237 = env3  in
+          let uu___1680_12257 = env3  in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1682_12237.FStar_TypeChecker_Env.solver);
+              (uu___1680_12257.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1682_12237.FStar_TypeChecker_Env.range);
+              (uu___1680_12257.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1682_12237.FStar_TypeChecker_Env.curmodule);
+              (uu___1680_12257.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1682_12237.FStar_TypeChecker_Env.gamma);
+              (uu___1680_12257.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1682_12237.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1680_12257.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1682_12237.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1680_12257.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1682_12237.FStar_TypeChecker_Env.modules);
+              (uu___1680_12257.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1682_12237.FStar_TypeChecker_Env.expected_typ);
+              (uu___1680_12257.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1682_12237.FStar_TypeChecker_Env.sigtab);
+              (uu___1680_12257.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1682_12237.FStar_TypeChecker_Env.attrtab);
+              (uu___1680_12257.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___1682_12237.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___1680_12257.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___1682_12237.FStar_TypeChecker_Env.effects);
+              (uu___1680_12257.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1682_12237.FStar_TypeChecker_Env.generalize);
+              (uu___1680_12257.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1682_12237.FStar_TypeChecker_Env.letrecs);
+              (uu___1680_12257.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___1682_12237.FStar_TypeChecker_Env.top_level);
+              (uu___1680_12257.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1682_12237.FStar_TypeChecker_Env.check_uvars);
+              (uu___1680_12257.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1682_12237.FStar_TypeChecker_Env.use_eq);
+              (uu___1680_12257.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1682_12237.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1680_12257.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1682_12237.FStar_TypeChecker_Env.is_iface);
+              (uu___1680_12257.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1682_12237.FStar_TypeChecker_Env.admit);
+              (uu___1680_12257.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax =
-              (uu___1682_12237.FStar_TypeChecker_Env.lax);
+              (uu___1680_12257.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___1682_12237.FStar_TypeChecker_Env.lax_universes);
+              (uu___1680_12257.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___1682_12237.FStar_TypeChecker_Env.phase1);
+              (uu___1680_12257.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard = true;
             FStar_TypeChecker_Env.nosynth =
-              (uu___1682_12237.FStar_TypeChecker_Env.nosynth);
+              (uu___1680_12257.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1682_12237.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1680_12257.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1682_12237.FStar_TypeChecker_Env.tc_term);
+              (uu___1680_12257.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1682_12237.FStar_TypeChecker_Env.type_of);
+              (uu___1680_12257.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1682_12237.FStar_TypeChecker_Env.universe_of);
+              (uu___1680_12257.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1682_12237.FStar_TypeChecker_Env.check_type_of);
+              (uu___1680_12257.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1682_12237.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1680_12257.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1682_12237.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1680_12257.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1682_12237.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1680_12257.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1682_12237.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1680_12257.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1682_12237.FStar_TypeChecker_Env.proof_ns);
+              (uu___1680_12257.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1682_12237.FStar_TypeChecker_Env.synth_hook);
+              (uu___1680_12257.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1682_12237.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1680_12257.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1682_12237.FStar_TypeChecker_Env.splice);
+              (uu___1680_12257.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1682_12237.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1680_12257.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1682_12237.FStar_TypeChecker_Env.postprocess);
+              (uu___1680_12257.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.is_native_tactic =
-              (uu___1682_12237.FStar_TypeChecker_Env.is_native_tactic);
+              (uu___1680_12257.FStar_TypeChecker_Env.is_native_tactic);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1682_12237.FStar_TypeChecker_Env.identifier_info);
+              (uu___1680_12257.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1682_12237.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1680_12257.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1682_12237.FStar_TypeChecker_Env.dsenv);
+              (uu___1680_12257.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1682_12237.FStar_TypeChecker_Env.nbe);
+              (uu___1680_12257.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1682_12237.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1680_12257.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1682_12237.FStar_TypeChecker_Env.erasable_types_tab)
+              (uu___1680_12257.FStar_TypeChecker_Env.erasable_types_tab)
           }  in
         env4
   
@@ -5797,11 +5812,11 @@ let (proofstate_of_goals :
         fun imps  ->
           let env2 = tac_env env1  in
           let ps =
-            let uu____12270 =
+            let uu____12290 =
               FStar_TypeChecker_Env.debug env2
                 (FStar_Options.Other "TacVerbose")
                in
-            let uu____12273 = FStar_Util.psmap_empty ()  in
+            let uu____12293 = FStar_Util.psmap_empty ()  in
             {
               FStar_Tactics_Types.main_context = env2;
               FStar_Tactics_Types.all_implicits = imps;
@@ -5814,8 +5829,8 @@ let (proofstate_of_goals :
               FStar_Tactics_Types.entry_range = rng;
               FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
               FStar_Tactics_Types.freshness = Prims.int_zero;
-              FStar_Tactics_Types.tac_verb_dbg = uu____12270;
-              FStar_Tactics_Types.local_state = uu____12273
+              FStar_Tactics_Types.tac_verb_dbg = uu____12290;
+              FStar_Tactics_Types.local_state = uu____12293
             }  in
           ps
   
@@ -5829,15 +5844,15 @@ let (proofstate_of_goal_ty :
     fun env1  ->
       fun typ  ->
         let env2 = tac_env env1  in
-        let uu____12299 = goal_of_goal_ty env2 typ  in
-        match uu____12299 with
+        let uu____12319 = goal_of_goal_ty env2 typ  in
+        match uu____12319 with
         | (g,g_u) ->
             let ps =
               proofstate_of_goals rng env2 [g]
                 g_u.FStar_TypeChecker_Common.implicits
                in
-            let uu____12311 = FStar_Tactics_Types.goal_witness g  in
-            (ps, uu____12311)
+            let uu____12331 = FStar_Tactics_Types.goal_witness g  in
+            (ps, uu____12331)
   
 let (goal_of_implicit :
   FStar_TypeChecker_Env.env ->
@@ -5845,9 +5860,9 @@ let (goal_of_implicit :
   =
   fun env1  ->
     fun i  ->
-      let uu____12323 = FStar_Options.peek ()  in
+      let uu____12343 = FStar_Options.peek ()  in
       FStar_Tactics_Types.mk_goal env1 i.FStar_TypeChecker_Common.imp_uvar
-        uu____12323 false ""
+        uu____12343 false ""
   
 let (proofstate_of_all_implicits :
   FStar_Range.range ->
@@ -5860,14 +5875,14 @@ let (proofstate_of_all_implicits :
       fun imps  ->
         let goals = FStar_List.map (goal_of_implicit env1) imps  in
         let w =
-          let uu____12350 = FStar_List.hd goals  in
-          FStar_Tactics_Types.goal_witness uu____12350  in
+          let uu____12370 = FStar_List.hd goals  in
+          FStar_Tactics_Types.goal_witness uu____12370  in
         let ps =
-          let uu____12352 =
+          let uu____12372 =
             FStar_TypeChecker_Env.debug env1
               (FStar_Options.Other "TacVerbose")
              in
-          let uu____12355 = FStar_Util.psmap_empty ()  in
+          let uu____12375 = FStar_Util.psmap_empty ()  in
           {
             FStar_Tactics_Types.main_context = env1;
             FStar_Tactics_Types.all_implicits = imps;
@@ -5881,8 +5896,8 @@ let (proofstate_of_all_implicits :
             FStar_Tactics_Types.entry_range = rng;
             FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
             FStar_Tactics_Types.freshness = Prims.int_zero;
-            FStar_Tactics_Types.tac_verb_dbg = uu____12352;
-            FStar_Tactics_Types.local_state = uu____12355
+            FStar_Tactics_Types.tac_verb_dbg = uu____12372;
+            FStar_Tactics_Types.local_state = uu____12375
           }  in
         (ps, w)
   

--- a/src/ocaml-output/FStar_Tactics_Printing.ml
+++ b/src/ocaml-output/FStar_Tactics_Printing.ml
@@ -30,56 +30,58 @@ let (unshadow :
   =
   fun bs  ->
     fun t  ->
-      let s b = (b.FStar_Syntax_Syntax.ppname).FStar_Ident.idText  in
+      let s b = FStar_Ident.text_of_id b.FStar_Syntax_Syntax.ppname  in
       let sset bv s1 =
-        FStar_Syntax_Syntax.gen_bv s1
-          (FStar_Pervasives_Native.Some
-             ((bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange))
-          bv.FStar_Syntax_Syntax.sort
+        let uu____74 =
+          let uu____77 =
+            FStar_Ident.range_of_id bv.FStar_Syntax_Syntax.ppname  in
+          FStar_Pervasives_Native.Some uu____77  in
+        FStar_Syntax_Syntax.gen_bv s1 uu____74 bv.FStar_Syntax_Syntax.sort
          in
       let fresh_until b f =
         let rec aux i =
           let t1 =
-            let uu____108 =
-              let uu____110 = FStar_Util.string_of_int i  in
-              Prims.op_Hat "'" uu____110  in
-            Prims.op_Hat b uu____108  in
-          let uu____113 = f t1  in
-          if uu____113 then t1 else aux (i + Prims.int_one)  in
-        let uu____120 = f b  in if uu____120 then b else aux Prims.int_zero
+            let uu____112 =
+              let uu____114 = FStar_Util.string_of_int i  in
+              Prims.op_Hat "'" uu____114  in
+            Prims.op_Hat b uu____112  in
+          let uu____117 = f t1  in
+          if uu____117 then t1 else aux (i + Prims.int_one)  in
+        let uu____124 = f b  in if uu____124 then b else aux Prims.int_zero
          in
       let rec go seen subst bs1 bs' t1 =
         match bs1 with
         | [] ->
-            let uu____225 = FStar_Syntax_Subst.subst subst t1  in
-            ((FStar_List.rev bs'), uu____225)
+            let uu____229 = FStar_Syntax_Subst.subst subst t1  in
+            ((FStar_List.rev bs'), uu____229)
         | b::bs2 ->
             let b1 =
-              let uu____269 = FStar_Syntax_Subst.subst_binders subst [b]  in
-              match uu____269 with
+              let uu____273 = FStar_Syntax_Subst.subst_binders subst [b]  in
+              match uu____273 with
               | b1::[] -> b1
-              | uu____307 -> failwith "impossible: unshadow subst_binders"
+              | uu____311 -> failwith "impossible: unshadow subst_binders"
                in
-            let uu____315 = b1  in
-            (match uu____315 with
+            let uu____319 = b1  in
+            (match uu____319 with
              | (bv0,q) ->
                  let nbs =
-                   fresh_until (s bv0)
+                   let uu____346 = s bv0  in
+                   fresh_until uu____346
                      (fun s1  -> Prims.op_Negation (FStar_List.mem s1 seen))
                     in
                  let bv = sset bv0 nbs  in
                  let b2 = (bv, q)  in
-                 let uu____356 =
-                   let uu____359 =
-                     let uu____362 =
-                       let uu____363 =
-                         let uu____370 = FStar_Syntax_Syntax.bv_to_name bv
+                 let uu____362 =
+                   let uu____365 =
+                     let uu____368 =
+                       let uu____369 =
+                         let uu____376 = FStar_Syntax_Syntax.bv_to_name bv
                             in
-                         (bv0, uu____370)  in
-                       FStar_Syntax_Syntax.NT uu____363  in
-                     [uu____362]  in
-                   FStar_List.append subst uu____359  in
-                 go (nbs :: seen) uu____356 bs2 (b2 :: bs') t1)
+                         (bv0, uu____376)  in
+                       FStar_Syntax_Syntax.NT uu____369  in
+                     [uu____368]  in
+                   FStar_List.append subst uu____365  in
+                 go (nbs :: seen) uu____362 bs2 (b2 :: bs') t1)
          in
       go [] [] bs [] t
   
@@ -94,28 +96,28 @@ let (goal_to_string :
       fun ps  ->
         fun g  ->
           let w =
-            let uu____432 = FStar_Options.print_implicits ()  in
-            if uu____432
+            let uu____438 = FStar_Options.print_implicits ()  in
+            if uu____438
             then
-              let uu____436 = FStar_Tactics_Types.goal_env g  in
-              let uu____437 = FStar_Tactics_Types.goal_witness g  in
-              term_to_string uu____436 uu____437
+              let uu____442 = FStar_Tactics_Types.goal_env g  in
+              let uu____443 = FStar_Tactics_Types.goal_witness g  in
+              term_to_string uu____442 uu____443
             else
-              (let uu____440 = FStar_Tactics_Types.check_goal_solved' g  in
-               match uu____440 with
+              (let uu____446 = FStar_Tactics_Types.check_goal_solved' g  in
+               match uu____446 with
                | FStar_Pervasives_Native.None  -> "_"
                | FStar_Pervasives_Native.Some t ->
-                   let uu____446 = FStar_Tactics_Types.goal_env g  in
-                   let uu____447 = FStar_Tactics_Types.goal_witness g  in
-                   term_to_string uu____446 uu____447)
+                   let uu____452 = FStar_Tactics_Types.goal_env g  in
+                   let uu____453 = FStar_Tactics_Types.goal_witness g  in
+                   term_to_string uu____452 uu____453)
              in
           let num =
             match maybe_num with
             | FStar_Pervasives_Native.None  -> ""
             | FStar_Pervasives_Native.Some (i,n) ->
-                let uu____470 = FStar_Util.string_of_int i  in
-                let uu____472 = FStar_Util.string_of_int n  in
-                FStar_Util.format2 " %s/%s" uu____470 uu____472
+                let uu____476 = FStar_Util.string_of_int i  in
+                let uu____478 = FStar_Util.string_of_int n  in
+                FStar_Util.format2 " %s/%s" uu____476 uu____478
              in
           let maybe_label =
             match g.FStar_Tactics_Types.label with
@@ -127,28 +129,28 @@ let (goal_to_string :
           let goal_ty =
             (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_typ
              in
-          let uu____496 = unshadow goal_binders goal_ty  in
-          match uu____496 with
+          let uu____502 = unshadow goal_binders goal_ty  in
+          match uu____502 with
           | (goal_binders1,goal_ty1) ->
               let actual_goal =
                 if ps.FStar_Tactics_Types.tac_verb_dbg
                 then goal_to_string_verbose g
                 else
-                  (let uu____510 =
+                  (let uu____516 =
                      FStar_Syntax_Print.binders_to_string ", " goal_binders1
                       in
-                   let uu____513 =
-                     let uu____515 = FStar_Tactics_Types.goal_env g  in
-                     term_to_string uu____515 goal_ty1  in
-                   FStar_Util.format3 "%s |- %s : %s\n" uu____510 w uu____513)
+                   let uu____519 =
+                     let uu____521 = FStar_Tactics_Types.goal_env g  in
+                     term_to_string uu____521 goal_ty1  in
+                   FStar_Util.format3 "%s |- %s : %s\n" uu____516 w uu____519)
                  in
               FStar_Util.format4 "%s%s%s:\n%s\n" kind num maybe_label
                 actual_goal
   
 let (ps_to_string :
   (Prims.string * FStar_Tactics_Types.proofstate) -> Prims.string) =
-  fun uu____529  ->
-    match uu____529 with
+  fun uu____535  ->
+    match uu____535 with
     | (msg,ps) ->
         let p_imp imp =
           FStar_Syntax_Print.uvar_to_string
@@ -157,46 +159,46 @@ let (ps_to_string :
         let n_active = FStar_List.length ps.FStar_Tactics_Types.goals  in
         let n_smt = FStar_List.length ps.FStar_Tactics_Types.smt_goals  in
         let n = n_active + n_smt  in
-        let uu____551 =
-          let uu____555 =
-            let uu____559 =
-              let uu____561 =
+        let uu____557 =
+          let uu____561 =
+            let uu____565 =
+              let uu____567 =
                 FStar_Util.string_of_int ps.FStar_Tactics_Types.depth  in
-              FStar_Util.format2 "State dump @ depth %s (%s):\n" uu____561
+              FStar_Util.format2 "State dump @ depth %s (%s):\n" uu____567
                 msg
                in
-            let uu____564 =
-              let uu____568 =
+            let uu____570 =
+              let uu____574 =
                 if
                   ps.FStar_Tactics_Types.entry_range <>
                     FStar_Range.dummyRange
                 then
-                  let uu____572 =
+                  let uu____578 =
                     FStar_Range.string_of_def_range
                       ps.FStar_Tactics_Types.entry_range
                      in
-                  FStar_Util.format1 "Location: %s\n" uu____572
+                  FStar_Util.format1 "Location: %s\n" uu____578
                 else ""  in
-              let uu____578 =
-                let uu____582 =
-                  let uu____584 =
+              let uu____584 =
+                let uu____588 =
+                  let uu____590 =
                     FStar_TypeChecker_Env.debug
                       ps.FStar_Tactics_Types.main_context
                       (FStar_Options.Other "Imp")
                      in
-                  if uu____584
+                  if uu____590
                   then
-                    let uu____589 =
+                    let uu____595 =
                       FStar_Common.string_of_list p_imp
                         ps.FStar_Tactics_Types.all_implicits
                        in
-                    FStar_Util.format1 "Imps: %s\n" uu____589
+                    FStar_Util.format1 "Imps: %s\n" uu____595
                   else ""  in
-                [uu____582]  in
-              uu____568 :: uu____578  in
-            uu____559 :: uu____564  in
-          let uu____599 =
-            let uu____603 =
+                [uu____588]  in
+              uu____574 :: uu____584  in
+            uu____565 :: uu____570  in
+          let uu____605 =
+            let uu____609 =
               FStar_List.mapi
                 (fun i  ->
                    fun g  ->
@@ -204,7 +206,7 @@ let (ps_to_string :
                        (FStar_Pervasives_Native.Some ((Prims.int_one + i), n))
                        ps g) ps.FStar_Tactics_Types.goals
                in
-            let uu____623 =
+            let uu____629 =
               FStar_List.mapi
                 (fun i  ->
                    fun g  ->
@@ -213,9 +215,9 @@ let (ps_to_string :
                           (((Prims.int_one + n_active) + i), n)) ps g)
                 ps.FStar_Tactics_Types.smt_goals
                in
-            FStar_List.append uu____603 uu____623  in
-          FStar_List.append uu____555 uu____599  in
-        FStar_String.concat "" uu____551
+            FStar_List.append uu____609 uu____629  in
+          FStar_List.append uu____561 uu____605  in
+        FStar_String.concat "" uu____557
   
 let (goal_to_json : FStar_Tactics_Types.goal -> FStar_Util.json) =
   fun g  ->
@@ -223,104 +225,104 @@ let (goal_to_json : FStar_Tactics_Types.goal -> FStar_Util.json) =
       (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_binders
        in
     let g_type = FStar_Tactics_Types.goal_type g  in
-    let uu____662 = unshadow g_binders g_type  in
-    match uu____662 with
+    let uu____668 = unshadow g_binders g_type  in
+    match uu____668 with
     | (g_binders1,g_type1) ->
         let j_binders =
-          let uu____670 =
-            let uu____671 = FStar_Tactics_Types.goal_env g  in
-            FStar_TypeChecker_Env.dsenv uu____671  in
-          FStar_Syntax_Print.binders_to_json uu____670 g_binders1  in
-        let uu____672 =
-          let uu____680 =
-            let uu____688 =
-              let uu____694 =
-                let uu____695 =
-                  let uu____703 =
-                    let uu____709 =
-                      let uu____710 =
-                        let uu____712 = FStar_Tactics_Types.goal_env g  in
-                        let uu____713 = FStar_Tactics_Types.goal_witness g
+          let uu____676 =
+            let uu____677 = FStar_Tactics_Types.goal_env g  in
+            FStar_TypeChecker_Env.dsenv uu____677  in
+          FStar_Syntax_Print.binders_to_json uu____676 g_binders1  in
+        let uu____678 =
+          let uu____686 =
+            let uu____694 =
+              let uu____700 =
+                let uu____701 =
+                  let uu____709 =
+                    let uu____715 =
+                      let uu____716 =
+                        let uu____718 = FStar_Tactics_Types.goal_env g  in
+                        let uu____719 = FStar_Tactics_Types.goal_witness g
                            in
-                        term_to_string uu____712 uu____713  in
-                      FStar_Util.JsonStr uu____710  in
-                    ("witness", uu____709)  in
-                  let uu____716 =
-                    let uu____724 =
-                      let uu____730 =
-                        let uu____731 =
-                          let uu____733 = FStar_Tactics_Types.goal_env g  in
-                          term_to_string uu____733 g_type1  in
-                        FStar_Util.JsonStr uu____731  in
-                      ("type", uu____730)  in
-                    [uu____724;
+                        term_to_string uu____718 uu____719  in
+                      FStar_Util.JsonStr uu____716  in
+                    ("witness", uu____715)  in
+                  let uu____722 =
+                    let uu____730 =
+                      let uu____736 =
+                        let uu____737 =
+                          let uu____739 = FStar_Tactics_Types.goal_env g  in
+                          term_to_string uu____739 g_type1  in
+                        FStar_Util.JsonStr uu____737  in
+                      ("type", uu____736)  in
+                    [uu____730;
                     ("label",
                       (FStar_Util.JsonStr (g.FStar_Tactics_Types.label)))]
                      in
-                  uu____703 :: uu____716  in
-                FStar_Util.JsonAssoc uu____695  in
-              ("goal", uu____694)  in
-            [uu____688]  in
-          ("hyps", j_binders) :: uu____680  in
-        FStar_Util.JsonAssoc uu____672
+                  uu____709 :: uu____722  in
+                FStar_Util.JsonAssoc uu____701  in
+              ("goal", uu____700)  in
+            [uu____694]  in
+          ("hyps", j_binders) :: uu____686  in
+        FStar_Util.JsonAssoc uu____678
   
 let (ps_to_json :
   (Prims.string * FStar_Tactics_Types.proofstate) -> FStar_Util.json) =
-  fun uu____787  ->
-    match uu____787 with
+  fun uu____793  ->
+    match uu____793 with
     | (msg,ps) ->
-        let uu____797 =
-          let uu____805 =
-            let uu____813 =
-              let uu____821 =
-                let uu____829 =
-                  let uu____835 =
-                    let uu____836 =
+        let uu____803 =
+          let uu____811 =
+            let uu____819 =
+              let uu____827 =
+                let uu____835 =
+                  let uu____841 =
+                    let uu____842 =
                       FStar_List.map goal_to_json
                         ps.FStar_Tactics_Types.goals
                        in
-                    FStar_Util.JsonList uu____836  in
-                  ("goals", uu____835)  in
-                let uu____841 =
-                  let uu____849 =
-                    let uu____855 =
-                      let uu____856 =
+                    FStar_Util.JsonList uu____842  in
+                  ("goals", uu____841)  in
+                let uu____847 =
+                  let uu____855 =
+                    let uu____861 =
+                      let uu____862 =
                         FStar_List.map goal_to_json
                           ps.FStar_Tactics_Types.smt_goals
                          in
-                      FStar_Util.JsonList uu____856  in
-                    ("smt-goals", uu____855)  in
-                  [uu____849]  in
-                uu____829 :: uu____841  in
+                      FStar_Util.JsonList uu____862  in
+                    ("smt-goals", uu____861)  in
+                  [uu____855]  in
+                uu____835 :: uu____847  in
               ("depth", (FStar_Util.JsonInt (ps.FStar_Tactics_Types.depth)))
-                :: uu____821
+                :: uu____827
                in
-            ("label", (FStar_Util.JsonStr msg)) :: uu____813  in
-          let uu____890 =
+            ("label", (FStar_Util.JsonStr msg)) :: uu____819  in
+          let uu____896 =
             if ps.FStar_Tactics_Types.entry_range <> FStar_Range.dummyRange
             then
-              let uu____906 =
-                let uu____912 =
+              let uu____912 =
+                let uu____918 =
                   FStar_Range.json_of_def_range
                     ps.FStar_Tactics_Types.entry_range
                    in
-                ("location", uu____912)  in
-              [uu____906]
+                ("location", uu____918)  in
+              [uu____912]
             else []  in
-          FStar_List.append uu____805 uu____890  in
-        FStar_Util.JsonAssoc uu____797
+          FStar_List.append uu____811 uu____896  in
+        FStar_Util.JsonAssoc uu____803
   
 let (do_dump_proofstate :
   FStar_Tactics_Types.proofstate -> Prims.string -> unit) =
   fun ps  ->
     fun msg  ->
-      let uu____950 =
-        let uu____952 = FStar_Options.silent ()  in
-        Prims.op_Negation uu____952  in
-      if uu____950
+      let uu____956 =
+        let uu____958 = FStar_Options.silent ()  in
+        Prims.op_Negation uu____958  in
+      if uu____956
       then
         FStar_Options.with_saved_options
-          (fun uu____958  ->
+          (fun uu____964  ->
              FStar_Options.set_option "print_effect_args"
                (FStar_Options.Bool true);
              FStar_Util.print_generic "proof-state" ps_to_string ps_to_json

--- a/src/ocaml-output/FStar_ToSyntax_Interleave.ml
+++ b/src/ocaml-output/FStar_ToSyntax_Interleave.ml
@@ -1,59 +1,67 @@
 open Prims
 let (id_eq_lid : FStar_Ident.ident -> FStar_Ident.lident -> Prims.bool) =
   fun i  ->
-    fun l  -> i.FStar_Ident.idText = (l.FStar_Ident.ident).FStar_Ident.idText
+    fun l  ->
+      let uu____11 = FStar_Ident.text_of_id i  in
+      let uu____13 =
+        let uu____15 = FStar_Ident.ident_of_lid l  in
+        FStar_Ident.text_of_id uu____15  in
+      uu____11 = uu____13
   
 let (is_val : FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
   fun x  ->
     fun d  ->
       match d.FStar_Parser_AST.d with
-      | FStar_Parser_AST.Val (y,uu____26) ->
-          x.FStar_Ident.idText = y.FStar_Ident.idText
-      | uu____28 -> false
+      | FStar_Parser_AST.Val (y,uu____31) ->
+          let uu____32 = FStar_Ident.text_of_id x  in
+          let uu____34 = FStar_Ident.text_of_id y  in uu____32 = uu____34
+      | uu____37 -> false
   
 let (is_type : FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
   fun x  ->
     fun d  ->
       match d.FStar_Parser_AST.d with
-      | FStar_Parser_AST.Tycon (uu____43,uu____44,tys) ->
+      | FStar_Parser_AST.Tycon (uu____52,uu____53,tys) ->
           FStar_All.pipe_right tys
             (FStar_Util.for_some
                (fun t  ->
-                  (FStar_Parser_AST.id_of_tycon t) = x.FStar_Ident.idText))
-      | uu____60 -> false
+                  let uu____70 = FStar_Parser_AST.id_of_tycon t  in
+                  let uu____72 = FStar_Ident.text_of_id x  in
+                  uu____70 = uu____72))
+      | uu____75 -> false
   
 let (definition_lids :
   FStar_Parser_AST.decl -> FStar_Ident.lident Prims.list) =
   fun d  ->
     match d.FStar_Parser_AST.d with
-    | FStar_Parser_AST.TopLevelLet (uu____72,defs) ->
+    | FStar_Parser_AST.TopLevelLet (uu____87,defs) ->
         FStar_Parser_AST.lids_of_let defs
-    | FStar_Parser_AST.Tycon (uu____86,uu____87,tys) ->
+    | FStar_Parser_AST.Tycon (uu____101,uu____102,tys) ->
         FStar_All.pipe_right tys
           (FStar_List.collect
-             (fun uu___0_107  ->
-                match uu___0_107 with
+             (fun uu___0_122  ->
+                match uu___0_122 with
                 | FStar_Parser_AST.TyconAbbrev
-                    (id,uu____111,uu____112,uu____113) ->
-                    let uu____122 = FStar_Ident.lid_of_ids [id]  in
-                    [uu____122]
+                    (id,uu____126,uu____127,uu____128) ->
+                    let uu____137 = FStar_Ident.lid_of_ids [id]  in
+                    [uu____137]
                 | FStar_Parser_AST.TyconRecord
-                    (id,uu____124,uu____125,uu____126) ->
-                    let uu____147 = FStar_Ident.lid_of_ids [id]  in
-                    [uu____147]
+                    (id,uu____139,uu____140,uu____141) ->
+                    let uu____162 = FStar_Ident.lid_of_ids [id]  in
+                    [uu____162]
                 | FStar_Parser_AST.TyconVariant
-                    (id,uu____149,uu____150,uu____151) ->
-                    let uu____182 = FStar_Ident.lid_of_ids [id]  in
-                    [uu____182]
-                | uu____183 -> []))
-    | uu____184 -> []
+                    (id,uu____164,uu____165,uu____166) ->
+                    let uu____197 = FStar_Ident.lid_of_ids [id]  in
+                    [uu____197]
+                | uu____198 -> []))
+    | uu____199 -> []
   
 let (is_definition_of :
   FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
   fun x  ->
     fun d  ->
-      let uu____197 = definition_lids d  in
-      FStar_Util.for_some (id_eq_lid x) uu____197
+      let uu____212 = definition_lids d  in
+      FStar_Util.for_some (id_eq_lid x) uu____212
   
 let rec (prefix_with_iface_decls :
   FStar_Parser_AST.decl Prims.list ->
@@ -70,11 +78,11 @@ let rec (prefix_with_iface_decls :
                   ("KremlinPrivate", (impl1.FStar_Parser_AST.drange))))
             impl1.FStar_Parser_AST.drange FStar_Parser_AST.Expr
            in
-        let uu___58_240 = impl1  in
+        let uu___58_255 = impl1  in
         {
-          FStar_Parser_AST.d = (uu___58_240.FStar_Parser_AST.d);
-          FStar_Parser_AST.drange = (uu___58_240.FStar_Parser_AST.drange);
-          FStar_Parser_AST.quals = (uu___58_240.FStar_Parser_AST.quals);
+          FStar_Parser_AST.d = (uu___58_255.FStar_Parser_AST.d);
+          FStar_Parser_AST.drange = (uu___58_255.FStar_Parser_AST.drange);
+          FStar_Parser_AST.quals = (uu___58_255.FStar_Parser_AST.quals);
           FStar_Parser_AST.attrs = (krem_private ::
             (impl1.FStar_Parser_AST.attrs))
         }  in
@@ -82,13 +90,13 @@ let rec (prefix_with_iface_decls :
       | [] -> ([], [qualify_kremlin_private impl])
       | iface_hd::iface_tl ->
           (match iface_hd.FStar_Parser_AST.d with
-           | FStar_Parser_AST.Tycon (uu____265,uu____266,tys) when
+           | FStar_Parser_AST.Tycon (uu____280,uu____281,tys) when
                FStar_All.pipe_right tys
                  (FStar_Util.for_some
-                    (fun uu___1_281  ->
-                       match uu___1_281 with
-                       | FStar_Parser_AST.TyconAbstract uu____283 -> true
-                       | uu____295 -> false))
+                    (fun uu___1_296  ->
+                       match uu___1_296 with
+                       | FStar_Parser_AST.TyconAbstract uu____298 -> true
+                       | uu____310 -> false))
                ->
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_AbstractTypeDeclarationInInterface,
@@ -99,91 +107,102 @@ let rec (prefix_with_iface_decls :
                let defines_x = FStar_Util.for_some (id_eq_lid x) def_ids  in
                if Prims.op_Negation defines_x
                then
-                 let uu____323 =
+                 let uu____338 =
                    FStar_All.pipe_right def_ids
                      (FStar_Util.for_some
                         (fun y  ->
-                           FStar_All.pipe_right iface_tl
-                             (FStar_Util.for_some
-                                (is_val y.FStar_Ident.ident))))
+                           let uu____346 =
+                             let uu____354 =
+                               let uu____360 = FStar_Ident.ident_of_lid y  in
+                               is_val uu____360  in
+                             FStar_Util.for_some uu____354  in
+                           FStar_All.pipe_right iface_tl uu____346))
                     in
-                 (if uu____323
+                 (if uu____338
                   then
-                    let uu____342 =
-                      let uu____348 =
-                        let uu____350 =
-                          let uu____352 =
+                    let uu____373 =
+                      let uu____379 =
+                        let uu____381 = FStar_Ident.text_of_id x  in
+                        let uu____383 =
+                          let uu____385 =
                             FStar_All.pipe_right def_ids
                               (FStar_List.map FStar_Ident.string_of_lid)
                              in
-                          FStar_All.pipe_right uu____352
+                          FStar_All.pipe_right uu____385
                             (FStar_String.concat ", ")
                            in
                         FStar_Util.format2
                           "Expected the definition of %s to precede %s"
-                          x.FStar_Ident.idText uu____350
+                          uu____381 uu____383
                          in
-                      (FStar_Errors.Fatal_WrongDefinitionOrder, uu____348)
+                      (FStar_Errors.Fatal_WrongDefinitionOrder, uu____379)
                        in
-                    FStar_Errors.raise_error uu____342
+                    FStar_Errors.raise_error uu____373
                       impl.FStar_Parser_AST.drange
                   else (iface, [qualify_kremlin_private impl]))
                else
                  (let mutually_defined_with_x =
                     FStar_All.pipe_right def_ids
                       (FStar_List.filter
-                         (fun y  -> Prims.op_Negation (id_eq_lid x y)))
+                         (fun y  ->
+                            let uu____428 = id_eq_lid x y  in
+                            Prims.op_Negation uu____428))
                      in
                   let rec aux mutuals iface1 =
                     match (mutuals, iface1) with
-                    | ([],uu____433) -> ([], iface1)
-                    | (uu____444::uu____445,[]) -> ([], [])
+                    | ([],uu____469) -> ([], iface1)
+                    | (uu____480::uu____481,[]) -> ([], [])
                     | (y::ys,iface_hd1::iface_tl1) ->
-                        if is_val y.FStar_Ident.ident iface_hd1
+                        let uu____504 =
+                          let uu____506 = FStar_Ident.ident_of_lid y  in
+                          is_val uu____506 iface_hd1  in
+                        if uu____504
                         then
-                          let uu____477 = aux ys iface_tl1  in
-                          (match uu____477 with
+                          let uu____516 = aux ys iface_tl1  in
+                          (match uu____516 with
                            | (val_ys,iface2) ->
                                ((iface_hd1 :: val_ys), iface2))
                         else
-                          (let uu____510 =
-                             let uu____512 =
-                               FStar_List.tryFind
-                                 (is_val y.FStar_Ident.ident) iface_tl1
-                                in
+                          (let uu____549 =
+                             let uu____551 =
+                               let uu____554 =
+                                 let uu____560 = FStar_Ident.ident_of_lid y
+                                    in
+                                 is_val uu____560  in
+                               FStar_List.tryFind uu____554 iface_tl1  in
                              FStar_All.pipe_left FStar_Option.isSome
-                               uu____512
+                               uu____551
                               in
-                           if uu____510
+                           if uu____549
                            then
-                             let uu____527 =
-                               let uu____533 =
-                                 let uu____535 =
+                             let uu____573 =
+                               let uu____579 =
+                                 let uu____581 =
                                    FStar_Parser_AST.decl_to_string iface_hd1
                                     in
-                                 let uu____537 = FStar_Ident.string_of_lid y
+                                 let uu____583 = FStar_Ident.string_of_lid y
                                     in
                                  FStar_Util.format2
                                    "%s is out of order with the definition of %s"
-                                   uu____535 uu____537
+                                   uu____581 uu____583
                                   in
                                (FStar_Errors.Fatal_WrongDefinitionOrder,
-                                 uu____533)
+                                 uu____579)
                                 in
-                             FStar_Errors.raise_error uu____527
+                             FStar_Errors.raise_error uu____573
                                iface_hd1.FStar_Parser_AST.drange
                            else aux ys iface1)
                      in
-                  let uu____551 = aux mutually_defined_with_x iface_tl  in
-                  match uu____551 with
+                  let uu____597 = aux mutually_defined_with_x iface_tl  in
+                  match uu____597 with
                   | (take_iface,rest_iface) ->
                       (rest_iface,
                         (FStar_List.append (iface_hd :: take_iface) [impl])))
-           | FStar_Parser_AST.Pragma uu____582 ->
+           | FStar_Parser_AST.Pragma uu____628 ->
                prefix_with_iface_decls iface_tl impl
-           | uu____583 ->
-               let uu____584 = prefix_with_iface_decls iface_tl impl  in
-               (match uu____584 with
+           | uu____629 ->
+               let uu____630 = prefix_with_iface_decls iface_tl impl  in
+               (match uu____630 with
                 | (iface1,ds) -> (iface1, (iface_hd :: ds))))
   
 let (check_initial_interface :
@@ -194,54 +213,56 @@ let (check_initial_interface :
       | [] -> ()
       | hd::tl ->
           (match hd.FStar_Parser_AST.d with
-           | FStar_Parser_AST.Tycon (uu____641,uu____642,tys) when
+           | FStar_Parser_AST.Tycon (uu____687,uu____688,tys) when
                FStar_All.pipe_right tys
                  (FStar_Util.for_some
-                    (fun uu___2_657  ->
-                       match uu___2_657 with
-                       | FStar_Parser_AST.TyconAbstract uu____659 -> true
-                       | uu____671 -> false))
+                    (fun uu___2_703  ->
+                       match uu___2_703 with
+                       | FStar_Parser_AST.TyconAbstract uu____705 -> true
+                       | uu____717 -> false))
                ->
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_AbstractTypeDeclarationInInterface,
                    "Interface contains an abstract 'type' declaration; use 'val' instead")
                  hd.FStar_Parser_AST.drange
            | FStar_Parser_AST.Val (x,t) ->
-               let uu____677 = FStar_Util.for_some (is_definition_of x) tl
+               let uu____723 = FStar_Util.for_some (is_definition_of x) tl
                   in
-               if uu____677
+               if uu____723
                then
-                 let uu____680 =
-                   let uu____686 =
+                 let uu____726 =
+                   let uu____732 =
+                     let uu____734 = FStar_Ident.text_of_id x  in
+                     let uu____736 = FStar_Ident.text_of_id x  in
                      FStar_Util.format2
                        "'val %s' and 'let %s' cannot both be provided in an interface"
-                       x.FStar_Ident.idText x.FStar_Ident.idText
+                       uu____734 uu____736
                       in
-                   (FStar_Errors.Fatal_BothValAndLetInInterface, uu____686)
+                   (FStar_Errors.Fatal_BothValAndLetInInterface, uu____732)
                     in
-                 FStar_Errors.raise_error uu____680
+                 FStar_Errors.raise_error uu____726
                    hd.FStar_Parser_AST.drange
                else
-                 (let uu____692 =
+                 (let uu____742 =
                     FStar_All.pipe_right hd.FStar_Parser_AST.quals
                       (FStar_List.contains FStar_Parser_AST.Assumption)
                      in
-                  if uu____692
+                  if uu____742
                   then
                     FStar_Errors.raise_error
                       (FStar_Errors.Fatal_AssumeValInInterface,
                         "Interfaces cannot use `assume val x : t`; just write `val x : t` instead")
                       hd.FStar_Parser_AST.drange
                   else ())
-           | uu____702 -> ())
+           | uu____752 -> ())
        in
     aux iface;
     FStar_All.pipe_right iface
       (FStar_List.filter
          (fun d  ->
             match d.FStar_Parser_AST.d with
-            | FStar_Parser_AST.TopLevelModule uu____712 -> false
-            | uu____714 -> true))
+            | FStar_Parser_AST.TopLevelModule uu____762 -> false
+            | uu____764 -> true))
   
 let (ml_mode_prefix_with_iface_decls :
   FStar_Parser_AST.decl Prims.list ->
@@ -251,23 +272,25 @@ let (ml_mode_prefix_with_iface_decls :
   fun iface  ->
     fun impl  ->
       match impl.FStar_Parser_AST.d with
-      | FStar_Parser_AST.TopLevelLet (uu____747,defs) ->
+      | FStar_Parser_AST.TopLevelLet (uu____797,defs) ->
           let xs = FStar_Parser_AST.lids_of_let defs  in
-          let uu____764 =
+          let uu____814 =
             FStar_List.partition
               (fun d  ->
                  FStar_All.pipe_right xs
                    (FStar_Util.for_some
-                      (fun x  -> is_val x.FStar_Ident.ident d))) iface
+                      (fun x  ->
+                         let uu____831 = FStar_Ident.ident_of_lid x  in
+                         is_val uu____831 d))) iface
              in
-          (match uu____764 with
+          (match uu____814 with
            | (val_xs,rest_iface) ->
                (rest_iface, (FStar_List.append val_xs [impl])))
-      | uu____802 -> (iface, [impl])
+      | uu____854 -> (iface, [impl])
   
 let ml_mode_check_initial_interface :
-  'uuuuuu814 .
-    'uuuuuu814 ->
+  'uuuuuu866 .
+    'uuuuuu866 ->
       FStar_Parser_AST.decl Prims.list -> FStar_Parser_AST.decl Prims.list
   =
   fun mname  ->
@@ -276,8 +299,8 @@ let ml_mode_check_initial_interface :
         (FStar_List.filter
            (fun d  ->
               match d.FStar_Parser_AST.d with
-              | FStar_Parser_AST.Val uu____839 -> true
-              | uu____845 -> false))
+              | FStar_Parser_AST.Val uu____891 -> true
+              | uu____897 -> false))
   
 let (ulib_modules : Prims.string Prims.list) =
   ["FStar.TSet";
@@ -296,15 +319,15 @@ let (ulib_modules : Prims.string Prims.list) =
 let (apply_ml_mode_optimizations : FStar_Ident.lident -> Prims.bool) =
   fun mname  ->
     ((FStar_Options.ml_ish ()) &&
-       (let uu____887 =
-          let uu____889 = FStar_Ident.string_of_lid mname  in
-          FStar_List.contains uu____889 FStar_Parser_Dep.core_modules  in
-        Prims.op_Negation uu____887))
+       (let uu____939 =
+          let uu____941 = FStar_Ident.string_of_lid mname  in
+          FStar_List.contains uu____941 FStar_Parser_Dep.core_modules  in
+        Prims.op_Negation uu____939))
       &&
-      (let uu____893 =
-         let uu____895 = FStar_Ident.string_of_lid mname  in
-         FStar_List.contains uu____895 ulib_modules  in
-       Prims.op_Negation uu____893)
+      (let uu____945 =
+         let uu____947 = FStar_Ident.string_of_lid mname  in
+         FStar_List.contains uu____947 ulib_modules  in
+       Prims.op_Negation uu____945)
   
 let (prefix_one_decl :
   FStar_Ident.lident ->
@@ -316,10 +339,10 @@ let (prefix_one_decl :
     fun iface  ->
       fun impl  ->
         match impl.FStar_Parser_AST.d with
-        | FStar_Parser_AST.TopLevelModule uu____934 -> (iface, [impl])
-        | uu____939 ->
-            let uu____940 = apply_ml_mode_optimizations mname  in
-            if uu____940
+        | FStar_Parser_AST.TopLevelModule uu____986 -> (iface, [impl])
+        | uu____991 ->
+            let uu____992 = apply_ml_mode_optimizations mname  in
+            if uu____992
             then ml_mode_prefix_with_iface_decls iface impl
             else prefix_with_iface_decls iface impl
   
@@ -331,26 +354,26 @@ let (initialize_interface :
     fun l  ->
       fun env  ->
         let decls =
-          let uu____978 = apply_ml_mode_optimizations mname  in
-          if uu____978
+          let uu____1030 = apply_ml_mode_optimizations mname  in
+          if uu____1030
           then ml_mode_check_initial_interface mname l
           else check_initial_interface l  in
-        let uu____985 = FStar_Syntax_DsEnv.iface_decls env mname  in
-        match uu____985 with
-        | FStar_Pervasives_Native.Some uu____994 ->
-            let uu____999 =
-              let uu____1005 =
-                let uu____1007 = FStar_Ident.string_of_lid mname  in
+        let uu____1037 = FStar_Syntax_DsEnv.iface_decls env mname  in
+        match uu____1037 with
+        | FStar_Pervasives_Native.Some uu____1046 ->
+            let uu____1051 =
+              let uu____1057 =
+                let uu____1059 = FStar_Ident.string_of_lid mname  in
                 FStar_Util.format1 "Interface %s has already been processed"
-                  uu____1007
+                  uu____1059
                  in
-              (FStar_Errors.Fatal_InterfaceAlreadyProcessed, uu____1005)  in
-            let uu____1011 = FStar_Ident.range_of_lid mname  in
-            FStar_Errors.raise_error uu____999 uu____1011
+              (FStar_Errors.Fatal_InterfaceAlreadyProcessed, uu____1057)  in
+            let uu____1063 = FStar_Ident.range_of_lid mname  in
+            FStar_Errors.raise_error uu____1051 uu____1063
         | FStar_Pervasives_Native.None  ->
-            let uu____1018 =
+            let uu____1070 =
               FStar_Syntax_DsEnv.set_iface_decls env mname decls  in
-            ((), uu____1018)
+            ((), uu____1070)
   
 let (prefix_with_interface_decls :
   FStar_Ident.lident ->
@@ -360,18 +383,18 @@ let (prefix_with_interface_decls :
   fun mname  ->
     fun impl  ->
       fun env  ->
-        let uu____1041 =
-          let uu____1046 = FStar_Syntax_DsEnv.current_module env  in
-          FStar_Syntax_DsEnv.iface_decls env uu____1046  in
-        match uu____1041 with
+        let uu____1093 =
+          let uu____1098 = FStar_Syntax_DsEnv.current_module env  in
+          FStar_Syntax_DsEnv.iface_decls env uu____1098  in
+        match uu____1093 with
         | FStar_Pervasives_Native.None  -> ([impl], env)
         | FStar_Pervasives_Native.Some iface ->
-            let uu____1062 = prefix_one_decl mname iface impl  in
-            (match uu____1062 with
+            let uu____1114 = prefix_one_decl mname iface impl  in
+            (match uu____1114 with
              | (iface1,impl1) ->
                  let env1 =
-                   let uu____1088 = FStar_Syntax_DsEnv.current_module env  in
-                   FStar_Syntax_DsEnv.set_iface_decls env uu____1088 iface1
+                   let uu____1140 = FStar_Syntax_DsEnv.current_module env  in
+                   FStar_Syntax_DsEnv.set_iface_decls env uu____1140 iface1
                     in
                  (impl1, env1))
   
@@ -383,86 +406,86 @@ let (interleave_module :
     fun expect_complete_modul  ->
       fun env  ->
         match a with
-        | FStar_Parser_AST.Interface uu____1115 -> (a, env)
+        | FStar_Parser_AST.Interface uu____1167 -> (a, env)
         | FStar_Parser_AST.Module (l,impls) ->
-            let uu____1131 = FStar_Syntax_DsEnv.iface_decls env l  in
-            (match uu____1131 with
+            let uu____1183 = FStar_Syntax_DsEnv.iface_decls env l  in
+            (match uu____1183 with
              | FStar_Pervasives_Native.None  -> (a, env)
              | FStar_Pervasives_Native.Some iface ->
-                 let uu____1147 =
+                 let uu____1199 =
                    FStar_List.fold_left
-                     (fun uu____1171  ->
+                     (fun uu____1223  ->
                         fun impl  ->
-                          match uu____1171 with
+                          match uu____1223 with
                           | (iface1,impls1) ->
-                              let uu____1199 = prefix_one_decl l iface1 impl
+                              let uu____1251 = prefix_one_decl l iface1 impl
                                  in
-                              (match uu____1199 with
+                              (match uu____1251 with
                                | (iface2,impls') ->
                                    (iface2,
                                      (FStar_List.append impls1 impls'))))
                      (iface, []) impls
                     in
-                 (match uu____1147 with
+                 (match uu____1199 with
                   | (iface1,impls1) ->
-                      let uu____1248 =
-                        let uu____1257 =
+                      let uu____1300 =
+                        let uu____1309 =
                           FStar_Util.prefix_until
-                            (fun uu___3_1275  ->
-                               match uu___3_1275 with
+                            (fun uu___3_1327  ->
+                               match uu___3_1327 with
                                | {
                                    FStar_Parser_AST.d = FStar_Parser_AST.Val
-                                     uu____1277;
-                                   FStar_Parser_AST.drange = uu____1278;
-                                   FStar_Parser_AST.quals = uu____1279;
-                                   FStar_Parser_AST.attrs = uu____1280;_} ->
+                                     uu____1329;
+                                   FStar_Parser_AST.drange = uu____1330;
+                                   FStar_Parser_AST.quals = uu____1331;
+                                   FStar_Parser_AST.attrs = uu____1332;_} ->
                                    true
-                               | uu____1286 -> false) iface1
+                               | uu____1338 -> false) iface1
                            in
-                        match uu____1257 with
+                        match uu____1309 with
                         | FStar_Pervasives_Native.None  -> (iface1, [])
                         | FStar_Pervasives_Native.Some (lets,one_val,rest) ->
                             (lets, (one_val :: rest))
                          in
-                      (match uu____1248 with
+                      (match uu____1300 with
                        | (iface_lets,remaining_iface_vals) ->
                            let impls2 = FStar_List.append impls1 iface_lets
                               in
                            let env1 =
-                             let uu____1353 = FStar_Options.interactive ()
+                             let uu____1405 = FStar_Options.interactive ()
                                 in
-                             if uu____1353
+                             if uu____1405
                              then
                                FStar_Syntax_DsEnv.set_iface_decls env l
                                  remaining_iface_vals
                              else env  in
                            let a1 = FStar_Parser_AST.Module (l, impls2)  in
                            (match remaining_iface_vals with
-                            | uu____1365::uu____1366 when
+                            | uu____1417::uu____1418 when
                                 expect_complete_modul ->
                                 let err =
-                                  let uu____1371 =
+                                  let uu____1423 =
                                     FStar_List.map
                                       FStar_Parser_AST.decl_to_string
                                       remaining_iface_vals
                                      in
-                                  FStar_All.pipe_right uu____1371
+                                  FStar_All.pipe_right uu____1423
                                     (FStar_String.concat "\n\t")
                                    in
-                                let uu____1381 =
-                                  let uu____1387 =
-                                    let uu____1389 =
+                                let uu____1433 =
+                                  let uu____1439 =
+                                    let uu____1441 =
                                       FStar_Ident.string_of_lid l  in
                                     FStar_Util.format2
                                       "Some interface elements were not implemented by module %s:\n\t%s"
-                                      uu____1389 err
+                                      uu____1441 err
                                      in
                                   (FStar_Errors.Fatal_InterfaceNotImplementedByModule,
-                                    uu____1387)
+                                    uu____1439)
                                    in
-                                let uu____1393 = FStar_Ident.range_of_lid l
+                                let uu____1445 = FStar_Ident.range_of_lid l
                                    in
-                                FStar_Errors.raise_error uu____1381
-                                  uu____1393
-                            | uu____1398 -> (a1, env1)))))
+                                FStar_Errors.raise_error uu____1433
+                                  uu____1445
+                            | uu____1450 -> (a1, env1)))))
   

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -299,19 +299,19 @@ let (compile_op_lid :
     fun s  ->
       fun r  ->
         let uu____712 =
-          let uu____715 =
-            let uu____716 =
-              let uu____722 = FStar_Parser_AST.compile_op n s r  in
-              (uu____722, r)  in
-            FStar_Ident.mk_ident uu____716  in
-          [uu____715]  in
+          let uu____713 =
+            let uu____714 =
+              let uu____720 = FStar_Parser_AST.compile_op n s r  in
+              (uu____720, r)  in
+            FStar_Ident.mk_ident uu____714  in
+          [uu____713]  in
         FStar_All.pipe_right uu____712 FStar_Ident.lid_of_ids
   
 let op_as_term :
-  'uuuuuu738 .
+  'uuuuuu734 .
     env_t ->
       Prims.int ->
-        'uuuuuu738 ->
+        'uuuuuu734 ->
           FStar_Ident.ident ->
             FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
@@ -320,18 +320,19 @@ let op_as_term :
       fun rng  ->
         fun op  ->
           let r l dd =
-            let uu____776 =
-              let uu____777 =
-                let uu____778 =
-                  FStar_Ident.set_lid_range l op.FStar_Ident.idRange  in
-                FStar_Syntax_Syntax.lid_as_fv uu____778 dd
+            let uu____772 =
+              let uu____773 =
+                let uu____774 =
+                  let uu____775 = FStar_Ident.range_of_id op  in
+                  FStar_Ident.set_lid_range l uu____775  in
+                FStar_Syntax_Syntax.lid_as_fv uu____774 dd
                   FStar_Pervasives_Native.None
                  in
-              FStar_All.pipe_right uu____777 FStar_Syntax_Syntax.fv_to_tm  in
-            FStar_Pervasives_Native.Some uu____776  in
-          let fallback uu____786 =
-            let uu____787 = FStar_Ident.text_of_id op  in
-            match uu____787 with
+              FStar_All.pipe_right uu____773 FStar_Syntax_Syntax.fv_to_tm  in
+            FStar_Pervasives_Native.Some uu____772  in
+          let fallback uu____783 =
+            let uu____784 = FStar_Ident.text_of_id op  in
+            match uu____784 with
             | "=" ->
                 r FStar_Parser_Const.op_Eq
                   FStar_Syntax_Syntax.delta_equational
@@ -375,8 +376,8 @@ let op_as_term :
                 r FStar_Parser_Const.read_lid
                   FStar_Syntax_Syntax.delta_equational
             | "@" ->
-                let uu____808 = FStar_Options.ml_ish ()  in
-                if uu____808
+                let uu____805 = FStar_Options.ml_ish ()  in
+                if uu____805
                 then
                   r FStar_Parser_Const.list_append_lid
                     (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -418,40 +419,46 @@ let op_as_term :
                 r FStar_Parser_Const.iff_lid
                   (FStar_Syntax_Syntax.Delta_constant_at_level
                      (Prims.of_int (2)))
-            | uu____833 -> FStar_Pervasives_Native.None  in
-          let uu____835 =
-            let uu____838 =
-              compile_op_lid arity op.FStar_Ident.idText
-                op.FStar_Ident.idRange
-               in
+            | uu____830 -> FStar_Pervasives_Native.None  in
+          let uu____832 =
+            let uu____835 =
+              let uu____836 = FStar_Ident.text_of_id op  in
+              let uu____838 = FStar_Ident.range_of_id op  in
+              compile_op_lid arity uu____836 uu____838  in
             desugar_name'
               (fun t  ->
-                 let uu___202_844 = t  in
+                 let uu___202_846 = t  in
+                 let uu____847 = FStar_Ident.range_of_id op  in
                  {
                    FStar_Syntax_Syntax.n =
-                     (uu___202_844.FStar_Syntax_Syntax.n);
-                   FStar_Syntax_Syntax.pos = (op.FStar_Ident.idRange);
+                     (uu___202_846.FStar_Syntax_Syntax.n);
+                   FStar_Syntax_Syntax.pos = uu____847;
                    FStar_Syntax_Syntax.vars =
-                     (uu___202_844.FStar_Syntax_Syntax.vars)
-                 }) env true uu____838
+                     (uu___202_846.FStar_Syntax_Syntax.vars)
+                 }) env true uu____835
              in
-          match uu____835 with
+          match uu____832 with
           | FStar_Pervasives_Native.Some t -> FStar_Pervasives_Native.Some t
-          | uu____849 -> fallback ()
+          | uu____852 -> fallback ()
   
 let (sort_ftv : FStar_Ident.ident Prims.list -> FStar_Ident.ident Prims.list)
   =
   fun ftv  ->
-    let uu____864 =
+    let uu____867 =
       FStar_Util.remove_dups
-        (fun x  -> fun y  -> x.FStar_Ident.idText = y.FStar_Ident.idText) ftv
+        (fun x  ->
+           fun y  ->
+             let uu____876 = FStar_Ident.text_of_id x  in
+             let uu____878 = FStar_Ident.text_of_id y  in
+             uu____876 = uu____878) ftv
        in
     FStar_All.pipe_left
       (FStar_Util.sort_with
          (fun x  ->
             fun y  ->
-              FStar_String.compare x.FStar_Ident.idText y.FStar_Ident.idText))
-      uu____864
+              let uu____891 = FStar_Ident.text_of_id x  in
+              let uu____893 = FStar_Ident.text_of_id y  in
+              FStar_String.compare uu____891 uu____893)) uu____867
   
 let rec (free_type_vars_b :
   FStar_Syntax_DsEnv.env ->
@@ -461,17 +468,17 @@ let rec (free_type_vars_b :
   fun env  ->
     fun binder  ->
       match binder.FStar_Parser_AST.b with
-      | FStar_Parser_AST.Variable uu____913 -> (env, [])
+      | FStar_Parser_AST.Variable uu____928 -> (env, [])
       | FStar_Parser_AST.TVariable x ->
-          let uu____917 = FStar_Syntax_DsEnv.push_bv env x  in
-          (match uu____917 with | (env1,uu____929) -> (env1, [x]))
-      | FStar_Parser_AST.Annotated (uu____932,term) ->
-          let uu____934 = free_type_vars env term  in (env, uu____934)
-      | FStar_Parser_AST.TAnnotated (id,uu____940) ->
-          let uu____941 = FStar_Syntax_DsEnv.push_bv env id  in
-          (match uu____941 with | (env1,uu____953) -> (env1, []))
+          let uu____932 = FStar_Syntax_DsEnv.push_bv env x  in
+          (match uu____932 with | (env1,uu____944) -> (env1, [x]))
+      | FStar_Parser_AST.Annotated (uu____947,term) ->
+          let uu____949 = free_type_vars env term  in (env, uu____949)
+      | FStar_Parser_AST.TAnnotated (id,uu____955) ->
+          let uu____956 = FStar_Syntax_DsEnv.push_bv env id  in
+          (match uu____956 with | (env1,uu____968) -> (env1, []))
       | FStar_Parser_AST.NoName t ->
-          let uu____957 = free_type_vars env t  in (env, uu____957)
+          let uu____972 = free_type_vars env t  in (env, uu____972)
 
 and (free_type_vars :
   FStar_Syntax_DsEnv.env ->
@@ -479,26 +486,26 @@ and (free_type_vars :
   =
   fun env  ->
     fun t  ->
-      let uu____964 =
-        let uu____965 = unparen t  in uu____965.FStar_Parser_AST.tm  in
-      match uu____964 with
-      | FStar_Parser_AST.Labeled uu____968 ->
+      let uu____979 =
+        let uu____980 = unparen t  in uu____980.FStar_Parser_AST.tm  in
+      match uu____979 with
+      | FStar_Parser_AST.Labeled uu____983 ->
           failwith "Impossible --- labeled source term"
       | FStar_Parser_AST.Tvar a ->
-          let uu____981 = FStar_Syntax_DsEnv.try_lookup_id env a  in
-          (match uu____981 with
+          let uu____996 = FStar_Syntax_DsEnv.try_lookup_id env a  in
+          (match uu____996 with
            | FStar_Pervasives_Native.None  -> [a]
-           | uu____986 -> [])
+           | uu____1001 -> [])
       | FStar_Parser_AST.Wild  -> []
-      | FStar_Parser_AST.Const uu____989 -> []
-      | FStar_Parser_AST.Uvar uu____990 -> []
-      | FStar_Parser_AST.Var uu____991 -> []
-      | FStar_Parser_AST.Projector uu____992 -> []
-      | FStar_Parser_AST.Discrim uu____997 -> []
-      | FStar_Parser_AST.Name uu____998 -> []
-      | FStar_Parser_AST.Requires (t1,uu____1000) -> free_type_vars env t1
-      | FStar_Parser_AST.Ensures (t1,uu____1008) -> free_type_vars env t1
-      | FStar_Parser_AST.NamedTyp (uu____1015,t1) -> free_type_vars env t1
+      | FStar_Parser_AST.Const uu____1004 -> []
+      | FStar_Parser_AST.Uvar uu____1005 -> []
+      | FStar_Parser_AST.Var uu____1006 -> []
+      | FStar_Parser_AST.Projector uu____1007 -> []
+      | FStar_Parser_AST.Discrim uu____1012 -> []
+      | FStar_Parser_AST.Name uu____1013 -> []
+      | FStar_Parser_AST.Requires (t1,uu____1015) -> free_type_vars env t1
+      | FStar_Parser_AST.Ensures (t1,uu____1023) -> free_type_vars env t1
+      | FStar_Parser_AST.NamedTyp (uu____1030,t1) -> free_type_vars env t1
       | FStar_Parser_AST.Paren t1 -> failwith "impossible"
       | FStar_Parser_AST.Ascribed (t1,t',tacopt) ->
           let ts = t1 :: t' ::
@@ -507,97 +514,97 @@ and (free_type_vars :
              | FStar_Pervasives_Native.Some t2 -> [t2])
              in
           FStar_List.collect (free_type_vars env) ts
-      | FStar_Parser_AST.Construct (uu____1034,ts) ->
+      | FStar_Parser_AST.Construct (uu____1049,ts) ->
           FStar_List.collect
-            (fun uu____1055  ->
-               match uu____1055 with
-               | (t1,uu____1063) -> free_type_vars env t1) ts
-      | FStar_Parser_AST.Op (uu____1064,ts) ->
+            (fun uu____1070  ->
+               match uu____1070 with
+               | (t1,uu____1078) -> free_type_vars env t1) ts
+      | FStar_Parser_AST.Op (uu____1079,ts) ->
           FStar_List.collect (free_type_vars env) ts
-      | FStar_Parser_AST.App (t1,t2,uu____1072) ->
-          let uu____1073 = free_type_vars env t1  in
-          let uu____1076 = free_type_vars env t2  in
-          FStar_List.append uu____1073 uu____1076
+      | FStar_Parser_AST.App (t1,t2,uu____1087) ->
+          let uu____1088 = free_type_vars env t1  in
+          let uu____1091 = free_type_vars env t2  in
+          FStar_List.append uu____1088 uu____1091
       | FStar_Parser_AST.Refine (b,t1) ->
-          let uu____1081 = free_type_vars_b env b  in
-          (match uu____1081 with
+          let uu____1096 = free_type_vars_b env b  in
+          (match uu____1096 with
            | (env1,f) ->
-               let uu____1096 = free_type_vars env1 t1  in
-               FStar_List.append f uu____1096)
+               let uu____1111 = free_type_vars env1 t1  in
+               FStar_List.append f uu____1111)
       | FStar_Parser_AST.Sum (binders,body) ->
-          let uu____1113 =
+          let uu____1128 =
             FStar_List.fold_left
-              (fun uu____1137  ->
+              (fun uu____1152  ->
                  fun bt  ->
-                   match uu____1137 with
+                   match uu____1152 with
                    | (env1,free) ->
-                       let uu____1161 =
+                       let uu____1176 =
                          match bt with
                          | FStar_Util.Inl binder ->
                              free_type_vars_b env1 binder
                          | FStar_Util.Inr t1 ->
-                             let uu____1176 = free_type_vars env1 body  in
-                             (env1, uu____1176)
+                             let uu____1191 = free_type_vars env1 body  in
+                             (env1, uu____1191)
                           in
-                       (match uu____1161 with
+                       (match uu____1176 with
                         | (env2,f) -> (env2, (FStar_List.append f free))))
               (env, []) binders
              in
-          (match uu____1113 with
+          (match uu____1128 with
            | (env1,free) ->
-               let uu____1205 = free_type_vars env1 body  in
-               FStar_List.append free uu____1205)
+               let uu____1220 = free_type_vars env1 body  in
+               FStar_List.append free uu____1220)
       | FStar_Parser_AST.Product (binders,body) ->
-          let uu____1214 =
+          let uu____1229 =
             FStar_List.fold_left
-              (fun uu____1234  ->
+              (fun uu____1249  ->
                  fun binder  ->
-                   match uu____1234 with
+                   match uu____1249 with
                    | (env1,free) ->
-                       let uu____1254 = free_type_vars_b env1 binder  in
-                       (match uu____1254 with
+                       let uu____1269 = free_type_vars_b env1 binder  in
+                       (match uu____1269 with
                         | (env2,f) -> (env2, (FStar_List.append f free))))
               (env, []) binders
              in
-          (match uu____1214 with
+          (match uu____1229 with
            | (env1,free) ->
-               let uu____1285 = free_type_vars env1 body  in
-               FStar_List.append free uu____1285)
-      | FStar_Parser_AST.Project (t1,uu____1289) -> free_type_vars env t1
+               let uu____1300 = free_type_vars env1 body  in
+               FStar_List.append free uu____1300)
+      | FStar_Parser_AST.Project (t1,uu____1304) -> free_type_vars env t1
       | FStar_Parser_AST.Attributes cattributes ->
           FStar_List.collect (free_type_vars env) cattributes
       | FStar_Parser_AST.CalcProof (rel,init,steps) ->
-          let uu____1300 = free_type_vars env rel  in
-          let uu____1303 =
-            let uu____1306 = free_type_vars env init  in
-            let uu____1309 =
+          let uu____1315 = free_type_vars env rel  in
+          let uu____1318 =
+            let uu____1321 = free_type_vars env init  in
+            let uu____1324 =
               FStar_List.collect
-                (fun uu____1318  ->
-                   match uu____1318 with
+                (fun uu____1333  ->
+                   match uu____1333 with
                    | FStar_Parser_AST.CalcStep (rel1,just,next) ->
-                       let uu____1324 = free_type_vars env rel1  in
-                       let uu____1327 =
-                         let uu____1330 = free_type_vars env just  in
-                         let uu____1333 = free_type_vars env next  in
-                         FStar_List.append uu____1330 uu____1333  in
-                       FStar_List.append uu____1324 uu____1327) steps
+                       let uu____1339 = free_type_vars env rel1  in
+                       let uu____1342 =
+                         let uu____1345 = free_type_vars env just  in
+                         let uu____1348 = free_type_vars env next  in
+                         FStar_List.append uu____1345 uu____1348  in
+                       FStar_List.append uu____1339 uu____1342) steps
                in
-            FStar_List.append uu____1306 uu____1309  in
-          FStar_List.append uu____1300 uu____1303
-      | FStar_Parser_AST.Abs uu____1336 -> []
-      | FStar_Parser_AST.Let uu____1343 -> []
-      | FStar_Parser_AST.LetOpen uu____1364 -> []
-      | FStar_Parser_AST.If uu____1369 -> []
-      | FStar_Parser_AST.QForall uu____1376 -> []
-      | FStar_Parser_AST.QExists uu____1395 -> []
-      | FStar_Parser_AST.Record uu____1414 -> []
-      | FStar_Parser_AST.Match uu____1427 -> []
-      | FStar_Parser_AST.TryWith uu____1442 -> []
-      | FStar_Parser_AST.Bind uu____1457 -> []
-      | FStar_Parser_AST.Quote uu____1464 -> []
-      | FStar_Parser_AST.VQuote uu____1469 -> []
-      | FStar_Parser_AST.Antiquote uu____1470 -> []
-      | FStar_Parser_AST.Seq uu____1471 -> []
+            FStar_List.append uu____1321 uu____1324  in
+          FStar_List.append uu____1315 uu____1318
+      | FStar_Parser_AST.Abs uu____1351 -> []
+      | FStar_Parser_AST.Let uu____1358 -> []
+      | FStar_Parser_AST.LetOpen uu____1379 -> []
+      | FStar_Parser_AST.If uu____1384 -> []
+      | FStar_Parser_AST.QForall uu____1391 -> []
+      | FStar_Parser_AST.QExists uu____1410 -> []
+      | FStar_Parser_AST.Record uu____1429 -> []
+      | FStar_Parser_AST.Match uu____1442 -> []
+      | FStar_Parser_AST.TryWith uu____1457 -> []
+      | FStar_Parser_AST.Bind uu____1472 -> []
+      | FStar_Parser_AST.Quote uu____1479 -> []
+      | FStar_Parser_AST.VQuote uu____1484 -> []
+      | FStar_Parser_AST.Antiquote uu____1485 -> []
+      | FStar_Parser_AST.Seq uu____1486 -> []
 
 let (head_and_args :
   FStar_Parser_AST.term ->
@@ -606,9 +613,9 @@ let (head_and_args :
   =
   fun t  ->
     let rec aux args t1 =
-      let uu____1525 =
-        let uu____1526 = unparen t1  in uu____1526.FStar_Parser_AST.tm  in
-      match uu____1525 with
+      let uu____1540 =
+        let uu____1541 = unparen t1  in uu____1541.FStar_Parser_AST.tm  in
+      match uu____1540 with
       | FStar_Parser_AST.App (t2,arg,imp) -> aux ((arg, imp) :: args) t2
       | FStar_Parser_AST.Construct (l,args') ->
           ({
@@ -616,7 +623,7 @@ let (head_and_args :
              FStar_Parser_AST.range = (t1.FStar_Parser_AST.range);
              FStar_Parser_AST.level = (t1.FStar_Parser_AST.level)
            }, (FStar_List.append args' args))
-      | uu____1568 -> (t1, args)  in
+      | uu____1583 -> (t1, args)  in
     aux [] t
   
 let (close :
@@ -624,8 +631,8 @@ let (close :
   fun env  ->
     fun t  ->
       let ftv =
-        let uu____1593 = free_type_vars env t  in
-        FStar_All.pipe_left sort_ftv uu____1593  in
+        let uu____1608 = free_type_vars env t  in
+        FStar_All.pipe_left sort_ftv uu____1608  in
       if (FStar_List.length ftv) = Prims.int_zero
       then t
       else
@@ -633,13 +640,16 @@ let (close :
            FStar_All.pipe_right ftv
              (FStar_List.map
                 (fun x  ->
-                   let uu____1615 =
-                     let uu____1616 =
-                       let uu____1621 = tm_type x.FStar_Ident.idRange  in
-                       (x, uu____1621)  in
-                     FStar_Parser_AST.TAnnotated uu____1616  in
-                   FStar_Parser_AST.mk_binder uu____1615
-                     x.FStar_Ident.idRange FStar_Parser_AST.Type_level
+                   let uu____1631 =
+                     let uu____1632 =
+                       let uu____1637 =
+                         let uu____1638 = FStar_Ident.range_of_id x  in
+                         tm_type uu____1638  in
+                       (x, uu____1637)  in
+                     FStar_Parser_AST.TAnnotated uu____1632  in
+                   let uu____1639 = FStar_Ident.range_of_id x  in
+                   FStar_Parser_AST.mk_binder uu____1631 uu____1639
+                     FStar_Parser_AST.Type_level
                      (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit)))
             in
          let result =
@@ -653,8 +663,8 @@ let (close_fun :
   fun env  ->
     fun t  ->
       let ftv =
-        let uu____1639 = free_type_vars env t  in
-        FStar_All.pipe_left sort_ftv uu____1639  in
+        let uu____1657 = free_type_vars env t  in
+        FStar_All.pipe_left sort_ftv uu____1657  in
       if (FStar_List.length ftv) = Prims.int_zero
       then t
       else
@@ -662,22 +672,25 @@ let (close_fun :
            FStar_All.pipe_right ftv
              (FStar_List.map
                 (fun x  ->
-                   let uu____1661 =
-                     let uu____1662 =
-                       let uu____1667 = tm_type x.FStar_Ident.idRange  in
-                       (x, uu____1667)  in
-                     FStar_Parser_AST.TAnnotated uu____1662  in
-                   FStar_Parser_AST.mk_binder uu____1661
-                     x.FStar_Ident.idRange FStar_Parser_AST.Type_level
+                   let uu____1680 =
+                     let uu____1681 =
+                       let uu____1686 =
+                         let uu____1687 = FStar_Ident.range_of_id x  in
+                         tm_type uu____1687  in
+                       (x, uu____1686)  in
+                     FStar_Parser_AST.TAnnotated uu____1681  in
+                   let uu____1688 = FStar_Ident.range_of_id x  in
+                   FStar_Parser_AST.mk_binder uu____1680 uu____1688
+                     FStar_Parser_AST.Type_level
                      (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit)))
             in
          let t1 =
-           let uu____1669 =
-             let uu____1670 = unparen t  in uu____1670.FStar_Parser_AST.tm
+           let uu____1690 =
+             let uu____1691 = unparen t  in uu____1691.FStar_Parser_AST.tm
               in
-           match uu____1669 with
-           | FStar_Parser_AST.Product uu____1671 -> t
-           | uu____1678 ->
+           match uu____1690 with
+           | FStar_Parser_AST.Product uu____1692 -> t
+           | uu____1699 ->
                FStar_Parser_AST.mk_term
                  (FStar_Parser_AST.App
                     ((FStar_Parser_AST.mk_term
@@ -703,26 +716,26 @@ let rec (uncurry :
       match t.FStar_Parser_AST.tm with
       | FStar_Parser_AST.Product (binders,t1) ->
           uncurry (FStar_List.append bs binders) t1
-      | uu____1715 -> (bs, t)
+      | uu____1736 -> (bs, t)
   
 let rec (is_var_pattern : FStar_Parser_AST.pattern -> Prims.bool) =
   fun p  ->
     match p.FStar_Parser_AST.pat with
-    | FStar_Parser_AST.PatWild uu____1726 -> true
-    | FStar_Parser_AST.PatTvar (uu____1730,uu____1731) -> true
-    | FStar_Parser_AST.PatVar (uu____1737,uu____1738) -> true
-    | FStar_Parser_AST.PatAscribed (p1,uu____1745) -> is_var_pattern p1
-    | uu____1758 -> false
+    | FStar_Parser_AST.PatWild uu____1747 -> true
+    | FStar_Parser_AST.PatTvar (uu____1751,uu____1752) -> true
+    | FStar_Parser_AST.PatVar (uu____1758,uu____1759) -> true
+    | FStar_Parser_AST.PatAscribed (p1,uu____1766) -> is_var_pattern p1
+    | uu____1779 -> false
   
 let rec (is_app_pattern : FStar_Parser_AST.pattern -> Prims.bool) =
   fun p  ->
     match p.FStar_Parser_AST.pat with
-    | FStar_Parser_AST.PatAscribed (p1,uu____1769) -> is_app_pattern p1
+    | FStar_Parser_AST.PatAscribed (p1,uu____1790) -> is_app_pattern p1
     | FStar_Parser_AST.PatApp
-        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar uu____1782;
-           FStar_Parser_AST.prange = uu____1783;_},uu____1784)
+        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar uu____1803;
+           FStar_Parser_AST.prange = uu____1804;_},uu____1805)
         -> true
-    | uu____1796 -> false
+    | uu____1817 -> false
   
 let (replace_unit_pattern :
   FStar_Parser_AST.pattern -> FStar_Parser_AST.pattern) =
@@ -736,7 +749,7 @@ let (replace_unit_pattern :
                  p.FStar_Parser_AST.prange),
                (unit_ty, FStar_Pervasives_Native.None)))
           p.FStar_Parser_AST.prange
-    | uu____1812 -> p
+    | uu____1833 -> p
   
 let rec (destruct_app_pattern :
   FStar_Syntax_DsEnv.env ->
@@ -752,25 +765,25 @@ let rec (destruct_app_pattern :
       fun p  ->
         match p.FStar_Parser_AST.pat with
         | FStar_Parser_AST.PatAscribed (p1,t) ->
-            let uu____1885 = destruct_app_pattern env is_top_level p1  in
-            (match uu____1885 with
-             | (name,args,uu____1928) ->
+            let uu____1906 = destruct_app_pattern env is_top_level p1  in
+            (match uu____1906 with
+             | (name,args,uu____1949) ->
                  (name, args, (FStar_Pervasives_Native.Some t)))
         | FStar_Parser_AST.PatApp
             ({
-               FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (id,uu____1978);
-               FStar_Parser_AST.prange = uu____1979;_},args)
+               FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (id,uu____1999);
+               FStar_Parser_AST.prange = uu____2000;_},args)
             when is_top_level ->
-            let uu____1989 =
-              let uu____1994 = FStar_Syntax_DsEnv.qualify env id  in
-              FStar_Util.Inr uu____1994  in
-            (uu____1989, args, FStar_Pervasives_Native.None)
+            let uu____2010 =
+              let uu____2015 = FStar_Syntax_DsEnv.qualify env id  in
+              FStar_Util.Inr uu____2015  in
+            (uu____2010, args, FStar_Pervasives_Native.None)
         | FStar_Parser_AST.PatApp
             ({
-               FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (id,uu____2016);
-               FStar_Parser_AST.prange = uu____2017;_},args)
+               FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (id,uu____2037);
+               FStar_Parser_AST.prange = uu____2038;_},args)
             -> ((FStar_Util.Inl id), args, FStar_Pervasives_Native.None)
-        | uu____2047 -> failwith "Not an app pattern"
+        | uu____2068 -> failwith "Not an app pattern"
   
 let rec (gather_pattern_bound_vars_maybe_top :
   FStar_Ident.ident FStar_Util.set ->
@@ -781,25 +794,25 @@ let rec (gather_pattern_bound_vars_maybe_top :
       let gather_pattern_bound_vars_from_list =
         FStar_List.fold_left gather_pattern_bound_vars_maybe_top acc  in
       match p.FStar_Parser_AST.pat with
-      | FStar_Parser_AST.PatWild uu____2099 -> acc
-      | FStar_Parser_AST.PatConst uu____2102 -> acc
-      | FStar_Parser_AST.PatName uu____2103 -> acc
-      | FStar_Parser_AST.PatOp uu____2104 -> acc
+      | FStar_Parser_AST.PatWild uu____2120 -> acc
+      | FStar_Parser_AST.PatConst uu____2123 -> acc
+      | FStar_Parser_AST.PatName uu____2124 -> acc
+      | FStar_Parser_AST.PatOp uu____2125 -> acc
       | FStar_Parser_AST.PatApp (phead,pats) ->
           gather_pattern_bound_vars_from_list (phead :: pats)
-      | FStar_Parser_AST.PatTvar (x,uu____2112) -> FStar_Util.set_add x acc
-      | FStar_Parser_AST.PatVar (x,uu____2118) -> FStar_Util.set_add x acc
+      | FStar_Parser_AST.PatTvar (x,uu____2133) -> FStar_Util.set_add x acc
+      | FStar_Parser_AST.PatVar (x,uu____2139) -> FStar_Util.set_add x acc
       | FStar_Parser_AST.PatList pats ->
           gather_pattern_bound_vars_from_list pats
-      | FStar_Parser_AST.PatTuple (pats,uu____2127) ->
+      | FStar_Parser_AST.PatTuple (pats,uu____2148) ->
           gather_pattern_bound_vars_from_list pats
       | FStar_Parser_AST.PatOr pats ->
           gather_pattern_bound_vars_from_list pats
       | FStar_Parser_AST.PatRecord guarded_pats ->
-          let uu____2144 =
+          let uu____2165 =
             FStar_List.map FStar_Pervasives_Native.snd guarded_pats  in
-          gather_pattern_bound_vars_from_list uu____2144
-      | FStar_Parser_AST.PatAscribed (pat,uu____2152) ->
+          gather_pattern_bound_vars_from_list uu____2165
+      | FStar_Parser_AST.PatAscribed (pat,uu____2173) ->
           gather_pattern_bound_vars_maybe_top acc pat
   
 let (gather_pattern_bound_vars :
@@ -808,9 +821,11 @@ let (gather_pattern_bound_vars :
     FStar_Util.new_set
       (fun id1  ->
          fun id2  ->
-           if id1.FStar_Ident.idText = id2.FStar_Ident.idText
-           then Prims.int_zero
-           else Prims.int_one)
+           let uu____2201 =
+             let uu____2203 = FStar_Ident.text_of_id id1  in
+             let uu____2205 = FStar_Ident.text_of_id id2  in
+             uu____2203 = uu____2205  in
+           if uu____2201 then Prims.int_zero else Prims.int_one)
      in
   fun p  -> gather_pattern_bound_vars_maybe_top acc p 
 type bnd =
@@ -819,14 +834,14 @@ type bnd =
   FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)) 
 let (uu___is_LocalBinder : bnd -> Prims.bool) =
   fun projectee  ->
-    match projectee with | LocalBinder _0 -> true | uu____2225 -> false
+    match projectee with | LocalBinder _0 -> true | uu____2253 -> false
   
 let (__proj__LocalBinder__item___0 :
   bnd -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual)) =
   fun projectee  -> match projectee with | LocalBinder _0 -> _0 
 let (uu___is_LetBinder : bnd -> Prims.bool) =
   fun projectee  ->
-    match projectee with | LetBinder _0 -> true | uu____2266 -> false
+    match projectee with | LetBinder _0 -> true | uu____2294 -> false
   
 let (__proj__LetBinder__item___0 :
   bnd ->
@@ -837,17 +852,17 @@ let (is_implicit : bnd -> Prims.bool) =
   fun b  ->
     match b with
     | LocalBinder
-        (uu____2314,FStar_Pervasives_Native.Some
-         (FStar_Syntax_Syntax.Implicit uu____2315))
+        (uu____2342,FStar_Pervasives_Native.Some
+         (FStar_Syntax_Syntax.Implicit uu____2343))
         -> true
-    | uu____2318 -> false
+    | uu____2346 -> false
   
 let (binder_of_bnd :
   bnd -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual)) =
-  fun uu___3_2329  ->
-    match uu___3_2329 with
+  fun uu___3_2357  ->
+    match uu___3_2357 with
     | LocalBinder (a,aq) -> (a, aq)
-    | uu____2336 -> failwith "Impossible"
+    | uu____2364 -> failwith "Impossible"
   
 let (mk_lb :
   (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list *
@@ -856,8 +871,8 @@ let (mk_lb :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax * FStar_Range.range)
     -> FStar_Syntax_Syntax.letbinding)
   =
-  fun uu____2369  ->
-    match uu____2369 with
+  fun uu____2397  ->
+    match uu____2397 with
     | (attrs,n,t,e,pos) ->
         {
           FStar_Syntax_Syntax.lbname = n;
@@ -883,20 +898,20 @@ let (mk_ref_read :
   =
   fun tm  ->
     let tm' =
-      let uu____2451 =
-        let uu____2468 =
-          let uu____2471 =
+      let uu____2479 =
+        let uu____2496 =
+          let uu____2499 =
             FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.sread_lid
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
              in
-          FStar_Syntax_Syntax.fv_to_tm uu____2471  in
-        let uu____2472 =
-          let uu____2483 =
-            let uu____2492 = FStar_Syntax_Syntax.as_implicit false  in
-            (tm, uu____2492)  in
-          [uu____2483]  in
-        (uu____2468, uu____2472)  in
-      FStar_Syntax_Syntax.Tm_app uu____2451  in
+          FStar_Syntax_Syntax.fv_to_tm uu____2499  in
+        let uu____2500 =
+          let uu____2511 =
+            let uu____2520 = FStar_Syntax_Syntax.as_implicit false  in
+            (tm, uu____2520)  in
+          [uu____2511]  in
+        (uu____2496, uu____2500)  in
+      FStar_Syntax_Syntax.Tm_app uu____2479  in
     FStar_Syntax_Syntax.mk tm' FStar_Pervasives_Native.None
       tm.FStar_Syntax_Syntax.pos
   
@@ -906,20 +921,20 @@ let (mk_ref_alloc :
   =
   fun tm  ->
     let tm' =
-      let uu____2541 =
-        let uu____2558 =
-          let uu____2561 =
+      let uu____2569 =
+        let uu____2586 =
+          let uu____2589 =
             FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.salloc_lid
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
              in
-          FStar_Syntax_Syntax.fv_to_tm uu____2561  in
-        let uu____2562 =
-          let uu____2573 =
-            let uu____2582 = FStar_Syntax_Syntax.as_implicit false  in
-            (tm, uu____2582)  in
-          [uu____2573]  in
-        (uu____2558, uu____2562)  in
-      FStar_Syntax_Syntax.Tm_app uu____2541  in
+          FStar_Syntax_Syntax.fv_to_tm uu____2589  in
+        let uu____2590 =
+          let uu____2601 =
+            let uu____2610 = FStar_Syntax_Syntax.as_implicit false  in
+            (tm, uu____2610)  in
+          [uu____2601]  in
+        (uu____2586, uu____2590)  in
+      FStar_Syntax_Syntax.Tm_app uu____2569  in
     FStar_Syntax_Syntax.mk tm' FStar_Pervasives_Native.None
       tm.FStar_Syntax_Syntax.pos
   
@@ -933,59 +948,59 @@ let (mk_ref_assign :
     fun t2  ->
       fun pos  ->
         let tm =
-          let uu____2645 =
-            let uu____2662 =
-              let uu____2665 =
+          let uu____2673 =
+            let uu____2690 =
+              let uu____2693 =
                 FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.swrite_lid
                   FStar_Syntax_Syntax.delta_constant
                   FStar_Pervasives_Native.None
                  in
-              FStar_Syntax_Syntax.fv_to_tm uu____2665  in
-            let uu____2666 =
-              let uu____2677 =
-                let uu____2686 = FStar_Syntax_Syntax.as_implicit false  in
-                (t1, uu____2686)  in
-              let uu____2694 =
-                let uu____2705 =
-                  let uu____2714 = FStar_Syntax_Syntax.as_implicit false  in
-                  (t2, uu____2714)  in
-                [uu____2705]  in
-              uu____2677 :: uu____2694  in
-            (uu____2662, uu____2666)  in
-          FStar_Syntax_Syntax.Tm_app uu____2645  in
+              FStar_Syntax_Syntax.fv_to_tm uu____2693  in
+            let uu____2694 =
+              let uu____2705 =
+                let uu____2714 = FStar_Syntax_Syntax.as_implicit false  in
+                (t1, uu____2714)  in
+              let uu____2722 =
+                let uu____2733 =
+                  let uu____2742 = FStar_Syntax_Syntax.as_implicit false  in
+                  (t2, uu____2742)  in
+                [uu____2733]  in
+              uu____2705 :: uu____2722  in
+            (uu____2690, uu____2694)  in
+          FStar_Syntax_Syntax.Tm_app uu____2673  in
         FStar_Syntax_Syntax.mk tm FStar_Pervasives_Native.None pos
   
 let rec (generalize_annotated_univs :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt) =
   fun s  ->
     let bs_univnames bs =
-      let uu____2774 =
-        let uu____2789 =
+      let uu____2802 =
+        let uu____2817 =
           FStar_Util.new_set FStar_Syntax_Syntax.order_univ_name  in
         FStar_List.fold_left
           (fun uvs  ->
-             fun uu____2808  ->
-               match uu____2808 with
-               | ({ FStar_Syntax_Syntax.ppname = uu____2819;
-                    FStar_Syntax_Syntax.index = uu____2820;
-                    FStar_Syntax_Syntax.sort = t;_},uu____2822)
+             fun uu____2836  ->
+               match uu____2836 with
+               | ({ FStar_Syntax_Syntax.ppname = uu____2847;
+                    FStar_Syntax_Syntax.index = uu____2848;
+                    FStar_Syntax_Syntax.sort = t;_},uu____2850)
                    ->
-                   let uu____2830 = FStar_Syntax_Free.univnames t  in
-                   FStar_Util.set_union uvs uu____2830) uu____2789
+                   let uu____2858 = FStar_Syntax_Free.univnames t  in
+                   FStar_Util.set_union uvs uu____2858) uu____2817
          in
-      FStar_All.pipe_right bs uu____2774  in
+      FStar_All.pipe_right bs uu____2802  in
     let empty_set = FStar_Util.new_set FStar_Syntax_Syntax.order_univ_name
        in
     match s.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_inductive_typ uu____2846 ->
+    | FStar_Syntax_Syntax.Sig_inductive_typ uu____2874 ->
         failwith
           "Impossible: collect_annotated_universes: bare data/type constructor"
-    | FStar_Syntax_Syntax.Sig_datacon uu____2864 ->
+    | FStar_Syntax_Syntax.Sig_datacon uu____2892 ->
         failwith
           "Impossible: collect_annotated_universes: bare data/type constructor"
     | FStar_Syntax_Syntax.Sig_bundle (sigs,lids) ->
         let uvs =
-          let uu____2892 =
+          let uu____2920 =
             FStar_All.pipe_right sigs
               (FStar_List.fold_left
                  (fun uvs  ->
@@ -993,294 +1008,294 @@ let rec (generalize_annotated_univs :
                       let se_univs =
                         match se.FStar_Syntax_Syntax.sigel with
                         | FStar_Syntax_Syntax.Sig_inductive_typ
-                            (uu____2913,uu____2914,bs,t,uu____2917,uu____2918)
+                            (uu____2941,uu____2942,bs,t,uu____2945,uu____2946)
                             ->
-                            let uu____2927 = bs_univnames bs  in
-                            let uu____2930 = FStar_Syntax_Free.univnames t
+                            let uu____2955 = bs_univnames bs  in
+                            let uu____2958 = FStar_Syntax_Free.univnames t
                                in
-                            FStar_Util.set_union uu____2927 uu____2930
+                            FStar_Util.set_union uu____2955 uu____2958
                         | FStar_Syntax_Syntax.Sig_datacon
-                            (uu____2933,uu____2934,t,uu____2936,uu____2937,uu____2938)
+                            (uu____2961,uu____2962,t,uu____2964,uu____2965,uu____2966)
                             -> FStar_Syntax_Free.univnames t
-                        | uu____2945 ->
+                        | uu____2973 ->
                             failwith
                               "Impossible: collect_annotated_universes: Sig_bundle should not have a non data/type sigelt"
                          in
                       FStar_Util.set_union uvs se_univs) empty_set)
              in
-          FStar_All.pipe_right uu____2892 FStar_Util.set_elements  in
+          FStar_All.pipe_right uu____2920 FStar_Util.set_elements  in
         let usubst = FStar_Syntax_Subst.univ_var_closing uvs  in
-        let uu___589_2954 = s  in
-        let uu____2955 =
-          let uu____2956 =
-            let uu____2965 =
+        let uu___589_2982 = s  in
+        let uu____2983 =
+          let uu____2984 =
+            let uu____2993 =
               FStar_All.pipe_right sigs
                 (FStar_List.map
                    (fun se  ->
                       match se.FStar_Syntax_Syntax.sigel with
                       | FStar_Syntax_Syntax.Sig_inductive_typ
-                          (lid,uu____2983,bs,t,lids1,lids2) ->
-                          let uu___600_2996 = se  in
-                          let uu____2997 =
-                            let uu____2998 =
-                              let uu____3015 =
+                          (lid,uu____3011,bs,t,lids1,lids2) ->
+                          let uu___600_3024 = se  in
+                          let uu____3025 =
+                            let uu____3026 =
+                              let uu____3043 =
                                 FStar_Syntax_Subst.subst_binders usubst bs
                                  in
-                              let uu____3016 =
-                                let uu____3017 =
+                              let uu____3044 =
+                                let uu____3045 =
                                   FStar_Syntax_Subst.shift_subst
                                     (FStar_List.length bs) usubst
                                    in
-                                FStar_Syntax_Subst.subst uu____3017 t  in
-                              (lid, uvs, uu____3015, uu____3016, lids1,
+                                FStar_Syntax_Subst.subst uu____3045 t  in
+                              (lid, uvs, uu____3043, uu____3044, lids1,
                                 lids2)
                                in
-                            FStar_Syntax_Syntax.Sig_inductive_typ uu____2998
+                            FStar_Syntax_Syntax.Sig_inductive_typ uu____3026
                              in
                           {
-                            FStar_Syntax_Syntax.sigel = uu____2997;
+                            FStar_Syntax_Syntax.sigel = uu____3025;
                             FStar_Syntax_Syntax.sigrng =
-                              (uu___600_2996.FStar_Syntax_Syntax.sigrng);
+                              (uu___600_3024.FStar_Syntax_Syntax.sigrng);
                             FStar_Syntax_Syntax.sigquals =
-                              (uu___600_2996.FStar_Syntax_Syntax.sigquals);
+                              (uu___600_3024.FStar_Syntax_Syntax.sigquals);
                             FStar_Syntax_Syntax.sigmeta =
-                              (uu___600_2996.FStar_Syntax_Syntax.sigmeta);
+                              (uu___600_3024.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___600_2996.FStar_Syntax_Syntax.sigattrs);
+                              (uu___600_3024.FStar_Syntax_Syntax.sigattrs);
                             FStar_Syntax_Syntax.sigopts =
-                              (uu___600_2996.FStar_Syntax_Syntax.sigopts)
+                              (uu___600_3024.FStar_Syntax_Syntax.sigopts)
                           }
                       | FStar_Syntax_Syntax.Sig_datacon
-                          (lid,uu____3031,t,tlid,n,lids1) ->
-                          let uu___610_3042 = se  in
-                          let uu____3043 =
-                            let uu____3044 =
-                              let uu____3060 =
+                          (lid,uu____3059,t,tlid,n,lids1) ->
+                          let uu___610_3070 = se  in
+                          let uu____3071 =
+                            let uu____3072 =
+                              let uu____3088 =
                                 FStar_Syntax_Subst.subst usubst t  in
-                              (lid, uvs, uu____3060, tlid, n, lids1)  in
-                            FStar_Syntax_Syntax.Sig_datacon uu____3044  in
+                              (lid, uvs, uu____3088, tlid, n, lids1)  in
+                            FStar_Syntax_Syntax.Sig_datacon uu____3072  in
                           {
-                            FStar_Syntax_Syntax.sigel = uu____3043;
+                            FStar_Syntax_Syntax.sigel = uu____3071;
                             FStar_Syntax_Syntax.sigrng =
-                              (uu___610_3042.FStar_Syntax_Syntax.sigrng);
+                              (uu___610_3070.FStar_Syntax_Syntax.sigrng);
                             FStar_Syntax_Syntax.sigquals =
-                              (uu___610_3042.FStar_Syntax_Syntax.sigquals);
+                              (uu___610_3070.FStar_Syntax_Syntax.sigquals);
                             FStar_Syntax_Syntax.sigmeta =
-                              (uu___610_3042.FStar_Syntax_Syntax.sigmeta);
+                              (uu___610_3070.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___610_3042.FStar_Syntax_Syntax.sigattrs);
+                              (uu___610_3070.FStar_Syntax_Syntax.sigattrs);
                             FStar_Syntax_Syntax.sigopts =
-                              (uu___610_3042.FStar_Syntax_Syntax.sigopts)
+                              (uu___610_3070.FStar_Syntax_Syntax.sigopts)
                           }
-                      | uu____3064 ->
+                      | uu____3092 ->
                           failwith
                             "Impossible: collect_annotated_universes: Sig_bundle should not have a non data/type sigelt"))
                in
-            (uu____2965, lids)  in
-          FStar_Syntax_Syntax.Sig_bundle uu____2956  in
+            (uu____2993, lids)  in
+          FStar_Syntax_Syntax.Sig_bundle uu____2984  in
         {
-          FStar_Syntax_Syntax.sigel = uu____2955;
+          FStar_Syntax_Syntax.sigel = uu____2983;
           FStar_Syntax_Syntax.sigrng =
-            (uu___589_2954.FStar_Syntax_Syntax.sigrng);
+            (uu___589_2982.FStar_Syntax_Syntax.sigrng);
           FStar_Syntax_Syntax.sigquals =
-            (uu___589_2954.FStar_Syntax_Syntax.sigquals);
+            (uu___589_2982.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta =
-            (uu___589_2954.FStar_Syntax_Syntax.sigmeta);
+            (uu___589_2982.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___589_2954.FStar_Syntax_Syntax.sigattrs);
+            (uu___589_2982.FStar_Syntax_Syntax.sigattrs);
           FStar_Syntax_Syntax.sigopts =
-            (uu___589_2954.FStar_Syntax_Syntax.sigopts)
+            (uu___589_2982.FStar_Syntax_Syntax.sigopts)
         }
-    | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____3071,t) ->
+    | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____3099,t) ->
         let uvs =
-          let uu____3074 = FStar_Syntax_Free.univnames t  in
-          FStar_All.pipe_right uu____3074 FStar_Util.set_elements  in
-        let uu___619_3079 = s  in
-        let uu____3080 =
-          let uu____3081 =
-            let uu____3088 = FStar_Syntax_Subst.close_univ_vars uvs t  in
-            (lid, uvs, uu____3088)  in
-          FStar_Syntax_Syntax.Sig_declare_typ uu____3081  in
+          let uu____3102 = FStar_Syntax_Free.univnames t  in
+          FStar_All.pipe_right uu____3102 FStar_Util.set_elements  in
+        let uu___619_3107 = s  in
+        let uu____3108 =
+          let uu____3109 =
+            let uu____3116 = FStar_Syntax_Subst.close_univ_vars uvs t  in
+            (lid, uvs, uu____3116)  in
+          FStar_Syntax_Syntax.Sig_declare_typ uu____3109  in
         {
-          FStar_Syntax_Syntax.sigel = uu____3080;
+          FStar_Syntax_Syntax.sigel = uu____3108;
           FStar_Syntax_Syntax.sigrng =
-            (uu___619_3079.FStar_Syntax_Syntax.sigrng);
+            (uu___619_3107.FStar_Syntax_Syntax.sigrng);
           FStar_Syntax_Syntax.sigquals =
-            (uu___619_3079.FStar_Syntax_Syntax.sigquals);
+            (uu___619_3107.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta =
-            (uu___619_3079.FStar_Syntax_Syntax.sigmeta);
+            (uu___619_3107.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___619_3079.FStar_Syntax_Syntax.sigattrs);
+            (uu___619_3107.FStar_Syntax_Syntax.sigattrs);
           FStar_Syntax_Syntax.sigopts =
-            (uu___619_3079.FStar_Syntax_Syntax.sigopts)
+            (uu___619_3107.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_let ((b,lbs),lids) ->
         let lb_univnames lb =
-          let uu____3112 =
+          let uu____3140 =
             FStar_Syntax_Free.univnames lb.FStar_Syntax_Syntax.lbtyp  in
-          let uu____3115 =
+          let uu____3143 =
             match (lb.FStar_Syntax_Syntax.lbdef).FStar_Syntax_Syntax.n with
-            | FStar_Syntax_Syntax.Tm_abs (bs,e,uu____3122) ->
+            | FStar_Syntax_Syntax.Tm_abs (bs,e,uu____3150) ->
                 let uvs1 = bs_univnames bs  in
                 let uvs2 =
                   match e.FStar_Syntax_Syntax.n with
                   | FStar_Syntax_Syntax.Tm_ascribed
-                      (uu____3155,(FStar_Util.Inl t,uu____3157),uu____3158)
+                      (uu____3183,(FStar_Util.Inl t,uu____3185),uu____3186)
                       -> FStar_Syntax_Free.univnames t
                   | FStar_Syntax_Syntax.Tm_ascribed
-                      (uu____3205,(FStar_Util.Inr c,uu____3207),uu____3208)
+                      (uu____3233,(FStar_Util.Inr c,uu____3235),uu____3236)
                       -> FStar_Syntax_Free.univnames_comp c
-                  | uu____3255 -> empty_set  in
+                  | uu____3283 -> empty_set  in
                 FStar_Util.set_union uvs1 uvs2
-            | FStar_Syntax_Syntax.Tm_arrow (bs,uu____3257) -> bs_univnames bs
+            | FStar_Syntax_Syntax.Tm_arrow (bs,uu____3285) -> bs_univnames bs
             | FStar_Syntax_Syntax.Tm_ascribed
-                (uu____3278,(FStar_Util.Inl t,uu____3280),uu____3281) ->
+                (uu____3306,(FStar_Util.Inl t,uu____3308),uu____3309) ->
                 FStar_Syntax_Free.univnames t
             | FStar_Syntax_Syntax.Tm_ascribed
-                (uu____3328,(FStar_Util.Inr c,uu____3330),uu____3331) ->
+                (uu____3356,(FStar_Util.Inr c,uu____3358),uu____3359) ->
                 FStar_Syntax_Free.univnames_comp c
-            | uu____3378 -> empty_set  in
-          FStar_Util.set_union uu____3112 uu____3115  in
+            | uu____3406 -> empty_set  in
+          FStar_Util.set_union uu____3140 uu____3143  in
         let all_lb_univs =
-          let uu____3382 =
+          let uu____3410 =
             FStar_All.pipe_right lbs
               (FStar_List.fold_left
                  (fun uvs  ->
                     fun lb  ->
-                      let uu____3398 = lb_univnames lb  in
-                      FStar_Util.set_union uvs uu____3398) empty_set)
+                      let uu____3426 = lb_univnames lb  in
+                      FStar_Util.set_union uvs uu____3426) empty_set)
              in
-          FStar_All.pipe_right uu____3382 FStar_Util.set_elements  in
+          FStar_All.pipe_right uu____3410 FStar_Util.set_elements  in
         let usubst = FStar_Syntax_Subst.univ_var_closing all_lb_univs  in
-        let uu___678_3408 = s  in
-        let uu____3409 =
-          let uu____3410 =
-            let uu____3417 =
-              let uu____3418 =
+        let uu___678_3436 = s  in
+        let uu____3437 =
+          let uu____3438 =
+            let uu____3445 =
+              let uu____3446 =
                 FStar_All.pipe_right lbs
                   (FStar_List.map
                      (fun lb  ->
-                        let uu___681_3430 = lb  in
-                        let uu____3431 =
+                        let uu___681_3458 = lb  in
+                        let uu____3459 =
                           FStar_Syntax_Subst.subst usubst
                             lb.FStar_Syntax_Syntax.lbtyp
                            in
-                        let uu____3434 =
+                        let uu____3462 =
                           FStar_Syntax_Subst.subst usubst
                             lb.FStar_Syntax_Syntax.lbdef
                            in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___681_3430.FStar_Syntax_Syntax.lbname);
+                            (uu___681_3458.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs = all_lb_univs;
-                          FStar_Syntax_Syntax.lbtyp = uu____3431;
+                          FStar_Syntax_Syntax.lbtyp = uu____3459;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___681_3430.FStar_Syntax_Syntax.lbeff);
-                          FStar_Syntax_Syntax.lbdef = uu____3434;
+                            (uu___681_3458.FStar_Syntax_Syntax.lbeff);
+                          FStar_Syntax_Syntax.lbdef = uu____3462;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___681_3430.FStar_Syntax_Syntax.lbattrs);
+                            (uu___681_3458.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___681_3430.FStar_Syntax_Syntax.lbpos)
+                            (uu___681_3458.FStar_Syntax_Syntax.lbpos)
                         }))
                  in
-              (b, uu____3418)  in
-            (uu____3417, lids)  in
-          FStar_Syntax_Syntax.Sig_let uu____3410  in
+              (b, uu____3446)  in
+            (uu____3445, lids)  in
+          FStar_Syntax_Syntax.Sig_let uu____3438  in
         {
-          FStar_Syntax_Syntax.sigel = uu____3409;
+          FStar_Syntax_Syntax.sigel = uu____3437;
           FStar_Syntax_Syntax.sigrng =
-            (uu___678_3408.FStar_Syntax_Syntax.sigrng);
+            (uu___678_3436.FStar_Syntax_Syntax.sigrng);
           FStar_Syntax_Syntax.sigquals =
-            (uu___678_3408.FStar_Syntax_Syntax.sigquals);
+            (uu___678_3436.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta =
-            (uu___678_3408.FStar_Syntax_Syntax.sigmeta);
+            (uu___678_3436.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___678_3408.FStar_Syntax_Syntax.sigattrs);
+            (uu___678_3436.FStar_Syntax_Syntax.sigattrs);
           FStar_Syntax_Syntax.sigopts =
-            (uu___678_3408.FStar_Syntax_Syntax.sigopts)
+            (uu___678_3436.FStar_Syntax_Syntax.sigopts)
         }
-    | FStar_Syntax_Syntax.Sig_assume (lid,uu____3443,fml) ->
+    | FStar_Syntax_Syntax.Sig_assume (lid,uu____3471,fml) ->
         let uvs =
-          let uu____3446 = FStar_Syntax_Free.univnames fml  in
-          FStar_All.pipe_right uu____3446 FStar_Util.set_elements  in
-        let uu___689_3451 = s  in
-        let uu____3452 =
-          let uu____3453 =
-            let uu____3460 = FStar_Syntax_Subst.close_univ_vars uvs fml  in
-            (lid, uvs, uu____3460)  in
-          FStar_Syntax_Syntax.Sig_assume uu____3453  in
+          let uu____3474 = FStar_Syntax_Free.univnames fml  in
+          FStar_All.pipe_right uu____3474 FStar_Util.set_elements  in
+        let uu___689_3479 = s  in
+        let uu____3480 =
+          let uu____3481 =
+            let uu____3488 = FStar_Syntax_Subst.close_univ_vars uvs fml  in
+            (lid, uvs, uu____3488)  in
+          FStar_Syntax_Syntax.Sig_assume uu____3481  in
         {
-          FStar_Syntax_Syntax.sigel = uu____3452;
+          FStar_Syntax_Syntax.sigel = uu____3480;
           FStar_Syntax_Syntax.sigrng =
-            (uu___689_3451.FStar_Syntax_Syntax.sigrng);
+            (uu___689_3479.FStar_Syntax_Syntax.sigrng);
           FStar_Syntax_Syntax.sigquals =
-            (uu___689_3451.FStar_Syntax_Syntax.sigquals);
+            (uu___689_3479.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta =
-            (uu___689_3451.FStar_Syntax_Syntax.sigmeta);
+            (uu___689_3479.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___689_3451.FStar_Syntax_Syntax.sigattrs);
+            (uu___689_3479.FStar_Syntax_Syntax.sigattrs);
           FStar_Syntax_Syntax.sigopts =
-            (uu___689_3451.FStar_Syntax_Syntax.sigopts)
+            (uu___689_3479.FStar_Syntax_Syntax.sigopts)
         }
-    | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,uu____3462,bs,c,flags) ->
+    | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,uu____3490,bs,c,flags) ->
         let uvs =
-          let uu____3471 =
-            let uu____3474 = bs_univnames bs  in
-            let uu____3477 = FStar_Syntax_Free.univnames_comp c  in
-            FStar_Util.set_union uu____3474 uu____3477  in
-          FStar_All.pipe_right uu____3471 FStar_Util.set_elements  in
+          let uu____3499 =
+            let uu____3502 = bs_univnames bs  in
+            let uu____3505 = FStar_Syntax_Free.univnames_comp c  in
+            FStar_Util.set_union uu____3502 uu____3505  in
+          FStar_All.pipe_right uu____3499 FStar_Util.set_elements  in
         let usubst = FStar_Syntax_Subst.univ_var_closing uvs  in
-        let uu___700_3485 = s  in
-        let uu____3486 =
-          let uu____3487 =
-            let uu____3500 = FStar_Syntax_Subst.subst_binders usubst bs  in
-            let uu____3501 = FStar_Syntax_Subst.subst_comp usubst c  in
-            (lid, uvs, uu____3500, uu____3501, flags)  in
-          FStar_Syntax_Syntax.Sig_effect_abbrev uu____3487  in
+        let uu___700_3513 = s  in
+        let uu____3514 =
+          let uu____3515 =
+            let uu____3528 = FStar_Syntax_Subst.subst_binders usubst bs  in
+            let uu____3529 = FStar_Syntax_Subst.subst_comp usubst c  in
+            (lid, uvs, uu____3528, uu____3529, flags)  in
+          FStar_Syntax_Syntax.Sig_effect_abbrev uu____3515  in
         {
-          FStar_Syntax_Syntax.sigel = uu____3486;
+          FStar_Syntax_Syntax.sigel = uu____3514;
           FStar_Syntax_Syntax.sigrng =
-            (uu___700_3485.FStar_Syntax_Syntax.sigrng);
+            (uu___700_3513.FStar_Syntax_Syntax.sigrng);
           FStar_Syntax_Syntax.sigquals =
-            (uu___700_3485.FStar_Syntax_Syntax.sigquals);
+            (uu___700_3513.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta =
-            (uu___700_3485.FStar_Syntax_Syntax.sigmeta);
+            (uu___700_3513.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___700_3485.FStar_Syntax_Syntax.sigattrs);
+            (uu___700_3513.FStar_Syntax_Syntax.sigattrs);
           FStar_Syntax_Syntax.sigopts =
-            (uu___700_3485.FStar_Syntax_Syntax.sigopts)
+            (uu___700_3513.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_fail (errs,lax,ses) ->
-        let uu___707_3519 = s  in
-        let uu____3520 =
-          let uu____3521 =
-            let uu____3534 = FStar_List.map generalize_annotated_univs ses
+        let uu___707_3547 = s  in
+        let uu____3548 =
+          let uu____3549 =
+            let uu____3562 = FStar_List.map generalize_annotated_univs ses
                in
-            (errs, lax, uu____3534)  in
-          FStar_Syntax_Syntax.Sig_fail uu____3521  in
+            (errs, lax, uu____3562)  in
+          FStar_Syntax_Syntax.Sig_fail uu____3549  in
         {
-          FStar_Syntax_Syntax.sigel = uu____3520;
+          FStar_Syntax_Syntax.sigel = uu____3548;
           FStar_Syntax_Syntax.sigrng =
-            (uu___707_3519.FStar_Syntax_Syntax.sigrng);
+            (uu___707_3547.FStar_Syntax_Syntax.sigrng);
           FStar_Syntax_Syntax.sigquals =
-            (uu___707_3519.FStar_Syntax_Syntax.sigquals);
+            (uu___707_3547.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta =
-            (uu___707_3519.FStar_Syntax_Syntax.sigmeta);
+            (uu___707_3547.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___707_3519.FStar_Syntax_Syntax.sigattrs);
+            (uu___707_3547.FStar_Syntax_Syntax.sigattrs);
           FStar_Syntax_Syntax.sigopts =
-            (uu___707_3519.FStar_Syntax_Syntax.sigopts)
+            (uu___707_3547.FStar_Syntax_Syntax.sigopts)
         }
-    | FStar_Syntax_Syntax.Sig_new_effect uu____3543 -> s
-    | FStar_Syntax_Syntax.Sig_sub_effect uu____3544 -> s
-    | FStar_Syntax_Syntax.Sig_main uu____3545 -> s
-    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____3546 -> s
-    | FStar_Syntax_Syntax.Sig_splice uu____3557 -> s
-    | FStar_Syntax_Syntax.Sig_pragma uu____3564 -> s
+    | FStar_Syntax_Syntax.Sig_new_effect uu____3571 -> s
+    | FStar_Syntax_Syntax.Sig_sub_effect uu____3572 -> s
+    | FStar_Syntax_Syntax.Sig_main uu____3573 -> s
+    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____3574 -> s
+    | FStar_Syntax_Syntax.Sig_splice uu____3585 -> s
+    | FStar_Syntax_Syntax.Sig_pragma uu____3592 -> s
   
 let (is_special_effect_combinator : Prims.string -> Prims.bool) =
-  fun uu___4_3572  ->
-    match uu___4_3572 with
+  fun uu___4_3600  ->
+    match uu___4_3600 with
     | "lift1" -> true
     | "lift2" -> true
     | "pure" -> true
@@ -1304,7 +1319,7 @@ let (is_special_effect_combinator : Prims.string -> Prims.bool) =
     | "post" -> true
     | "pre" -> true
     | "wp" -> true
-    | uu____3621 -> false
+    | uu____3649 -> false
   
 let rec (sum_to_universe :
   FStar_Syntax_Syntax.universe -> Prims.int -> FStar_Syntax_Syntax.universe)
@@ -1314,8 +1329,8 @@ let rec (sum_to_universe :
       if n = Prims.int_zero
       then u
       else
-        (let uu____3642 = sum_to_universe u (n - Prims.int_one)  in
-         FStar_Syntax_Syntax.U_succ uu____3642)
+        (let uu____3670 = sum_to_universe u (n - Prims.int_one)  in
+         FStar_Syntax_Syntax.U_succ uu____3670)
   
 let (int_to_universe : Prims.int -> FStar_Syntax_Syntax.universe) =
   fun n  -> sum_to_universe FStar_Syntax_Syntax.U_zero n 
@@ -1324,17 +1339,17 @@ let rec (desugar_maybe_non_constant_universe :
     (Prims.int,FStar_Syntax_Syntax.universe) FStar_Util.either)
   =
   fun t  ->
-    let uu____3668 =
-      let uu____3669 = unparen t  in uu____3669.FStar_Parser_AST.tm  in
-    match uu____3668 with
+    let uu____3696 =
+      let uu____3697 = unparen t  in uu____3697.FStar_Parser_AST.tm  in
+    match uu____3696 with
     | FStar_Parser_AST.Wild  ->
-        let uu____3675 =
-          let uu____3676 = FStar_Syntax_Unionfind.univ_fresh ()  in
-          FStar_Syntax_Syntax.U_unif uu____3676  in
-        FStar_Util.Inr uu____3675
+        let uu____3703 =
+          let uu____3704 = FStar_Syntax_Unionfind.univ_fresh ()  in
+          FStar_Syntax_Syntax.U_unif uu____3704  in
+        FStar_Util.Inr uu____3703
     | FStar_Parser_AST.Uvar u ->
         FStar_Util.Inr (FStar_Syntax_Syntax.U_name u)
-    | FStar_Parser_AST.Const (FStar_Const.Const_int (repr,uu____3689)) ->
+    | FStar_Parser_AST.Const (FStar_Const.Const_int (repr,uu____3717)) ->
         let n = FStar_Util.int_of_string repr  in
         (if n < Prims.int_zero
          then
@@ -1351,85 +1366,85 @@ let rec (desugar_maybe_non_constant_universe :
         (match (u1, u2) with
          | (FStar_Util.Inl n1,FStar_Util.Inl n2) -> FStar_Util.Inl (n1 + n2)
          | (FStar_Util.Inl n,FStar_Util.Inr u) ->
-             let uu____3780 = sum_to_universe u n  in
-             FStar_Util.Inr uu____3780
+             let uu____3808 = sum_to_universe u n  in
+             FStar_Util.Inr uu____3808
          | (FStar_Util.Inr u,FStar_Util.Inl n) ->
-             let uu____3797 = sum_to_universe u n  in
-             FStar_Util.Inr uu____3797
+             let uu____3825 = sum_to_universe u n  in
+             FStar_Util.Inr uu____3825
          | (FStar_Util.Inr u11,FStar_Util.Inr u21) ->
-             let uu____3813 =
-               let uu____3819 =
-                 let uu____3821 = FStar_Parser_AST.term_to_string t  in
+             let uu____3841 =
+               let uu____3847 =
+                 let uu____3849 = FStar_Parser_AST.term_to_string t  in
                  Prims.op_Hat
                    "This universe might contain a sum of two universe variables "
-                   uu____3821
+                   uu____3849
                   in
                (FStar_Errors.Fatal_UniverseMightContainSumOfTwoUnivVars,
-                 uu____3819)
+                 uu____3847)
                 in
-             FStar_Errors.raise_error uu____3813 t.FStar_Parser_AST.range)
-    | FStar_Parser_AST.App uu____3830 ->
+             FStar_Errors.raise_error uu____3841 t.FStar_Parser_AST.range)
+    | FStar_Parser_AST.App uu____3858 ->
         let rec aux t1 univargs =
-          let uu____3867 =
-            let uu____3868 = unparen t1  in uu____3868.FStar_Parser_AST.tm
+          let uu____3895 =
+            let uu____3896 = unparen t1  in uu____3896.FStar_Parser_AST.tm
              in
-          match uu____3867 with
-          | FStar_Parser_AST.App (t2,targ,uu____3876) ->
+          match uu____3895 with
+          | FStar_Parser_AST.App (t2,targ,uu____3904) ->
               let uarg = desugar_maybe_non_constant_universe targ  in
               aux t2 (uarg :: univargs)
           | FStar_Parser_AST.Var max_lid ->
               if
                 FStar_List.existsb
-                  (fun uu___5_3903  ->
-                     match uu___5_3903 with
-                     | FStar_Util.Inr uu____3910 -> true
-                     | uu____3913 -> false) univargs
+                  (fun uu___5_3931  ->
+                     match uu___5_3931 with
+                     | FStar_Util.Inr uu____3938 -> true
+                     | uu____3941 -> false) univargs
               then
-                let uu____3921 =
-                  let uu____3922 =
+                let uu____3949 =
+                  let uu____3950 =
                     FStar_List.map
-                      (fun uu___6_3932  ->
-                         match uu___6_3932 with
+                      (fun uu___6_3960  ->
+                         match uu___6_3960 with
                          | FStar_Util.Inl n -> int_to_universe n
                          | FStar_Util.Inr u -> u) univargs
                      in
-                  FStar_Syntax_Syntax.U_max uu____3922  in
-                FStar_Util.Inr uu____3921
+                  FStar_Syntax_Syntax.U_max uu____3950  in
+                FStar_Util.Inr uu____3949
               else
                 (let nargs =
                    FStar_List.map
-                     (fun uu___7_3958  ->
-                        match uu___7_3958 with
+                     (fun uu___7_3986  ->
+                        match uu___7_3986 with
                         | FStar_Util.Inl n -> n
-                        | FStar_Util.Inr uu____3968 -> failwith "impossible")
+                        | FStar_Util.Inr uu____3996 -> failwith "impossible")
                      univargs
                     in
-                 let uu____3972 =
+                 let uu____4000 =
                    FStar_List.fold_left
                      (fun m  -> fun n  -> if m > n then m else n)
                      Prims.int_zero nargs
                     in
-                 FStar_Util.Inl uu____3972)
-          | uu____3988 ->
-              let uu____3989 =
-                let uu____3995 =
-                  let uu____3997 =
-                    let uu____3999 = FStar_Parser_AST.term_to_string t1  in
-                    Prims.op_Hat uu____3999 " in universe context"  in
-                  Prims.op_Hat "Unexpected term " uu____3997  in
-                (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu____3995)  in
-              FStar_Errors.raise_error uu____3989 t1.FStar_Parser_AST.range
+                 FStar_Util.Inl uu____4000)
+          | uu____4016 ->
+              let uu____4017 =
+                let uu____4023 =
+                  let uu____4025 =
+                    let uu____4027 = FStar_Parser_AST.term_to_string t1  in
+                    Prims.op_Hat uu____4027 " in universe context"  in
+                  Prims.op_Hat "Unexpected term " uu____4025  in
+                (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu____4023)  in
+              FStar_Errors.raise_error uu____4017 t1.FStar_Parser_AST.range
            in
         aux t []
-    | uu____4014 ->
-        let uu____4015 =
-          let uu____4021 =
-            let uu____4023 =
-              let uu____4025 = FStar_Parser_AST.term_to_string t  in
-              Prims.op_Hat uu____4025 " in universe context"  in
-            Prims.op_Hat "Unexpected term " uu____4023  in
-          (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu____4021)  in
-        FStar_Errors.raise_error uu____4015 t.FStar_Parser_AST.range
+    | uu____4042 ->
+        let uu____4043 =
+          let uu____4049 =
+            let uu____4051 =
+              let uu____4053 = FStar_Parser_AST.term_to_string t  in
+              Prims.op_Hat uu____4053 " in universe context"  in
+            Prims.op_Hat "Unexpected term " uu____4051  in
+          (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu____4049)  in
+        FStar_Errors.raise_error uu____4043 t.FStar_Parser_AST.range
   
 let (desugar_universe :
   FStar_Parser_AST.term -> FStar_Syntax_Syntax.universe) =
@@ -1448,63 +1463,67 @@ let (check_no_aq : FStar_Syntax_Syntax.antiquotations -> unit) =
               (e,{
                    FStar_Syntax_Syntax.qkind =
                      FStar_Syntax_Syntax.Quote_dynamic ;
-                   FStar_Syntax_Syntax.antiquotes = uu____4066;_});
-            FStar_Syntax_Syntax.pos = uu____4067;
-            FStar_Syntax_Syntax.vars = uu____4068;_})::uu____4069
+                   FStar_Syntax_Syntax.antiquotes = uu____4094;_});
+            FStar_Syntax_Syntax.pos = uu____4095;
+            FStar_Syntax_Syntax.vars = uu____4096;_})::uu____4097
         ->
-        let uu____4100 =
-          let uu____4106 =
-            let uu____4108 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "Unexpected antiquotation: `@(%s)" uu____4108
+        let uu____4128 =
+          let uu____4134 =
+            let uu____4136 = FStar_Syntax_Print.term_to_string e  in
+            FStar_Util.format1 "Unexpected antiquotation: `@(%s)" uu____4136
              in
-          (FStar_Errors.Fatal_UnexpectedAntiquotation, uu____4106)  in
-        FStar_Errors.raise_error uu____4100 e.FStar_Syntax_Syntax.pos
-    | (bv,e)::uu____4114 ->
-        let uu____4133 =
-          let uu____4139 =
-            let uu____4141 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "Unexpected antiquotation: `#(%s)" uu____4141
+          (FStar_Errors.Fatal_UnexpectedAntiquotation, uu____4134)  in
+        FStar_Errors.raise_error uu____4128 e.FStar_Syntax_Syntax.pos
+    | (bv,e)::uu____4142 ->
+        let uu____4161 =
+          let uu____4167 =
+            let uu____4169 = FStar_Syntax_Print.term_to_string e  in
+            FStar_Util.format1 "Unexpected antiquotation: `#(%s)" uu____4169
              in
-          (FStar_Errors.Fatal_UnexpectedAntiquotation, uu____4139)  in
-        FStar_Errors.raise_error uu____4133 e.FStar_Syntax_Syntax.pos
+          (FStar_Errors.Fatal_UnexpectedAntiquotation, uu____4167)  in
+        FStar_Errors.raise_error uu____4161 e.FStar_Syntax_Syntax.pos
   
 let check_fields :
-  'uuuuuu4154 .
+  'uuuuuu4182 .
     FStar_Syntax_DsEnv.env ->
-      (FStar_Ident.lident * 'uuuuuu4154) Prims.list ->
+      (FStar_Ident.lident * 'uuuuuu4182) Prims.list ->
         FStar_Range.range -> FStar_Syntax_DsEnv.record_or_dc
   =
   fun env  ->
     fun fields  ->
       fun rg  ->
-        let uu____4182 = FStar_List.hd fields  in
-        match uu____4182 with
-        | (f,uu____4192) ->
+        let uu____4210 = FStar_List.hd fields  in
+        match uu____4210 with
+        | (f,uu____4220) ->
             let record =
               FStar_Syntax_DsEnv.fail_or env
                 (FStar_Syntax_DsEnv.try_lookup_record_by_field_name env) f
                in
-            let check_field uu____4203 =
-              match uu____4203 with
-              | (f',uu____4209) ->
-                  let uu____4210 =
+            let check_field uu____4231 =
+              match uu____4231 with
+              | (f',uu____4237) ->
+                  let uu____4238 =
                     FStar_Syntax_DsEnv.belongs_to_record env f' record  in
-                  if uu____4210
+                  if uu____4238
                   then ()
                   else
                     (let msg =
+                       let uu____4245 = FStar_Ident.string_of_lid f  in
+                       let uu____4247 =
+                         FStar_Ident.string_of_lid
+                           record.FStar_Syntax_DsEnv.typename
+                          in
+                       let uu____4249 = FStar_Ident.string_of_lid f'  in
                        FStar_Util.format3
                          "Field %s belongs to record type %s, whereas field %s does not"
-                         f.FStar_Ident.str
-                         (record.FStar_Syntax_DsEnv.typename).FStar_Ident.str
-                         f'.FStar_Ident.str
+                         uu____4245 uu____4247 uu____4249
                         in
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_FieldsNotBelongToSameRecordType,
                          msg) rg)
                in
-            ((let uu____4220 = FStar_List.tl fields  in
-              FStar_List.iter check_field uu____4220);
+            ((let uu____4254 = FStar_List.tl fields  in
+              FStar_List.iter check_field uu____4254);
              (match () with | () -> record))
   
 let (check_linear_pattern_variables :
@@ -1515,72 +1534,80 @@ let (check_linear_pattern_variables :
     fun r  ->
       let rec pat_vars p =
         match p.FStar_Syntax_Syntax.v with
-        | FStar_Syntax_Syntax.Pat_dot_term uu____4268 ->
+        | FStar_Syntax_Syntax.Pat_dot_term uu____4302 ->
             FStar_Syntax_Syntax.no_names
-        | FStar_Syntax_Syntax.Pat_wild uu____4275 ->
+        | FStar_Syntax_Syntax.Pat_wild uu____4309 ->
             FStar_Syntax_Syntax.no_names
-        | FStar_Syntax_Syntax.Pat_constant uu____4276 ->
+        | FStar_Syntax_Syntax.Pat_constant uu____4310 ->
             FStar_Syntax_Syntax.no_names
         | FStar_Syntax_Syntax.Pat_var x ->
             FStar_Util.set_add x FStar_Syntax_Syntax.no_names
-        | FStar_Syntax_Syntax.Pat_cons (uu____4278,pats1) ->
-            let aux out uu____4319 =
-              match uu____4319 with
-              | (p1,uu____4332) ->
+        | FStar_Syntax_Syntax.Pat_cons (uu____4312,pats1) ->
+            let aux out uu____4353 =
+              match uu____4353 with
+              | (p1,uu____4366) ->
                   let intersection =
-                    let uu____4342 = pat_vars p1  in
-                    FStar_Util.set_intersect uu____4342 out  in
-                  let uu____4345 = FStar_Util.set_is_empty intersection  in
-                  if uu____4345
+                    let uu____4376 = pat_vars p1  in
+                    FStar_Util.set_intersect uu____4376 out  in
+                  let uu____4379 = FStar_Util.set_is_empty intersection  in
+                  if uu____4379
                   then
-                    let uu____4350 = pat_vars p1  in
-                    FStar_Util.set_union out uu____4350
+                    let uu____4384 = pat_vars p1  in
+                    FStar_Util.set_union out uu____4384
                   else
                     (let duplicate_bv =
-                       let uu____4356 = FStar_Util.set_elements intersection
+                       let uu____4390 = FStar_Util.set_elements intersection
                           in
-                       FStar_List.hd uu____4356  in
-                     let uu____4359 =
-                       let uu____4365 =
+                       FStar_List.hd uu____4390  in
+                     let uu____4393 =
+                       let uu____4399 =
+                         let uu____4401 =
+                           FStar_Ident.text_of_id
+                             duplicate_bv.FStar_Syntax_Syntax.ppname
+                            in
                          FStar_Util.format1
                            "Non-linear patterns are not permitted: `%s` appears more than once in this pattern."
-                           (duplicate_bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                           uu____4401
                           in
                        (FStar_Errors.Fatal_NonLinearPatternNotPermitted,
-                         uu____4365)
+                         uu____4399)
                         in
-                     FStar_Errors.raise_error uu____4359 r)
+                     FStar_Errors.raise_error uu____4393 r)
                in
             FStar_List.fold_left aux FStar_Syntax_Syntax.no_names pats1
          in
       match pats with
       | [] -> ()
       | p::[] ->
-          let uu____4389 = pat_vars p  in
-          FStar_All.pipe_right uu____4389 (fun uu____4394  -> ())
+          let uu____4425 = pat_vars p  in
+          FStar_All.pipe_right uu____4425 (fun uu____4430  -> ())
       | p::ps ->
           let pvars = pat_vars p  in
           let aux p1 =
-            let uu____4418 =
-              let uu____4420 = pat_vars p1  in
-              FStar_Util.set_eq pvars uu____4420  in
-            if uu____4418
+            let uu____4454 =
+              let uu____4456 = pat_vars p1  in
+              FStar_Util.set_eq pvars uu____4456  in
+            if uu____4454
             then ()
             else
               (let nonlinear_vars =
-                 let uu____4429 = pat_vars p1  in
-                 FStar_Util.set_symmetric_difference pvars uu____4429  in
+                 let uu____4465 = pat_vars p1  in
+                 FStar_Util.set_symmetric_difference pvars uu____4465  in
                let first_nonlinear_var =
-                 let uu____4433 = FStar_Util.set_elements nonlinear_vars  in
-                 FStar_List.hd uu____4433  in
-               let uu____4436 =
-                 let uu____4442 =
+                 let uu____4469 = FStar_Util.set_elements nonlinear_vars  in
+                 FStar_List.hd uu____4469  in
+               let uu____4472 =
+                 let uu____4478 =
+                   let uu____4480 =
+                     FStar_Ident.text_of_id
+                       first_nonlinear_var.FStar_Syntax_Syntax.ppname
+                      in
                    FStar_Util.format1
                      "Patterns in this match are incoherent, variable %s is bound in some but not all patterns."
-                     (first_nonlinear_var.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                     uu____4480
                     in
-                 (FStar_Errors.Fatal_IncoherentPatterns, uu____4442)  in
-               FStar_Errors.raise_error uu____4436 r)
+                 (FStar_Errors.Fatal_IncoherentPatterns, uu____4478)  in
+               FStar_Errors.raise_error uu____4472 r)
              in
           FStar_List.iter aux ps
   
@@ -1597,17 +1624,19 @@ let rec (desugar_data_pat :
     fun env  ->
       fun p  ->
         let resolvex l e x =
-          let uu____4769 =
+          let uu____4807 =
             FStar_Util.find_opt
               (fun y  ->
-                 (y.FStar_Syntax_Syntax.ppname).FStar_Ident.idText =
-                   x.FStar_Ident.idText) l
+                 let uu____4814 =
+                   FStar_Ident.text_of_id y.FStar_Syntax_Syntax.ppname  in
+                 let uu____4816 = FStar_Ident.text_of_id x  in
+                 uu____4814 = uu____4816) l
              in
-          match uu____4769 with
+          match uu____4807 with
           | FStar_Pervasives_Native.Some y -> (l, e, y)
-          | uu____4786 ->
-              let uu____4789 = FStar_Syntax_DsEnv.push_bv e x  in
-              (match uu____4789 with | (e1,x1) -> ((x1 :: l), e1, x1))
+          | uu____4830 ->
+              let uu____4833 = FStar_Syntax_DsEnv.push_bv e x  in
+              (match uu____4833 with | (e1,x1) -> ((x1 :: l), e1, x1))
            in
         let rec aux' top loc env1 p1 =
           let pos q =
@@ -1615,64 +1644,67 @@ let rec (desugar_data_pat :
           let pos_r r q = FStar_Syntax_Syntax.withinfo q r  in
           let orig = p1  in
           match p1.FStar_Parser_AST.pat with
-          | FStar_Parser_AST.PatOr uu____4930 ->
+          | FStar_Parser_AST.PatOr uu____4974 ->
               failwith "impossible: PatOr handled below"
           | FStar_Parser_AST.PatOp op ->
               let id_op =
-                let uu____4952 =
-                  let uu____4958 =
-                    FStar_Parser_AST.compile_op Prims.int_zero
-                      op.FStar_Ident.idText op.FStar_Ident.idRange
+                let uu____4996 =
+                  let uu____5002 =
+                    let uu____5004 = FStar_Ident.text_of_id op  in
+                    let uu____5006 = FStar_Ident.range_of_id op  in
+                    FStar_Parser_AST.compile_op Prims.int_zero uu____5004
+                      uu____5006
                      in
-                  (uu____4958, (op.FStar_Ident.idRange))  in
-                FStar_Ident.mk_ident uu____4952  in
+                  let uu____5008 = FStar_Ident.range_of_id op  in
+                  (uu____5002, uu____5008)  in
+                FStar_Ident.mk_ident uu____4996  in
               let p2 =
-                let uu___934_4963 = p1  in
+                let uu___934_5011 = p1  in
                 {
                   FStar_Parser_AST.pat =
                     (FStar_Parser_AST.PatVar
                        (id_op, FStar_Pervasives_Native.None));
                   FStar_Parser_AST.prange =
-                    (uu___934_4963.FStar_Parser_AST.prange)
+                    (uu___934_5011.FStar_Parser_AST.prange)
                 }  in
               aux loc env1 p2
           | FStar_Parser_AST.PatAscribed (p2,(t,tacopt)) ->
               ((match tacopt with
                 | FStar_Pervasives_Native.None  -> ()
-                | FStar_Pervasives_Native.Some uu____4980 ->
+                | FStar_Pervasives_Native.Some uu____5028 ->
                     FStar_Errors.raise_error
                       (FStar_Errors.Fatal_TypeWithinPatternsAllowedOnVariablesOnly,
                         "Type ascriptions within patterns cannot be associated with a tactic")
                       orig.FStar_Parser_AST.prange);
-               (let uu____4983 = aux loc env1 p2  in
-                match uu____4983 with
+               (let uu____5031 = aux loc env1 p2  in
+                match uu____5031 with
                 | (loc1,env',binder,p3,annots) ->
-                    let uu____5039 =
+                    let uu____5087 =
                       match binder with
-                      | LetBinder uu____5060 -> failwith "impossible"
+                      | LetBinder uu____5108 -> failwith "impossible"
                       | LocalBinder (x,aq) ->
                           let t1 =
-                            let uu____5085 = close_fun env1 t  in
-                            desugar_term env1 uu____5085  in
+                            let uu____5133 = close_fun env1 t  in
+                            desugar_term env1 uu____5133  in
                           let x1 =
-                            let uu___960_5087 = x  in
+                            let uu___960_5135 = x  in
                             {
                               FStar_Syntax_Syntax.ppname =
-                                (uu___960_5087.FStar_Syntax_Syntax.ppname);
+                                (uu___960_5135.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
-                                (uu___960_5087.FStar_Syntax_Syntax.index);
+                                (uu___960_5135.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = t1
                             }  in
                           ([(x1, t1)], (LocalBinder (x1, aq)))
                        in
-                    (match uu____5039 with
+                    (match uu____5087 with
                      | (annots',binder1) ->
                          ((match p3.FStar_Syntax_Syntax.v with
-                           | FStar_Syntax_Syntax.Pat_var uu____5133 -> ()
-                           | FStar_Syntax_Syntax.Pat_wild uu____5134 -> ()
-                           | uu____5135 when top && top_level_ascr_allowed ->
+                           | FStar_Syntax_Syntax.Pat_var uu____5181 -> ()
+                           | FStar_Syntax_Syntax.Pat_wild uu____5182 -> ()
+                           | uu____5183 when top && top_level_ascr_allowed ->
                                ()
-                           | uu____5136 ->
+                           | uu____5184 ->
                                FStar_Errors.raise_error
                                  (FStar_Errors.Fatal_TypeWithinPatternsAllowedOnVariablesOnly,
                                    "Type ascriptions within patterns are only allowed on variables")
@@ -1686,40 +1718,40 @@ let rec (desugar_data_pat :
                   (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
                   FStar_Syntax_Syntax.tun
                  in
-              let uu____5154 =
+              let uu____5202 =
                 FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_wild x)  in
-              (loc, env1, (LocalBinder (x, aq1)), uu____5154, [])
+              (loc, env1, (LocalBinder (x, aq1)), uu____5202, [])
           | FStar_Parser_AST.PatConst c ->
               let x =
                 FStar_Syntax_Syntax.new_bv
                   (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
                   FStar_Syntax_Syntax.tun
                  in
-              let uu____5167 =
+              let uu____5215 =
                 FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_constant c)
                  in
               (loc, env1, (LocalBinder (x, FStar_Pervasives_Native.None)),
-                uu____5167, [])
+                uu____5215, [])
           | FStar_Parser_AST.PatTvar (x,aq) ->
               let aq1 = trans_aqual env1 aq  in
-              let uu____5185 = resolvex loc env1 x  in
-              (match uu____5185 with
+              let uu____5233 = resolvex loc env1 x  in
+              (match uu____5233 with
                | (loc1,env2,xbv) ->
-                   let uu____5217 =
+                   let uu____5265 =
                      FStar_All.pipe_left pos
                        (FStar_Syntax_Syntax.Pat_var xbv)
                       in
-                   (loc1, env2, (LocalBinder (xbv, aq1)), uu____5217, []))
+                   (loc1, env2, (LocalBinder (xbv, aq1)), uu____5265, []))
           | FStar_Parser_AST.PatVar (x,aq) ->
               let aq1 = trans_aqual env1 aq  in
-              let uu____5235 = resolvex loc env1 x  in
-              (match uu____5235 with
+              let uu____5283 = resolvex loc env1 x  in
+              (match uu____5283 with
                | (loc1,env2,xbv) ->
-                   let uu____5267 =
+                   let uu____5315 =
                      FStar_All.pipe_left pos
                        (FStar_Syntax_Syntax.Pat_var xbv)
                       in
-                   (loc1, env2, (LocalBinder (xbv, aq1)), uu____5267, []))
+                   (loc1, env2, (LocalBinder (xbv, aq1)), uu____5315, []))
           | FStar_Parser_AST.PatName l ->
               let l1 =
                 FStar_Syntax_DsEnv.fail_or env1
@@ -1730,31 +1762,31 @@ let rec (desugar_data_pat :
                   (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
                   FStar_Syntax_Syntax.tun
                  in
-              let uu____5281 =
+              let uu____5329 =
                 FStar_All.pipe_left pos
                   (FStar_Syntax_Syntax.Pat_cons (l1, []))
                  in
               (loc, env1, (LocalBinder (x, FStar_Pervasives_Native.None)),
-                uu____5281, [])
+                uu____5329, [])
           | FStar_Parser_AST.PatApp
               ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName l;
-                 FStar_Parser_AST.prange = uu____5309;_},args)
+                 FStar_Parser_AST.prange = uu____5357;_},args)
               ->
-              let uu____5315 =
+              let uu____5363 =
                 FStar_List.fold_right
                   (fun arg  ->
-                     fun uu____5376  ->
-                       match uu____5376 with
+                     fun uu____5424  ->
+                       match uu____5424 with
                        | (loc1,env2,annots,args1) ->
-                           let uu____5457 = aux loc1 env2 arg  in
-                           (match uu____5457 with
+                           let uu____5505 = aux loc1 env2 arg  in
+                           (match uu____5505 with
                             | (loc2,env3,b,arg1,ans) ->
                                 let imp = is_implicit b  in
                                 (loc2, env3, (FStar_List.append ans annots),
                                   ((arg1, imp) :: args1)))) args
                   (loc, env1, [], [])
                  in
-              (match uu____5315 with
+              (match uu____5363 with
                | (loc1,env2,annots,args1) ->
                    let l1 =
                      FStar_Syntax_DsEnv.fail_or env2
@@ -1766,51 +1798,51 @@ let rec (desugar_data_pat :
                           (p1.FStar_Parser_AST.prange))
                        FStar_Syntax_Syntax.tun
                       in
-                   let uu____5629 =
+                   let uu____5677 =
                      FStar_All.pipe_left pos
                        (FStar_Syntax_Syntax.Pat_cons (l1, args1))
                       in
                    (loc1, env2,
                      (LocalBinder (x, FStar_Pervasives_Native.None)),
-                     uu____5629, annots))
-          | FStar_Parser_AST.PatApp uu____5645 ->
+                     uu____5677, annots))
+          | FStar_Parser_AST.PatApp uu____5693 ->
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_UnexpectedPattern, "Unexpected pattern")
                 p1.FStar_Parser_AST.prange
           | FStar_Parser_AST.PatList pats ->
-              let uu____5673 =
+              let uu____5721 =
                 FStar_List.fold_right
                   (fun pat  ->
-                     fun uu____5723  ->
-                       match uu____5723 with
+                     fun uu____5771  ->
+                       match uu____5771 with
                        | (loc1,env2,annots,pats1) ->
-                           let uu____5784 = aux loc1 env2 pat  in
-                           (match uu____5784 with
-                            | (loc2,env3,uu____5823,pat1,ans) ->
+                           let uu____5832 = aux loc1 env2 pat  in
+                           (match uu____5832 with
+                            | (loc2,env3,uu____5871,pat1,ans) ->
                                 (loc2, env3, (FStar_List.append ans annots),
                                   (pat1 :: pats1)))) pats (loc, env1, [], [])
                  in
-              (match uu____5673 with
+              (match uu____5721 with
                | (loc1,env2,annots,pats1) ->
                    let pat =
-                     let uu____5917 =
-                       let uu____5920 =
-                         let uu____5927 =
+                     let uu____5965 =
+                       let uu____5968 =
+                         let uu____5975 =
                            FStar_Range.end_range p1.FStar_Parser_AST.prange
                             in
-                         pos_r uu____5927  in
-                       let uu____5928 =
-                         let uu____5929 =
-                           let uu____5943 =
+                         pos_r uu____5975  in
+                       let uu____5976 =
+                         let uu____5977 =
+                           let uu____5991 =
                              FStar_Syntax_Syntax.lid_as_fv
                                FStar_Parser_Const.nil_lid
                                FStar_Syntax_Syntax.delta_constant
                                (FStar_Pervasives_Native.Some
                                   FStar_Syntax_Syntax.Data_ctor)
                               in
-                           (uu____5943, [])  in
-                         FStar_Syntax_Syntax.Pat_cons uu____5929  in
-                       FStar_All.pipe_left uu____5920 uu____5928  in
+                           (uu____5991, [])  in
+                         FStar_Syntax_Syntax.Pat_cons uu____5977  in
+                       FStar_All.pipe_left uu____5968 uu____5976  in
                      FStar_List.fold_right
                        (fun hd  ->
                           fun tl  ->
@@ -1819,19 +1851,19 @@ let rec (desugar_data_pat :
                                 hd.FStar_Syntax_Syntax.p
                                 tl.FStar_Syntax_Syntax.p
                                in
-                            let uu____5977 =
-                              let uu____5978 =
-                                let uu____5992 =
+                            let uu____6025 =
+                              let uu____6026 =
+                                let uu____6040 =
                                   FStar_Syntax_Syntax.lid_as_fv
                                     FStar_Parser_Const.cons_lid
                                     FStar_Syntax_Syntax.delta_constant
                                     (FStar_Pervasives_Native.Some
                                        FStar_Syntax_Syntax.Data_ctor)
                                    in
-                                (uu____5992, [(hd, false); (tl, false)])  in
-                              FStar_Syntax_Syntax.Pat_cons uu____5978  in
-                            FStar_All.pipe_left (pos_r r) uu____5977) pats1
-                       uu____5917
+                                (uu____6040, [(hd, false); (tl, false)])  in
+                              FStar_Syntax_Syntax.Pat_cons uu____6026  in
+                            FStar_All.pipe_left (pos_r r) uu____6025) pats1
+                       uu____5965
                       in
                    let x =
                      FStar_Syntax_Syntax.new_bv
@@ -1843,20 +1875,20 @@ let rec (desugar_data_pat :
                      (LocalBinder (x, FStar_Pervasives_Native.None)), pat,
                      annots))
           | FStar_Parser_AST.PatTuple (args,dep) ->
-              let uu____6048 =
+              let uu____6096 =
                 FStar_List.fold_left
-                  (fun uu____6107  ->
+                  (fun uu____6155  ->
                      fun p2  ->
-                       match uu____6107 with
+                       match uu____6155 with
                        | (loc1,env2,annots,pats) ->
-                           let uu____6189 = aux loc1 env2 p2  in
-                           (match uu____6189 with
-                            | (loc2,env3,uu____6233,pat,ans) ->
+                           let uu____6237 = aux loc1 env2 p2  in
+                           (match uu____6237 with
+                            | (loc2,env3,uu____6281,pat,ans) ->
                                 (loc2, env3, (FStar_List.append ans annots),
                                   ((pat, false) :: pats))))
                   (loc, env1, [], []) args
                  in
-              (match uu____6048 with
+              (match uu____6096 with
                | (loc1,env2,annots,args1) ->
                    let args2 = FStar_List.rev args1  in
                    let l =
@@ -1875,20 +1907,20 @@ let rec (desugar_data_pat :
                    let l1 =
                      match constr.FStar_Syntax_Syntax.n with
                      | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-                     | uu____6396 -> failwith "impossible"  in
+                     | uu____6444 -> failwith "impossible"  in
                    let x =
                      FStar_Syntax_Syntax.new_bv
                        (FStar_Pervasives_Native.Some
                           (p1.FStar_Parser_AST.prange))
                        FStar_Syntax_Syntax.tun
                       in
-                   let uu____6399 =
+                   let uu____6447 =
                      FStar_All.pipe_left pos
                        (FStar_Syntax_Syntax.Pat_cons (l1, args2))
                       in
                    (loc1, env2,
                      (LocalBinder (x, FStar_Pervasives_Native.None)),
-                     uu____6399, annots))
+                     uu____6447, annots))
           | FStar_Parser_AST.PatRecord [] ->
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_UnexpectedPattern, "Unexpected pattern")
@@ -1899,90 +1931,99 @@ let rec (desugar_data_pat :
               let fields1 =
                 FStar_All.pipe_right fields
                   (FStar_List.map
-                     (fun uu____6475  ->
-                        match uu____6475 with
-                        | (f,p2) -> ((f.FStar_Ident.ident), p2)))
+                     (fun uu____6524  ->
+                        match uu____6524 with
+                        | (f,p2) ->
+                            let uu____6535 = FStar_Ident.ident_of_lid f  in
+                            (uu____6535, p2)))
                  in
               let args =
                 FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                   (FStar_List.map
-                     (fun uu____6505  ->
-                        match uu____6505 with
-                        | (f,uu____6511) ->
-                            let uu____6512 =
+                     (fun uu____6555  ->
+                        match uu____6555 with
+                        | (f,uu____6561) ->
+                            let uu____6562 =
                               FStar_All.pipe_right fields1
                                 (FStar_List.tryFind
-                                   (fun uu____6538  ->
-                                      match uu____6538 with
-                                      | (g,uu____6545) ->
-                                          f.FStar_Ident.idText =
-                                            g.FStar_Ident.idText))
+                                   (fun uu____6590  ->
+                                      match uu____6590 with
+                                      | (g,uu____6597) ->
+                                          let uu____6598 =
+                                            FStar_Ident.text_of_id f  in
+                                          let uu____6600 =
+                                            FStar_Ident.text_of_id g  in
+                                          uu____6598 = uu____6600))
                                in
-                            (match uu____6512 with
+                            (match uu____6562 with
                              | FStar_Pervasives_Native.None  ->
                                  FStar_Parser_AST.mk_pattern
                                    (FStar_Parser_AST.PatWild
                                       FStar_Pervasives_Native.None)
                                    p1.FStar_Parser_AST.prange
-                             | FStar_Pervasives_Native.Some (uu____6551,p2)
+                             | FStar_Pervasives_Native.Some (uu____6607,p2)
                                  -> p2)))
                  in
               let app =
-                let uu____6558 =
-                  let uu____6559 =
-                    let uu____6566 =
-                      let uu____6567 =
-                        let uu____6568 =
-                          FStar_Ident.lid_of_ids
-                            (FStar_List.append
-                               (record.FStar_Syntax_DsEnv.typename).FStar_Ident.ns
-                               [record.FStar_Syntax_DsEnv.constrname])
-                           in
-                        FStar_Parser_AST.PatName uu____6568  in
-                      FStar_Parser_AST.mk_pattern uu____6567
+                let uu____6614 =
+                  let uu____6615 =
+                    let uu____6622 =
+                      let uu____6623 =
+                        let uu____6624 =
+                          let uu____6625 =
+                            let uu____6626 =
+                              FStar_Ident.ns_of_lid
+                                record.FStar_Syntax_DsEnv.typename
+                               in
+                            FStar_List.append uu____6626
+                              [record.FStar_Syntax_DsEnv.constrname]
+                             in
+                          FStar_Ident.lid_of_ids uu____6625  in
+                        FStar_Parser_AST.PatName uu____6624  in
+                      FStar_Parser_AST.mk_pattern uu____6623
                         p1.FStar_Parser_AST.prange
                        in
-                    (uu____6566, args)  in
-                  FStar_Parser_AST.PatApp uu____6559  in
-                FStar_Parser_AST.mk_pattern uu____6558
+                    (uu____6622, args)  in
+                  FStar_Parser_AST.PatApp uu____6615  in
+                FStar_Parser_AST.mk_pattern uu____6614
                   p1.FStar_Parser_AST.prange
                  in
-              let uu____6571 = aux loc env1 app  in
-              (match uu____6571 with
+              let uu____6631 = aux loc env1 app  in
+              (match uu____6631 with
                | (env2,e,b,p2,annots) ->
                    let p3 =
                      match p2.FStar_Syntax_Syntax.v with
                      | FStar_Syntax_Syntax.Pat_cons (fv,args1) ->
-                         let uu____6648 =
-                           let uu____6649 =
-                             let uu____6663 =
-                               let uu___1110_6664 = fv  in
-                               let uu____6665 =
-                                 let uu____6668 =
-                                   let uu____6669 =
-                                     let uu____6676 =
+                         let uu____6708 =
+                           let uu____6709 =
+                             let uu____6723 =
+                               let uu___1110_6724 = fv  in
+                               let uu____6725 =
+                                 let uu____6728 =
+                                   let uu____6729 =
+                                     let uu____6736 =
                                        FStar_All.pipe_right
                                          record.FStar_Syntax_DsEnv.fields
                                          (FStar_List.map
                                             FStar_Pervasives_Native.fst)
                                         in
                                      ((record.FStar_Syntax_DsEnv.typename),
-                                       uu____6676)
+                                       uu____6736)
                                       in
-                                   FStar_Syntax_Syntax.Record_ctor uu____6669
+                                   FStar_Syntax_Syntax.Record_ctor uu____6729
                                     in
-                                 FStar_Pervasives_Native.Some uu____6668  in
+                                 FStar_Pervasives_Native.Some uu____6728  in
                                {
                                  FStar_Syntax_Syntax.fv_name =
-                                   (uu___1110_6664.FStar_Syntax_Syntax.fv_name);
+                                   (uu___1110_6724.FStar_Syntax_Syntax.fv_name);
                                  FStar_Syntax_Syntax.fv_delta =
-                                   (uu___1110_6664.FStar_Syntax_Syntax.fv_delta);
-                                 FStar_Syntax_Syntax.fv_qual = uu____6665
+                                   (uu___1110_6724.FStar_Syntax_Syntax.fv_delta);
+                                 FStar_Syntax_Syntax.fv_qual = uu____6725
                                }  in
-                             (uu____6663, args1)  in
-                           FStar_Syntax_Syntax.Pat_cons uu____6649  in
-                         FStar_All.pipe_left pos uu____6648
-                     | uu____6702 -> p2  in
+                             (uu____6723, args1)  in
+                           FStar_Syntax_Syntax.Pat_cons uu____6709  in
+                         FStar_All.pipe_left pos uu____6708
+                     | uu____6762 -> p2  in
                    (env2, e, b, p3, annots))
         
         and aux loc env1 p1 = aux' false loc env1 p1
@@ -1992,36 +2033,36 @@ let rec (desugar_data_pat :
           match p1.FStar_Parser_AST.pat with
           | FStar_Parser_AST.PatOr [] -> failwith "impossible"
           | FStar_Parser_AST.PatOr (p2::ps) ->
-              let uu____6786 = aux' true loc env1 p2  in
-              (match uu____6786 with
+              let uu____6846 = aux' true loc env1 p2  in
+              (match uu____6846 with
                | (loc1,env2,var,p3,ans) ->
-                   let uu____6839 =
+                   let uu____6899 =
                      FStar_List.fold_left
-                       (fun uu____6887  ->
+                       (fun uu____6947  ->
                           fun p4  ->
-                            match uu____6887 with
+                            match uu____6947 with
                             | (loc2,env3,ps1) ->
-                                let uu____6952 = aux' true loc2 env3 p4  in
-                                (match uu____6952 with
-                                 | (loc3,env4,uu____6990,p5,ans1) ->
+                                let uu____7012 = aux' true loc2 env3 p4  in
+                                (match uu____7012 with
+                                 | (loc3,env4,uu____7050,p5,ans1) ->
                                      (loc3, env4, ((p5, ans1) :: ps1))))
                        (loc1, env2, []) ps
                       in
-                   (match uu____6839 with
+                   (match uu____6899 with
                     | (loc2,env3,ps1) ->
                         let pats = (p3, ans) :: (FStar_List.rev ps1)  in
                         (env3, var, pats)))
-          | uu____7151 ->
-              let uu____7152 = aux' true loc env1 p1  in
-              (match uu____7152 with
+          | uu____7211 ->
+              let uu____7212 = aux' true loc env1 p1  in
+              (match uu____7212 with
                | (loc1,env2,vars,pat,ans) -> (env2, vars, [(pat, ans)]))
            in
-        let uu____7243 = aux_maybe_or env p  in
-        match uu____7243 with
+        let uu____7303 = aux_maybe_or env p  in
+        match uu____7303 with
         | (env1,b,pats) ->
-            ((let uu____7298 =
+            ((let uu____7358 =
                 FStar_List.map FStar_Pervasives_Native.fst pats  in
-              check_linear_pattern_variables uu____7298
+              check_linear_pattern_variables uu____7358
                 p.FStar_Parser_AST.prange);
              (env1, b, pats))
 
@@ -2036,66 +2077,69 @@ and (desugar_binding_pat_maybe_top :
         if top
         then
           let mklet x ty tacopt =
-            let uu____7372 =
-              let uu____7373 =
-                let uu____7384 = FStar_Syntax_DsEnv.qualify env x  in
-                (uu____7384, (ty, tacopt))  in
-              LetBinder uu____7373  in
-            (env, uu____7372, [])  in
+            let uu____7432 =
+              let uu____7433 =
+                let uu____7444 = FStar_Syntax_DsEnv.qualify env x  in
+                (uu____7444, (ty, tacopt))  in
+              LetBinder uu____7433  in
+            (env, uu____7432, [])  in
           let op_to_ident x =
-            let uu____7401 =
-              let uu____7407 =
-                FStar_Parser_AST.compile_op Prims.int_zero
-                  x.FStar_Ident.idText x.FStar_Ident.idRange
+            let uu____7461 =
+              let uu____7467 =
+                let uu____7469 = FStar_Ident.text_of_id x  in
+                let uu____7471 = FStar_Ident.range_of_id x  in
+                FStar_Parser_AST.compile_op Prims.int_zero uu____7469
+                  uu____7471
                  in
-              (uu____7407, (x.FStar_Ident.idRange))  in
-            FStar_Ident.mk_ident uu____7401  in
+              let uu____7473 = FStar_Ident.range_of_id x  in
+              (uu____7467, uu____7473)  in
+            FStar_Ident.mk_ident uu____7461  in
           match p.FStar_Parser_AST.pat with
           | FStar_Parser_AST.PatOp x ->
-              let uu____7420 = op_to_ident x  in
-              mklet uu____7420 FStar_Syntax_Syntax.tun
+              let uu____7484 = op_to_ident x  in
+              mklet uu____7484 FStar_Syntax_Syntax.tun
                 FStar_Pervasives_Native.None
-          | FStar_Parser_AST.PatVar (x,uu____7422) ->
+          | FStar_Parser_AST.PatVar (x,uu____7486) ->
               mklet x FStar_Syntax_Syntax.tun FStar_Pervasives_Native.None
           | FStar_Parser_AST.PatAscribed
               ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatOp x;
-                 FStar_Parser_AST.prange = uu____7428;_},(t,tacopt))
+                 FStar_Parser_AST.prange = uu____7492;_},(t,tacopt))
               ->
               let tacopt1 = FStar_Util.map_opt tacopt (desugar_term env)  in
-              let uu____7444 = op_to_ident x  in
-              let uu____7445 = desugar_term env t  in
-              mklet uu____7444 uu____7445 tacopt1
+              let uu____7508 = op_to_ident x  in
+              let uu____7509 = desugar_term env t  in
+              mklet uu____7508 uu____7509 tacopt1
           | FStar_Parser_AST.PatAscribed
               ({
                  FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                   (x,uu____7447);
-                 FStar_Parser_AST.prange = uu____7448;_},(t,tacopt))
+                   (x,uu____7511);
+                 FStar_Parser_AST.prange = uu____7512;_},(t,tacopt))
               ->
               let tacopt1 = FStar_Util.map_opt tacopt (desugar_term env)  in
-              let uu____7468 = desugar_term env t  in
-              mklet x uu____7468 tacopt1
-          | uu____7469 ->
+              let uu____7532 = desugar_term env t  in
+              mklet x uu____7532 tacopt1
+          | uu____7533 ->
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_UnexpectedPattern,
                   "Unexpected pattern at the top-level")
                 p.FStar_Parser_AST.prange
         else
-          (let uu____7482 = desugar_data_pat true env p  in
-           match uu____7482 with
+          (let uu____7546 = desugar_data_pat true env p  in
+           match uu____7546 with
            | (env1,binder,p1) ->
                let p2 =
                  match p1 with
                  | ({
                       FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_var
-                        uu____7512;
-                      FStar_Syntax_Syntax.p = uu____7513;_},uu____7514)::[]
+                        uu____7576;
+                      FStar_Syntax_Syntax.p = uu____7577;_},uu____7578)::[]
                      -> []
                  | ({
                       FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_wild
-                        uu____7527;
-                      FStar_Syntax_Syntax.p = uu____7528;_},uu____7529)::[]
+                        uu____7591;
+                      FStar_Syntax_Syntax.p = uu____7592;_},uu____7593)::[]
                      -> []
-                 | uu____7542 -> p1  in
+                 | uu____7606 -> p1  in
                (env1, binder, p2))
 
 and (desugar_binding_pat :
@@ -2107,11 +2151,11 @@ and (desugar_match_pat_maybe_top :
   Prims.bool ->
     env_t -> FStar_Parser_AST.pattern -> (env_t * annotated_pat Prims.list))
   =
-  fun uu____7550  ->
+  fun uu____7614  ->
     fun env  ->
       fun pat  ->
-        let uu____7554 = desugar_data_pat false env pat  in
-        match uu____7554 with | (env1,uu____7571,pat1) -> (env1, pat1)
+        let uu____7618 = desugar_data_pat false env pat  in
+        match uu____7618 with | (env1,uu____7635,pat1) -> (env1, pat1)
 
 and (desugar_match_pat :
   env_t -> FStar_Parser_AST.pattern -> (env_t * annotated_pat Prims.list)) =
@@ -2132,8 +2176,8 @@ and (desugar_term :
   =
   fun env  ->
     fun e  ->
-      let uu____7593 = desugar_term_aq env e  in
-      match uu____7593 with | (t,aq) -> (check_no_aq aq; t)
+      let uu____7657 = desugar_term_aq env e  in
+      match uu____7657 with | (t,aq) -> (check_no_aq aq; t)
 
 and (desugar_typ_aq :
   FStar_Syntax_DsEnv.env ->
@@ -2150,8 +2194,8 @@ and (desugar_typ :
   =
   fun env  ->
     fun e  ->
-      let uu____7612 = desugar_typ_aq env e  in
-      match uu____7612 with | (t,aq) -> (check_no_aq aq; t)
+      let uu____7676 = desugar_typ_aq env e  in
+      match uu____7676 with | (t,aq) -> (check_no_aq aq; t)
 
 and (desugar_machine_integer :
   FStar_Syntax_DsEnv.env ->
@@ -2161,9 +2205,9 @@ and (desugar_machine_integer :
   =
   fun env  ->
     fun repr  ->
-      fun uu____7622  ->
+      fun uu____7686  ->
         fun range  ->
-          match uu____7622 with
+          match uu____7686 with
           | (signedness,width) ->
               let tnm =
                 Prims.op_Hat "FStar."
@@ -2178,19 +2222,19 @@ and (desugar_machine_integer :
                          | FStar_Const.Int32  -> "32"
                          | FStar_Const.Int64  -> "64")))
                  in
-              ((let uu____7644 =
-                  let uu____7646 =
+              ((let uu____7708 =
+                  let uu____7710 =
                     FStar_Const.within_bounds repr signedness width  in
-                  Prims.op_Negation uu____7646  in
-                if uu____7644
+                  Prims.op_Negation uu____7710  in
+                if uu____7708
                 then
-                  let uu____7649 =
-                    let uu____7655 =
+                  let uu____7713 =
+                    let uu____7719 =
                       FStar_Util.format2
                         "%s is not in the expected range for %s" repr tnm
                        in
-                    (FStar_Errors.Error_OutOfRange, uu____7655)  in
-                  FStar_Errors.log_issue range uu____7649
+                    (FStar_Errors.Error_OutOfRange, uu____7719)  in
+                  FStar_Errors.log_issue range uu____7713
                 else ());
                (let private_intro_nm =
                   Prims.op_Hat tnm
@@ -2209,51 +2253,51 @@ and (desugar_machine_integer :
                            | FStar_Const.Signed  -> "") "int_to_t"))
                    in
                 let lid =
-                  let uu____7676 = FStar_Ident.path_of_text intro_nm  in
-                  FStar_Ident.lid_of_path uu____7676 range  in
+                  let uu____7740 = FStar_Ident.path_of_text intro_nm  in
+                  FStar_Ident.lid_of_path uu____7740 range  in
                 let lid1 =
-                  let uu____7680 = FStar_Syntax_DsEnv.try_lookup_lid env lid
+                  let uu____7744 = FStar_Syntax_DsEnv.try_lookup_lid env lid
                      in
-                  match uu____7680 with
+                  match uu____7744 with
                   | FStar_Pervasives_Native.Some intro_term ->
                       (match intro_term.FStar_Syntax_Syntax.n with
                        | FStar_Syntax_Syntax.Tm_fvar fv ->
                            let private_lid =
-                             let uu____7690 =
+                             let uu____7754 =
                                FStar_Ident.path_of_text private_intro_nm  in
-                             FStar_Ident.lid_of_path uu____7690 range  in
+                             FStar_Ident.lid_of_path uu____7754 range  in
                            let private_fv =
-                             let uu____7692 =
+                             let uu____7756 =
                                FStar_Syntax_Util.incr_delta_depth
                                  fv.FStar_Syntax_Syntax.fv_delta
                                 in
                              FStar_Syntax_Syntax.lid_as_fv private_lid
-                               uu____7692 fv.FStar_Syntax_Syntax.fv_qual
+                               uu____7756 fv.FStar_Syntax_Syntax.fv_qual
                               in
-                           let uu___1277_7693 = intro_term  in
+                           let uu___1277_7757 = intro_term  in
                            {
                              FStar_Syntax_Syntax.n =
                                (FStar_Syntax_Syntax.Tm_fvar private_fv);
                              FStar_Syntax_Syntax.pos =
-                               (uu___1277_7693.FStar_Syntax_Syntax.pos);
+                               (uu___1277_7757.FStar_Syntax_Syntax.pos);
                              FStar_Syntax_Syntax.vars =
-                               (uu___1277_7693.FStar_Syntax_Syntax.vars)
+                               (uu___1277_7757.FStar_Syntax_Syntax.vars)
                            }
-                       | uu____7694 ->
+                       | uu____7758 ->
                            failwith
                              (Prims.op_Hat "Unexpected non-fvar for "
                                 intro_nm))
                   | FStar_Pervasives_Native.None  ->
-                      let uu____7698 =
-                        let uu____7704 =
+                      let uu____7762 =
+                        let uu____7768 =
                           FStar_Util.format1
                             "Unexpected numeric literal.  Restart F* to load %s."
                             tnm
                            in
                         (FStar_Errors.Fatal_UnexpectedNumericLiteral,
-                          uu____7704)
+                          uu____7768)
                          in
-                      FStar_Errors.raise_error uu____7698 range
+                      FStar_Errors.raise_error uu____7762 range
                    in
                 let repr1 =
                   FStar_Syntax_Syntax.mk
@@ -2262,19 +2306,19 @@ and (desugar_machine_integer :
                           (repr, FStar_Pervasives_Native.None)))
                     FStar_Pervasives_Native.None range
                    in
-                let uu____7724 =
-                  let uu____7731 =
-                    let uu____7732 =
-                      let uu____7749 =
-                        let uu____7760 =
-                          let uu____7769 =
+                let uu____7788 =
+                  let uu____7795 =
+                    let uu____7796 =
+                      let uu____7813 =
+                        let uu____7824 =
+                          let uu____7833 =
                             FStar_Syntax_Syntax.as_implicit false  in
-                          (repr1, uu____7769)  in
-                        [uu____7760]  in
-                      (lid1, uu____7749)  in
-                    FStar_Syntax_Syntax.Tm_app uu____7732  in
-                  FStar_Syntax_Syntax.mk uu____7731  in
-                uu____7724 FStar_Pervasives_Native.None range))
+                          (repr1, uu____7833)  in
+                        [uu____7824]  in
+                      (lid1, uu____7813)  in
+                    FStar_Syntax_Syntax.Tm_app uu____7796  in
+                  FStar_Syntax_Syntax.mk uu____7795  in
+                uu____7788 FStar_Pervasives_Native.None range))
 
 and (desugar_term_maybe_top :
   Prims.bool ->
@@ -2292,406 +2336,404 @@ and (desugar_term_maybe_top :
         let noaqs = []  in
         let join_aqs aqs = FStar_List.flatten aqs  in
         let setpos e =
-          let uu___1293_7888 = e  in
+          let uu___1293_7952 = e  in
           {
-            FStar_Syntax_Syntax.n = (uu___1293_7888.FStar_Syntax_Syntax.n);
+            FStar_Syntax_Syntax.n = (uu___1293_7952.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = (top.FStar_Parser_AST.range);
             FStar_Syntax_Syntax.vars =
-              (uu___1293_7888.FStar_Syntax_Syntax.vars)
+              (uu___1293_7952.FStar_Syntax_Syntax.vars)
           }  in
-        let uu____7891 =
-          let uu____7892 = unparen top  in uu____7892.FStar_Parser_AST.tm  in
-        match uu____7891 with
+        let uu____7955 =
+          let uu____7956 = unparen top  in uu____7956.FStar_Parser_AST.tm  in
+        match uu____7955 with
         | FStar_Parser_AST.Wild  -> ((setpos FStar_Syntax_Syntax.tun), noaqs)
-        | FStar_Parser_AST.Labeled uu____7897 ->
-            let uu____7906 = desugar_formula env top  in (uu____7906, noaqs)
+        | FStar_Parser_AST.Labeled uu____7961 ->
+            let uu____7970 = desugar_formula env top  in (uu____7970, noaqs)
         | FStar_Parser_AST.Requires (t,lopt) ->
-            let uu____7915 = desugar_formula env t  in (uu____7915, noaqs)
+            let uu____7979 = desugar_formula env t  in (uu____7979, noaqs)
         | FStar_Parser_AST.Ensures (t,lopt) ->
-            let uu____7924 = desugar_formula env t  in (uu____7924, noaqs)
+            let uu____7988 = desugar_formula env t  in (uu____7988, noaqs)
         | FStar_Parser_AST.Attributes ts ->
             failwith
               "Attributes should not be desugared by desugar_term_maybe_top"
         | FStar_Parser_AST.Const (FStar_Const.Const_int
             (i,FStar_Pervasives_Native.Some size)) ->
-            let uu____7951 =
+            let uu____8015 =
               desugar_machine_integer env i size top.FStar_Parser_AST.range
                in
-            (uu____7951, noaqs)
+            (uu____8015, noaqs)
         | FStar_Parser_AST.Const c ->
-            let uu____7953 = mk (FStar_Syntax_Syntax.Tm_constant c)  in
-            (uu____7953, noaqs)
-        | FStar_Parser_AST.Op
-            ({ FStar_Ident.idText = "=!="; FStar_Ident.idRange = r;_},args)
+            let uu____8017 = mk (FStar_Syntax_Syntax.Tm_constant c)  in
+            (uu____8017, noaqs)
+        | FStar_Parser_AST.Op (id,args) when
+            let uu____8024 = FStar_Ident.text_of_id id  in uu____8024 = "=!="
             ->
+            let r = FStar_Ident.range_of_id id  in
             let e =
-              let uu____7962 =
-                let uu____7963 =
-                  let uu____7970 = FStar_Ident.mk_ident ("==", r)  in
-                  (uu____7970, args)  in
-                FStar_Parser_AST.Op uu____7963  in
-              FStar_Parser_AST.mk_term uu____7962 top.FStar_Parser_AST.range
+              let uu____8030 =
+                let uu____8031 =
+                  let uu____8038 = FStar_Ident.mk_ident ("==", r)  in
+                  (uu____8038, args)  in
+                FStar_Parser_AST.Op uu____8031  in
+              FStar_Parser_AST.mk_term uu____8030 top.FStar_Parser_AST.range
                 top.FStar_Parser_AST.level
                in
-            let uu____7975 =
-              let uu____7976 =
-                let uu____7977 =
-                  let uu____7984 = FStar_Ident.mk_ident ("~", r)  in
-                  (uu____7984, [e])  in
-                FStar_Parser_AST.Op uu____7977  in
-              FStar_Parser_AST.mk_term uu____7976 top.FStar_Parser_AST.range
+            let uu____8043 =
+              let uu____8044 =
+                let uu____8045 =
+                  let uu____8052 = FStar_Ident.mk_ident ("~", r)  in
+                  (uu____8052, [e])  in
+                FStar_Parser_AST.Op uu____8045  in
+              FStar_Parser_AST.mk_term uu____8044 top.FStar_Parser_AST.range
                 top.FStar_Parser_AST.level
                in
-            desugar_term_aq env uu____7975
+            desugar_term_aq env uu____8043
         | FStar_Parser_AST.Op (op_star,lhs::rhs::[]) when
-            (let uu____7996 = FStar_Ident.text_of_id op_star  in
-             uu____7996 = "*") &&
-              (let uu____8001 =
+            (let uu____8064 = FStar_Ident.text_of_id op_star  in
+             uu____8064 = "*") &&
+              (let uu____8069 =
                  op_as_term env (Prims.of_int (2)) top.FStar_Parser_AST.range
                    op_star
                   in
-               FStar_All.pipe_right uu____8001 FStar_Option.isNone)
+               FStar_All.pipe_right uu____8069 FStar_Option.isNone)
             ->
             let rec flatten t =
               match t.FStar_Parser_AST.tm with
-              | FStar_Parser_AST.Op
-                  ({ FStar_Ident.idText = "*";
-                     FStar_Ident.idRange = uu____8018;_},t1::t2::[])
-                  when
-                  let uu____8024 =
-                    op_as_term env (Prims.of_int (2))
-                      top.FStar_Parser_AST.range op_star
-                     in
-                  FStar_All.pipe_right uu____8024 FStar_Option.isNone ->
-                  let uu____8031 = flatten t1  in
-                  FStar_List.append uu____8031 [t2]
-              | uu____8034 -> [t]  in
+              | FStar_Parser_AST.Op (id,t1::t2::[]) when
+                  (let uu____8093 = FStar_Ident.text_of_id id  in
+                   uu____8093 = "*") &&
+                    (let uu____8098 =
+                       op_as_term env (Prims.of_int (2))
+                         top.FStar_Parser_AST.range op_star
+                        in
+                     FStar_All.pipe_right uu____8098 FStar_Option.isNone)
+                  ->
+                  let uu____8105 = flatten t1  in
+                  FStar_List.append uu____8105 [t2]
+              | uu____8108 -> [t]  in
             let terms = flatten lhs  in
             let t =
-              let uu___1341_8039 = top  in
-              let uu____8040 =
-                let uu____8041 =
-                  let uu____8052 =
+              let uu___1338_8113 = top  in
+              let uu____8114 =
+                let uu____8115 =
+                  let uu____8126 =
                     FStar_List.map
-                      (fun uu____8063  -> FStar_Util.Inr uu____8063) terms
+                      (fun uu____8137  -> FStar_Util.Inr uu____8137) terms
                      in
-                  (uu____8052, rhs)  in
-                FStar_Parser_AST.Sum uu____8041  in
+                  (uu____8126, rhs)  in
+                FStar_Parser_AST.Sum uu____8115  in
               {
-                FStar_Parser_AST.tm = uu____8040;
+                FStar_Parser_AST.tm = uu____8114;
                 FStar_Parser_AST.range =
-                  (uu___1341_8039.FStar_Parser_AST.range);
+                  (uu___1338_8113.FStar_Parser_AST.range);
                 FStar_Parser_AST.level =
-                  (uu___1341_8039.FStar_Parser_AST.level)
+                  (uu___1338_8113.FStar_Parser_AST.level)
               }  in
             desugar_term_maybe_top top_level env t
         | FStar_Parser_AST.Tvar a ->
-            let uu____8071 =
-              let uu____8072 =
+            let uu____8145 =
+              let uu____8146 =
                 FStar_Syntax_DsEnv.fail_or2
                   (FStar_Syntax_DsEnv.try_lookup_id env) a
                  in
-              FStar_All.pipe_left setpos uu____8072  in
-            (uu____8071, noaqs)
+              FStar_All.pipe_left setpos uu____8146  in
+            (uu____8145, noaqs)
         | FStar_Parser_AST.Uvar u ->
-            let uu____8078 =
-              let uu____8084 =
-                let uu____8086 =
-                  let uu____8088 = FStar_Ident.text_of_id u  in
-                  Prims.op_Hat uu____8088 " in non-universe context"  in
-                Prims.op_Hat "Unexpected universe variable " uu____8086  in
-              (FStar_Errors.Fatal_UnexpectedUniverseVariable, uu____8084)  in
-            FStar_Errors.raise_error uu____8078 top.FStar_Parser_AST.range
+            let uu____8152 =
+              let uu____8158 =
+                let uu____8160 =
+                  let uu____8162 = FStar_Ident.text_of_id u  in
+                  Prims.op_Hat uu____8162 " in non-universe context"  in
+                Prims.op_Hat "Unexpected universe variable " uu____8160  in
+              (FStar_Errors.Fatal_UnexpectedUniverseVariable, uu____8158)  in
+            FStar_Errors.raise_error uu____8152 top.FStar_Parser_AST.range
         | FStar_Parser_AST.Op (s,args) ->
-            let uu____8103 =
+            let uu____8177 =
               op_as_term env (FStar_List.length args)
                 top.FStar_Parser_AST.range s
                in
-            (match uu____8103 with
+            (match uu____8177 with
              | FStar_Pervasives_Native.None  ->
-                 let uu____8110 =
-                   let uu____8116 =
-                     let uu____8118 = FStar_Ident.text_of_id s  in
+                 let uu____8184 =
+                   let uu____8190 =
+                     let uu____8192 = FStar_Ident.text_of_id s  in
                      Prims.op_Hat "Unexpected or unbound operator: "
-                       uu____8118
+                       uu____8192
                       in
                    (FStar_Errors.Fatal_UnepxectedOrUnboundOperator,
-                     uu____8116)
+                     uu____8190)
                     in
-                 FStar_Errors.raise_error uu____8110
+                 FStar_Errors.raise_error uu____8184
                    top.FStar_Parser_AST.range
              | FStar_Pervasives_Native.Some op ->
                  if (FStar_List.length args) > Prims.int_zero
                  then
-                   let uu____8133 =
-                     let uu____8158 =
+                   let uu____8207 =
+                     let uu____8232 =
                        FStar_All.pipe_right args
                          (FStar_List.map
                             (fun t  ->
-                               let uu____8220 = desugar_term_aq env t  in
-                               match uu____8220 with
+                               let uu____8294 = desugar_term_aq env t  in
+                               match uu____8294 with
                                | (t',s1) ->
                                    ((t', FStar_Pervasives_Native.None), s1)))
                         in
-                     FStar_All.pipe_right uu____8158 FStar_List.unzip  in
-                   (match uu____8133 with
+                     FStar_All.pipe_right uu____8232 FStar_List.unzip  in
+                   (match uu____8207 with
                     | (args1,aqs) ->
-                        let uu____8353 =
+                        let uu____8427 =
                           mk (FStar_Syntax_Syntax.Tm_app (op, args1))  in
-                        (uu____8353, (join_aqs aqs)))
+                        (uu____8427, (join_aqs aqs)))
                  else (op, noaqs))
-        | FStar_Parser_AST.Construct (n,(a,uu____8370)::[]) when
-            n.FStar_Ident.str = "SMTPat" ->
-            let uu____8387 =
-              let uu___1370_8388 = top  in
-              let uu____8389 =
-                let uu____8390 =
-                  let uu____8397 =
-                    let uu___1372_8398 = top  in
-                    let uu____8399 =
-                      let uu____8400 = smt_pat_lid top.FStar_Parser_AST.range
+        | FStar_Parser_AST.Construct (n,(a,uu____8444)::[]) when
+            let uu____8459 = FStar_Ident.string_of_lid n  in
+            uu____8459 = "SMTPat" ->
+            let uu____8463 =
+              let uu___1367_8464 = top  in
+              let uu____8465 =
+                let uu____8466 =
+                  let uu____8473 =
+                    let uu___1369_8474 = top  in
+                    let uu____8475 =
+                      let uu____8476 = smt_pat_lid top.FStar_Parser_AST.range
                          in
-                      FStar_Parser_AST.Var uu____8400  in
+                      FStar_Parser_AST.Var uu____8476  in
                     {
-                      FStar_Parser_AST.tm = uu____8399;
+                      FStar_Parser_AST.tm = uu____8475;
                       FStar_Parser_AST.range =
-                        (uu___1372_8398.FStar_Parser_AST.range);
+                        (uu___1369_8474.FStar_Parser_AST.range);
                       FStar_Parser_AST.level =
-                        (uu___1372_8398.FStar_Parser_AST.level)
+                        (uu___1369_8474.FStar_Parser_AST.level)
                     }  in
-                  (uu____8397, a, FStar_Parser_AST.Nothing)  in
-                FStar_Parser_AST.App uu____8390  in
+                  (uu____8473, a, FStar_Parser_AST.Nothing)  in
+                FStar_Parser_AST.App uu____8466  in
               {
-                FStar_Parser_AST.tm = uu____8389;
+                FStar_Parser_AST.tm = uu____8465;
                 FStar_Parser_AST.range =
-                  (uu___1370_8388.FStar_Parser_AST.range);
+                  (uu___1367_8464.FStar_Parser_AST.range);
                 FStar_Parser_AST.level =
-                  (uu___1370_8388.FStar_Parser_AST.level)
+                  (uu___1367_8464.FStar_Parser_AST.level)
               }  in
-            desugar_term_maybe_top top_level env uu____8387
-        | FStar_Parser_AST.Construct (n,(a,uu____8403)::[]) when
-            n.FStar_Ident.str = "SMTPatT" ->
+            desugar_term_maybe_top top_level env uu____8463
+        | FStar_Parser_AST.Construct (n,(a,uu____8479)::[]) when
+            let uu____8494 = FStar_Ident.string_of_lid n  in
+            uu____8494 = "SMTPatT" ->
             (FStar_Errors.log_issue top.FStar_Parser_AST.range
                (FStar_Errors.Warning_SMTPatTDeprecated,
                  "SMTPatT is deprecated; please just use SMTPat");
-             (let uu____8423 =
-                let uu___1382_8424 = top  in
-                let uu____8425 =
-                  let uu____8426 =
-                    let uu____8433 =
-                      let uu___1384_8434 = top  in
-                      let uu____8435 =
-                        let uu____8436 =
+             (let uu____8501 =
+                let uu___1379_8502 = top  in
+                let uu____8503 =
+                  let uu____8504 =
+                    let uu____8511 =
+                      let uu___1381_8512 = top  in
+                      let uu____8513 =
+                        let uu____8514 =
                           smt_pat_lid top.FStar_Parser_AST.range  in
-                        FStar_Parser_AST.Var uu____8436  in
+                        FStar_Parser_AST.Var uu____8514  in
                       {
-                        FStar_Parser_AST.tm = uu____8435;
+                        FStar_Parser_AST.tm = uu____8513;
                         FStar_Parser_AST.range =
-                          (uu___1384_8434.FStar_Parser_AST.range);
+                          (uu___1381_8512.FStar_Parser_AST.range);
                         FStar_Parser_AST.level =
-                          (uu___1384_8434.FStar_Parser_AST.level)
+                          (uu___1381_8512.FStar_Parser_AST.level)
                       }  in
-                    (uu____8433, a, FStar_Parser_AST.Nothing)  in
-                  FStar_Parser_AST.App uu____8426  in
+                    (uu____8511, a, FStar_Parser_AST.Nothing)  in
+                  FStar_Parser_AST.App uu____8504  in
                 {
-                  FStar_Parser_AST.tm = uu____8425;
+                  FStar_Parser_AST.tm = uu____8503;
                   FStar_Parser_AST.range =
-                    (uu___1382_8424.FStar_Parser_AST.range);
+                    (uu___1379_8502.FStar_Parser_AST.range);
                   FStar_Parser_AST.level =
-                    (uu___1382_8424.FStar_Parser_AST.level)
+                    (uu___1379_8502.FStar_Parser_AST.level)
                 }  in
-              desugar_term_maybe_top top_level env uu____8423))
-        | FStar_Parser_AST.Construct (n,(a,uu____8439)::[]) when
-            n.FStar_Ident.str = "SMTPatOr" ->
-            let uu____8456 =
-              let uu___1393_8457 = top  in
-              let uu____8458 =
-                let uu____8459 =
-                  let uu____8466 =
-                    let uu___1395_8467 = top  in
-                    let uu____8468 =
-                      let uu____8469 =
+              desugar_term_maybe_top top_level env uu____8501))
+        | FStar_Parser_AST.Construct (n,(a,uu____8517)::[]) when
+            let uu____8532 = FStar_Ident.string_of_lid n  in
+            uu____8532 = "SMTPatOr" ->
+            let uu____8536 =
+              let uu___1390_8537 = top  in
+              let uu____8538 =
+                let uu____8539 =
+                  let uu____8546 =
+                    let uu___1392_8547 = top  in
+                    let uu____8548 =
+                      let uu____8549 =
                         smt_pat_or_lid top.FStar_Parser_AST.range  in
-                      FStar_Parser_AST.Var uu____8469  in
+                      FStar_Parser_AST.Var uu____8549  in
                     {
-                      FStar_Parser_AST.tm = uu____8468;
+                      FStar_Parser_AST.tm = uu____8548;
                       FStar_Parser_AST.range =
-                        (uu___1395_8467.FStar_Parser_AST.range);
+                        (uu___1392_8547.FStar_Parser_AST.range);
                       FStar_Parser_AST.level =
-                        (uu___1395_8467.FStar_Parser_AST.level)
+                        (uu___1392_8547.FStar_Parser_AST.level)
                     }  in
-                  (uu____8466, a, FStar_Parser_AST.Nothing)  in
-                FStar_Parser_AST.App uu____8459  in
+                  (uu____8546, a, FStar_Parser_AST.Nothing)  in
+                FStar_Parser_AST.App uu____8539  in
               {
-                FStar_Parser_AST.tm = uu____8458;
+                FStar_Parser_AST.tm = uu____8538;
                 FStar_Parser_AST.range =
-                  (uu___1393_8457.FStar_Parser_AST.range);
+                  (uu___1390_8537.FStar_Parser_AST.range);
                 FStar_Parser_AST.level =
-                  (uu___1393_8457.FStar_Parser_AST.level)
+                  (uu___1390_8537.FStar_Parser_AST.level)
               }  in
-            desugar_term_maybe_top top_level env uu____8456
-        | FStar_Parser_AST.Name
-            { FStar_Ident.ns = uu____8470; FStar_Ident.ident = uu____8471;
-              FStar_Ident.nsstr = uu____8472; FStar_Ident.str = "Type0";_}
-            ->
-            let uu____8477 =
+            desugar_term_maybe_top top_level env uu____8536
+        | FStar_Parser_AST.Name lid when
+            let uu____8551 = FStar_Ident.string_of_lid lid  in
+            uu____8551 = "Type0" ->
+            let uu____8555 =
               mk (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_zero)  in
-            (uu____8477, noaqs)
-        | FStar_Parser_AST.Name
-            { FStar_Ident.ns = uu____8478; FStar_Ident.ident = uu____8479;
-              FStar_Ident.nsstr = uu____8480; FStar_Ident.str = "Type";_}
-            ->
-            let uu____8485 =
+            (uu____8555, noaqs)
+        | FStar_Parser_AST.Name lid when
+            let uu____8557 = FStar_Ident.string_of_lid lid  in
+            uu____8557 = "Type" ->
+            let uu____8561 =
               mk (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)
                in
-            (uu____8485, noaqs)
-        | FStar_Parser_AST.Construct
-            ({ FStar_Ident.ns = uu____8486; FStar_Ident.ident = uu____8487;
-               FStar_Ident.nsstr = uu____8488; FStar_Ident.str = "Type";_},
-             (t,FStar_Parser_AST.UnivApp )::[])
-            ->
-            let uu____8508 =
-              let uu____8509 =
-                let uu____8510 = desugar_universe t  in
-                FStar_Syntax_Syntax.Tm_type uu____8510  in
-              mk uu____8509  in
-            (uu____8508, noaqs)
-        | FStar_Parser_AST.Name
-            { FStar_Ident.ns = uu____8511; FStar_Ident.ident = uu____8512;
-              FStar_Ident.nsstr = uu____8513; FStar_Ident.str = "Effect";_}
-            ->
-            let uu____8518 =
+            (uu____8561, noaqs)
+        | FStar_Parser_AST.Construct (lid,(t,FStar_Parser_AST.UnivApp )::[])
+            when
+            let uu____8578 = FStar_Ident.string_of_lid lid  in
+            uu____8578 = "Type" ->
+            let uu____8582 =
+              let uu____8583 =
+                let uu____8584 = desugar_universe t  in
+                FStar_Syntax_Syntax.Tm_type uu____8584  in
+              mk uu____8583  in
+            (uu____8582, noaqs)
+        | FStar_Parser_AST.Name lid when
+            let uu____8586 = FStar_Ident.string_of_lid lid  in
+            uu____8586 = "Effect" ->
+            let uu____8590 =
               mk (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_effect)
                in
-            (uu____8518, noaqs)
-        | FStar_Parser_AST.Name
-            { FStar_Ident.ns = uu____8519; FStar_Ident.ident = uu____8520;
-              FStar_Ident.nsstr = uu____8521; FStar_Ident.str = "True";_}
-            ->
-            let uu____8526 =
-              let uu____8527 =
+            (uu____8590, noaqs)
+        | FStar_Parser_AST.Name lid when
+            let uu____8592 = FStar_Ident.string_of_lid lid  in
+            uu____8592 = "True" ->
+            let uu____8596 =
+              let uu____8597 =
                 FStar_Ident.set_lid_range FStar_Parser_Const.true_lid
                   top.FStar_Parser_AST.range
                  in
-              FStar_Syntax_Syntax.fvar uu____8527
+              FStar_Syntax_Syntax.fvar uu____8597
                 FStar_Syntax_Syntax.delta_constant
                 FStar_Pervasives_Native.None
                in
-            (uu____8526, noaqs)
-        | FStar_Parser_AST.Name
-            { FStar_Ident.ns = uu____8528; FStar_Ident.ident = uu____8529;
-              FStar_Ident.nsstr = uu____8530; FStar_Ident.str = "False";_}
-            ->
-            let uu____8535 =
-              let uu____8536 =
+            (uu____8596, noaqs)
+        | FStar_Parser_AST.Name lid when
+            let uu____8599 = FStar_Ident.string_of_lid lid  in
+            uu____8599 = "False" ->
+            let uu____8603 =
+              let uu____8604 =
                 FStar_Ident.set_lid_range FStar_Parser_Const.false_lid
                   top.FStar_Parser_AST.range
                  in
-              FStar_Syntax_Syntax.fvar uu____8536
+              FStar_Syntax_Syntax.fvar uu____8604
                 FStar_Syntax_Syntax.delta_constant
                 FStar_Pervasives_Native.None
                in
-            (uu____8535, noaqs)
-        | FStar_Parser_AST.Projector
-            (eff_name,{ FStar_Ident.idText = txt;
-                        FStar_Ident.idRange = uu____8539;_})
-            when
-            (is_special_effect_combinator txt) &&
+            (uu____8603, noaqs)
+        | FStar_Parser_AST.Projector (eff_name,id) when
+            (let uu____8609 = FStar_Ident.text_of_id id  in
+             is_special_effect_combinator uu____8609) &&
               (FStar_Syntax_DsEnv.is_effect_name env eff_name)
             ->
-            let uu____8541 =
+            let txt = FStar_Ident.text_of_id id  in
+            let uu____8613 =
               FStar_Syntax_DsEnv.try_lookup_effect_defn env eff_name  in
-            (match uu____8541 with
+            (match uu____8613 with
              | FStar_Pervasives_Native.Some ed ->
                  let lid = FStar_Syntax_Util.dm4f_lid ed txt  in
-                 let uu____8550 =
+                 let uu____8622 =
                    FStar_Syntax_Syntax.fvar lid
                      (FStar_Syntax_Syntax.Delta_constant_at_level
                         Prims.int_one) FStar_Pervasives_Native.None
                     in
-                 (uu____8550, noaqs)
+                 (uu____8622, noaqs)
              | FStar_Pervasives_Native.None  ->
-                 let uu____8552 =
-                   let uu____8554 = FStar_Ident.text_of_lid eff_name  in
+                 let uu____8624 =
+                   let uu____8626 = FStar_Ident.string_of_lid eff_name  in
                    FStar_Util.format2
                      "Member %s of effect %s is not accessible (using an effect abbreviation instead of the original effect ?)"
-                     uu____8554 txt
+                     uu____8626 txt
                     in
-                 failwith uu____8552)
+                 failwith uu____8624)
         | FStar_Parser_AST.Var l ->
-            let uu____8562 = desugar_name mk setpos env true l  in
-            (uu____8562, noaqs)
+            let uu____8634 = desugar_name mk setpos env true l  in
+            (uu____8634, noaqs)
         | FStar_Parser_AST.Name l ->
-            let uu____8570 = desugar_name mk setpos env true l  in
-            (uu____8570, noaqs)
+            let uu____8642 = desugar_name mk setpos env true l  in
+            (uu____8642, noaqs)
         | FStar_Parser_AST.Projector (l,i) ->
             let name =
-              let uu____8587 = FStar_Syntax_DsEnv.try_lookup_datacon env l
+              let uu____8659 = FStar_Syntax_DsEnv.try_lookup_datacon env l
                  in
-              match uu____8587 with
-              | FStar_Pervasives_Native.Some uu____8597 ->
+              match uu____8659 with
+              | FStar_Pervasives_Native.Some uu____8669 ->
                   FStar_Pervasives_Native.Some (true, l)
               | FStar_Pervasives_Native.None  ->
-                  let uu____8605 =
+                  let uu____8677 =
                     FStar_Syntax_DsEnv.try_lookup_root_effect_name env l  in
-                  (match uu____8605 with
+                  (match uu____8677 with
                    | FStar_Pervasives_Native.Some new_name ->
                        FStar_Pervasives_Native.Some (false, new_name)
-                   | uu____8623 -> FStar_Pervasives_Native.None)
+                   | uu____8695 -> FStar_Pervasives_Native.None)
                in
             (match name with
              | FStar_Pervasives_Native.Some (resolve,new_name) ->
-                 let uu____8644 =
-                   let uu____8645 =
+                 let uu____8716 =
+                   let uu____8717 =
                      FStar_Syntax_Util.mk_field_projector_name_from_ident
                        new_name i
                       in
-                   desugar_name mk setpos env resolve uu____8645  in
-                 (uu____8644, noaqs)
-             | uu____8651 ->
-                 let uu____8659 =
-                   let uu____8665 =
+                   desugar_name mk setpos env resolve uu____8717  in
+                 (uu____8716, noaqs)
+             | uu____8723 ->
+                 let uu____8731 =
+                   let uu____8737 =
+                     let uu____8739 = FStar_Ident.string_of_lid l  in
                      FStar_Util.format1
-                       "Data constructor or effect %s not found"
-                       l.FStar_Ident.str
+                       "Data constructor or effect %s not found" uu____8739
                       in
-                   (FStar_Errors.Fatal_EffectNotFound, uu____8665)  in
-                 FStar_Errors.raise_error uu____8659
+                   (FStar_Errors.Fatal_EffectNotFound, uu____8737)  in
+                 FStar_Errors.raise_error uu____8731
                    top.FStar_Parser_AST.range)
         | FStar_Parser_AST.Discrim lid ->
-            let uu____8674 = FStar_Syntax_DsEnv.try_lookup_datacon env lid
+            let uu____8748 = FStar_Syntax_DsEnv.try_lookup_datacon env lid
                in
-            (match uu____8674 with
+            (match uu____8748 with
              | FStar_Pervasives_Native.None  ->
-                 let uu____8681 =
-                   let uu____8687 =
+                 let uu____8755 =
+                   let uu____8761 =
+                     let uu____8763 = FStar_Ident.string_of_lid lid  in
                      FStar_Util.format1 "Data constructor %s not found"
-                       lid.FStar_Ident.str
+                       uu____8763
                       in
-                   (FStar_Errors.Fatal_DataContructorNotFound, uu____8687)
+                   (FStar_Errors.Fatal_DataContructorNotFound, uu____8761)
                     in
-                 FStar_Errors.raise_error uu____8681
+                 FStar_Errors.raise_error uu____8755
                    top.FStar_Parser_AST.range
-             | uu____8695 ->
+             | uu____8771 ->
                  let lid' = FStar_Syntax_Util.mk_discriminator lid  in
-                 let uu____8699 = desugar_name mk setpos env true lid'  in
-                 (uu____8699, noaqs))
+                 let uu____8775 = desugar_name mk setpos env true lid'  in
+                 (uu____8775, noaqs))
         | FStar_Parser_AST.Construct (l,args) ->
-            let uu____8720 = FStar_Syntax_DsEnv.try_lookup_datacon env l  in
-            (match uu____8720 with
+            let uu____8796 = FStar_Syntax_DsEnv.try_lookup_datacon env l  in
+            (match uu____8796 with
              | FStar_Pervasives_Native.Some head ->
                  let head1 = mk (FStar_Syntax_Syntax.Tm_fvar head)  in
                  (match args with
                   | [] -> (head1, noaqs)
-                  | uu____8739 ->
-                      let uu____8746 =
+                  | uu____8815 ->
+                      let uu____8822 =
                         FStar_Util.take
-                          (fun uu____8770  ->
-                             match uu____8770 with
-                             | (uu____8776,imp) ->
+                          (fun uu____8846  ->
+                             match uu____8846 with
+                             | (uu____8852,imp) ->
                                  imp = FStar_Parser_AST.UnivApp) args
                          in
-                      (match uu____8746 with
+                      (match uu____8822 with
                        | (universes,args1) ->
                            let universes1 =
                              FStar_List.map
@@ -2700,22 +2742,22 @@ and (desugar_term_maybe_top :
                                     (FStar_Pervasives_Native.fst x))
                                universes
                               in
-                           let uu____8821 =
-                             let uu____8846 =
+                           let uu____8897 =
+                             let uu____8922 =
                                FStar_List.map
-                                 (fun uu____8889  ->
-                                    match uu____8889 with
+                                 (fun uu____8965  ->
+                                    match uu____8965 with
                                     | (t,imp) ->
-                                        let uu____8906 =
+                                        let uu____8982 =
                                           desugar_term_aq env t  in
-                                        (match uu____8906 with
+                                        (match uu____8982 with
                                          | (te,aq) ->
                                              ((arg_withimp_e imp te), aq)))
                                  args1
                                 in
-                             FStar_All.pipe_right uu____8846 FStar_List.unzip
+                             FStar_All.pipe_right uu____8922 FStar_List.unzip
                               in
-                           (match uu____8821 with
+                           (match uu____8897 with
                             | (args2,aqs) ->
                                 let head2 =
                                   if universes1 = []
@@ -2725,188 +2767,195 @@ and (desugar_term_maybe_top :
                                       (FStar_Syntax_Syntax.Tm_uinst
                                          (head1, universes1))
                                    in
-                                let uu____9049 =
+                                let uu____9125 =
                                   mk
                                     (FStar_Syntax_Syntax.Tm_app
                                        (head2, args2))
                                    in
-                                (uu____9049, (join_aqs aqs)))))
+                                (uu____9125, (join_aqs aqs)))))
              | FStar_Pervasives_Native.None  ->
                  let err =
-                   let uu____9068 =
+                   let uu____9144 =
                      FStar_Syntax_DsEnv.try_lookup_effect_name env l  in
-                   match uu____9068 with
+                   match uu____9144 with
                    | FStar_Pervasives_Native.None  ->
-                       (FStar_Errors.Fatal_ConstructorNotFound,
-                         (Prims.op_Hat "Constructor "
-                            (Prims.op_Hat l.FStar_Ident.str " not found")))
-                   | FStar_Pervasives_Native.Some uu____9079 ->
-                       (FStar_Errors.Fatal_UnexpectedEffect,
-                         (Prims.op_Hat "Effect "
-                            (Prims.op_Hat l.FStar_Ident.str
-                               " used at an unexpected position")))
+                       let uu____9152 =
+                         let uu____9154 =
+                           let uu____9156 = FStar_Ident.string_of_lid l  in
+                           Prims.op_Hat uu____9156 " not found"  in
+                         Prims.op_Hat "Constructor " uu____9154  in
+                       (FStar_Errors.Fatal_ConstructorNotFound, uu____9152)
+                   | FStar_Pervasives_Native.Some uu____9161 ->
+                       let uu____9162 =
+                         let uu____9164 =
+                           let uu____9166 = FStar_Ident.string_of_lid l  in
+                           Prims.op_Hat uu____9166
+                             " used at an unexpected position"
+                            in
+                         Prims.op_Hat "Effect " uu____9164  in
+                       (FStar_Errors.Fatal_UnexpectedEffect, uu____9162)
                     in
                  FStar_Errors.raise_error err top.FStar_Parser_AST.range)
         | FStar_Parser_AST.Sum (binders,t) when
             FStar_Util.for_all
-              (fun uu___8_9107  ->
-                 match uu___8_9107 with
-                 | FStar_Util.Inr uu____9113 -> true
-                 | uu____9115 -> false) binders
+              (fun uu___8_9195  ->
+                 match uu___8_9195 with
+                 | FStar_Util.Inr uu____9201 -> true
+                 | uu____9203 -> false) binders
             ->
             let terms =
-              let uu____9124 =
+              let uu____9212 =
                 FStar_All.pipe_right binders
                   (FStar_List.map
-                     (fun uu___9_9141  ->
-                        match uu___9_9141 with
+                     (fun uu___9_9229  ->
+                        match uu___9_9229 with
                         | FStar_Util.Inr x -> x
-                        | FStar_Util.Inl uu____9147 -> failwith "Impossible"))
+                        | FStar_Util.Inl uu____9235 -> failwith "Impossible"))
                  in
-              FStar_List.append uu____9124 [t]  in
-            let uu____9149 =
-              let uu____9174 =
+              FStar_List.append uu____9212 [t]  in
+            let uu____9237 =
+              let uu____9262 =
                 FStar_All.pipe_right terms
                   (FStar_List.map
                      (fun t1  ->
-                        let uu____9231 = desugar_typ_aq env t1  in
-                        match uu____9231 with
+                        let uu____9319 = desugar_typ_aq env t1  in
+                        match uu____9319 with
                         | (t',aq) ->
-                            let uu____9242 = FStar_Syntax_Syntax.as_arg t'
+                            let uu____9330 = FStar_Syntax_Syntax.as_arg t'
                                in
-                            (uu____9242, aq)))
+                            (uu____9330, aq)))
                  in
-              FStar_All.pipe_right uu____9174 FStar_List.unzip  in
-            (match uu____9149 with
+              FStar_All.pipe_right uu____9262 FStar_List.unzip  in
+            (match uu____9237 with
              | (targs,aqs) ->
                  let tup =
-                   let uu____9352 =
+                   let uu____9440 =
                      FStar_Parser_Const.mk_tuple_lid
                        (FStar_List.length targs) top.FStar_Parser_AST.range
                       in
                    FStar_Syntax_DsEnv.fail_or env
-                     (FStar_Syntax_DsEnv.try_lookup_lid env) uu____9352
+                     (FStar_Syntax_DsEnv.try_lookup_lid env) uu____9440
                     in
-                 let uu____9361 =
+                 let uu____9449 =
                    mk (FStar_Syntax_Syntax.Tm_app (tup, targs))  in
-                 (uu____9361, (join_aqs aqs)))
+                 (uu____9449, (join_aqs aqs)))
         | FStar_Parser_AST.Sum (binders,t) ->
-            let uu____9388 =
-              let uu____9405 =
-                let uu____9412 =
-                  let uu____9419 =
+            let uu____9476 =
+              let uu____9493 =
+                let uu____9500 =
+                  let uu____9507 =
                     FStar_All.pipe_left
-                      (fun uu____9428  -> FStar_Util.Inl uu____9428)
+                      (fun uu____9516  -> FStar_Util.Inl uu____9516)
                       (FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName t)
                          t.FStar_Parser_AST.range FStar_Parser_AST.Type_level
                          FStar_Pervasives_Native.None)
                      in
-                  [uu____9419]  in
-                FStar_List.append binders uu____9412  in
+                  [uu____9507]  in
+                FStar_List.append binders uu____9500  in
               FStar_List.fold_left
-                (fun uu____9473  ->
+                (fun uu____9561  ->
                    fun b  ->
-                     match uu____9473 with
+                     match uu____9561 with
                      | (env1,tparams,typs) ->
-                         let uu____9534 =
+                         let uu____9622 =
                            match b with
                            | FStar_Util.Inl b1 -> desugar_binder env1 b1
                            | FStar_Util.Inr t1 ->
-                               let uu____9549 = desugar_typ env1 t1  in
-                               (FStar_Pervasives_Native.None, uu____9549)
+                               let uu____9637 = desugar_typ env1 t1  in
+                               (FStar_Pervasives_Native.None, uu____9637)
                             in
-                         (match uu____9534 with
+                         (match uu____9622 with
                           | (xopt,t1) ->
-                              let uu____9574 =
+                              let uu____9662 =
                                 match xopt with
                                 | FStar_Pervasives_Native.None  ->
-                                    let uu____9583 =
+                                    let uu____9671 =
                                       FStar_Syntax_Syntax.new_bv
                                         (FStar_Pervasives_Native.Some
                                            (top.FStar_Parser_AST.range))
                                         FStar_Syntax_Syntax.tun
                                        in
-                                    (env1, uu____9583)
+                                    (env1, uu____9671)
                                 | FStar_Pervasives_Native.Some x ->
                                     FStar_Syntax_DsEnv.push_bv env1 x
                                  in
-                              (match uu____9574 with
+                              (match uu____9662 with
                                | (env2,x) ->
-                                   let uu____9603 =
-                                     let uu____9606 =
-                                       let uu____9609 =
-                                         let uu____9610 =
+                                   let uu____9691 =
+                                     let uu____9694 =
+                                       let uu____9697 =
+                                         let uu____9698 =
                                            no_annot_abs tparams t1  in
                                          FStar_All.pipe_left
                                            FStar_Syntax_Syntax.as_arg
-                                           uu____9610
+                                           uu____9698
                                           in
-                                       [uu____9609]  in
-                                     FStar_List.append typs uu____9606  in
+                                       [uu____9697]  in
+                                     FStar_List.append typs uu____9694  in
                                    (env2,
                                      (FStar_List.append tparams
-                                        [(((let uu___1549_9636 = x  in
+                                        [(((let uu___1521_9724 = x  in
                                             {
                                               FStar_Syntax_Syntax.ppname =
-                                                (uu___1549_9636.FStar_Syntax_Syntax.ppname);
+                                                (uu___1521_9724.FStar_Syntax_Syntax.ppname);
                                               FStar_Syntax_Syntax.index =
-                                                (uu___1549_9636.FStar_Syntax_Syntax.index);
+                                                (uu___1521_9724.FStar_Syntax_Syntax.index);
                                               FStar_Syntax_Syntax.sort = t1
                                             })),
                                            FStar_Pervasives_Native.None)]),
-                                     uu____9603)))) (env, [], []) uu____9405
+                                     uu____9691)))) (env, [], []) uu____9493
                in
-            (match uu____9388 with
-             | (env1,uu____9664,targs) ->
+            (match uu____9476 with
+             | (env1,uu____9752,targs) ->
                  let tup =
-                   let uu____9687 =
+                   let uu____9775 =
                      FStar_Parser_Const.mk_dtuple_lid
                        (FStar_List.length targs) top.FStar_Parser_AST.range
                       in
                    FStar_Syntax_DsEnv.fail_or env1
-                     (FStar_Syntax_DsEnv.try_lookup_lid env1) uu____9687
+                     (FStar_Syntax_DsEnv.try_lookup_lid env1) uu____9775
                     in
-                 let uu____9688 =
+                 let uu____9776 =
                    FStar_All.pipe_left mk
                      (FStar_Syntax_Syntax.Tm_app (tup, targs))
                     in
-                 (uu____9688, noaqs))
+                 (uu____9776, noaqs))
         | FStar_Parser_AST.Product (binders,t) ->
-            let uu____9707 = uncurry binders t  in
-            (match uu____9707 with
+            let uu____9795 = uncurry binders t  in
+            (match uu____9795 with
              | (bs,t1) ->
-                 let rec aux env1 bs1 uu___10_9751 =
-                   match uu___10_9751 with
+                 let rec aux env1 bs1 uu___10_9839 =
+                   match uu___10_9839 with
                    | [] ->
                        let cod =
                          desugar_comp top.FStar_Parser_AST.range true env1 t1
                           in
-                       let uu____9768 =
+                       let uu____9856 =
                          FStar_Syntax_Util.arrow (FStar_List.rev bs1) cod  in
-                       FStar_All.pipe_left setpos uu____9768
+                       FStar_All.pipe_left setpos uu____9856
                    | hd::tl ->
                        let bb = desugar_binder env1 hd  in
-                       let uu____9792 =
+                       let uu____9880 =
                          as_binder env1 hd.FStar_Parser_AST.aqual bb  in
-                       (match uu____9792 with
+                       (match uu____9880 with
                         | (b,env2) -> aux env2 (b :: bs1) tl)
                     in
-                 let uu____9825 = aux env [] bs  in (uu____9825, noaqs))
+                 let uu____9913 = aux env [] bs  in (uu____9913, noaqs))
         | FStar_Parser_AST.Refine (b,f) ->
-            let uu____9834 = desugar_binder env b  in
-            (match uu____9834 with
-             | (FStar_Pervasives_Native.None ,uu____9845) ->
+            let uu____9922 = desugar_binder env b  in
+            (match uu____9922 with
+             | (FStar_Pervasives_Native.None ,uu____9933) ->
                  failwith "Missing binder in refinement"
              | b1 ->
-                 let uu____9860 =
+                 let uu____9948 =
                    as_binder env FStar_Pervasives_Native.None b1  in
-                 (match uu____9860 with
-                  | ((x,uu____9876),env1) ->
+                 (match uu____9948 with
+                  | ((x,uu____9964),env1) ->
                       let f1 = desugar_formula env1 f  in
-                      let uu____9889 =
-                        let uu____9890 = FStar_Syntax_Util.refine x f1  in
-                        FStar_All.pipe_left setpos uu____9890  in
-                      (uu____9889, noaqs)))
+                      let uu____9977 =
+                        let uu____9978 = FStar_Syntax_Util.refine x f1  in
+                        FStar_All.pipe_left setpos uu____9978  in
+                      (uu____9977, noaqs)))
         | FStar_Parser_AST.Abs (binders,body) ->
             let bvss = FStar_List.map gather_pattern_bound_vars binders  in
             let check_disjoint sets =
@@ -2915,74 +2964,75 @@ and (desugar_term_maybe_top :
                 | [] -> FStar_Pervasives_Native.None
                 | set::sets2 ->
                     let i = FStar_Util.set_intersect acc set  in
-                    let uu____9968 = FStar_Util.set_is_empty i  in
-                    if uu____9968
+                    let uu____10056 = FStar_Util.set_is_empty i  in
+                    if uu____10056
                     then
-                      let uu____9973 = FStar_Util.set_union acc set  in
-                      aux uu____9973 sets2
+                      let uu____10061 = FStar_Util.set_union acc set  in
+                      aux uu____10061 sets2
                     else
-                      (let uu____9978 =
-                         let uu____9979 = FStar_Util.set_elements i  in
-                         FStar_List.hd uu____9979  in
-                       FStar_Pervasives_Native.Some uu____9978)
+                      (let uu____10066 =
+                         let uu____10067 = FStar_Util.set_elements i  in
+                         FStar_List.hd uu____10067  in
+                       FStar_Pervasives_Native.Some uu____10066)
                  in
-              let uu____9982 = FStar_Syntax_Syntax.new_id_set ()  in
-              aux uu____9982 sets  in
-            ((let uu____9986 = check_disjoint bvss  in
-              match uu____9986 with
+              let uu____10070 = FStar_Syntax_Syntax.new_id_set ()  in
+              aux uu____10070 sets  in
+            ((let uu____10074 = check_disjoint bvss  in
+              match uu____10074 with
               | FStar_Pervasives_Native.None  -> ()
               | FStar_Pervasives_Native.Some id ->
-                  let uu____9990 =
-                    let uu____9996 =
+                  let uu____10078 =
+                    let uu____10084 =
+                      let uu____10086 = FStar_Ident.text_of_id id  in
                       FStar_Util.format1
                         "Non-linear patterns are not permitted: `%s` appears more than once in this function definition."
-                        id.FStar_Ident.idText
+                        uu____10086
                        in
                     (FStar_Errors.Fatal_NonLinearPatternNotPermitted,
-                      uu____9996)
+                      uu____10084)
                      in
-                  let uu____10000 = FStar_Ident.range_of_id id  in
-                  FStar_Errors.raise_error uu____9990 uu____10000);
+                  let uu____10090 = FStar_Ident.range_of_id id  in
+                  FStar_Errors.raise_error uu____10078 uu____10090);
              (let binders1 =
                 FStar_All.pipe_right binders
                   (FStar_List.map replace_unit_pattern)
                  in
-              let uu____10008 =
+              let uu____10098 =
                 FStar_List.fold_left
-                  (fun uu____10028  ->
+                  (fun uu____10118  ->
                      fun pat  ->
-                       match uu____10028 with
+                       match uu____10118 with
                        | (env1,ftvs) ->
                            (match pat.FStar_Parser_AST.pat with
                             | FStar_Parser_AST.PatAscribed
-                                (uu____10054,(t,FStar_Pervasives_Native.None
+                                (uu____10144,(t,FStar_Pervasives_Native.None
                                               ))
                                 ->
-                                let uu____10064 =
-                                  let uu____10067 = free_type_vars env1 t  in
-                                  FStar_List.append uu____10067 ftvs  in
-                                (env1, uu____10064)
+                                let uu____10154 =
+                                  let uu____10157 = free_type_vars env1 t  in
+                                  FStar_List.append uu____10157 ftvs  in
+                                (env1, uu____10154)
                             | FStar_Parser_AST.PatAscribed
-                                (uu____10072,(t,FStar_Pervasives_Native.Some
+                                (uu____10162,(t,FStar_Pervasives_Native.Some
                                               tac))
                                 ->
-                                let uu____10083 =
-                                  let uu____10086 = free_type_vars env1 t  in
-                                  let uu____10089 =
-                                    let uu____10092 = free_type_vars env1 tac
+                                let uu____10173 =
+                                  let uu____10176 = free_type_vars env1 t  in
+                                  let uu____10179 =
+                                    let uu____10182 = free_type_vars env1 tac
                                        in
-                                    FStar_List.append uu____10092 ftvs  in
-                                  FStar_List.append uu____10086 uu____10089
+                                    FStar_List.append uu____10182 ftvs  in
+                                  FStar_List.append uu____10176 uu____10179
                                    in
-                                (env1, uu____10083)
-                            | uu____10097 -> (env1, ftvs))) (env, [])
+                                (env1, uu____10173)
+                            | uu____10187 -> (env1, ftvs))) (env, [])
                   binders1
                  in
-              match uu____10008 with
-              | (uu____10106,ftv) ->
+              match uu____10098 with
+              | (uu____10196,ftv) ->
                   let ftv1 = sort_ftv ftv  in
                   let binders2 =
-                    let uu____10118 =
+                    let uu____10208 =
                       FStar_All.pipe_right ftv1
                         (FStar_List.map
                            (fun a  ->
@@ -2993,25 +3043,25 @@ and (desugar_term_maybe_top :
                                         FStar_Parser_AST.Implicit)))
                                 top.FStar_Parser_AST.range))
                        in
-                    FStar_List.append uu____10118 binders1  in
+                    FStar_List.append uu____10208 binders1  in
                   let rec aux env1 bs sc_pat_opt pats =
                     match pats with
                     | [] ->
-                        let uu____10198 = desugar_term_aq env1 body  in
-                        (match uu____10198 with
+                        let uu____10288 = desugar_term_aq env1 body  in
+                        (match uu____10288 with
                          | (body1,aq) ->
                              let body2 =
                                match sc_pat_opt with
                                | FStar_Pervasives_Native.Some (sc,pat) ->
                                    let body2 =
-                                     let uu____10233 =
-                                       let uu____10234 =
+                                     let uu____10323 =
+                                       let uu____10324 =
                                          FStar_Syntax_Syntax.pat_bvs pat  in
-                                       FStar_All.pipe_right uu____10234
+                                       FStar_All.pipe_right uu____10324
                                          (FStar_List.map
                                             FStar_Syntax_Syntax.mk_binder)
                                         in
-                                     FStar_Syntax_Subst.close uu____10233
+                                     FStar_Syntax_Subst.close uu____10323
                                        body1
                                       in
                                    FStar_Syntax_Syntax.mk
@@ -3023,44 +3073,44 @@ and (desugar_term_maybe_top :
                                      FStar_Pervasives_Native.None
                                      body2.FStar_Syntax_Syntax.pos
                                | FStar_Pervasives_Native.None  -> body1  in
-                             let uu____10303 =
-                               let uu____10304 =
+                             let uu____10393 =
+                               let uu____10394 =
                                  no_annot_abs (FStar_List.rev bs) body2  in
-                               setpos uu____10304  in
-                             (uu____10303, aq))
+                               setpos uu____10394  in
+                             (uu____10393, aq))
                     | p::rest ->
-                        let uu____10317 = desugar_binding_pat env1 p  in
-                        (match uu____10317 with
+                        let uu____10407 = desugar_binding_pat env1 p  in
+                        (match uu____10407 with
                          | (env2,b,pat) ->
                              let pat1 =
                                match pat with
                                | [] -> FStar_Pervasives_Native.None
-                               | (p1,uu____10349)::[] ->
+                               | (p1,uu____10439)::[] ->
                                    FStar_Pervasives_Native.Some p1
-                               | uu____10364 ->
+                               | uu____10454 ->
                                    FStar_Errors.raise_error
                                      (FStar_Errors.Fatal_UnsupportedDisjuctivePatterns,
                                        "Disjunctive patterns are not supported in abstractions")
                                      p.FStar_Parser_AST.prange
                                 in
-                             let uu____10373 =
+                             let uu____10463 =
                                match b with
-                               | LetBinder uu____10414 ->
+                               | LetBinder uu____10504 ->
                                    failwith "Impossible"
                                | LocalBinder (x,aq) ->
                                    let sc_pat_opt1 =
                                      match (pat1, sc_pat_opt) with
                                      | (FStar_Pervasives_Native.None
-                                        ,uu____10483) -> sc_pat_opt
+                                        ,uu____10573) -> sc_pat_opt
                                      | (FStar_Pervasives_Native.Some
                                         p1,FStar_Pervasives_Native.None ) ->
-                                         let uu____10537 =
-                                           let uu____10546 =
+                                         let uu____10627 =
+                                           let uu____10636 =
                                              FStar_Syntax_Syntax.bv_to_name x
                                               in
-                                           (uu____10546, p1)  in
+                                           (uu____10636, p1)  in
                                          FStar_Pervasives_Native.Some
-                                           uu____10537
+                                           uu____10627
                                      | (FStar_Pervasives_Native.Some
                                         p1,FStar_Pervasives_Native.Some
                                         (sc,p')) ->
@@ -3068,62 +3118,62 @@ and (desugar_term_maybe_top :
                                                   (p'.FStar_Syntax_Syntax.v))
                                           with
                                           | (FStar_Syntax_Syntax.Tm_name
-                                             uu____10608,uu____10609) ->
+                                             uu____10698,uu____10699) ->
                                               let tup2 =
-                                                let uu____10611 =
+                                                let uu____10701 =
                                                   FStar_Parser_Const.mk_tuple_data_lid
                                                     (Prims.of_int (2))
                                                     top.FStar_Parser_AST.range
                                                    in
                                                 FStar_Syntax_Syntax.lid_as_fv
-                                                  uu____10611
+                                                  uu____10701
                                                   FStar_Syntax_Syntax.delta_constant
                                                   (FStar_Pervasives_Native.Some
                                                      FStar_Syntax_Syntax.Data_ctor)
                                                  in
                                               let sc1 =
-                                                let uu____10616 =
-                                                  let uu____10623 =
-                                                    let uu____10624 =
-                                                      let uu____10641 =
+                                                let uu____10706 =
+                                                  let uu____10713 =
+                                                    let uu____10714 =
+                                                      let uu____10731 =
                                                         mk
                                                           (FStar_Syntax_Syntax.Tm_fvar
                                                              tup2)
                                                          in
-                                                      let uu____10644 =
-                                                        let uu____10655 =
+                                                      let uu____10734 =
+                                                        let uu____10745 =
                                                           FStar_Syntax_Syntax.as_arg
                                                             sc
                                                            in
-                                                        let uu____10664 =
-                                                          let uu____10675 =
-                                                            let uu____10684 =
+                                                        let uu____10754 =
+                                                          let uu____10765 =
+                                                            let uu____10774 =
                                                               FStar_Syntax_Syntax.bv_to_name
                                                                 x
                                                                in
                                                             FStar_All.pipe_left
                                                               FStar_Syntax_Syntax.as_arg
-                                                              uu____10684
+                                                              uu____10774
                                                              in
-                                                          [uu____10675]  in
-                                                        uu____10655 ::
-                                                          uu____10664
+                                                          [uu____10765]  in
+                                                        uu____10745 ::
+                                                          uu____10754
                                                          in
-                                                      (uu____10641,
-                                                        uu____10644)
+                                                      (uu____10731,
+                                                        uu____10734)
                                                        in
                                                     FStar_Syntax_Syntax.Tm_app
-                                                      uu____10624
+                                                      uu____10714
                                                      in
                                                   FStar_Syntax_Syntax.mk
-                                                    uu____10623
+                                                    uu____10713
                                                    in
-                                                uu____10616
+                                                uu____10706
                                                   FStar_Pervasives_Native.None
                                                   top.FStar_Parser_AST.range
                                                  in
                                               let p2 =
-                                                let uu____10732 =
+                                                let uu____10822 =
                                                   FStar_Range.union_ranges
                                                     p'.FStar_Syntax_Syntax.p
                                                     p1.FStar_Syntax_Syntax.p
@@ -3133,15 +3183,15 @@ and (desugar_term_maybe_top :
                                                      (tup2,
                                                        [(p', false);
                                                        (p1, false)]))
-                                                  uu____10732
+                                                  uu____10822
                                                  in
                                               FStar_Pervasives_Native.Some
                                                 (sc1, p2)
                                           | (FStar_Syntax_Syntax.Tm_app
-                                             (uu____10783,args),FStar_Syntax_Syntax.Pat_cons
-                                             (uu____10785,pats1)) ->
+                                             (uu____10873,args),FStar_Syntax_Syntax.Pat_cons
+                                             (uu____10875,pats1)) ->
                                               let tupn =
-                                                let uu____10830 =
+                                                let uu____10920 =
                                                   FStar_Parser_Const.mk_tuple_data_lid
                                                     (Prims.int_one +
                                                        (FStar_List.length
@@ -3149,43 +3199,43 @@ and (desugar_term_maybe_top :
                                                     top.FStar_Parser_AST.range
                                                    in
                                                 FStar_Syntax_Syntax.lid_as_fv
-                                                  uu____10830
+                                                  uu____10920
                                                   FStar_Syntax_Syntax.delta_constant
                                                   (FStar_Pervasives_Native.Some
                                                      FStar_Syntax_Syntax.Data_ctor)
                                                  in
                                               let sc1 =
-                                                let uu____10843 =
-                                                  let uu____10844 =
-                                                    let uu____10861 =
+                                                let uu____10933 =
+                                                  let uu____10934 =
+                                                    let uu____10951 =
                                                       mk
                                                         (FStar_Syntax_Syntax.Tm_fvar
                                                            tupn)
                                                        in
-                                                    let uu____10864 =
-                                                      let uu____10875 =
-                                                        let uu____10886 =
-                                                          let uu____10895 =
+                                                    let uu____10954 =
+                                                      let uu____10965 =
+                                                        let uu____10976 =
+                                                          let uu____10985 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x
                                                              in
                                                           FStar_All.pipe_left
                                                             FStar_Syntax_Syntax.as_arg
-                                                            uu____10895
+                                                            uu____10985
                                                            in
-                                                        [uu____10886]  in
+                                                        [uu____10976]  in
                                                       FStar_List.append args
-                                                        uu____10875
+                                                        uu____10965
                                                        in
-                                                    (uu____10861,
-                                                      uu____10864)
+                                                    (uu____10951,
+                                                      uu____10954)
                                                      in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____10844
+                                                    uu____10934
                                                    in
-                                                mk uu____10843  in
+                                                mk uu____10933  in
                                               let p2 =
-                                                let uu____10943 =
+                                                let uu____11033 =
                                                   FStar_Range.union_ranges
                                                     p'.FStar_Syntax_Syntax.p
                                                     p1.FStar_Syntax_Syntax.p
@@ -3195,83 +3245,86 @@ and (desugar_term_maybe_top :
                                                      (tupn,
                                                        (FStar_List.append
                                                           pats1 [(p1, false)])))
-                                                  uu____10943
+                                                  uu____11033
                                                  in
                                               FStar_Pervasives_Native.Some
                                                 (sc1, p2)
-                                          | uu____10990 ->
+                                          | uu____11080 ->
                                               failwith "Impossible")
                                       in
                                    ((x, aq), sc_pat_opt1)
                                 in
-                             (match uu____10373 with
+                             (match uu____10463 with
                               | (b1,sc_pat_opt1) ->
                                   aux env2 (b1 :: bs) sc_pat_opt1 rest))
                      in
                   aux env [] FStar_Pervasives_Native.None binders2))
         | FStar_Parser_AST.App
-            (uu____11082,uu____11083,FStar_Parser_AST.UnivApp ) ->
+            (uu____11172,uu____11173,FStar_Parser_AST.UnivApp ) ->
             let rec aux universes e =
-              let uu____11105 =
-                let uu____11106 = unparen e  in
-                uu____11106.FStar_Parser_AST.tm  in
-              match uu____11105 with
+              let uu____11195 =
+                let uu____11196 = unparen e  in
+                uu____11196.FStar_Parser_AST.tm  in
+              match uu____11195 with
               | FStar_Parser_AST.App (e1,t,FStar_Parser_AST.UnivApp ) ->
                   let univ_arg = desugar_universe t  in
                   aux (univ_arg :: universes) e1
-              | uu____11116 ->
-                  let uu____11117 = desugar_term_aq env e  in
-                  (match uu____11117 with
+              | uu____11206 ->
+                  let uu____11207 = desugar_term_aq env e  in
+                  (match uu____11207 with
                    | (head,aq) ->
-                       let uu____11130 =
+                       let uu____11220 =
                          mk (FStar_Syntax_Syntax.Tm_uinst (head, universes))
                           in
-                       (uu____11130, aq))
+                       (uu____11220, aq))
                in
             aux [] top
-        | FStar_Parser_AST.App uu____11137 ->
+        | FStar_Parser_AST.App uu____11227 ->
             let rec aux args aqs e =
-              let uu____11214 =
-                let uu____11215 = unparen e  in
-                uu____11215.FStar_Parser_AST.tm  in
-              match uu____11214 with
+              let uu____11304 =
+                let uu____11305 = unparen e  in
+                uu____11305.FStar_Parser_AST.tm  in
+              match uu____11304 with
               | FStar_Parser_AST.App (e1,t,imp) when
                   imp <> FStar_Parser_AST.UnivApp ->
-                  let uu____11233 = desugar_term_aq env t  in
-                  (match uu____11233 with
+                  let uu____11323 = desugar_term_aq env t  in
+                  (match uu____11323 with
                    | (t1,aq) ->
                        let arg = arg_withimp_e imp t1  in
                        aux (arg :: args) (aq :: aqs) e1)
-              | uu____11281 ->
-                  let uu____11282 = desugar_term_aq env e  in
-                  (match uu____11282 with
+              | uu____11371 ->
+                  let uu____11372 = desugar_term_aq env e  in
+                  (match uu____11372 with
                    | (head,aq) ->
-                       let uu____11303 =
+                       let uu____11393 =
                          mk (FStar_Syntax_Syntax.Tm_app (head, args))  in
-                       (uu____11303, (join_aqs (aq :: aqs))))
+                       (uu____11393, (join_aqs (aq :: aqs))))
                in
             aux [] [] top
         | FStar_Parser_AST.Bind (x,t1,t2) ->
             let xpat =
+              let uu____11446 = FStar_Ident.range_of_id x  in
               FStar_Parser_AST.mk_pattern
                 (FStar_Parser_AST.PatVar (x, FStar_Pervasives_Native.None))
-                x.FStar_Ident.idRange
+                uu____11446
                in
             let k =
               FStar_Parser_AST.mk_term (FStar_Parser_AST.Abs ([xpat], t2))
                 t2.FStar_Parser_AST.range t2.FStar_Parser_AST.level
                in
             let bind_lid =
-              FStar_Ident.lid_of_path ["bind"] x.FStar_Ident.idRange  in
+              let uu____11453 = FStar_Ident.range_of_id x  in
+              FStar_Ident.lid_of_path ["bind"] uu____11453  in
             let bind =
+              let uu____11458 = FStar_Ident.range_of_id x  in
               FStar_Parser_AST.mk_term (FStar_Parser_AST.Var bind_lid)
-                x.FStar_Ident.idRange FStar_Parser_AST.Expr
+                uu____11458 FStar_Parser_AST.Expr
                in
-            let uu____11366 =
+            let uu____11459 =
               FStar_Parser_AST.mkExplicitApp bind [t1; k]
                 top.FStar_Parser_AST.range
                in
-            desugar_term_aq env uu____11366
+            desugar_term_aq env uu____11459
         | FStar_Parser_AST.Seq (t1,t2) ->
             let t =
               FStar_Parser_AST.mk_term
@@ -3284,150 +3337,152 @@ and (desugar_term_maybe_top :
                             t1.FStar_Parser_AST.range), t1))], t2))
                 top.FStar_Parser_AST.range FStar_Parser_AST.Expr
                in
-            let uu____11418 = desugar_term_aq env t  in
-            (match uu____11418 with
+            let uu____11511 = desugar_term_aq env t  in
+            (match uu____11511 with
              | (tm,s) ->
-                 let uu____11429 =
+                 let uu____11522 =
                    mk
                      (FStar_Syntax_Syntax.Tm_meta
                         (tm,
                           (FStar_Syntax_Syntax.Meta_desugared
                              FStar_Syntax_Syntax.Sequence)))
                     in
-                 (uu____11429, s))
+                 (uu____11522, s))
         | FStar_Parser_AST.LetOpen (lid,e) ->
             let env1 = FStar_Syntax_DsEnv.push_namespace env lid  in
-            let uu____11435 =
-              let uu____11448 = FStar_Syntax_DsEnv.expect_typ env1  in
-              if uu____11448 then desugar_typ_aq else desugar_term_aq  in
-            uu____11435 env1 e
+            let uu____11528 =
+              let uu____11541 = FStar_Syntax_DsEnv.expect_typ env1  in
+              if uu____11541 then desugar_typ_aq else desugar_term_aq  in
+            uu____11528 env1 e
         | FStar_Parser_AST.Let (qual,lbs,body) ->
             let is_rec = qual = FStar_Parser_AST.Rec  in
-            let ds_let_rec_or_app uu____11515 =
+            let ds_let_rec_or_app uu____11608 =
               let bindings = lbs  in
               let funs =
                 FStar_All.pipe_right bindings
                   (FStar_List.map
-                     (fun uu____11658  ->
-                        match uu____11658 with
+                     (fun uu____11751  ->
+                        match uu____11751 with
                         | (attr_opt,(p,def)) ->
-                            let uu____11716 = is_app_pattern p  in
-                            if uu____11716
+                            let uu____11809 = is_app_pattern p  in
+                            if uu____11809
                             then
-                              let uu____11749 =
+                              let uu____11842 =
                                 destruct_app_pattern env top_level p  in
-                              (attr_opt, uu____11749, def)
+                              (attr_opt, uu____11842, def)
                             else
                               (match FStar_Parser_AST.un_function p def with
                                | FStar_Pervasives_Native.Some (p1,def1) ->
-                                   let uu____11832 =
+                                   let uu____11925 =
                                      destruct_app_pattern env top_level p1
                                       in
-                                   (attr_opt, uu____11832, def1)
-                               | uu____11877 ->
+                                   (attr_opt, uu____11925, def1)
+                               | uu____11970 ->
                                    (match p.FStar_Parser_AST.pat with
                                     | FStar_Parser_AST.PatAscribed
                                         ({
                                            FStar_Parser_AST.pat =
                                              FStar_Parser_AST.PatVar
-                                             (id,uu____11915);
+                                             (id,uu____12008);
                                            FStar_Parser_AST.prange =
-                                             uu____11916;_},t)
+                                             uu____12009;_},t)
                                         ->
                                         if top_level
                                         then
-                                          let uu____11965 =
-                                            let uu____11986 =
-                                              let uu____11991 =
+                                          let uu____12058 =
+                                            let uu____12079 =
+                                              let uu____12084 =
                                                 FStar_Syntax_DsEnv.qualify
                                                   env id
                                                  in
-                                              FStar_Util.Inr uu____11991  in
-                                            (uu____11986, [],
+                                              FStar_Util.Inr uu____12084  in
+                                            (uu____12079, [],
                                               (FStar_Pervasives_Native.Some t))
                                              in
-                                          (attr_opt, uu____11965, def)
+                                          (attr_opt, uu____12058, def)
                                         else
                                           (attr_opt,
                                             ((FStar_Util.Inl id), [],
                                               (FStar_Pervasives_Native.Some t)),
                                             def)
                                     | FStar_Parser_AST.PatVar
-                                        (id,uu____12083) ->
+                                        (id,uu____12176) ->
                                         if top_level
                                         then
-                                          let uu____12119 =
-                                            let uu____12140 =
-                                              let uu____12145 =
+                                          let uu____12212 =
+                                            let uu____12233 =
+                                              let uu____12238 =
                                                 FStar_Syntax_DsEnv.qualify
                                                   env id
                                                  in
-                                              FStar_Util.Inr uu____12145  in
-                                            (uu____12140, [],
+                                              FStar_Util.Inr uu____12238  in
+                                            (uu____12233, [],
                                               FStar_Pervasives_Native.None)
                                              in
-                                          (attr_opt, uu____12119, def)
+                                          (attr_opt, uu____12212, def)
                                         else
                                           (attr_opt,
                                             ((FStar_Util.Inl id), [],
                                               FStar_Pervasives_Native.None),
                                             def)
-                                    | uu____12236 ->
+                                    | uu____12329 ->
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_UnexpectedLetBinding,
                                             "Unexpected let binding")
                                           p.FStar_Parser_AST.prange))))
                  in
-              let uu____12269 =
+              let uu____12362 =
                 FStar_List.fold_left
-                  (fun uu____12358  ->
-                     fun uu____12359  ->
-                       match (uu____12358, uu____12359) with
+                  (fun uu____12451  ->
+                     fun uu____12452  ->
+                       match (uu____12451, uu____12452) with
                        | ((env1,fnames,rec_bindings,used_markers),(_attr_opt,
-                                                                   (f,uu____12489,uu____12490),uu____12491))
+                                                                   (f,uu____12582,uu____12583),uu____12584))
                            ->
-                           let uu____12625 =
+                           let uu____12718 =
                              match f with
                              | FStar_Util.Inl x ->
-                                 let uu____12665 =
+                                 let uu____12758 =
                                    FStar_Syntax_DsEnv.push_bv' env1 x  in
-                                 (match uu____12665 with
+                                 (match uu____12758 with
                                   | (env2,xx,used_marker) ->
                                       let dummy_ref = FStar_Util.mk_ref true
                                          in
-                                      let uu____12700 =
-                                        let uu____12703 =
+                                      let uu____12793 =
+                                        let uu____12796 =
                                           FStar_Syntax_Syntax.mk_binder xx
                                            in
-                                        uu____12703 :: rec_bindings  in
+                                        uu____12796 :: rec_bindings  in
                                       (env2, (FStar_Util.Inl xx),
-                                        uu____12700, (used_marker ::
+                                        uu____12793, (used_marker ::
                                         used_markers)))
                              | FStar_Util.Inr l ->
-                                 let uu____12719 =
+                                 let uu____12812 =
+                                   let uu____12820 =
+                                     FStar_Ident.ident_of_lid l  in
                                    FStar_Syntax_DsEnv.push_top_level_rec_binding
-                                     env1 l.FStar_Ident.ident
+                                     env1 uu____12820
                                      FStar_Syntax_Syntax.delta_equational
                                     in
-                                 (match uu____12719 with
+                                 (match uu____12812 with
                                   | (env2,used_marker) ->
                                       (env2, (FStar_Util.Inr l),
                                         rec_bindings, (used_marker ::
                                         used_markers)))
                               in
-                           (match uu____12625 with
+                           (match uu____12718 with
                             | (env2,lbname,rec_bindings1,used_markers1) ->
                                 (env2, (lbname :: fnames), rec_bindings1,
                                   used_markers1))) (env, [], [], []) funs
                  in
-              match uu____12269 with
+              match uu____12362 with
               | (env',fnames,rec_bindings,used_markers) ->
                   let fnames1 = FStar_List.rev fnames  in
                   let rec_bindings1 = FStar_List.rev rec_bindings  in
                   let used_markers1 = FStar_List.rev used_markers  in
-                  let desugar_one_def env1 lbname uu____12972 =
-                    match uu____12972 with
-                    | (attrs_opt,(uu____13012,args,result_t),def) ->
+                  let desugar_one_def env1 lbname uu____13066 =
+                    match uu____13066 with
+                    | (attrs_opt,(uu____13106,args,result_t),def) ->
                         let args1 =
                           FStar_All.pipe_right args
                             (FStar_List.map replace_unit_pattern)
@@ -3438,18 +3493,18 @@ and (desugar_term_maybe_top :
                           | FStar_Pervasives_Native.None  -> def
                           | FStar_Pervasives_Native.Some (t,tacopt) ->
                               let t1 =
-                                let uu____13104 = is_comp_type env1 t  in
-                                if uu____13104
+                                let uu____13198 = is_comp_type env1 t  in
+                                if uu____13198
                                 then
-                                  ((let uu____13108 =
+                                  ((let uu____13202 =
                                       FStar_All.pipe_right args1
                                         (FStar_List.tryFind
                                            (fun x  ->
-                                              let uu____13118 =
+                                              let uu____13212 =
                                                 is_var_pattern x  in
-                                              Prims.op_Negation uu____13118))
+                                              Prims.op_Negation uu____13212))
                                        in
-                                    match uu____13108 with
+                                    match uu____13202 with
                                     | FStar_Pervasives_Native.None  -> ()
                                     | FStar_Pervasives_Native.Some p ->
                                         FStar_Errors.raise_error
@@ -3458,20 +3513,20 @@ and (desugar_term_maybe_top :
                                           p.FStar_Parser_AST.prange);
                                    t)
                                 else
-                                  (let uu____13125 =
+                                  (let uu____13219 =
                                      ((FStar_Options.ml_ish ()) &&
-                                        (let uu____13128 =
+                                        (let uu____13222 =
                                            FStar_Syntax_DsEnv.try_lookup_effect_name
                                              env1
                                              FStar_Parser_Const.effect_ML_lid
                                             in
-                                         FStar_Option.isSome uu____13128))
+                                         FStar_Option.isSome uu____13222))
                                        &&
                                        ((Prims.op_Negation is_rec) ||
                                           ((FStar_List.length args1) <>
                                              Prims.int_zero))
                                       in
-                                   if uu____13125
+                                   if uu____13219
                                    then FStar_Parser_AST.ml_comp t
                                    else FStar_Parser_AST.tot_comp t)
                                  in
@@ -3483,29 +3538,29 @@ and (desugar_term_maybe_top :
                         let def2 =
                           match args1 with
                           | [] -> def1
-                          | uu____13139 ->
+                          | uu____13233 ->
                               FStar_Parser_AST.mk_term
                                 (FStar_Parser_AST.un_curry_abs args1 def1)
                                 top.FStar_Parser_AST.range
                                 top.FStar_Parser_AST.level
                            in
-                        let uu____13142 = desugar_term_aq env1 def2  in
-                        (match uu____13142 with
+                        let uu____13236 = desugar_term_aq env1 def2  in
+                        (match uu____13236 with
                          | (body1,aq) ->
                              let lbname1 =
                                match lbname with
                                | FStar_Util.Inl x -> FStar_Util.Inl x
                                | FStar_Util.Inr l ->
-                                   let uu____13164 =
-                                     let uu____13165 =
+                                   let uu____13258 =
+                                     let uu____13259 =
                                        FStar_Syntax_Util.incr_delta_qualifier
                                          body1
                                         in
                                      FStar_Syntax_Syntax.lid_as_fv l
-                                       uu____13165
+                                       uu____13259
                                        FStar_Pervasives_Native.None
                                       in
-                                   FStar_Util.Inr uu____13164
+                                   FStar_Util.Inr uu____13258
                                 in
                              let body2 =
                                if is_rec
@@ -3522,83 +3577,82 @@ and (desugar_term_maybe_top :
                                  (attrs, lbname1, FStar_Syntax_Syntax.tun,
                                    body2, pos)), aq))
                      in
-                  let uu____13206 =
-                    let uu____13223 =
+                  let uu____13300 =
+                    let uu____13317 =
                       FStar_List.map2
                         (desugar_one_def (if is_rec then env' else env))
                         fnames1 funs
                        in
-                    FStar_All.pipe_right uu____13223 FStar_List.unzip  in
-                  (match uu____13206 with
+                    FStar_All.pipe_right uu____13317 FStar_List.unzip  in
+                  (match uu____13300 with
                    | (lbs1,aqss) ->
-                       let uu____13365 = desugar_term_aq env' body  in
-                       (match uu____13365 with
+                       let uu____13459 = desugar_term_aq env' body  in
+                       (match uu____13459 with
                         | (body1,aq) ->
                             (if is_rec
                              then
                                FStar_List.iter2
-                                 (fun uu____13471  ->
+                                 (fun uu____13565  ->
                                     fun used_marker  ->
-                                      match uu____13471 with
-                                      | (_attr_opt,(f,uu____13545,uu____13546),uu____13547)
+                                      match uu____13565 with
+                                      | (_attr_opt,(f,uu____13639,uu____13640),uu____13641)
                                           ->
-                                          let uu____13604 =
-                                            let uu____13606 =
+                                          let uu____13698 =
+                                            let uu____13700 =
                                               FStar_ST.op_Bang used_marker
                                                in
-                                            Prims.op_Negation uu____13606  in
-                                          if uu____13604
+                                            Prims.op_Negation uu____13700  in
+                                          if uu____13698
                                           then
-                                            let uu____13630 =
+                                            let uu____13724 =
                                               match f with
                                               | FStar_Util.Inl x ->
-                                                  let uu____13648 =
-                                                    FStar_Ident.string_of_ident
-                                                      x
+                                                  let uu____13742 =
+                                                    FStar_Ident.text_of_id x
                                                      in
-                                                  let uu____13650 =
+                                                  let uu____13744 =
                                                     FStar_Ident.range_of_id x
                                                      in
-                                                  (uu____13648, "Local",
-                                                    uu____13650)
+                                                  (uu____13742, "Local",
+                                                    uu____13744)
                                               | FStar_Util.Inr l ->
-                                                  let uu____13655 =
+                                                  let uu____13749 =
                                                     FStar_Ident.string_of_lid
                                                       l
                                                      in
-                                                  let uu____13657 =
+                                                  let uu____13751 =
                                                     FStar_Ident.range_of_lid
                                                       l
                                                      in
-                                                  (uu____13655, "Global",
-                                                    uu____13657)
+                                                  (uu____13749, "Global",
+                                                    uu____13751)
                                                in
-                                            (match uu____13630 with
+                                            (match uu____13724 with
                                              | (nm,gl,rng) ->
-                                                 let uu____13668 =
-                                                   let uu____13674 =
+                                                 let uu____13762 =
+                                                   let uu____13768 =
                                                      FStar_Util.format2
                                                        "%s binding %s is recursive but not used in its body"
                                                        gl nm
                                                       in
                                                    (FStar_Errors.Warning_UnusedLetRec,
-                                                     uu____13674)
+                                                     uu____13768)
                                                     in
                                                  FStar_Errors.log_issue rng
-                                                   uu____13668)
+                                                   uu____13762)
                                           else ()) funs used_markers1
                              else ();
-                             (let uu____13682 =
-                                let uu____13685 =
-                                  let uu____13686 =
-                                    let uu____13700 =
+                             (let uu____13776 =
+                                let uu____13779 =
+                                  let uu____13780 =
+                                    let uu____13794 =
                                       FStar_Syntax_Subst.close rec_bindings1
                                         body1
                                        in
-                                    ((is_rec, lbs1), uu____13700)  in
-                                  FStar_Syntax_Syntax.Tm_let uu____13686  in
-                                FStar_All.pipe_left mk uu____13685  in
-                              (uu____13682,
+                                    ((is_rec, lbs1), uu____13794)  in
+                                  FStar_Syntax_Syntax.Tm_let uu____13780  in
+                                FStar_All.pipe_left mk uu____13779  in
+                              (uu____13776,
                                 (FStar_List.append aq
                                    (FStar_List.flatten aqss)))))))
                in
@@ -3609,29 +3663,29 @@ and (desugar_term_maybe_top :
                 | FStar_Pervasives_Native.Some l ->
                     FStar_List.map (desugar_term env) l
                  in
-              let uu____13802 = desugar_term_aq env t1  in
-              match uu____13802 with
+              let uu____13896 = desugar_term_aq env t1  in
+              match uu____13896 with
               | (t11,aq0) ->
-                  let uu____13823 =
+                  let uu____13917 =
                     desugar_binding_pat_maybe_top top_level env pat  in
-                  (match uu____13823 with
+                  (match uu____13917 with
                    | (env1,binder,pat1) ->
-                       let uu____13853 =
+                       let uu____13947 =
                          match binder with
                          | LetBinder (l,(t,_tacopt)) ->
-                             let uu____13895 = desugar_term_aq env1 t2  in
-                             (match uu____13895 with
+                             let uu____13989 = desugar_term_aq env1 t2  in
+                             (match uu____13989 with
                               | (body1,aq) ->
                                   let fv =
-                                    let uu____13917 =
+                                    let uu____14011 =
                                       FStar_Syntax_Util.incr_delta_qualifier
                                         t11
                                        in
                                     FStar_Syntax_Syntax.lid_as_fv l
-                                      uu____13917
+                                      uu____14011
                                       FStar_Pervasives_Native.None
                                      in
-                                  let uu____13918 =
+                                  let uu____14012 =
                                     FStar_All.pipe_left mk
                                       (FStar_Syntax_Syntax.Tm_let
                                          ((false,
@@ -3641,10 +3695,10 @@ and (desugar_term_maybe_top :
                                                  (t11.FStar_Syntax_Syntax.pos))]),
                                            body1))
                                      in
-                                  (uu____13918, aq))
-                         | LocalBinder (x,uu____13959) ->
-                             let uu____13960 = desugar_term_aq env1 t2  in
-                             (match uu____13960 with
+                                  (uu____14012, aq))
+                         | LocalBinder (x,uu____14053) ->
+                             let uu____14054 = desugar_term_aq env1 t2  in
+                             (match uu____14054 with
                               | (body1,aq) ->
                                   let body2 =
                                     match pat1 with
@@ -3652,44 +3706,44 @@ and (desugar_term_maybe_top :
                                     | ({
                                          FStar_Syntax_Syntax.v =
                                            FStar_Syntax_Syntax.Pat_wild
-                                           uu____13982;
-                                         FStar_Syntax_Syntax.p = uu____13983;_},uu____13984)::[]
+                                           uu____14076;
+                                         FStar_Syntax_Syntax.p = uu____14077;_},uu____14078)::[]
                                         -> body1
-                                    | uu____13997 ->
-                                        let uu____14000 =
-                                          let uu____14007 =
-                                            let uu____14008 =
-                                              let uu____14031 =
+                                    | uu____14091 ->
+                                        let uu____14094 =
+                                          let uu____14101 =
+                                            let uu____14102 =
+                                              let uu____14125 =
                                                 FStar_Syntax_Syntax.bv_to_name
                                                   x
                                                  in
-                                              let uu____14034 =
+                                              let uu____14128 =
                                                 desugar_disjunctive_pattern
                                                   pat1
                                                   FStar_Pervasives_Native.None
                                                   body1
                                                  in
-                                              (uu____14031, uu____14034)  in
+                                              (uu____14125, uu____14128)  in
                                             FStar_Syntax_Syntax.Tm_match
-                                              uu____14008
+                                              uu____14102
                                              in
-                                          FStar_Syntax_Syntax.mk uu____14007
+                                          FStar_Syntax_Syntax.mk uu____14101
                                            in
-                                        uu____14000
+                                        uu____14094
                                           FStar_Pervasives_Native.None
                                           top.FStar_Parser_AST.range
                                      in
-                                  let uu____14071 =
-                                    let uu____14074 =
-                                      let uu____14075 =
-                                        let uu____14089 =
-                                          let uu____14092 =
-                                            let uu____14093 =
+                                  let uu____14165 =
+                                    let uu____14168 =
+                                      let uu____14169 =
+                                        let uu____14183 =
+                                          let uu____14186 =
+                                            let uu____14187 =
                                               FStar_Syntax_Syntax.mk_binder x
                                                in
-                                            [uu____14093]  in
+                                            [uu____14187]  in
                                           FStar_Syntax_Subst.close
-                                            uu____14092 body2
+                                            uu____14186 body2
                                            in
                                         ((false,
                                            [mk_lb
@@ -3697,21 +3751,21 @@ and (desugar_term_maybe_top :
                                                 (x.FStar_Syntax_Syntax.sort),
                                                 t11,
                                                 (t11.FStar_Syntax_Syntax.pos))]),
-                                          uu____14089)
+                                          uu____14183)
                                          in
-                                      FStar_Syntax_Syntax.Tm_let uu____14075
+                                      FStar_Syntax_Syntax.Tm_let uu____14169
                                        in
-                                    FStar_All.pipe_left mk uu____14074  in
-                                  (uu____14071, aq))
+                                    FStar_All.pipe_left mk uu____14168  in
+                                  (uu____14165, aq))
                           in
-                       (match uu____13853 with
+                       (match uu____13947 with
                         | (tm,aq1) -> (tm, (FStar_List.append aq0 aq1))))
                in
-            let uu____14201 = FStar_List.hd lbs  in
-            (match uu____14201 with
+            let uu____14295 = FStar_List.hd lbs  in
+            (match uu____14295 with
              | (attrs,(head_pat,defn)) ->
-                 let uu____14245 = is_rec || (is_app_pattern head_pat)  in
-                 if uu____14245
+                 let uu____14339 = is_rec || (is_app_pattern head_pat)  in
+                 if uu____14339
                  then ds_let_rec_or_app ()
                  else ds_non_rec attrs head_pat defn body)
         | FStar_Parser_AST.If (t1,t2,t3) ->
@@ -3721,53 +3775,53 @@ and (desugar_term_maybe_top :
                 FStar_Syntax_Syntax.tun
                in
             let t_bool =
-              let uu____14261 =
-                let uu____14262 =
+              let uu____14355 =
+                let uu____14356 =
                   FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.bool_lid
                     FStar_Syntax_Syntax.delta_constant
                     FStar_Pervasives_Native.None
                    in
-                FStar_Syntax_Syntax.Tm_fvar uu____14262  in
-              mk uu____14261  in
-            let uu____14263 = desugar_term_aq env t1  in
-            (match uu____14263 with
+                FStar_Syntax_Syntax.Tm_fvar uu____14356  in
+              mk uu____14355  in
+            let uu____14357 = desugar_term_aq env t1  in
+            (match uu____14357 with
              | (t1',aq1) ->
-                 let uu____14274 = desugar_term_aq env t2  in
-                 (match uu____14274 with
+                 let uu____14368 = desugar_term_aq env t2  in
+                 (match uu____14368 with
                   | (t2',aq2) ->
-                      let uu____14285 = desugar_term_aq env t3  in
-                      (match uu____14285 with
+                      let uu____14379 = desugar_term_aq env t3  in
+                      (match uu____14379 with
                        | (t3',aq3) ->
-                           let uu____14296 =
-                             let uu____14297 =
-                               let uu____14298 =
-                                 let uu____14321 =
-                                   let uu____14338 =
-                                     let uu____14353 =
+                           let uu____14390 =
+                             let uu____14391 =
+                               let uu____14392 =
+                                 let uu____14415 =
+                                   let uu____14432 =
+                                     let uu____14447 =
                                        FStar_Syntax_Syntax.withinfo
                                          (FStar_Syntax_Syntax.Pat_constant
                                             (FStar_Const.Const_bool true))
                                          t1.FStar_Parser_AST.range
                                         in
-                                     (uu____14353,
+                                     (uu____14447,
                                        FStar_Pervasives_Native.None, t2')
                                       in
-                                   let uu____14367 =
-                                     let uu____14384 =
-                                       let uu____14399 =
+                                   let uu____14461 =
+                                     let uu____14478 =
+                                       let uu____14493 =
                                          FStar_Syntax_Syntax.withinfo
                                            (FStar_Syntax_Syntax.Pat_wild x)
                                            t1.FStar_Parser_AST.range
                                           in
-                                       (uu____14399,
+                                       (uu____14493,
                                          FStar_Pervasives_Native.None, t3')
                                         in
-                                     [uu____14384]  in
-                                   uu____14338 :: uu____14367  in
-                                 (t1', uu____14321)  in
-                               FStar_Syntax_Syntax.Tm_match uu____14298  in
-                             mk uu____14297  in
-                           (uu____14296, (join_aqs [aq1; aq2; aq3])))))
+                                     [uu____14478]  in
+                                   uu____14432 :: uu____14461  in
+                                 (t1', uu____14415)  in
+                               FStar_Syntax_Syntax.Tm_match uu____14392  in
+                             mk uu____14391  in
+                           (uu____14390, (join_aqs [aq1; aq2; aq3])))))
         | FStar_Parser_AST.TryWith (e,branches) ->
             let r = top.FStar_Parser_AST.range  in
             let handler = FStar_Parser_AST.mk_function branches r r  in
@@ -3795,75 +3849,75 @@ and (desugar_term_maybe_top :
                in
             desugar_term_aq env a2
         | FStar_Parser_AST.Match (e,branches) ->
-            let desugar_branch uu____14595 =
-              match uu____14595 with
+            let desugar_branch uu____14689 =
+              match uu____14689 with
               | (pat,wopt,b) ->
-                  let uu____14617 = desugar_match_pat env pat  in
-                  (match uu____14617 with
+                  let uu____14711 = desugar_match_pat env pat  in
+                  (match uu____14711 with
                    | (env1,pat1) ->
                        let wopt1 =
                          match wopt with
                          | FStar_Pervasives_Native.None  ->
                              FStar_Pervasives_Native.None
                          | FStar_Pervasives_Native.Some e1 ->
-                             let uu____14648 = desugar_term env1 e1  in
-                             FStar_Pervasives_Native.Some uu____14648
+                             let uu____14742 = desugar_term env1 e1  in
+                             FStar_Pervasives_Native.Some uu____14742
                           in
-                       let uu____14653 = desugar_term_aq env1 b  in
-                       (match uu____14653 with
+                       let uu____14747 = desugar_term_aq env1 b  in
+                       (match uu____14747 with
                         | (b1,aq) ->
-                            let uu____14666 =
+                            let uu____14760 =
                               desugar_disjunctive_pattern pat1 wopt1 b1  in
-                            (uu____14666, aq)))
+                            (uu____14760, aq)))
                in
-            let uu____14671 = desugar_term_aq env e  in
-            (match uu____14671 with
+            let uu____14765 = desugar_term_aq env e  in
+            (match uu____14765 with
              | (e1,aq) ->
-                 let uu____14682 =
-                   let uu____14713 =
-                     let uu____14746 = FStar_List.map desugar_branch branches
+                 let uu____14776 =
+                   let uu____14807 =
+                     let uu____14840 = FStar_List.map desugar_branch branches
                         in
-                     FStar_All.pipe_right uu____14746 FStar_List.unzip  in
-                   FStar_All.pipe_right uu____14713
-                     (fun uu____14964  ->
-                        match uu____14964 with
+                     FStar_All.pipe_right uu____14840 FStar_List.unzip  in
+                   FStar_All.pipe_right uu____14807
+                     (fun uu____15058  ->
+                        match uu____15058 with
                         | (x,y) -> ((FStar_List.flatten x), y))
                     in
-                 (match uu____14682 with
+                 (match uu____14776 with
                   | (brs,aqs) ->
-                      let uu____15183 =
+                      let uu____15277 =
                         FStar_All.pipe_left mk
                           (FStar_Syntax_Syntax.Tm_match (e1, brs))
                          in
-                      (uu____15183, (join_aqs (aq :: aqs)))))
+                      (uu____15277, (join_aqs (aq :: aqs)))))
         | FStar_Parser_AST.Ascribed (e,t,tac_opt) ->
-            let uu____15217 =
-              let uu____15238 = is_comp_type env t  in
-              if uu____15238
+            let uu____15311 =
+              let uu____15332 = is_comp_type env t  in
+              if uu____15332
               then
                 let comp = desugar_comp t.FStar_Parser_AST.range true env t
                    in
                 ((FStar_Util.Inr comp), [])
               else
-                (let uu____15293 = desugar_term_aq env t  in
-                 match uu____15293 with
+                (let uu____15387 = desugar_term_aq env t  in
+                 match uu____15387 with
                  | (tm,aq) -> ((FStar_Util.Inl tm), aq))
                in
-            (match uu____15217 with
+            (match uu____15311 with
              | (annot,aq0) ->
                  let tac_opt1 = FStar_Util.map_opt tac_opt (desugar_term env)
                     in
-                 let uu____15385 = desugar_term_aq env e  in
-                 (match uu____15385 with
+                 let uu____15479 = desugar_term_aq env e  in
+                 (match uu____15479 with
                   | (e1,aq) ->
-                      let uu____15396 =
+                      let uu____15490 =
                         FStar_All.pipe_left mk
                           (FStar_Syntax_Syntax.Tm_ascribed
                              (e1, (annot, tac_opt1),
                                FStar_Pervasives_Native.None))
                          in
-                      (uu____15396, (FStar_List.append aq0 aq))))
-        | FStar_Parser_AST.Record (uu____15435,[]) ->
+                      (uu____15490, (FStar_List.append aq0 aq))))
+        | FStar_Parser_AST.Record (uu____15529,[]) ->
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_UnexpectedEmptyRecord,
                 "Unexpected empty record") top.FStar_Parser_AST.range
@@ -3871,37 +3925,45 @@ and (desugar_term_maybe_top :
             let record = check_fields env fields top.FStar_Parser_AST.range
                in
             let user_ns =
-              let uu____15478 = FStar_List.hd fields  in
-              match uu____15478 with | (f,uu____15490) -> f.FStar_Ident.ns
-               in
+              let uu____15572 = FStar_List.hd fields  in
+              match uu____15572 with
+              | (f,uu____15584) -> FStar_Ident.ns_of_lid f  in
             let get_field xopt f =
               let found =
                 FStar_All.pipe_right fields
                   (FStar_Util.find_opt
-                     (fun uu____15536  ->
-                        match uu____15536 with
-                        | (g,uu____15543) ->
-                            f.FStar_Ident.idText =
-                              (g.FStar_Ident.ident).FStar_Ident.idText))
+                     (fun uu____15632  ->
+                        match uu____15632 with
+                        | (g,uu____15639) ->
+                            let uu____15640 = FStar_Ident.text_of_id f  in
+                            let uu____15642 =
+                              let uu____15644 = FStar_Ident.ident_of_lid g
+                                 in
+                              FStar_Ident.text_of_id uu____15644  in
+                            uu____15640 = uu____15642))
                  in
               let fn = FStar_Ident.lid_of_ids (FStar_List.append user_ns [f])
                  in
               match found with
-              | FStar_Pervasives_Native.Some (uu____15550,e) -> (fn, e)
+              | FStar_Pervasives_Native.Some (uu____15651,e) -> (fn, e)
               | FStar_Pervasives_Native.None  ->
                   (match xopt with
                    | FStar_Pervasives_Native.None  ->
-                       let uu____15564 =
-                         let uu____15570 =
+                       let uu____15665 =
+                         let uu____15671 =
+                           let uu____15673 = FStar_Ident.text_of_id f  in
+                           let uu____15675 =
+                             FStar_Ident.string_of_lid
+                               record.FStar_Syntax_DsEnv.typename
+                              in
                            FStar_Util.format2
                              "Field %s of record type %s is missing"
-                             f.FStar_Ident.idText
-                             (record.FStar_Syntax_DsEnv.typename).FStar_Ident.str
+                             uu____15673 uu____15675
                             in
                          (FStar_Errors.Fatal_MissingFieldInRecord,
-                           uu____15570)
+                           uu____15671)
                           in
-                       FStar_Errors.raise_error uu____15564
+                       FStar_Errors.raise_error uu____15665
                          top.FStar_Parser_AST.range
                    | FStar_Pervasives_Native.Some x ->
                        (fn,
@@ -3917,191 +3979,208 @@ and (desugar_term_maybe_top :
             let recterm =
               match eopt with
               | FStar_Pervasives_Native.None  ->
-                  let uu____15581 =
-                    let uu____15592 =
+                  let uu____15686 =
+                    let uu____15697 =
                       FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                         (FStar_List.map
-                           (fun uu____15623  ->
-                              match uu____15623 with
-                              | (f,uu____15633) ->
-                                  let uu____15634 =
-                                    let uu____15635 =
+                           (fun uu____15728  ->
+                              match uu____15728 with
+                              | (f,uu____15738) ->
+                                  let uu____15739 =
+                                    let uu____15740 =
                                       get_field FStar_Pervasives_Native.None
                                         f
                                        in
                                     FStar_All.pipe_left
-                                      FStar_Pervasives_Native.snd uu____15635
+                                      FStar_Pervasives_Native.snd uu____15740
                                      in
-                                  (uu____15634, FStar_Parser_AST.Nothing)))
+                                  (uu____15739, FStar_Parser_AST.Nothing)))
                        in
-                    (user_constrname, uu____15592)  in
-                  FStar_Parser_AST.Construct uu____15581
+                    (user_constrname, uu____15697)  in
+                  FStar_Parser_AST.Construct uu____15686
               | FStar_Pervasives_Native.Some e ->
                   let x = FStar_Ident.gen e.FStar_Parser_AST.range  in
                   let xterm =
-                    let uu____15653 =
-                      let uu____15654 = FStar_Ident.lid_of_ids [x]  in
-                      FStar_Parser_AST.Var uu____15654  in
-                    FStar_Parser_AST.mk_term uu____15653
-                      x.FStar_Ident.idRange FStar_Parser_AST.Expr
+                    let uu____15758 =
+                      let uu____15759 = FStar_Ident.lid_of_ids [x]  in
+                      FStar_Parser_AST.Var uu____15759  in
+                    let uu____15760 = FStar_Ident.range_of_id x  in
+                    FStar_Parser_AST.mk_term uu____15758 uu____15760
+                      FStar_Parser_AST.Expr
                      in
                   let record1 =
-                    let uu____15656 =
-                      let uu____15669 =
+                    let uu____15762 =
+                      let uu____15775 =
                         FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                           (FStar_List.map
-                             (fun uu____15699  ->
-                                match uu____15699 with
-                                | (f,uu____15709) ->
+                             (fun uu____15805  ->
+                                match uu____15805 with
+                                | (f,uu____15815) ->
                                     get_field
                                       (FStar_Pervasives_Native.Some xterm) f))
                          in
-                      (FStar_Pervasives_Native.None, uu____15669)  in
-                    FStar_Parser_AST.Record uu____15656  in
-                  FStar_Parser_AST.Let
-                    (FStar_Parser_AST.NoLetQualifier,
-                      [(FStar_Pervasives_Native.None,
-                         ((FStar_Parser_AST.mk_pattern
-                             (FStar_Parser_AST.PatVar
-                                (x, FStar_Pervasives_Native.None))
-                             x.FStar_Ident.idRange), e))],
+                      (FStar_Pervasives_Native.None, uu____15775)  in
+                    FStar_Parser_AST.Record uu____15762  in
+                  let uu____15824 =
+                    let uu____15845 =
+                      let uu____15860 =
+                        let uu____15873 =
+                          let uu____15878 =
+                            let uu____15879 = FStar_Ident.range_of_id x  in
+                            FStar_Parser_AST.mk_pattern
+                              (FStar_Parser_AST.PatVar
+                                 (x, FStar_Pervasives_Native.None))
+                              uu____15879
+                             in
+                          (uu____15878, e)  in
+                        (FStar_Pervasives_Native.None, uu____15873)  in
+                      [uu____15860]  in
+                    (FStar_Parser_AST.NoLetQualifier, uu____15845,
                       (FStar_Parser_AST.mk_term record1
                          top.FStar_Parser_AST.range
                          top.FStar_Parser_AST.level))
+                     in
+                  FStar_Parser_AST.Let uu____15824
                in
             let recterm1 =
               FStar_Parser_AST.mk_term recterm top.FStar_Parser_AST.range
                 top.FStar_Parser_AST.level
                in
-            let uu____15769 = desugar_term_aq env recterm1  in
-            (match uu____15769 with
+            let uu____15931 = desugar_term_aq env recterm1  in
+            (match uu____15931 with
              | (e,s) ->
                  (match e.FStar_Syntax_Syntax.n with
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv;
-                         FStar_Syntax_Syntax.pos = uu____15785;
-                         FStar_Syntax_Syntax.vars = uu____15786;_},args)
+                         FStar_Syntax_Syntax.pos = uu____15947;
+                         FStar_Syntax_Syntax.vars = uu____15948;_},args)
                       ->
-                      let uu____15812 =
-                        let uu____15813 =
-                          let uu____15814 =
-                            let uu____15831 =
-                              let uu____15834 =
+                      let uu____15974 =
+                        let uu____15975 =
+                          let uu____15976 =
+                            let uu____15993 =
+                              let uu____15996 =
                                 FStar_Ident.set_lid_range
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                   e.FStar_Syntax_Syntax.pos
                                  in
-                              let uu____15835 =
-                                let uu____15838 =
-                                  let uu____15839 =
-                                    let uu____15846 =
+                              let uu____15997 =
+                                let uu____16000 =
+                                  let uu____16001 =
+                                    let uu____16008 =
                                       FStar_All.pipe_right
                                         record.FStar_Syntax_DsEnv.fields
                                         (FStar_List.map
                                            FStar_Pervasives_Native.fst)
                                        in
                                     ((record.FStar_Syntax_DsEnv.typename),
-                                      uu____15846)
+                                      uu____16008)
                                      in
-                                  FStar_Syntax_Syntax.Record_ctor uu____15839
+                                  FStar_Syntax_Syntax.Record_ctor uu____16001
                                    in
-                                FStar_Pervasives_Native.Some uu____15838  in
-                              FStar_Syntax_Syntax.fvar uu____15834
+                                FStar_Pervasives_Native.Some uu____16000  in
+                              FStar_Syntax_Syntax.fvar uu____15996
                                 FStar_Syntax_Syntax.delta_constant
-                                uu____15835
+                                uu____15997
                                in
-                            (uu____15831, args)  in
-                          FStar_Syntax_Syntax.Tm_app uu____15814  in
-                        FStar_All.pipe_left mk uu____15813  in
-                      (uu____15812, s)
-                  | uu____15875 -> (e, s)))
+                            (uu____15993, args)  in
+                          FStar_Syntax_Syntax.Tm_app uu____15976  in
+                        FStar_All.pipe_left mk uu____15975  in
+                      (uu____15974, s)
+                  | uu____16037 -> (e, s)))
         | FStar_Parser_AST.Project (e,f) ->
-            let uu____15878 =
+            let uu____16040 =
               FStar_Syntax_DsEnv.fail_or env
                 (FStar_Syntax_DsEnv.try_lookup_dc_by_field_name env) f
                in
-            (match uu____15878 with
+            (match uu____16040 with
              | (constrname,is_rec) ->
-                 let uu____15897 = desugar_term_aq env e  in
-                 (match uu____15897 with
+                 let uu____16059 = desugar_term_aq env e  in
+                 (match uu____16059 with
                   | (e1,s) ->
                       let projname =
+                        let uu____16071 = FStar_Ident.ident_of_lid f  in
                         FStar_Syntax_Util.mk_field_projector_name_from_ident
-                          constrname f.FStar_Ident.ident
+                          constrname uu____16071
                          in
                       let qual =
                         if is_rec
                         then
-                          FStar_Pervasives_Native.Some
-                            (FStar_Syntax_Syntax.Record_projector
-                               (constrname, (f.FStar_Ident.ident)))
+                          let uu____16078 =
+                            let uu____16079 =
+                              let uu____16084 = FStar_Ident.ident_of_lid f
+                                 in
+                              (constrname, uu____16084)  in
+                            FStar_Syntax_Syntax.Record_projector uu____16079
+                             in
+                          FStar_Pervasives_Native.Some uu____16078
                         else FStar_Pervasives_Native.None  in
-                      let uu____15917 =
-                        let uu____15918 =
-                          let uu____15919 =
-                            let uu____15936 =
-                              let uu____15939 =
-                                let uu____15940 = FStar_Ident.range_of_lid f
+                      let uu____16087 =
+                        let uu____16088 =
+                          let uu____16089 =
+                            let uu____16106 =
+                              let uu____16109 =
+                                let uu____16110 = FStar_Ident.range_of_lid f
                                    in
                                 FStar_Ident.set_lid_range projname
-                                  uu____15940
+                                  uu____16110
                                  in
-                              FStar_Syntax_Syntax.fvar uu____15939
+                              FStar_Syntax_Syntax.fvar uu____16109
                                 (FStar_Syntax_Syntax.Delta_equational_at_level
                                    Prims.int_one) qual
                                in
-                            let uu____15942 =
-                              let uu____15953 = FStar_Syntax_Syntax.as_arg e1
+                            let uu____16112 =
+                              let uu____16123 = FStar_Syntax_Syntax.as_arg e1
                                  in
-                              [uu____15953]  in
-                            (uu____15936, uu____15942)  in
-                          FStar_Syntax_Syntax.Tm_app uu____15919  in
-                        FStar_All.pipe_left mk uu____15918  in
-                      (uu____15917, s)))
+                              [uu____16123]  in
+                            (uu____16106, uu____16112)  in
+                          FStar_Syntax_Syntax.Tm_app uu____16089  in
+                        FStar_All.pipe_left mk uu____16088  in
+                      (uu____16087, s)))
         | FStar_Parser_AST.NamedTyp (n,e) ->
-            ((let uu____15993 = FStar_Ident.range_of_id n  in
-              FStar_Errors.log_issue uu____15993
+            ((let uu____16163 = FStar_Ident.range_of_id n  in
+              FStar_Errors.log_issue uu____16163
                 (FStar_Errors.Warning_IgnoredBinding,
                   "This name is being ignored"));
              desugar_term_aq env e)
         | FStar_Parser_AST.Paren e -> failwith "impossible"
         | FStar_Parser_AST.VQuote e ->
             let tm = desugar_term env e  in
-            let uu____16004 =
-              let uu____16005 = FStar_Syntax_Subst.compress tm  in
-              uu____16005.FStar_Syntax_Syntax.n  in
-            (match uu____16004 with
+            let uu____16174 =
+              let uu____16175 = FStar_Syntax_Subst.compress tm  in
+              uu____16175.FStar_Syntax_Syntax.n  in
+            (match uu____16174 with
              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                 let uu____16013 =
-                   let uu___2117_16014 =
-                     let uu____16015 =
-                       let uu____16017 = FStar_Syntax_Syntax.lid_of_fv fv  in
-                       FStar_Ident.string_of_lid uu____16017  in
-                     FStar_Syntax_Util.exp_string uu____16015  in
+                 let uu____16183 =
+                   let uu___2089_16184 =
+                     let uu____16185 =
+                       let uu____16187 = FStar_Syntax_Syntax.lid_of_fv fv  in
+                       FStar_Ident.string_of_lid uu____16187  in
+                     FStar_Syntax_Util.exp_string uu____16185  in
                    {
                      FStar_Syntax_Syntax.n =
-                       (uu___2117_16014.FStar_Syntax_Syntax.n);
+                       (uu___2089_16184.FStar_Syntax_Syntax.n);
                      FStar_Syntax_Syntax.pos = (e.FStar_Parser_AST.range);
                      FStar_Syntax_Syntax.vars =
-                       (uu___2117_16014.FStar_Syntax_Syntax.vars)
+                       (uu___2089_16184.FStar_Syntax_Syntax.vars)
                    }  in
-                 (uu____16013, noaqs)
-             | uu____16018 ->
-                 let uu____16019 =
-                   let uu____16025 =
-                     let uu____16027 = FStar_Syntax_Print.term_to_string tm
+                 (uu____16183, noaqs)
+             | uu____16188 ->
+                 let uu____16189 =
+                   let uu____16195 =
+                     let uu____16197 = FStar_Syntax_Print.term_to_string tm
                         in
                      Prims.op_Hat "VQuote, expected an fvar, got: "
-                       uu____16027
+                       uu____16197
                       in
-                   (FStar_Errors.Fatal_UnexpectedTermVQuote, uu____16025)  in
-                 FStar_Errors.raise_error uu____16019
+                   (FStar_Errors.Fatal_UnexpectedTermVQuote, uu____16195)  in
+                 FStar_Errors.raise_error uu____16189
                    top.FStar_Parser_AST.range)
         | FStar_Parser_AST.Quote (e,FStar_Parser_AST.Static ) ->
-            let uu____16036 = desugar_term_aq env e  in
-            (match uu____16036 with
+            let uu____16206 = desugar_term_aq env e  in
+            (match uu____16206 with
              | (tm,vts) ->
                  let qi =
                    {
@@ -4109,38 +4188,38 @@ and (desugar_term_maybe_top :
                        FStar_Syntax_Syntax.Quote_static;
                      FStar_Syntax_Syntax.antiquotes = vts
                    }  in
-                 let uu____16048 =
+                 let uu____16218 =
                    FStar_All.pipe_left mk
                      (FStar_Syntax_Syntax.Tm_quoted (tm, qi))
                     in
-                 (uu____16048, noaqs))
+                 (uu____16218, noaqs))
         | FStar_Parser_AST.Antiquote e ->
             let bv =
               FStar_Syntax_Syntax.new_bv
                 (FStar_Pervasives_Native.Some (e.FStar_Parser_AST.range))
                 FStar_Syntax_Syntax.tun
                in
-            let uu____16053 = FStar_Syntax_Syntax.bv_to_name bv  in
-            let uu____16054 =
-              let uu____16055 =
-                let uu____16062 = desugar_term env e  in (bv, uu____16062)
+            let uu____16223 = FStar_Syntax_Syntax.bv_to_name bv  in
+            let uu____16224 =
+              let uu____16225 =
+                let uu____16232 = desugar_term env e  in (bv, uu____16232)
                  in
-              [uu____16055]  in
-            (uu____16053, uu____16054)
+              [uu____16225]  in
+            (uu____16223, uu____16224)
         | FStar_Parser_AST.Quote (e,FStar_Parser_AST.Dynamic ) ->
             let qi =
               {
                 FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_dynamic;
                 FStar_Syntax_Syntax.antiquotes = []
               }  in
-            let uu____16087 =
-              let uu____16088 =
-                let uu____16089 =
-                  let uu____16096 = desugar_term env e  in (uu____16096, qi)
+            let uu____16257 =
+              let uu____16258 =
+                let uu____16259 =
+                  let uu____16266 = desugar_term env e  in (uu____16266, qi)
                    in
-                FStar_Syntax_Syntax.Tm_quoted uu____16089  in
-              FStar_All.pipe_left mk uu____16088  in
-            (uu____16087, noaqs)
+                FStar_Syntax_Syntax.Tm_quoted uu____16259  in
+              FStar_All.pipe_left mk uu____16258  in
+            (uu____16257, noaqs)
         | FStar_Parser_AST.CalcProof (rel,init_expr,steps) ->
             let is_impl rel1 =
               let is_impl_t t =
@@ -4148,32 +4227,32 @@ and (desugar_term_maybe_top :
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.imp_lid
-                | uu____16125 -> false  in
-              let uu____16127 =
-                let uu____16128 = unparen rel1  in
-                uu____16128.FStar_Parser_AST.tm  in
-              match uu____16127 with
-              | FStar_Parser_AST.Op (id,uu____16131) ->
-                  let uu____16136 =
+                | uu____16295 -> false  in
+              let uu____16297 =
+                let uu____16298 = unparen rel1  in
+                uu____16298.FStar_Parser_AST.tm  in
+              match uu____16297 with
+              | FStar_Parser_AST.Op (id,uu____16301) ->
+                  let uu____16306 =
                     op_as_term env (Prims.of_int (2)) FStar_Range.dummyRange
                       id
                      in
-                  (match uu____16136 with
+                  (match uu____16306 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None  -> false)
               | FStar_Parser_AST.Var lid ->
-                  let uu____16144 = desugar_name' (fun x  -> x) env true lid
+                  let uu____16314 = desugar_name' (fun x  -> x) env true lid
                      in
-                  (match uu____16144 with
+                  (match uu____16314 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None  -> false)
               | FStar_Parser_AST.Tvar id ->
-                  let uu____16155 = FStar_Syntax_DsEnv.try_lookup_id env id
+                  let uu____16325 = FStar_Syntax_DsEnv.try_lookup_id env id
                      in
-                  (match uu____16155 with
+                  (match uu____16325 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None  -> false)
-              | uu____16161 -> false  in
+              | uu____16331 -> false  in
             let eta_and_annot rel1 =
               let x = FStar_Ident.gen' "x" rel1.FStar_Parser_AST.range  in
               let y = FStar_Ident.gen' "y" rel1.FStar_Parser_AST.range  in
@@ -4193,35 +4272,35 @@ and (desugar_term_maybe_top :
                   (FStar_Parser_AST.PatVar (y, FStar_Pervasives_Native.None))
                   rel1.FStar_Parser_AST.range]
                  in
-              let uu____16182 =
-                let uu____16183 =
-                  let uu____16190 =
-                    let uu____16191 =
-                      let uu____16192 =
-                        let uu____16201 =
+              let uu____16352 =
+                let uu____16353 =
+                  let uu____16360 =
+                    let uu____16361 =
+                      let uu____16362 =
+                        let uu____16371 =
                           FStar_Parser_AST.mkApp rel1
                             [(xt, FStar_Parser_AST.Nothing);
                             (yt, FStar_Parser_AST.Nothing)]
                             rel1.FStar_Parser_AST.range
                            in
-                        let uu____16214 =
-                          let uu____16215 =
-                            let uu____16216 = FStar_Ident.lid_of_str "Type0"
+                        let uu____16384 =
+                          let uu____16385 =
+                            let uu____16386 = FStar_Ident.lid_of_str "Type0"
                                in
-                            FStar_Parser_AST.Name uu____16216  in
-                          FStar_Parser_AST.mk_term uu____16215
+                            FStar_Parser_AST.Name uu____16386  in
+                          FStar_Parser_AST.mk_term uu____16385
                             rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr
                            in
-                        (uu____16201, uu____16214,
+                        (uu____16371, uu____16384,
                           FStar_Pervasives_Native.None)
                          in
-                      FStar_Parser_AST.Ascribed uu____16192  in
-                    FStar_Parser_AST.mk_term uu____16191
+                      FStar_Parser_AST.Ascribed uu____16362  in
+                    FStar_Parser_AST.mk_term uu____16361
                       rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr
                      in
-                  (pats, uu____16190)  in
-                FStar_Parser_AST.Abs uu____16183  in
-              FStar_Parser_AST.mk_term uu____16182
+                  (pats, uu____16360)  in
+                FStar_Parser_AST.Abs uu____16353  in
+              FStar_Parser_AST.mk_term uu____16352
                 rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr
                in
             let rel1 = eta_and_annot rel  in
@@ -4240,11 +4319,11 @@ and (desugar_term_maybe_top :
                 r FStar_Parser_AST.Expr
                in
             let last_expr =
-              let uu____16237 = FStar_List.last steps  in
-              match uu____16237 with
+              let uu____16407 = FStar_List.last steps  in
+              match uu____16407 with
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.CalcStep
-                  (uu____16240,uu____16241,last_expr)) -> last_expr
-              | uu____16243 -> failwith "impossible: no last_expr on calc"
+                  (uu____16410,uu____16411,last_expr)) -> last_expr
+              | uu____16413 -> failwith "impossible: no last_expr on calc"
                in
             let step r =
               FStar_Parser_AST.mk_term
@@ -4263,98 +4342,98 @@ and (desugar_term_maybe_top :
                 [(init_expr, FStar_Parser_AST.Nothing)]
                 FStar_Range.dummyRange
                in
-            let uu____16271 =
+            let uu____16441 =
               FStar_List.fold_left
-                (fun uu____16289  ->
-                   fun uu____16290  ->
-                     match (uu____16289, uu____16290) with
+                (fun uu____16459  ->
+                   fun uu____16460  ->
+                     match (uu____16459, uu____16460) with
                      | ((e1,prev),FStar_Parser_AST.CalcStep
                         (rel2,just,next_expr)) ->
                          let just1 =
-                           let uu____16313 = is_impl rel2  in
-                           if uu____16313
+                           let uu____16483 = is_impl rel2  in
+                           if uu____16483
                            then
-                             let uu____16316 =
-                               let uu____16323 =
-                                 let uu____16328 =
+                             let uu____16486 =
+                               let uu____16493 =
+                                 let uu____16498 =
                                    FStar_Parser_AST.thunk just  in
-                                 (uu____16328, FStar_Parser_AST.Nothing)  in
-                               [uu____16323]  in
+                                 (uu____16498, FStar_Parser_AST.Nothing)  in
+                               [uu____16493]  in
                              FStar_Parser_AST.mkApp
                                (push_impl just.FStar_Parser_AST.range)
-                               uu____16316 just.FStar_Parser_AST.range
+                               uu____16486 just.FStar_Parser_AST.range
                            else just  in
                          let pf =
-                           let uu____16340 =
-                             let uu____16347 =
-                               let uu____16354 =
-                                 let uu____16361 =
-                                   let uu____16368 =
-                                     let uu____16373 = eta_and_annot rel2  in
-                                     (uu____16373, FStar_Parser_AST.Nothing)
+                           let uu____16510 =
+                             let uu____16517 =
+                               let uu____16524 =
+                                 let uu____16531 =
+                                   let uu____16538 =
+                                     let uu____16543 = eta_and_annot rel2  in
+                                     (uu____16543, FStar_Parser_AST.Nothing)
                                       in
-                                   let uu____16374 =
-                                     let uu____16381 =
-                                       let uu____16388 =
-                                         let uu____16393 =
+                                   let uu____16544 =
+                                     let uu____16551 =
+                                       let uu____16558 =
+                                         let uu____16563 =
                                            FStar_Parser_AST.thunk e1  in
-                                         (uu____16393,
+                                         (uu____16563,
                                            FStar_Parser_AST.Nothing)
                                           in
-                                       let uu____16394 =
-                                         let uu____16401 =
-                                           let uu____16406 =
+                                       let uu____16564 =
+                                         let uu____16571 =
+                                           let uu____16576 =
                                              FStar_Parser_AST.thunk just1  in
-                                           (uu____16406,
+                                           (uu____16576,
                                              FStar_Parser_AST.Nothing)
                                             in
-                                         [uu____16401]  in
-                                       uu____16388 :: uu____16394  in
+                                         [uu____16571]  in
+                                       uu____16558 :: uu____16564  in
                                      (next_expr, FStar_Parser_AST.Nothing) ::
-                                       uu____16381
+                                       uu____16551
                                       in
-                                   uu____16368 :: uu____16374  in
-                                 (prev, FStar_Parser_AST.Hash) :: uu____16361
+                                   uu____16538 :: uu____16544  in
+                                 (prev, FStar_Parser_AST.Hash) :: uu____16531
                                   in
                                (init_expr, FStar_Parser_AST.Hash) ::
-                                 uu____16354
+                                 uu____16524
                                 in
                              ((wild rel2.FStar_Parser_AST.range),
-                               FStar_Parser_AST.Hash) :: uu____16347
+                               FStar_Parser_AST.Hash) :: uu____16517
                               in
                            FStar_Parser_AST.mkApp
-                             (step rel2.FStar_Parser_AST.range) uu____16340
+                             (step rel2.FStar_Parser_AST.range) uu____16510
                              FStar_Range.dummyRange
                             in
                          (pf, next_expr)) (e, init_expr) steps
                in
-            (match uu____16271 with
-             | (e1,uu____16444) ->
+            (match uu____16441 with
+             | (e1,uu____16614) ->
                  let e2 =
-                   let uu____16446 =
-                     let uu____16453 =
-                       let uu____16460 =
-                         let uu____16467 =
-                           let uu____16472 = FStar_Parser_AST.thunk e1  in
-                           (uu____16472, FStar_Parser_AST.Nothing)  in
-                         [uu____16467]  in
-                       (last_expr, FStar_Parser_AST.Hash) :: uu____16460  in
-                     (init_expr, FStar_Parser_AST.Hash) :: uu____16453  in
-                   FStar_Parser_AST.mkApp finish uu____16446
+                   let uu____16616 =
+                     let uu____16623 =
+                       let uu____16630 =
+                         let uu____16637 =
+                           let uu____16642 = FStar_Parser_AST.thunk e1  in
+                           (uu____16642, FStar_Parser_AST.Nothing)  in
+                         [uu____16637]  in
+                       (last_expr, FStar_Parser_AST.Hash) :: uu____16630  in
+                     (init_expr, FStar_Parser_AST.Hash) :: uu____16623  in
+                   FStar_Parser_AST.mkApp finish uu____16616
                      FStar_Range.dummyRange
                     in
                  desugar_term_maybe_top top_level env e2)
-        | uu____16489 when
+        | uu____16659 when
             top.FStar_Parser_AST.level = FStar_Parser_AST.Formula ->
-            let uu____16490 = desugar_formula env top  in
-            (uu____16490, noaqs)
-        | uu____16491 ->
-            let uu____16492 =
-              let uu____16498 =
-                let uu____16500 = FStar_Parser_AST.term_to_string top  in
-                Prims.op_Hat "Unexpected term: " uu____16500  in
-              (FStar_Errors.Fatal_UnexpectedTerm, uu____16498)  in
-            FStar_Errors.raise_error uu____16492 top.FStar_Parser_AST.range
+            let uu____16660 = desugar_formula env top  in
+            (uu____16660, noaqs)
+        | uu____16661 ->
+            let uu____16662 =
+              let uu____16668 =
+                let uu____16670 = FStar_Parser_AST.term_to_string top  in
+                Prims.op_Hat "Unexpected term: " uu____16670  in
+              (FStar_Errors.Fatal_UnexpectedTerm, uu____16668)  in
+            FStar_Errors.raise_error uu____16662 top.FStar_Parser_AST.range
 
 and (desugar_args :
   FStar_Syntax_DsEnv.env ->
@@ -4366,11 +4445,11 @@ and (desugar_args :
     fun args  ->
       FStar_All.pipe_right args
         (FStar_List.map
-           (fun uu____16544  ->
-              match uu____16544 with
+           (fun uu____16714  ->
+              match uu____16714 with
               | (a,imp) ->
-                  let uu____16557 = desugar_term env a  in
-                  arg_withimp_e imp uu____16557))
+                  let uu____16727 = desugar_term env a  in
+                  arg_withimp_e imp uu____16727))
 
 and (desugar_comp :
   FStar_Range.range ->
@@ -4384,83 +4463,94 @@ and (desugar_comp :
       fun env  ->
         fun t  ->
           let fail err = FStar_Errors.raise_error err r  in
-          let is_requires uu____16594 =
-            match uu____16594 with
-            | (t1,uu____16601) ->
-                let uu____16602 =
-                  let uu____16603 = unparen t1  in
-                  uu____16603.FStar_Parser_AST.tm  in
-                (match uu____16602 with
-                 | FStar_Parser_AST.Requires uu____16605 -> true
-                 | uu____16614 -> false)
+          let is_requires uu____16764 =
+            match uu____16764 with
+            | (t1,uu____16771) ->
+                let uu____16772 =
+                  let uu____16773 = unparen t1  in
+                  uu____16773.FStar_Parser_AST.tm  in
+                (match uu____16772 with
+                 | FStar_Parser_AST.Requires uu____16775 -> true
+                 | uu____16784 -> false)
              in
-          let is_ensures uu____16626 =
-            match uu____16626 with
-            | (t1,uu____16633) ->
-                let uu____16634 =
-                  let uu____16635 = unparen t1  in
-                  uu____16635.FStar_Parser_AST.tm  in
-                (match uu____16634 with
-                 | FStar_Parser_AST.Ensures uu____16637 -> true
-                 | uu____16646 -> false)
+          let is_ensures uu____16796 =
+            match uu____16796 with
+            | (t1,uu____16803) ->
+                let uu____16804 =
+                  let uu____16805 = unparen t1  in
+                  uu____16805.FStar_Parser_AST.tm  in
+                (match uu____16804 with
+                 | FStar_Parser_AST.Ensures uu____16807 -> true
+                 | uu____16816 -> false)
              in
-          let is_app head uu____16664 =
-            match uu____16664 with
-            | (t1,uu____16672) ->
-                let uu____16673 =
-                  let uu____16674 = unparen t1  in
-                  uu____16674.FStar_Parser_AST.tm  in
-                (match uu____16673 with
+          let is_app head uu____16834 =
+            match uu____16834 with
+            | (t1,uu____16842) ->
+                let uu____16843 =
+                  let uu____16844 = unparen t1  in
+                  uu____16844.FStar_Parser_AST.tm  in
+                (match uu____16843 with
                  | FStar_Parser_AST.App
                      ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var d;
-                        FStar_Parser_AST.range = uu____16677;
-                        FStar_Parser_AST.level = uu____16678;_},uu____16679,uu____16680)
-                     -> (d.FStar_Ident.ident).FStar_Ident.idText = head
-                 | uu____16682 -> false)
+                        FStar_Parser_AST.range = uu____16847;
+                        FStar_Parser_AST.level = uu____16848;_},uu____16849,uu____16850)
+                     ->
+                     let uu____16851 =
+                       let uu____16853 = FStar_Ident.ident_of_lid d  in
+                       FStar_Ident.text_of_id uu____16853  in
+                     uu____16851 = head
+                 | uu____16855 -> false)
              in
-          let is_smt_pat uu____16694 =
-            match uu____16694 with
-            | (t1,uu____16701) ->
-                let uu____16702 =
-                  let uu____16703 = unparen t1  in
-                  uu____16703.FStar_Parser_AST.tm  in
-                (match uu____16702 with
+          let is_smt_pat uu____16867 =
+            match uu____16867 with
+            | (t1,uu____16874) ->
+                let uu____16875 =
+                  let uu____16876 = unparen t1  in
+                  uu____16876.FStar_Parser_AST.tm  in
+                (match uu____16875 with
                  | FStar_Parser_AST.Construct
                      (cons,({
                               FStar_Parser_AST.tm =
                                 FStar_Parser_AST.Construct
-                                (smtpat,uu____16707);
-                              FStar_Parser_AST.range = uu____16708;
-                              FStar_Parser_AST.level = uu____16709;_},uu____16710)::uu____16711::[])
+                                (smtpat,uu____16880);
+                              FStar_Parser_AST.range = uu____16881;
+                              FStar_Parser_AST.level = uu____16882;_},uu____16883)::uu____16884::[])
                      ->
                      (FStar_Ident.lid_equals cons FStar_Parser_Const.cons_lid)
                        &&
                        (FStar_Util.for_some
-                          (fun s  -> smtpat.FStar_Ident.str = s)
+                          (fun s  ->
+                             let uu____16924 =
+                               FStar_Ident.string_of_lid smtpat  in
+                             uu____16924 = s)
                           ["SMTPat"; "SMTPatT"; "SMTPatOr"])
                  | FStar_Parser_AST.Construct
                      (cons,({
                               FStar_Parser_AST.tm = FStar_Parser_AST.Var
                                 smtpat;
-                              FStar_Parser_AST.range = uu____16760;
-                              FStar_Parser_AST.level = uu____16761;_},uu____16762)::uu____16763::[])
+                              FStar_Parser_AST.range = uu____16936;
+                              FStar_Parser_AST.level = uu____16937;_},uu____16938)::uu____16939::[])
                      ->
                      (FStar_Ident.lid_equals cons FStar_Parser_Const.cons_lid)
                        &&
                        (FStar_Util.for_some
-                          (fun s  -> smtpat.FStar_Ident.str = s)
-                          ["smt_pat"; "smt_pat_or"])
-                 | uu____16796 -> false)
+                          (fun s  ->
+                             let uu____16967 =
+                               FStar_Ident.string_of_lid smtpat  in
+                             uu____16967 = s) ["smt_pat"; "smt_pat_or"])
+                 | uu____16975 -> false)
              in
           let is_decreases = is_app "decreases"  in
           let pre_process_comp_typ t1 =
-            let uu____16831 = head_and_args t1  in
-            match uu____16831 with
+            let uu____17010 = head_and_args t1  in
+            match uu____17010 with
             | (head,args) ->
                 (match head.FStar_Parser_AST.tm with
                  | FStar_Parser_AST.Name lemma when
-                     (lemma.FStar_Ident.ident).FStar_Ident.idText = "Lemma"
-                     ->
+                     let uu____17068 =
+                       let uu____17070 = FStar_Ident.ident_of_lid lemma  in
+                       FStar_Ident.text_of_id uu____17070  in
+                     uu____17068 = "Lemma" ->
                      let unit_tm =
                        ((FStar_Parser_AST.mk_term
                            (FStar_Parser_AST.Name FStar_Parser_Const.unit_lid)
@@ -4489,13 +4579,13 @@ and (desugar_comp :
                            FStar_Parser_AST.Type_level),
                          FStar_Parser_AST.Nothing)
                         in
-                     let thunk_ens uu____16924 =
-                       match uu____16924 with
+                     let thunk_ens uu____17106 =
+                       match uu____17106 with
                        | (e,i) ->
-                           let uu____16935 = FStar_Parser_AST.thunk e  in
-                           (uu____16935, i)
+                           let uu____17117 = FStar_Parser_AST.thunk e  in
+                           (uu____17117, i)
                         in
-                     let fail_lemma uu____16947 =
+                     let fail_lemma uu____17129 =
                        let expected_one_of =
                          ["Lemma post";
                          "Lemma (ensures post)";
@@ -4523,85 +4613,85 @@ and (desugar_comp :
                        | smtpat::[] when is_smt_pat smtpat -> fail_lemma ()
                        | dec::[] when is_decreases dec -> fail_lemma ()
                        | ens::[] ->
-                           let uu____17053 =
-                             let uu____17060 =
-                               let uu____17067 = thunk_ens ens  in
-                               [uu____17067; nil_pat]  in
-                             req_true :: uu____17060  in
-                           unit_tm :: uu____17053
+                           let uu____17235 =
+                             let uu____17242 =
+                               let uu____17249 = thunk_ens ens  in
+                               [uu____17249; nil_pat]  in
+                             req_true :: uu____17242  in
+                           unit_tm :: uu____17235
                        | req::ens::[] when
                            (is_requires req) && (is_ensures ens) ->
-                           let uu____17114 =
-                             let uu____17121 =
-                               let uu____17128 = thunk_ens ens  in
-                               [uu____17128; nil_pat]  in
-                             req :: uu____17121  in
-                           unit_tm :: uu____17114
+                           let uu____17296 =
+                             let uu____17303 =
+                               let uu____17310 = thunk_ens ens  in
+                               [uu____17310; nil_pat]  in
+                             req :: uu____17303  in
+                           unit_tm :: uu____17296
                        | ens::smtpat::[] when
-                           (((let uu____17177 = is_requires ens  in
-                              Prims.op_Negation uu____17177) &&
-                               (let uu____17180 = is_smt_pat ens  in
-                                Prims.op_Negation uu____17180))
+                           (((let uu____17359 = is_requires ens  in
+                              Prims.op_Negation uu____17359) &&
+                               (let uu____17362 = is_smt_pat ens  in
+                                Prims.op_Negation uu____17362))
                               &&
-                              (let uu____17183 = is_decreases ens  in
-                               Prims.op_Negation uu____17183))
+                              (let uu____17365 = is_decreases ens  in
+                               Prims.op_Negation uu____17365))
                              && (is_smt_pat smtpat)
                            ->
-                           let uu____17185 =
-                             let uu____17192 =
-                               let uu____17199 = thunk_ens ens  in
-                               [uu____17199; smtpat]  in
-                             req_true :: uu____17192  in
-                           unit_tm :: uu____17185
+                           let uu____17367 =
+                             let uu____17374 =
+                               let uu____17381 = thunk_ens ens  in
+                               [uu____17381; smtpat]  in
+                             req_true :: uu____17374  in
+                           unit_tm :: uu____17367
                        | ens::dec::[] when
                            (is_ensures ens) && (is_decreases dec) ->
-                           let uu____17246 =
-                             let uu____17253 =
-                               let uu____17260 = thunk_ens ens  in
-                               [uu____17260; nil_pat; dec]  in
-                             req_true :: uu____17253  in
-                           unit_tm :: uu____17246
+                           let uu____17428 =
+                             let uu____17435 =
+                               let uu____17442 = thunk_ens ens  in
+                               [uu____17442; nil_pat; dec]  in
+                             req_true :: uu____17435  in
+                           unit_tm :: uu____17428
                        | ens::dec::smtpat::[] when
                            ((is_ensures ens) && (is_decreases dec)) &&
                              (is_smt_pat smtpat)
                            ->
-                           let uu____17320 =
-                             let uu____17327 =
-                               let uu____17334 = thunk_ens ens  in
-                               [uu____17334; smtpat; dec]  in
-                             req_true :: uu____17327  in
-                           unit_tm :: uu____17320
+                           let uu____17502 =
+                             let uu____17509 =
+                               let uu____17516 = thunk_ens ens  in
+                               [uu____17516; smtpat; dec]  in
+                             req_true :: uu____17509  in
+                           unit_tm :: uu____17502
                        | req::ens::dec::[] when
                            ((is_requires req) && (is_ensures ens)) &&
                              (is_decreases dec)
                            ->
-                           let uu____17394 =
-                             let uu____17401 =
-                               let uu____17408 = thunk_ens ens  in
-                               [uu____17408; nil_pat; dec]  in
-                             req :: uu____17401  in
-                           unit_tm :: uu____17394
+                           let uu____17576 =
+                             let uu____17583 =
+                               let uu____17590 = thunk_ens ens  in
+                               [uu____17590; nil_pat; dec]  in
+                             req :: uu____17583  in
+                           unit_tm :: uu____17576
                        | req::ens::smtpat::[] when
                            ((is_requires req) && (is_ensures ens)) &&
                              (is_smt_pat smtpat)
                            ->
-                           let uu____17468 =
-                             let uu____17475 =
-                               let uu____17482 = thunk_ens ens  in
-                               [uu____17482; smtpat]  in
-                             req :: uu____17475  in
-                           unit_tm :: uu____17468
+                           let uu____17650 =
+                             let uu____17657 =
+                               let uu____17664 = thunk_ens ens  in
+                               [uu____17664; smtpat]  in
+                             req :: uu____17657  in
+                           unit_tm :: uu____17650
                        | req::ens::dec::smtpat::[] when
                            (((is_requires req) && (is_ensures ens)) &&
                               (is_smt_pat smtpat))
                              && (is_decreases dec)
                            ->
-                           let uu____17547 =
-                             let uu____17554 =
-                               let uu____17561 = thunk_ens ens  in
-                               [uu____17561; dec; smtpat]  in
-                             req :: uu____17554  in
-                           unit_tm :: uu____17547
+                           let uu____17729 =
+                             let uu____17736 =
+                               let uu____17743 = thunk_ens ens  in
+                               [uu____17743; dec; smtpat]  in
+                             req :: uu____17736  in
+                           unit_tm :: uu____17729
                        | _other -> fail_lemma ()  in
                      let head_and_attributes =
                        FStar_Syntax_DsEnv.fail_or env
@@ -4611,65 +4701,82 @@ and (desugar_comp :
                      (head_and_attributes, args1)
                  | FStar_Parser_AST.Name l when
                      FStar_Syntax_DsEnv.is_effect_name env l ->
-                     let uu____17623 =
+                     let uu____17805 =
                        FStar_Syntax_DsEnv.fail_or env
                          (FStar_Syntax_DsEnv.try_lookup_effect_name_and_attributes
                             env) l
                         in
-                     (uu____17623, args)
+                     (uu____17805, args)
                  | FStar_Parser_AST.Name l when
-                     (let uu____17651 = FStar_Syntax_DsEnv.current_module env
+                     (let uu____17833 = FStar_Syntax_DsEnv.current_module env
                          in
-                      FStar_Ident.lid_equals uu____17651
+                      FStar_Ident.lid_equals uu____17833
                         FStar_Parser_Const.prims_lid)
-                       && ((l.FStar_Ident.ident).FStar_Ident.idText = "Tot")
+                       &&
+                       (let uu____17835 =
+                          let uu____17837 = FStar_Ident.ident_of_lid l  in
+                          FStar_Ident.text_of_id uu____17837  in
+                        uu____17835 = "Tot")
                      ->
-                     let uu____17654 =
-                       let uu____17661 =
+                     let uu____17840 =
+                       let uu____17847 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_Tot_lid
                            head.FStar_Parser_AST.range
                           in
-                       (uu____17661, [])  in
-                     (uu____17654, args)
+                       (uu____17847, [])  in
+                     (uu____17840, args)
                  | FStar_Parser_AST.Name l when
-                     (let uu____17679 = FStar_Syntax_DsEnv.current_module env
+                     (let uu____17865 = FStar_Syntax_DsEnv.current_module env
                          in
-                      FStar_Ident.lid_equals uu____17679
+                      FStar_Ident.lid_equals uu____17865
                         FStar_Parser_Const.prims_lid)
-                       && ((l.FStar_Ident.ident).FStar_Ident.idText = "GTot")
+                       &&
+                       (let uu____17867 =
+                          let uu____17869 = FStar_Ident.ident_of_lid l  in
+                          FStar_Ident.text_of_id uu____17869  in
+                        uu____17867 = "GTot")
                      ->
-                     let uu____17682 =
-                       let uu____17689 =
+                     let uu____17872 =
+                       let uu____17879 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_GTot_lid
                            head.FStar_Parser_AST.range
                           in
-                       (uu____17689, [])  in
-                     (uu____17682, args)
+                       (uu____17879, [])  in
+                     (uu____17872, args)
                  | FStar_Parser_AST.Name l when
-                     (((l.FStar_Ident.ident).FStar_Ident.idText = "Type") ||
-                        ((l.FStar_Ident.ident).FStar_Ident.idText = "Type0"))
+                     ((let uu____17897 =
+                         let uu____17899 = FStar_Ident.ident_of_lid l  in
+                         FStar_Ident.text_of_id uu____17899  in
+                       uu____17897 = "Type") ||
+                        (let uu____17903 =
+                           let uu____17905 = FStar_Ident.ident_of_lid l  in
+                           FStar_Ident.text_of_id uu____17905  in
+                         uu____17903 = "Type0"))
                        ||
-                       ((l.FStar_Ident.ident).FStar_Ident.idText = "Effect")
+                       (let uu____17909 =
+                          let uu____17911 = FStar_Ident.ident_of_lid l  in
+                          FStar_Ident.text_of_id uu____17911  in
+                        uu____17909 = "Effect")
                      ->
-                     let uu____17711 =
-                       let uu____17718 =
+                     let uu____17914 =
+                       let uu____17921 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_Tot_lid
                            head.FStar_Parser_AST.range
                           in
-                       (uu____17718, [])  in
-                     (uu____17711, [(t1, FStar_Parser_AST.Nothing)])
-                 | uu____17741 when allow_type_promotion ->
+                       (uu____17921, [])  in
+                     (uu____17914, [(t1, FStar_Parser_AST.Nothing)])
+                 | uu____17944 when allow_type_promotion ->
                      let default_effect =
-                       let uu____17743 = FStar_Options.ml_ish ()  in
-                       if uu____17743
+                       let uu____17946 = FStar_Options.ml_ish ()  in
+                       if uu____17946
                        then FStar_Parser_Const.effect_ML_lid
                        else
-                         ((let uu____17749 =
+                         ((let uu____17952 =
                              FStar_Options.warn_default_effects ()  in
-                           if uu____17749
+                           if uu____17952
                            then
                              FStar_Errors.log_issue
                                head.FStar_Parser_AST.range
@@ -4678,152 +4785,152 @@ and (desugar_comp :
                            else ());
                           FStar_Parser_Const.effect_Tot_lid)
                         in
-                     let uu____17756 =
-                       let uu____17763 =
+                     let uu____17959 =
+                       let uu____17966 =
                          FStar_Ident.set_lid_range default_effect
                            head.FStar_Parser_AST.range
                           in
-                       (uu____17763, [])  in
-                     (uu____17756, [(t1, FStar_Parser_AST.Nothing)])
-                 | uu____17786 ->
+                       (uu____17966, [])  in
+                     (uu____17959, [(t1, FStar_Parser_AST.Nothing)])
+                 | uu____17989 ->
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_EffectNotFound,
                          "Expected an effect constructor")
                        t1.FStar_Parser_AST.range)
              in
-          let uu____17805 = pre_process_comp_typ t  in
-          match uu____17805 with
+          let uu____18008 = pre_process_comp_typ t  in
+          match uu____18008 with
           | ((eff,cattributes),args) ->
               (if (FStar_List.length args) = Prims.int_zero
                then
-                 (let uu____17857 =
-                    let uu____17863 =
-                      let uu____17865 = FStar_Syntax_Print.lid_to_string eff
+                 (let uu____18060 =
+                    let uu____18066 =
+                      let uu____18068 = FStar_Syntax_Print.lid_to_string eff
                          in
                       FStar_Util.format1 "Not enough args to effect %s"
-                        uu____17865
+                        uu____18068
                        in
-                    (FStar_Errors.Fatal_NotEnoughArgsToEffect, uu____17863)
+                    (FStar_Errors.Fatal_NotEnoughArgsToEffect, uu____18066)
                      in
-                  fail uu____17857)
+                  fail uu____18060)
                else ();
-               (let is_universe uu____17881 =
-                  match uu____17881 with
-                  | (uu____17887,imp) -> imp = FStar_Parser_AST.UnivApp  in
-                let uu____17889 = FStar_Util.take is_universe args  in
-                match uu____17889 with
+               (let is_universe uu____18084 =
+                  match uu____18084 with
+                  | (uu____18090,imp) -> imp = FStar_Parser_AST.UnivApp  in
+                let uu____18092 = FStar_Util.take is_universe args  in
+                match uu____18092 with
                 | (universes,args1) ->
                     let universes1 =
                       FStar_List.map
-                        (fun uu____17948  ->
-                           match uu____17948 with
+                        (fun uu____18151  ->
+                           match uu____18151 with
                            | (u,imp) -> desugar_universe u) universes
                        in
-                    let uu____17955 =
-                      let uu____17970 = FStar_List.hd args1  in
-                      let uu____17979 = FStar_List.tl args1  in
-                      (uu____17970, uu____17979)  in
-                    (match uu____17955 with
+                    let uu____18158 =
+                      let uu____18173 = FStar_List.hd args1  in
+                      let uu____18182 = FStar_List.tl args1  in
+                      (uu____18173, uu____18182)  in
+                    (match uu____18158 with
                      | (result_arg,rest) ->
                          let result_typ =
                            desugar_typ env
                              (FStar_Pervasives_Native.fst result_arg)
                             in
                          let rest1 = desugar_args env rest  in
-                         let uu____18034 =
-                           let is_decrease uu____18073 =
-                             match uu____18073 with
-                             | (t1,uu____18084) ->
+                         let uu____18237 =
+                           let is_decrease uu____18276 =
+                             match uu____18276 with
+                             | (t1,uu____18287) ->
                                  (match t1.FStar_Syntax_Syntax.n with
                                   | FStar_Syntax_Syntax.Tm_app
                                       ({
                                          FStar_Syntax_Syntax.n =
                                            FStar_Syntax_Syntax.Tm_fvar fv;
                                          FStar_Syntax_Syntax.pos =
-                                           uu____18095;
+                                           uu____18298;
                                          FStar_Syntax_Syntax.vars =
-                                           uu____18096;_},uu____18097::[])
+                                           uu____18299;_},uu____18300::[])
                                       ->
                                       FStar_Syntax_Syntax.fv_eq_lid fv
                                         FStar_Parser_Const.decreases_lid
-                                  | uu____18136 -> false)
+                                  | uu____18339 -> false)
                               in
                            FStar_All.pipe_right rest1
                              (FStar_List.partition is_decrease)
                             in
-                         (match uu____18034 with
+                         (match uu____18237 with
                           | (dec,rest2) ->
                               let decreases_clause =
                                 FStar_All.pipe_right dec
                                   (FStar_List.map
-                                     (fun uu____18253  ->
-                                        match uu____18253 with
-                                        | (t1,uu____18263) ->
+                                     (fun uu____18456  ->
+                                        match uu____18456 with
+                                        | (t1,uu____18466) ->
                                             (match t1.FStar_Syntax_Syntax.n
                                              with
                                              | FStar_Syntax_Syntax.Tm_app
-                                                 (uu____18272,(arg,uu____18274)::[])
+                                                 (uu____18475,(arg,uu____18477)::[])
                                                  ->
                                                  FStar_Syntax_Syntax.DECREASES
                                                    arg
-                                             | uu____18313 ->
+                                             | uu____18516 ->
                                                  failwith "impos")))
                                  in
                               let no_additional_args =
                                 let is_empty l =
                                   match l with
                                   | [] -> true
-                                  | uu____18334 -> false  in
+                                  | uu____18537 -> false  in
                                 (((is_empty decreases_clause) &&
                                     (is_empty rest2))
                                    && (is_empty cattributes))
                                   && (is_empty universes1)
                                  in
-                              let uu____18346 =
+                              let uu____18549 =
                                 no_additional_args &&
                                   (FStar_Ident.lid_equals eff
                                      FStar_Parser_Const.effect_Tot_lid)
                                  in
-                              if uu____18346
+                              if uu____18549
                               then FStar_Syntax_Syntax.mk_Total result_typ
                               else
-                                (let uu____18353 =
+                                (let uu____18556 =
                                    no_additional_args &&
                                      (FStar_Ident.lid_equals eff
                                         FStar_Parser_Const.effect_GTot_lid)
                                     in
-                                 if uu____18353
+                                 if uu____18556
                                  then
                                    FStar_Syntax_Syntax.mk_GTotal result_typ
                                  else
                                    (let flags =
-                                      let uu____18363 =
+                                      let uu____18566 =
                                         FStar_Ident.lid_equals eff
                                           FStar_Parser_Const.effect_Lemma_lid
                                          in
-                                      if uu____18363
+                                      if uu____18566
                                       then [FStar_Syntax_Syntax.LEMMA]
                                       else
-                                        (let uu____18370 =
+                                        (let uu____18573 =
                                            FStar_Ident.lid_equals eff
                                              FStar_Parser_Const.effect_Tot_lid
                                             in
-                                         if uu____18370
+                                         if uu____18573
                                          then [FStar_Syntax_Syntax.TOTAL]
                                          else
-                                           (let uu____18377 =
+                                           (let uu____18580 =
                                               FStar_Ident.lid_equals eff
                                                 FStar_Parser_Const.effect_ML_lid
                                                in
-                                            if uu____18377
+                                            if uu____18580
                                             then
                                               [FStar_Syntax_Syntax.MLEFFECT]
                                             else
-                                              (let uu____18384 =
+                                              (let uu____18587 =
                                                  FStar_Ident.lid_equals eff
                                                    FStar_Parser_Const.effect_GTot_lid
                                                   in
-                                               if uu____18384
+                                               if uu____18587
                                                then
                                                  [FStar_Syntax_Syntax.SOMETRIVIAL]
                                                else [])))
@@ -4831,11 +4938,11 @@ and (desugar_comp :
                                     let flags1 =
                                       FStar_List.append flags cattributes  in
                                     let rest3 =
-                                      let uu____18405 =
+                                      let uu____18608 =
                                         FStar_Ident.lid_equals eff
                                           FStar_Parser_Const.effect_Lemma_lid
                                          in
-                                      if uu____18405
+                                      if uu____18608
                                       then
                                         match rest2 with
                                         | req::ens::(pat,aq)::[] ->
@@ -4854,13 +4961,13 @@ and (desugar_comp :
                                                       [FStar_Syntax_Syntax.U_zero]
                                                      in
                                                   let pattern =
-                                                    let uu____18496 =
+                                                    let uu____18699 =
                                                       FStar_Ident.set_lid_range
                                                         FStar_Parser_Const.pattern_lid
                                                         pat.FStar_Syntax_Syntax.pos
                                                        in
                                                     FStar_Syntax_Syntax.fvar
-                                                      uu____18496
+                                                      uu____18699
                                                       FStar_Syntax_Syntax.delta_constant
                                                       FStar_Pervasives_Native.None
                                                      in
@@ -4871,11 +4978,11 @@ and (desugar_comp :
                                                           FStar_Syntax_Syntax.imp_tag))]
                                                     FStar_Pervasives_Native.None
                                                     pat.FStar_Syntax_Syntax.pos
-                                              | uu____18517 -> pat  in
-                                            let uu____18518 =
-                                              let uu____18529 =
-                                                let uu____18540 =
-                                                  let uu____18549 =
+                                              | uu____18720 -> pat  in
+                                            let uu____18721 =
+                                              let uu____18732 =
+                                                let uu____18743 =
+                                                  let uu____18752 =
                                                     FStar_Syntax_Syntax.mk
                                                       (FStar_Syntax_Syntax.Tm_meta
                                                          (pat1,
@@ -4884,11 +4991,11 @@ and (desugar_comp :
                                                       FStar_Pervasives_Native.None
                                                       pat1.FStar_Syntax_Syntax.pos
                                                      in
-                                                  (uu____18549, aq)  in
-                                                [uu____18540]  in
-                                              ens :: uu____18529  in
-                                            req :: uu____18518
-                                        | uu____18590 -> rest2
+                                                  (uu____18752, aq)  in
+                                                [uu____18743]  in
+                                              ens :: uu____18732  in
+                                            req :: uu____18721
+                                        | uu____18793 -> rest2
                                       else rest2  in
                                     FStar_Syntax_Syntax.mk_Comp
                                       {
@@ -4914,50 +5021,50 @@ and (desugar_formula :
           f.FStar_Parser_AST.range
          in
       let setpos t =
-        let uu___2442_18625 = t  in
+        let uu___2414_18828 = t  in
         {
-          FStar_Syntax_Syntax.n = (uu___2442_18625.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___2414_18828.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (f.FStar_Parser_AST.range);
           FStar_Syntax_Syntax.vars =
-            (uu___2442_18625.FStar_Syntax_Syntax.vars)
+            (uu___2414_18828.FStar_Syntax_Syntax.vars)
         }  in
       let desugar_quant q b pats body =
         let tk =
           desugar_binder env
-            (let uu___2449_18679 = b  in
+            (let uu___2421_18882 = b  in
              {
-               FStar_Parser_AST.b = (uu___2449_18679.FStar_Parser_AST.b);
+               FStar_Parser_AST.b = (uu___2421_18882.FStar_Parser_AST.b);
                FStar_Parser_AST.brange =
-                 (uu___2449_18679.FStar_Parser_AST.brange);
+                 (uu___2421_18882.FStar_Parser_AST.brange);
                FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
                FStar_Parser_AST.aqual =
-                 (uu___2449_18679.FStar_Parser_AST.aqual)
+                 (uu___2421_18882.FStar_Parser_AST.aqual)
              })
            in
-        let with_pats env1 uu____18708 body1 =
-          match uu____18708 with
+        let with_pats env1 uu____18911 body1 =
+          match uu____18911 with
           | (names,pats1) ->
               (match (names, pats1) with
                | ([],[]) -> body1
-               | ([],uu____18754::uu____18755) ->
+               | ([],uu____18957::uu____18958) ->
                    failwith
                      "Impossible: Annotated pattern without binders in scope"
-               | uu____18773 ->
+               | uu____18976 ->
                    let names1 =
                      FStar_All.pipe_right names
                        (FStar_List.map
                           (fun i  ->
-                             let uu___2468_18800 =
+                             let uu___2440_19004 =
                                FStar_Syntax_DsEnv.fail_or2
                                  (FStar_Syntax_DsEnv.try_lookup_id env1) i
                                 in
+                             let uu____19005 = FStar_Ident.range_of_id i  in
                              {
                                FStar_Syntax_Syntax.n =
-                                 (uu___2468_18800.FStar_Syntax_Syntax.n);
-                               FStar_Syntax_Syntax.pos =
-                                 (i.FStar_Ident.idRange);
+                                 (uu___2440_19004.FStar_Syntax_Syntax.n);
+                               FStar_Syntax_Syntax.pos = uu____19005;
                                FStar_Syntax_Syntax.vars =
-                                 (uu___2468_18800.FStar_Syntax_Syntax.vars)
+                                 (uu___2440_19004.FStar_Syntax_Syntax.vars)
                              }))
                       in
                    let pats2 =
@@ -4967,12 +5074,12 @@ and (desugar_formula :
                              FStar_All.pipe_right es
                                (FStar_List.map
                                   (fun e  ->
-                                     let uu____18863 = desugar_term env1 e
+                                     let uu____19068 = desugar_term env1 e
                                         in
                                      FStar_All.pipe_left
                                        (arg_withimp_t
                                           FStar_Parser_AST.Nothing)
-                                       uu____18863))))
+                                       uu____19068))))
                       in
                    mk
                      (FStar_Syntax_Syntax.Tm_meta
@@ -4981,65 +5088,65 @@ and (desugar_formula :
            in
         match tk with
         | (FStar_Pervasives_Native.Some a,k) ->
-            let uu____18894 = FStar_Syntax_DsEnv.push_bv env a  in
-            (match uu____18894 with
+            let uu____19099 = FStar_Syntax_DsEnv.push_bv env a  in
+            (match uu____19099 with
              | (env1,a1) ->
                  let a2 =
-                   let uu___2481_18904 = a1  in
+                   let uu___2453_19109 = a1  in
                    {
                      FStar_Syntax_Syntax.ppname =
-                       (uu___2481_18904.FStar_Syntax_Syntax.ppname);
+                       (uu___2453_19109.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
-                       (uu___2481_18904.FStar_Syntax_Syntax.index);
+                       (uu___2453_19109.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort = k
                    }  in
                  let body1 = desugar_formula env1 body  in
                  let body2 = with_pats env1 pats body1  in
                  let body3 =
-                   let uu____18910 =
-                     let uu____18913 =
-                       let uu____18914 = FStar_Syntax_Syntax.mk_binder a2  in
-                       [uu____18914]  in
-                     no_annot_abs uu____18913 body2  in
-                   FStar_All.pipe_left setpos uu____18910  in
-                 let uu____18935 =
-                   let uu____18936 =
-                     let uu____18953 =
-                       let uu____18956 =
+                   let uu____19115 =
+                     let uu____19118 =
+                       let uu____19119 = FStar_Syntax_Syntax.mk_binder a2  in
+                       [uu____19119]  in
+                     no_annot_abs uu____19118 body2  in
+                   FStar_All.pipe_left setpos uu____19115  in
+                 let uu____19140 =
+                   let uu____19141 =
+                     let uu____19158 =
+                       let uu____19161 =
                          FStar_Ident.set_lid_range q
                            b.FStar_Parser_AST.brange
                           in
-                       FStar_Syntax_Syntax.fvar uu____18956
+                       FStar_Syntax_Syntax.fvar uu____19161
                          (FStar_Syntax_Syntax.Delta_constant_at_level
                             Prims.int_one) FStar_Pervasives_Native.None
                         in
-                     let uu____18958 =
-                       let uu____18969 = FStar_Syntax_Syntax.as_arg body3  in
-                       [uu____18969]  in
-                     (uu____18953, uu____18958)  in
-                   FStar_Syntax_Syntax.Tm_app uu____18936  in
-                 FStar_All.pipe_left mk uu____18935)
-        | uu____19008 -> failwith "impossible"  in
+                     let uu____19163 =
+                       let uu____19174 = FStar_Syntax_Syntax.as_arg body3  in
+                       [uu____19174]  in
+                     (uu____19158, uu____19163)  in
+                   FStar_Syntax_Syntax.Tm_app uu____19141  in
+                 FStar_All.pipe_left mk uu____19140)
+        | uu____19213 -> failwith "impossible"  in
       let push_quant q binders pats body =
         match binders with
         | b::b'::_rest ->
             let rest = b' :: _rest  in
             let body1 =
-              let uu____19073 = q (rest, pats, body)  in
-              let uu____19076 =
+              let uu____19278 = q (rest, pats, body)  in
+              let uu____19281 =
                 FStar_Range.union_ranges b'.FStar_Parser_AST.brange
                   body.FStar_Parser_AST.range
                  in
-              FStar_Parser_AST.mk_term uu____19073 uu____19076
+              FStar_Parser_AST.mk_term uu____19278 uu____19281
                 FStar_Parser_AST.Formula
                in
-            let uu____19077 = q ([b], ([], []), body1)  in
-            FStar_Parser_AST.mk_term uu____19077 f.FStar_Parser_AST.range
+            let uu____19282 = q ([b], ([], []), body1)  in
+            FStar_Parser_AST.mk_term uu____19282 f.FStar_Parser_AST.range
               FStar_Parser_AST.Formula
-        | uu____19088 -> failwith "impossible"  in
-      let uu____19092 =
-        let uu____19093 = unparen f  in uu____19093.FStar_Parser_AST.tm  in
-      match uu____19092 with
+        | uu____19293 -> failwith "impossible"  in
+      let uu____19297 =
+        let uu____19298 = unparen f  in uu____19298.FStar_Parser_AST.tm  in
+      match uu____19297 with
       | FStar_Parser_AST.Labeled (f1,l,p) ->
           let f2 = desugar_formula env f1  in
           FStar_All.pipe_left mk
@@ -5047,30 +5154,30 @@ and (desugar_formula :
                (f2,
                  (FStar_Syntax_Syntax.Meta_labeled
                     (l, (f2.FStar_Syntax_Syntax.pos), p))))
-      | FStar_Parser_AST.QForall ([],uu____19106,uu____19107) ->
+      | FStar_Parser_AST.QForall ([],uu____19311,uu____19312) ->
           failwith "Impossible: Quantifier without binders"
-      | FStar_Parser_AST.QExists ([],uu____19131,uu____19132) ->
+      | FStar_Parser_AST.QExists ([],uu____19336,uu____19337) ->
           failwith "Impossible: Quantifier without binders"
       | FStar_Parser_AST.QForall (_1::_2::_3,pats,body) ->
           let binders = _1 :: _2 :: _3  in
-          let uu____19188 =
+          let uu____19393 =
             push_quant (fun x  -> FStar_Parser_AST.QForall x) binders pats
               body
              in
-          desugar_formula env uu____19188
+          desugar_formula env uu____19393
       | FStar_Parser_AST.QExists (_1::_2::_3,pats,body) ->
           let binders = _1 :: _2 :: _3  in
-          let uu____19232 =
+          let uu____19437 =
             push_quant (fun x  -> FStar_Parser_AST.QExists x) binders pats
               body
              in
-          desugar_formula env uu____19232
+          desugar_formula env uu____19437
       | FStar_Parser_AST.QForall (b::[],pats,body) ->
           desugar_quant FStar_Parser_Const.forall_lid b pats body
       | FStar_Parser_AST.QExists (b::[],pats,body) ->
           desugar_quant FStar_Parser_Const.exists_lid b pats body
       | FStar_Parser_AST.Paren f1 -> failwith "impossible"
-      | uu____19296 -> desugar_term env f
+      | uu____19501 -> desugar_term env f
 
 and (desugar_binder :
   FStar_Syntax_DsEnv.env ->
@@ -5082,21 +5189,22 @@ and (desugar_binder :
     fun b  ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.TAnnotated (x,t) ->
-          let uu____19307 = desugar_typ env t  in
-          ((FStar_Pervasives_Native.Some x), uu____19307)
+          let uu____19512 = desugar_typ env t  in
+          ((FStar_Pervasives_Native.Some x), uu____19512)
       | FStar_Parser_AST.Annotated (x,t) ->
-          let uu____19312 = desugar_typ env t  in
-          ((FStar_Pervasives_Native.Some x), uu____19312)
+          let uu____19517 = desugar_typ env t  in
+          ((FStar_Pervasives_Native.Some x), uu____19517)
       | FStar_Parser_AST.TVariable x ->
-          let uu____19316 =
+          let uu____19521 =
+            let uu____19522 = FStar_Ident.range_of_id x  in
             FStar_Syntax_Syntax.mk
               (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)
-              FStar_Pervasives_Native.None x.FStar_Ident.idRange
+              FStar_Pervasives_Native.None uu____19522
              in
-          ((FStar_Pervasives_Native.Some x), uu____19316)
+          ((FStar_Pervasives_Native.Some x), uu____19521)
       | FStar_Parser_AST.NoName t ->
-          let uu____19320 = desugar_typ env t  in
-          (FStar_Pervasives_Native.None, uu____19320)
+          let uu____19526 = desugar_typ env t  in
+          (FStar_Pervasives_Native.None, uu____19526)
       | FStar_Parser_AST.Variable x ->
           ((FStar_Pervasives_Native.Some x), FStar_Syntax_Syntax.tun)
 
@@ -5110,27 +5218,27 @@ and (as_binder :
   =
   fun env  ->
     fun imp  ->
-      fun uu___11_19328  ->
-        match uu___11_19328 with
+      fun uu___11_19534  ->
+        match uu___11_19534 with
         | (FStar_Pervasives_Native.None ,k) ->
-            let uu____19350 = FStar_Syntax_Syntax.null_binder k  in
-            (uu____19350, env)
+            let uu____19556 = FStar_Syntax_Syntax.null_binder k  in
+            (uu____19556, env)
         | (FStar_Pervasives_Native.Some a,k) ->
-            let uu____19367 = FStar_Syntax_DsEnv.push_bv env a  in
-            (match uu____19367 with
+            let uu____19573 = FStar_Syntax_DsEnv.push_bv env a  in
+            (match uu____19573 with
              | (env1,a1) ->
-                 let uu____19384 =
-                   let uu____19391 = trans_aqual env1 imp  in
-                   ((let uu___2581_19397 = a1  in
+                 let uu____19590 =
+                   let uu____19597 = trans_aqual env1 imp  in
+                   ((let uu___2553_19603 = a1  in
                      {
                        FStar_Syntax_Syntax.ppname =
-                         (uu___2581_19397.FStar_Syntax_Syntax.ppname);
+                         (uu___2553_19603.FStar_Syntax_Syntax.ppname);
                        FStar_Syntax_Syntax.index =
-                         (uu___2581_19397.FStar_Syntax_Syntax.index);
+                         (uu___2553_19603.FStar_Syntax_Syntax.index);
                        FStar_Syntax_Syntax.sort = k
-                     }), uu____19391)
+                     }), uu____19597)
                     in
-                 (uu____19384, env1))
+                 (uu____19590, env1))
 
 and (trans_aqual :
   env_t ->
@@ -5138,17 +5246,17 @@ and (trans_aqual :
       FStar_Syntax_Syntax.aqual)
   =
   fun env  ->
-    fun uu___12_19405  ->
-      match uu___12_19405 with
+    fun uu___12_19611  ->
+      match uu___12_19611 with
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit ) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.imp_tag
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Equality ) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Equality
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta t) ->
-          let uu____19409 =
-            let uu____19410 = desugar_term env t  in
-            FStar_Syntax_Syntax.Meta uu____19410  in
-          FStar_Pervasives_Native.Some uu____19409
+          let uu____19615 =
+            let uu____19616 = desugar_term env t  in
+            FStar_Syntax_Syntax.Meta uu____19616  in
+          FStar_Pervasives_Native.Some uu____19615
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
 
 let (typars_of_binders :
@@ -5159,55 +5267,55 @@ let (typars_of_binders :
   =
   fun env  ->
     fun bs  ->
-      let uu____19438 =
+      let uu____19644 =
         FStar_List.fold_left
-          (fun uu____19471  ->
+          (fun uu____19677  ->
              fun b  ->
-               match uu____19471 with
+               match uu____19677 with
                | (env1,out) ->
                    let tk =
                      desugar_binder env1
-                       (let uu___2599_19515 = b  in
+                       (let uu___2571_19721 = b  in
                         {
                           FStar_Parser_AST.b =
-                            (uu___2599_19515.FStar_Parser_AST.b);
+                            (uu___2571_19721.FStar_Parser_AST.b);
                           FStar_Parser_AST.brange =
-                            (uu___2599_19515.FStar_Parser_AST.brange);
+                            (uu___2571_19721.FStar_Parser_AST.brange);
                           FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
                           FStar_Parser_AST.aqual =
-                            (uu___2599_19515.FStar_Parser_AST.aqual)
+                            (uu___2571_19721.FStar_Parser_AST.aqual)
                         })
                       in
                    (match tk with
                     | (FStar_Pervasives_Native.Some a,k) ->
-                        let uu____19530 = FStar_Syntax_DsEnv.push_bv env1 a
+                        let uu____19736 = FStar_Syntax_DsEnv.push_bv env1 a
                            in
-                        (match uu____19530 with
+                        (match uu____19736 with
                          | (env2,a1) ->
                              let a2 =
-                               let uu___2609_19548 = a1  in
+                               let uu___2581_19754 = a1  in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___2609_19548.FStar_Syntax_Syntax.ppname);
+                                   (uu___2581_19754.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___2609_19548.FStar_Syntax_Syntax.index);
+                                   (uu___2581_19754.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = k
                                }  in
-                             let uu____19549 =
-                               let uu____19556 =
-                                 let uu____19561 =
+                             let uu____19755 =
+                               let uu____19762 =
+                                 let uu____19767 =
                                    trans_aqual env2 b.FStar_Parser_AST.aqual
                                     in
-                                 (a2, uu____19561)  in
-                               uu____19556 :: out  in
-                             (env2, uu____19549))
-                    | uu____19572 ->
+                                 (a2, uu____19767)  in
+                               uu____19762 :: out  in
+                             (env2, uu____19755))
+                    | uu____19778 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_UnexpectedBinder,
                             "Unexpected binder") b.FStar_Parser_AST.brange))
           (env, []) bs
          in
-      match uu____19438 with | (env1,tpars) -> (env1, (FStar_List.rev tpars))
+      match uu____19644 with | (env1,tpars) -> (env1, (FStar_List.rev tpars))
   
 let (desugar_attributes :
   env_t ->
@@ -5216,20 +5324,19 @@ let (desugar_attributes :
   fun env  ->
     fun cattributes  ->
       let desugar_attribute t =
-        let uu____19660 =
-          let uu____19661 = unparen t  in uu____19661.FStar_Parser_AST.tm  in
-        match uu____19660 with
-        | FStar_Parser_AST.Var
-            { FStar_Ident.ns = uu____19662; FStar_Ident.ident = uu____19663;
-              FStar_Ident.nsstr = uu____19664; FStar_Ident.str = "cps";_}
-            -> FStar_Syntax_Syntax.CPS
-        | uu____19669 ->
-            let uu____19670 =
-              let uu____19676 =
-                let uu____19678 = FStar_Parser_AST.term_to_string t  in
-                Prims.op_Hat "Unknown attribute " uu____19678  in
-              (FStar_Errors.Fatal_UnknownAttribute, uu____19676)  in
-            FStar_Errors.raise_error uu____19670 t.FStar_Parser_AST.range
+        let uu____19866 =
+          let uu____19867 = unparen t  in uu____19867.FStar_Parser_AST.tm  in
+        match uu____19866 with
+        | FStar_Parser_AST.Var lid when
+            let uu____19869 = FStar_Ident.string_of_lid lid  in
+            uu____19869 = "cps" -> FStar_Syntax_Syntax.CPS
+        | uu____19873 ->
+            let uu____19874 =
+              let uu____19880 =
+                let uu____19882 = FStar_Parser_AST.term_to_string t  in
+                Prims.op_Hat "Unknown attribute " uu____19882  in
+              (FStar_Errors.Fatal_UnknownAttribute, uu____19880)  in
+            FStar_Errors.raise_error uu____19874 t.FStar_Parser_AST.range
          in
       FStar_List.map desugar_attribute cattributes
   
@@ -5238,21 +5345,21 @@ let (binder_ident :
   =
   fun b  ->
     match b.FStar_Parser_AST.b with
-    | FStar_Parser_AST.TAnnotated (x,uu____19695) ->
+    | FStar_Parser_AST.TAnnotated (x,uu____19899) ->
         FStar_Pervasives_Native.Some x
-    | FStar_Parser_AST.Annotated (x,uu____19697) ->
+    | FStar_Parser_AST.Annotated (x,uu____19901) ->
         FStar_Pervasives_Native.Some x
     | FStar_Parser_AST.TVariable x -> FStar_Pervasives_Native.Some x
     | FStar_Parser_AST.Variable x -> FStar_Pervasives_Native.Some x
-    | FStar_Parser_AST.NoName uu____19700 -> FStar_Pervasives_Native.None
+    | FStar_Parser_AST.NoName uu____19904 -> FStar_Pervasives_Native.None
   
 let (binder_idents :
   FStar_Parser_AST.binder Prims.list -> FStar_Ident.ident Prims.list) =
   fun bs  ->
     FStar_List.collect
       (fun b  ->
-         let uu____19718 = binder_ident b  in
-         FStar_Common.list_of_option uu____19718) bs
+         let uu____19922 = binder_ident b  in
+         FStar_Common.list_of_option uu____19922) bs
   
 let (mk_data_discriminators :
   FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -5265,28 +5372,28 @@ let (mk_data_discriminators :
         let quals1 =
           FStar_All.pipe_right quals
             (FStar_List.filter
-               (fun uu___13_19755  ->
-                  match uu___13_19755 with
+               (fun uu___13_19959  ->
+                  match uu___13_19959 with
                   | FStar_Syntax_Syntax.NoExtract  -> true
                   | FStar_Syntax_Syntax.Abstract  -> true
                   | FStar_Syntax_Syntax.Private  -> true
-                  | uu____19760 -> false))
+                  | uu____19964 -> false))
            in
         let quals2 q =
-          let uu____19774 =
-            (let uu____19778 = FStar_Syntax_DsEnv.iface env  in
-             Prims.op_Negation uu____19778) ||
+          let uu____19978 =
+            (let uu____19982 = FStar_Syntax_DsEnv.iface env  in
+             Prims.op_Negation uu____19982) ||
               (FStar_Syntax_DsEnv.admitted_iface env)
              in
-          if uu____19774
+          if uu____19978
           then FStar_List.append (FStar_Syntax_Syntax.Assumption :: q) quals1
           else FStar_List.append q quals1  in
         FStar_All.pipe_right datas
           (FStar_List.map
              (fun d  ->
                 let disc_name = FStar_Syntax_Util.mk_discriminator d  in
-                let uu____19795 = FStar_Ident.range_of_lid disc_name  in
-                let uu____19796 =
+                let uu____19999 = FStar_Ident.range_of_lid disc_name  in
+                let uu____20000 =
                   quals2
                     [FStar_Syntax_Syntax.OnlyName;
                     FStar_Syntax_Syntax.Discriminator d]
@@ -5295,8 +5402,8 @@ let (mk_data_discriminators :
                   FStar_Syntax_Syntax.sigel =
                     (FStar_Syntax_Syntax.Sig_declare_typ
                        (disc_name, [], FStar_Syntax_Syntax.tun));
-                  FStar_Syntax_Syntax.sigrng = uu____19795;
-                  FStar_Syntax_Syntax.sigquals = uu____19796;
+                  FStar_Syntax_Syntax.sigrng = uu____19999;
+                  FStar_Syntax_Syntax.sigquals = uu____20000;
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
                   FStar_Syntax_Syntax.sigattrs = [];
@@ -5317,31 +5424,31 @@ let (mk_indexed_projector_names :
         fun lid  ->
           fun fields  ->
             let p = FStar_Ident.range_of_lid lid  in
-            let uu____19836 =
+            let uu____20040 =
               FStar_All.pipe_right fields
                 (FStar_List.mapi
                    (fun i  ->
-                      fun uu____19872  ->
-                        match uu____19872 with
-                        | (x,uu____19883) ->
+                      fun uu____20076  ->
+                        match uu____20076 with
+                        | (x,uu____20087) ->
                             let field_name =
                               FStar_Syntax_Util.mk_field_projector_name lid x
                                 i
                                in
                             let only_decl =
-                              ((let uu____19893 =
+                              ((let uu____20097 =
                                   FStar_Syntax_DsEnv.current_module env  in
                                 FStar_Ident.lid_equals
-                                  FStar_Parser_Const.prims_lid uu____19893)
+                                  FStar_Parser_Const.prims_lid uu____20097)
                                  || (fvq <> FStar_Syntax_Syntax.Data_ctor))
                                 ||
-                                (let uu____19895 =
-                                   let uu____19897 =
+                                (let uu____20099 =
+                                   let uu____20101 =
                                      FStar_Syntax_DsEnv.current_module env
                                       in
-                                   uu____19897.FStar_Ident.str  in
+                                   FStar_Ident.string_of_lid uu____20101  in
                                  FStar_Options.dont_gen_projectors
-                                   uu____19895)
+                                   uu____20099)
                                in
                             let no_decl =
                               FStar_Syntax_Syntax.is_type
@@ -5350,29 +5457,29 @@ let (mk_indexed_projector_names :
                             let quals q =
                               if only_decl
                               then
-                                let uu____19915 =
+                                let uu____20119 =
                                   FStar_List.filter
-                                    (fun uu___14_19919  ->
-                                       match uu___14_19919 with
+                                    (fun uu___14_20123  ->
+                                       match uu___14_20123 with
                                        | FStar_Syntax_Syntax.Abstract  ->
                                            false
-                                       | uu____19922 -> true) q
+                                       | uu____20126 -> true) q
                                    in
-                                FStar_Syntax_Syntax.Assumption :: uu____19915
+                                FStar_Syntax_Syntax.Assumption :: uu____20119
                               else q  in
                             let quals1 =
                               let iquals1 =
                                 FStar_All.pipe_right iquals
                                   (FStar_List.filter
-                                     (fun uu___15_19937  ->
-                                        match uu___15_19937 with
+                                     (fun uu___15_20141  ->
+                                        match uu___15_20141 with
                                         | FStar_Syntax_Syntax.NoExtract  ->
                                             true
                                         | FStar_Syntax_Syntax.Abstract  ->
                                             true
                                         | FStar_Syntax_Syntax.Private  ->
                                             true
-                                        | uu____19942 -> false))
+                                        | uu____20146 -> false))
                                  in
                               quals (FStar_Syntax_Syntax.OnlyName ::
                                 (FStar_Syntax_Syntax.Projector
@@ -5380,14 +5487,14 @@ let (mk_indexed_projector_names :
                                 iquals1)
                                in
                             let decl =
-                              let uu____19945 =
+                              let uu____20149 =
                                 FStar_Ident.range_of_lid field_name  in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_declare_typ
                                      (field_name, [],
                                        FStar_Syntax_Syntax.tun));
-                                FStar_Syntax_Syntax.sigrng = uu____19945;
+                                FStar_Syntax_Syntax.sigrng = uu____20149;
                                 FStar_Syntax_Syntax.sigquals = quals1;
                                 FStar_Syntax_Syntax.sigmeta =
                                   FStar_Syntax_Syntax.default_sigmeta;
@@ -5399,12 +5506,12 @@ let (mk_indexed_projector_names :
                             then [decl]
                             else
                               (let dd =
-                                 let uu____19952 =
+                                 let uu____20156 =
                                    FStar_All.pipe_right quals1
                                      (FStar_List.contains
                                         FStar_Syntax_Syntax.Abstract)
                                     in
-                                 if uu____19952
+                                 if uu____20156
                                  then
                                    FStar_Syntax_Syntax.Delta_abstract
                                      (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -5414,14 +5521,14 @@ let (mk_indexed_projector_names :
                                      Prims.int_one
                                   in
                                let lb =
-                                 let uu____19963 =
-                                   let uu____19968 =
+                                 let uu____20167 =
+                                   let uu____20172 =
                                      FStar_Syntax_Syntax.lid_as_fv field_name
                                        dd FStar_Pervasives_Native.None
                                       in
-                                   FStar_Util.Inr uu____19968  in
+                                   FStar_Util.Inr uu____20172  in
                                  {
-                                   FStar_Syntax_Syntax.lbname = uu____19963;
+                                   FStar_Syntax_Syntax.lbname = uu____20167;
                                    FStar_Syntax_Syntax.lbunivs = [];
                                    FStar_Syntax_Syntax.lbtyp =
                                      FStar_Syntax_Syntax.tun;
@@ -5434,25 +5541,25 @@ let (mk_indexed_projector_names :
                                      FStar_Range.dummyRange
                                  }  in
                                let impl =
-                                 let uu____19972 =
-                                   let uu____19973 =
-                                     let uu____19980 =
-                                       let uu____19983 =
-                                         let uu____19984 =
+                                 let uu____20176 =
+                                   let uu____20177 =
+                                     let uu____20184 =
+                                       let uu____20187 =
+                                         let uu____20188 =
                                            FStar_All.pipe_right
                                              lb.FStar_Syntax_Syntax.lbname
                                              FStar_Util.right
                                             in
-                                         FStar_All.pipe_right uu____19984
+                                         FStar_All.pipe_right uu____20188
                                            (fun fv  ->
                                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                                           in
-                                       [uu____19983]  in
-                                     ((false, [lb]), uu____19980)  in
-                                   FStar_Syntax_Syntax.Sig_let uu____19973
+                                       [uu____20187]  in
+                                     ((false, [lb]), uu____20184)  in
+                                   FStar_Syntax_Syntax.Sig_let uu____20177
                                     in
                                  {
-                                   FStar_Syntax_Syntax.sigel = uu____19972;
+                                   FStar_Syntax_Syntax.sigel = uu____20176;
                                    FStar_Syntax_Syntax.sigrng = p;
                                    FStar_Syntax_Syntax.sigquals = quals1;
                                    FStar_Syntax_Syntax.sigmeta =
@@ -5463,7 +5570,7 @@ let (mk_indexed_projector_names :
                                  }  in
                                if no_decl then [impl] else [decl; impl])))
                in
-            FStar_All.pipe_right uu____19836 FStar_List.flatten
+            FStar_All.pipe_right uu____20040 FStar_List.flatten
   
 let (mk_data_projector_names :
   FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -5475,29 +5582,29 @@ let (mk_data_projector_names :
       fun se  ->
         match se.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_datacon
-            (lid,uu____20033,t,uu____20035,n,uu____20037) when
-            let uu____20044 =
+            (lid,uu____20237,t,uu____20239,n,uu____20241) when
+            let uu____20248 =
               FStar_Ident.lid_equals lid FStar_Parser_Const.lexcons_lid  in
-            Prims.op_Negation uu____20044 ->
-            let uu____20046 = FStar_Syntax_Util.arrow_formals t  in
-            (match uu____20046 with
-             | (formals,uu____20056) ->
+            Prims.op_Negation uu____20248 ->
+            let uu____20250 = FStar_Syntax_Util.arrow_formals t  in
+            (match uu____20250 with
+             | (formals,uu____20260) ->
                  (match formals with
                   | [] -> []
-                  | uu____20069 ->
-                      let filter_records uu___16_20077 =
-                        match uu___16_20077 with
+                  | uu____20273 ->
+                      let filter_records uu___16_20281 =
+                        match uu___16_20281 with
                         | FStar_Syntax_Syntax.RecordConstructor
-                            (uu____20080,fns) ->
+                            (uu____20284,fns) ->
                             FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Record_ctor (lid, fns))
-                        | uu____20092 -> FStar_Pervasives_Native.None  in
+                        | uu____20296 -> FStar_Pervasives_Native.None  in
                       let fv_qual =
-                        let uu____20094 =
+                        let uu____20298 =
                           FStar_Util.find_map se.FStar_Syntax_Syntax.sigquals
                             filter_records
                            in
-                        match uu____20094 with
+                        match uu____20298 with
                         | FStar_Pervasives_Native.None  ->
                             FStar_Syntax_Syntax.Data_ctor
                         | FStar_Pervasives_Native.Some q -> q  in
@@ -5511,12 +5618,12 @@ let (mk_data_projector_names :
                                   FStar_Syntax_Syntax.Private iquals))
                         then FStar_Syntax_Syntax.Private :: iquals
                         else iquals  in
-                      let uu____20106 = FStar_Util.first_N n formals  in
-                      (match uu____20106 with
-                       | (uu____20135,rest) ->
+                      let uu____20310 = FStar_Util.first_N n formals  in
+                      (match uu____20310 with
+                       | (uu____20339,rest) ->
                            mk_indexed_projector_names iquals1 fv_qual env lid
                              rest)))
-        | uu____20169 -> []
+        | uu____20373 -> []
   
 let (mk_typ_abbrev :
   FStar_Syntax_DsEnv.env ->
@@ -5546,48 +5653,48 @@ let (mk_typ_abbrev :
                           d.FStar_Parser_AST.attrs
                          in
                       let val_attrs =
-                        let uu____20263 =
+                        let uu____20467 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env lid
                            in
-                        FStar_All.pipe_right uu____20263
+                        FStar_All.pipe_right uu____20467
                           FStar_Pervasives_Native.snd
                          in
                       let dd =
-                        let uu____20287 =
+                        let uu____20491 =
                           FStar_All.pipe_right quals
                             (FStar_List.contains FStar_Syntax_Syntax.Abstract)
                            in
-                        if uu____20287
+                        if uu____20491
                         then
-                          let uu____20293 =
+                          let uu____20497 =
                             FStar_Syntax_Util.incr_delta_qualifier t  in
-                          FStar_Syntax_Syntax.Delta_abstract uu____20293
+                          FStar_Syntax_Syntax.Delta_abstract uu____20497
                         else FStar_Syntax_Util.incr_delta_qualifier t  in
                       let lb =
-                        let uu____20297 =
-                          let uu____20302 =
+                        let uu____20501 =
+                          let uu____20506 =
                             FStar_Syntax_Syntax.lid_as_fv lid dd
                               FStar_Pervasives_Native.None
                              in
-                          FStar_Util.Inr uu____20302  in
-                        let uu____20303 =
+                          FStar_Util.Inr uu____20506  in
+                        let uu____20507 =
                           if FStar_Util.is_some kopt
                           then
-                            let uu____20309 =
-                              let uu____20312 =
+                            let uu____20513 =
+                              let uu____20516 =
                                 FStar_All.pipe_right kopt FStar_Util.must  in
-                              FStar_Syntax_Syntax.mk_Total uu____20312  in
-                            FStar_Syntax_Util.arrow typars uu____20309
+                              FStar_Syntax_Syntax.mk_Total uu____20516  in
+                            FStar_Syntax_Util.arrow typars uu____20513
                           else FStar_Syntax_Syntax.tun  in
-                        let uu____20317 = no_annot_abs typars t  in
+                        let uu____20521 = no_annot_abs typars t  in
                         {
-                          FStar_Syntax_Syntax.lbname = uu____20297;
+                          FStar_Syntax_Syntax.lbname = uu____20501;
                           FStar_Syntax_Syntax.lbunivs = uvs;
-                          FStar_Syntax_Syntax.lbtyp = uu____20303;
+                          FStar_Syntax_Syntax.lbtyp = uu____20507;
                           FStar_Syntax_Syntax.lbeff =
                             FStar_Parser_Const.effect_Tot_lid;
-                          FStar_Syntax_Syntax.lbdef = uu____20317;
+                          FStar_Syntax_Syntax.lbdef = uu____20521;
                           FStar_Syntax_Syntax.lbattrs = [];
                           FStar_Syntax_Syntax.lbpos = rng
                         }  in
@@ -5616,37 +5723,41 @@ let rec (desugar_tycon :
       fun quals  ->
         fun tcs  ->
           let rng = d.FStar_Parser_AST.drange  in
-          let tycon_id uu___17_20371 =
-            match uu___17_20371 with
-            | FStar_Parser_AST.TyconAbstract (id,uu____20373,uu____20374) ->
+          let tycon_id uu___17_20575 =
+            match uu___17_20575 with
+            | FStar_Parser_AST.TyconAbstract (id,uu____20577,uu____20578) ->
                 id
             | FStar_Parser_AST.TyconAbbrev
-                (id,uu____20384,uu____20385,uu____20386) -> id
+                (id,uu____20588,uu____20589,uu____20590) -> id
             | FStar_Parser_AST.TyconRecord
-                (id,uu____20396,uu____20397,uu____20398) -> id
+                (id,uu____20600,uu____20601,uu____20602) -> id
             | FStar_Parser_AST.TyconVariant
-                (id,uu____20420,uu____20421,uu____20422) -> id
+                (id,uu____20624,uu____20625,uu____20626) -> id
              in
           let binder_to_term b =
             match b.FStar_Parser_AST.b with
-            | FStar_Parser_AST.Annotated (x,uu____20460) ->
-                let uu____20461 =
-                  let uu____20462 = FStar_Ident.lid_of_ids [x]  in
-                  FStar_Parser_AST.Var uu____20462  in
-                FStar_Parser_AST.mk_term uu____20461 x.FStar_Ident.idRange
+            | FStar_Parser_AST.Annotated (x,uu____20664) ->
+                let uu____20665 =
+                  let uu____20666 = FStar_Ident.lid_of_ids [x]  in
+                  FStar_Parser_AST.Var uu____20666  in
+                let uu____20667 = FStar_Ident.range_of_id x  in
+                FStar_Parser_AST.mk_term uu____20665 uu____20667
                   FStar_Parser_AST.Expr
             | FStar_Parser_AST.Variable x ->
-                let uu____20464 =
-                  let uu____20465 = FStar_Ident.lid_of_ids [x]  in
-                  FStar_Parser_AST.Var uu____20465  in
-                FStar_Parser_AST.mk_term uu____20464 x.FStar_Ident.idRange
+                let uu____20669 =
+                  let uu____20670 = FStar_Ident.lid_of_ids [x]  in
+                  FStar_Parser_AST.Var uu____20670  in
+                let uu____20671 = FStar_Ident.range_of_id x  in
+                FStar_Parser_AST.mk_term uu____20669 uu____20671
                   FStar_Parser_AST.Expr
-            | FStar_Parser_AST.TAnnotated (a,uu____20467) ->
+            | FStar_Parser_AST.TAnnotated (a,uu____20673) ->
+                let uu____20674 = FStar_Ident.range_of_id a  in
                 FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a)
-                  a.FStar_Ident.idRange FStar_Parser_AST.Type_level
+                  uu____20674 FStar_Parser_AST.Type_level
             | FStar_Parser_AST.TVariable a ->
+                let uu____20676 = FStar_Ident.range_of_id a  in
                 FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a)
-                  a.FStar_Ident.idRange FStar_Parser_AST.Type_level
+                  uu____20676 FStar_Parser_AST.Type_level
             | FStar_Parser_AST.NoName t -> t  in
           let tot =
             FStar_Parser_AST.mk_term
@@ -5663,79 +5774,85 @@ let rec (desugar_tycon :
               match b.FStar_Parser_AST.aqual with
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit ) ->
                   FStar_Parser_AST.Hash
-              | uu____20498 -> FStar_Parser_AST.Nothing  in
+              | uu____20706 -> FStar_Parser_AST.Nothing  in
             FStar_List.fold_left
               (fun out  ->
                  fun b  ->
-                   let uu____20506 =
-                     let uu____20507 =
-                       let uu____20514 = binder_to_term b  in
-                       (out, uu____20514, (imp_of_aqual b))  in
-                     FStar_Parser_AST.App uu____20507  in
-                   FStar_Parser_AST.mk_term uu____20506
+                   let uu____20714 =
+                     let uu____20715 =
+                       let uu____20722 = binder_to_term b  in
+                       (out, uu____20722, (imp_of_aqual b))  in
+                     FStar_Parser_AST.App uu____20715  in
+                   FStar_Parser_AST.mk_term uu____20714
                      out.FStar_Parser_AST.range out.FStar_Parser_AST.level) t
               binders
              in
-          let tycon_record_as_variant uu___18_20526 =
-            match uu___18_20526 with
+          let tycon_record_as_variant uu___18_20734 =
+            match uu___18_20734 with
             | FStar_Parser_AST.TyconRecord (id,parms,kopt,fields) ->
                 let constrName =
-                  FStar_Ident.mk_ident
-                    ((Prims.op_Hat "Mk" id.FStar_Ident.idText),
-                      (id.FStar_Ident.idRange))
-                   in
+                  let uu____20766 =
+                    let uu____20772 =
+                      let uu____20774 = FStar_Ident.text_of_id id  in
+                      Prims.op_Hat "Mk" uu____20774  in
+                    let uu____20777 = FStar_Ident.range_of_id id  in
+                    (uu____20772, uu____20777)  in
+                  FStar_Ident.mk_ident uu____20766  in
                 let mfields =
                   FStar_List.map
-                    (fun uu____20570  ->
-                       match uu____20570 with
+                    (fun uu____20790  ->
+                       match uu____20790 with
                        | (x,t) ->
+                           let uu____20797 = FStar_Ident.range_of_id x  in
                            FStar_Parser_AST.mk_binder
-                             (FStar_Parser_AST.Annotated (x, t))
-                             x.FStar_Ident.idRange FStar_Parser_AST.Expr
+                             (FStar_Parser_AST.Annotated (x, t)) uu____20797
+                             FStar_Parser_AST.Expr
                              FStar_Pervasives_Native.None) fields
                    in
                 let result =
-                  let uu____20578 =
-                    let uu____20579 =
-                      let uu____20580 = FStar_Ident.lid_of_ids [id]  in
-                      FStar_Parser_AST.Var uu____20580  in
-                    FStar_Parser_AST.mk_term uu____20579
-                      id.FStar_Ident.idRange FStar_Parser_AST.Type_level
+                  let uu____20799 =
+                    let uu____20800 =
+                      let uu____20801 = FStar_Ident.lid_of_ids [id]  in
+                      FStar_Parser_AST.Var uu____20801  in
+                    let uu____20802 = FStar_Ident.range_of_id id  in
+                    FStar_Parser_AST.mk_term uu____20800 uu____20802
+                      FStar_Parser_AST.Type_level
                      in
-                  apply_binders uu____20578 parms  in
+                  apply_binders uu____20799 parms  in
                 let constrTyp =
+                  let uu____20804 = FStar_Ident.range_of_id id  in
                   FStar_Parser_AST.mk_term
                     (FStar_Parser_AST.Product
                        (mfields, (with_constructor_effect result)))
-                    id.FStar_Ident.idRange FStar_Parser_AST.Type_level
+                    uu____20804 FStar_Parser_AST.Type_level
                    in
                 let names =
-                  let uu____20587 = binder_idents parms  in id :: uu____20587
+                  let uu____20810 = binder_idents parms  in id :: uu____20810
                    in
                 (FStar_List.iter
-                   (fun uu____20600  ->
-                      match uu____20600 with
-                      | (f,uu____20606) ->
-                          let uu____20607 =
+                   (fun uu____20824  ->
+                      match uu____20824 with
+                      | (f,uu____20830) ->
+                          let uu____20831 =
                             FStar_Util.for_some
                               (fun i  -> FStar_Ident.ident_equals f i) names
                              in
-                          if uu____20607
+                          if uu____20831
                           then
-                            let uu____20612 =
-                              let uu____20618 =
-                                let uu____20620 =
-                                  FStar_Ident.string_of_ident f  in
+                            let uu____20836 =
+                              let uu____20842 =
+                                let uu____20844 = FStar_Ident.text_of_id f
+                                   in
                                 FStar_Util.format1
                                   "Field %s shadows the record's name or a parameter of it, please rename it"
-                                  uu____20620
+                                  uu____20844
                                  in
-                              (FStar_Errors.Error_FieldShadow, uu____20618)
+                              (FStar_Errors.Error_FieldShadow, uu____20842)
                                in
-                            FStar_Errors.raise_error uu____20612
-                              f.FStar_Ident.idRange
+                            let uu____20848 = FStar_Ident.range_of_id f  in
+                            FStar_Errors.raise_error uu____20836 uu____20848
                           else ()) fields;
-                 (let uu____20626 =
+                 (let uu____20851 =
                     FStar_All.pipe_right fields
                       (FStar_List.map FStar_Pervasives_Native.fst)
                      in
@@ -5743,13 +5860,13 @@ let rec (desugar_tycon :
                       (id, parms, kopt,
                         [(constrName,
                            (FStar_Pervasives_Native.Some constrTyp), false)])),
-                    uu____20626)))
-            | uu____20680 -> failwith "impossible"  in
-          let desugar_abstract_tc quals1 _env mutuals uu___19_20720 =
-            match uu___19_20720 with
+                    uu____20851)))
+            | uu____20905 -> failwith "impossible"  in
+          let desugar_abstract_tc quals1 _env mutuals uu___19_20945 =
+            match uu___19_20945 with
             | FStar_Parser_AST.TyconAbstract (id,binders,kopt) ->
-                let uu____20744 = typars_of_binders _env binders  in
-                (match uu____20744 with
+                let uu____20969 = typars_of_binders _env binders  in
+                (match uu____20969 with
                  | (_env',typars) ->
                      let k =
                        match kopt with
@@ -5759,14 +5876,15 @@ let rec (desugar_tycon :
                            desugar_term _env' k
                         in
                      let tconstr =
-                       let uu____20780 =
-                         let uu____20781 =
-                           let uu____20782 = FStar_Ident.lid_of_ids [id]  in
-                           FStar_Parser_AST.Var uu____20782  in
-                         FStar_Parser_AST.mk_term uu____20781
-                           id.FStar_Ident.idRange FStar_Parser_AST.Type_level
+                       let uu____21005 =
+                         let uu____21006 =
+                           let uu____21007 = FStar_Ident.lid_of_ids [id]  in
+                           FStar_Parser_AST.Var uu____21007  in
+                         let uu____21008 = FStar_Ident.range_of_id id  in
+                         FStar_Parser_AST.mk_term uu____21006 uu____21008
+                           FStar_Parser_AST.Type_level
                           in
-                       apply_binders uu____20780 binders  in
+                       apply_binders uu____21005 binders  in
                      let qlid = FStar_Syntax_DsEnv.qualify _env id  in
                      let typars1 = FStar_Syntax_Subst.close_binders typars
                         in
@@ -5784,53 +5902,55 @@ let rec (desugar_tycon :
                          FStar_Syntax_Syntax.sigopts =
                            FStar_Pervasives_Native.None
                        }  in
-                     let uu____20791 =
+                     let uu____21017 =
                        FStar_Syntax_DsEnv.push_top_level_rec_binding _env id
                          FStar_Syntax_Syntax.delta_constant
                         in
-                     (match uu____20791 with
-                      | (_env1,uu____20808) ->
-                          let uu____20815 =
+                     (match uu____21017 with
+                      | (_env1,uu____21034) ->
+                          let uu____21041 =
                             FStar_Syntax_DsEnv.push_top_level_rec_binding
                               _env' id FStar_Syntax_Syntax.delta_constant
                              in
-                          (match uu____20815 with
-                           | (_env2,uu____20832) ->
+                          (match uu____21041 with
+                           | (_env2,uu____21058) ->
                                (_env1, _env2, se, tconstr))))
-            | uu____20839 -> failwith "Unexpected tycon"  in
+            | uu____21065 -> failwith "Unexpected tycon"  in
           let push_tparams env1 bs =
-            let uu____20882 =
+            let uu____21108 =
               FStar_List.fold_left
-                (fun uu____20916  ->
-                   fun uu____20917  ->
-                     match (uu____20916, uu____20917) with
+                (fun uu____21142  ->
+                   fun uu____21143  ->
+                     match (uu____21142, uu____21143) with
                      | ((env2,tps),(x,imp)) ->
-                         let uu____20986 =
+                         let uu____21212 =
                            FStar_Syntax_DsEnv.push_bv env2
                              x.FStar_Syntax_Syntax.ppname
                             in
-                         (match uu____20986 with
+                         (match uu____21212 with
                           | (env3,y) -> (env3, ((y, imp) :: tps))))
                 (env1, []) bs
                in
-            match uu____20882 with
+            match uu____21108 with
             | (env2,bs1) -> (env2, (FStar_List.rev bs1))  in
           match tcs with
           | (FStar_Parser_AST.TyconAbstract (id,bs,kopt))::[] ->
               let kopt1 =
                 match kopt with
                 | FStar_Pervasives_Native.None  ->
-                    let uu____21077 = tm_type_z id.FStar_Ident.idRange  in
-                    FStar_Pervasives_Native.Some uu____21077
-                | uu____21078 -> kopt  in
+                    let uu____21303 =
+                      let uu____21304 = FStar_Ident.range_of_id id  in
+                      tm_type_z uu____21304  in
+                    FStar_Pervasives_Native.Some uu____21303
+                | uu____21305 -> kopt  in
               let tc = FStar_Parser_AST.TyconAbstract (id, bs, kopt1)  in
-              let uu____21086 = desugar_abstract_tc quals env [] tc  in
-              (match uu____21086 with
-               | (uu____21099,uu____21100,se,uu____21102) ->
+              let uu____21313 = desugar_abstract_tc quals env [] tc  in
+              (match uu____21313 with
+               | (uu____21326,uu____21327,se,uu____21329) ->
                    let se1 =
                      match se.FStar_Syntax_Syntax.sigel with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (l,uu____21105,typars,k,[],[]) ->
+                         (l,uu____21332,typars,k,[],[]) ->
                          let quals1 = se.FStar_Syntax_Syntax.sigquals  in
                          let quals2 =
                            if
@@ -5838,25 +5958,25 @@ let rec (desugar_tycon :
                                FStar_Syntax_Syntax.Assumption quals1
                            then quals1
                            else
-                             ((let uu____21124 =
-                                 let uu____21126 = FStar_Options.ml_ish ()
+                             ((let uu____21351 =
+                                 let uu____21353 = FStar_Options.ml_ish ()
                                     in
-                                 Prims.op_Negation uu____21126  in
-                               if uu____21124
+                                 Prims.op_Negation uu____21353  in
+                               if uu____21351
                                then
-                                 let uu____21129 =
-                                   let uu____21135 =
-                                     let uu____21137 =
+                                 let uu____21356 =
+                                   let uu____21362 =
+                                     let uu____21364 =
                                        FStar_Syntax_Print.lid_to_string l  in
                                      FStar_Util.format1
                                        "Adding an implicit 'assume new' qualifier on %s"
-                                       uu____21137
+                                       uu____21364
                                       in
                                    (FStar_Errors.Warning_AddImplicitAssumeNewQualifier,
-                                     uu____21135)
+                                     uu____21362)
                                     in
                                  FStar_Errors.log_issue
-                                   se.FStar_Syntax_Syntax.sigrng uu____21129
+                                   se.FStar_Syntax_Syntax.sigrng uu____21356
                                else ());
                               FStar_Syntax_Syntax.Assumption
                               ::
@@ -5867,70 +5987,70 @@ let rec (desugar_tycon :
                          let t =
                            match typars with
                            | [] -> k
-                           | uu____21150 ->
-                               let uu____21151 =
-                                 let uu____21158 =
-                                   let uu____21159 =
-                                     let uu____21174 =
+                           | uu____21377 ->
+                               let uu____21378 =
+                                 let uu____21385 =
+                                   let uu____21386 =
+                                     let uu____21401 =
                                        FStar_Syntax_Syntax.mk_Total k  in
-                                     (typars, uu____21174)  in
-                                   FStar_Syntax_Syntax.Tm_arrow uu____21159
+                                     (typars, uu____21401)  in
+                                   FStar_Syntax_Syntax.Tm_arrow uu____21386
                                     in
-                                 FStar_Syntax_Syntax.mk uu____21158  in
-                               uu____21151 FStar_Pervasives_Native.None
+                                 FStar_Syntax_Syntax.mk uu____21385  in
+                               uu____21378 FStar_Pervasives_Native.None
                                  se.FStar_Syntax_Syntax.sigrng
                             in
-                         let uu___2890_21187 = se  in
+                         let uu___2858_21414 = se  in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_declare_typ (l, [], t));
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___2890_21187.FStar_Syntax_Syntax.sigrng);
+                             (uu___2858_21414.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals = quals2;
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___2890_21187.FStar_Syntax_Syntax.sigmeta);
+                             (uu___2858_21414.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___2890_21187.FStar_Syntax_Syntax.sigattrs);
+                             (uu___2858_21414.FStar_Syntax_Syntax.sigattrs);
                            FStar_Syntax_Syntax.sigopts =
-                             (uu___2890_21187.FStar_Syntax_Syntax.sigopts)
+                             (uu___2858_21414.FStar_Syntax_Syntax.sigopts)
                          }
-                     | uu____21188 -> failwith "Impossible"  in
+                     | uu____21415 -> failwith "Impossible"  in
                    let env1 = FStar_Syntax_DsEnv.push_sigelt env se1  in
                    (env1, [se1]))
           | (FStar_Parser_AST.TyconAbbrev (id,binders,kopt,t))::[] ->
-              let uu____21203 = typars_of_binders env binders  in
-              (match uu____21203 with
+              let uu____21430 = typars_of_binders env binders  in
+              (match uu____21430 with
                | (env',typars) ->
                    let kopt1 =
                      match kopt with
                      | FStar_Pervasives_Native.None  ->
-                         let uu____21237 =
+                         let uu____21464 =
                            FStar_Util.for_some
-                             (fun uu___20_21240  ->
-                                match uu___20_21240 with
+                             (fun uu___20_21467  ->
+                                match uu___20_21467 with
                                 | FStar_Syntax_Syntax.Effect  -> true
-                                | uu____21243 -> false) quals
+                                | uu____21470 -> false) quals
                             in
-                         if uu____21237
+                         if uu____21464
                          then
                            FStar_Pervasives_Native.Some
                              FStar_Syntax_Syntax.teff
                          else FStar_Pervasives_Native.None
                      | FStar_Pervasives_Native.Some k ->
-                         let uu____21251 = desugar_term env' k  in
-                         FStar_Pervasives_Native.Some uu____21251
+                         let uu____21478 = desugar_term env' k  in
+                         FStar_Pervasives_Native.Some uu____21478
                       in
                    let t0 = t  in
                    let quals1 =
-                     let uu____21256 =
+                     let uu____21483 =
                        FStar_All.pipe_right quals
                          (FStar_Util.for_some
-                            (fun uu___21_21262  ->
-                               match uu___21_21262 with
+                            (fun uu___21_21489  ->
+                               match uu___21_21489 with
                                | FStar_Syntax_Syntax.Logic  -> true
-                               | uu____21265 -> false))
+                               | uu____21492 -> false))
                         in
-                     if uu____21256
+                     if uu____21483
                      then quals
                      else
                        if
@@ -5940,40 +6060,40 @@ let rec (desugar_tycon :
                       in
                    let qlid = FStar_Syntax_DsEnv.qualify env id  in
                    let se =
-                     let uu____21279 =
+                     let uu____21506 =
                        FStar_All.pipe_right quals1
                          (FStar_List.contains FStar_Syntax_Syntax.Effect)
                         in
-                     if uu____21279
+                     if uu____21506
                      then
-                       let uu____21285 =
-                         let uu____21292 =
-                           let uu____21293 = unparen t  in
-                           uu____21293.FStar_Parser_AST.tm  in
-                         match uu____21292 with
+                       let uu____21512 =
+                         let uu____21519 =
+                           let uu____21520 = unparen t  in
+                           uu____21520.FStar_Parser_AST.tm  in
+                         match uu____21519 with
                          | FStar_Parser_AST.Construct (head,args) ->
-                             let uu____21314 =
+                             let uu____21541 =
                                match FStar_List.rev args with
-                               | (last_arg,uu____21344)::args_rev ->
-                                   let uu____21356 =
-                                     let uu____21357 = unparen last_arg  in
-                                     uu____21357.FStar_Parser_AST.tm  in
-                                   (match uu____21356 with
+                               | (last_arg,uu____21571)::args_rev ->
+                                   let uu____21583 =
+                                     let uu____21584 = unparen last_arg  in
+                                     uu____21584.FStar_Parser_AST.tm  in
+                                   (match uu____21583 with
                                     | FStar_Parser_AST.Attributes ts ->
                                         (ts, (FStar_List.rev args_rev))
-                                    | uu____21385 -> ([], args))
-                               | uu____21394 -> ([], args)  in
-                             (match uu____21314 with
+                                    | uu____21612 -> ([], args))
+                               | uu____21621 -> ([], args)  in
+                             (match uu____21541 with
                               | (cattributes,args1) ->
-                                  let uu____21433 =
+                                  let uu____21660 =
                                     desugar_attributes env cattributes  in
                                   ((FStar_Parser_AST.mk_term
                                       (FStar_Parser_AST.Construct
                                          (head, args1))
                                       t.FStar_Parser_AST.range
-                                      t.FStar_Parser_AST.level), uu____21433))
-                         | uu____21444 -> (t, [])  in
-                       match uu____21285 with
+                                      t.FStar_Parser_AST.level), uu____21660))
+                         | uu____21671 -> (t, [])  in
+                       match uu____21512 with
                        | (t1,cattributes) ->
                            let c =
                              desugar_comp t1.FStar_Parser_AST.range false
@@ -5986,10 +6106,10 @@ let rec (desugar_tycon :
                            let quals2 =
                              FStar_All.pipe_right quals1
                                (FStar_List.filter
-                                  (fun uu___22_21467  ->
-                                     match uu___22_21467 with
+                                  (fun uu___22_21694  ->
+                                     match uu___22_21694 with
                                      | FStar_Syntax_Syntax.Effect  -> false
-                                     | uu____21470 -> true))
+                                     | uu____21697 -> true))
                               in
                            {
                              FStar_Syntax_Syntax.sigel =
@@ -6012,23 +6132,23 @@ let rec (desugar_tycon :
                       in
                    let env1 = FStar_Syntax_DsEnv.push_sigelt env se  in
                    (env1, [se]))
-          | (FStar_Parser_AST.TyconRecord uu____21478)::[] ->
+          | (FStar_Parser_AST.TyconRecord uu____21705)::[] ->
               let trec = FStar_List.hd tcs  in
-              let uu____21498 = tycon_record_as_variant trec  in
-              (match uu____21498 with
+              let uu____21725 = tycon_record_as_variant trec  in
+              (match uu____21725 with
                | (t,fs) ->
-                   let uu____21515 =
-                     let uu____21518 =
-                       let uu____21519 =
-                         let uu____21528 =
-                           let uu____21531 =
+                   let uu____21742 =
+                     let uu____21745 =
+                       let uu____21746 =
+                         let uu____21755 =
+                           let uu____21758 =
                              FStar_Syntax_DsEnv.current_module env  in
-                           FStar_Ident.ids_of_lid uu____21531  in
-                         (uu____21528, fs)  in
-                       FStar_Syntax_Syntax.RecordType uu____21519  in
-                     uu____21518 :: quals  in
-                   desugar_tycon env d uu____21515 [t])
-          | uu____21536::uu____21537 ->
+                           FStar_Ident.ids_of_lid uu____21758  in
+                         (uu____21755, fs)  in
+                       FStar_Syntax_Syntax.RecordType uu____21746  in
+                     uu____21745 :: quals  in
+                   desugar_tycon env d uu____21742 [t])
+          | uu____21763::uu____21764 ->
               let env0 = env  in
               let mutuals =
                 FStar_List.map
@@ -6037,90 +6157,90 @@ let rec (desugar_tycon :
                        (tycon_id x)) tcs
                  in
               let rec collect_tcs quals1 et tc =
-                let uu____21695 = et  in
-                match uu____21695 with
+                let uu____21922 = et  in
+                match uu____21922 with
                 | (env1,tcs1) ->
                     (match tc with
-                     | FStar_Parser_AST.TyconRecord uu____21905 ->
+                     | FStar_Parser_AST.TyconRecord uu____22132 ->
                          let trec = tc  in
-                         let uu____21925 = tycon_record_as_variant trec  in
-                         (match uu____21925 with
+                         let uu____22152 = tycon_record_as_variant trec  in
+                         (match uu____22152 with
                           | (t,fs) ->
-                              let uu____21981 =
-                                let uu____21984 =
-                                  let uu____21985 =
-                                    let uu____21994 =
-                                      let uu____21997 =
+                              let uu____22208 =
+                                let uu____22211 =
+                                  let uu____22212 =
+                                    let uu____22221 =
+                                      let uu____22224 =
                                         FStar_Syntax_DsEnv.current_module
                                           env1
                                          in
-                                      FStar_Ident.ids_of_lid uu____21997  in
-                                    (uu____21994, fs)  in
-                                  FStar_Syntax_Syntax.RecordType uu____21985
+                                      FStar_Ident.ids_of_lid uu____22224  in
+                                    (uu____22221, fs)  in
+                                  FStar_Syntax_Syntax.RecordType uu____22212
                                    in
-                                uu____21984 :: quals1  in
-                              collect_tcs uu____21981 (env1, tcs1) t)
+                                uu____22211 :: quals1  in
+                              collect_tcs uu____22208 (env1, tcs1) t)
                      | FStar_Parser_AST.TyconVariant
                          (id,binders,kopt,constructors) ->
-                         let uu____22075 =
+                         let uu____22302 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
                                 (id, binders, kopt))
                             in
-                         (match uu____22075 with
-                          | (env2,uu____22132,se,tconstr) ->
+                         (match uu____22302 with
+                          | (env2,uu____22359,se,tconstr) ->
                               (env2,
                                 ((FStar_Util.Inl
                                     (se, constructors, tconstr, quals1)) ::
                                 tcs1)))
                      | FStar_Parser_AST.TyconAbbrev (id,binders,kopt,t) ->
-                         let uu____22269 =
+                         let uu____22496 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
                                 (id, binders, kopt))
                             in
-                         (match uu____22269 with
-                          | (env2,uu____22326,se,tconstr) ->
+                         (match uu____22496 with
+                          | (env2,uu____22553,se,tconstr) ->
                               (env2,
                                 ((FStar_Util.Inr (se, binders, t, quals1)) ::
                                 tcs1)))
-                     | uu____22442 ->
+                     | uu____22669 ->
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_NonInductiveInMutuallyDefinedType,
                              "Mutually defined type contains a non-inductive element")
                            rng)
                  in
-              let uu____22488 =
+              let uu____22715 =
                 FStar_List.fold_left (collect_tcs quals) (env, []) tcs  in
-              (match uu____22488 with
+              (match uu____22715 with
                | (env1,tcs1) ->
                    let tcs2 = FStar_List.rev tcs1  in
                    let tps_sigelts =
                      FStar_All.pipe_right tcs2
                        (FStar_List.collect
-                          (fun uu___24_22940  ->
-                             match uu___24_22940 with
+                          (fun uu___24_23167  ->
+                             match uu___24_23167 with
                              | FStar_Util.Inr
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (id,uvs,tpars,k,uu____22994,uu____22995);
-                                    FStar_Syntax_Syntax.sigrng = uu____22996;
+                                      (id,uvs,tpars,k,uu____23221,uu____23222);
+                                    FStar_Syntax_Syntax.sigrng = uu____23223;
                                     FStar_Syntax_Syntax.sigquals =
-                                      uu____22997;
-                                    FStar_Syntax_Syntax.sigmeta = uu____22998;
+                                      uu____23224;
+                                    FStar_Syntax_Syntax.sigmeta = uu____23225;
                                     FStar_Syntax_Syntax.sigattrs =
-                                      uu____22999;
-                                    FStar_Syntax_Syntax.sigopts = uu____23000;_},binders,t,quals1)
+                                      uu____23226;
+                                    FStar_Syntax_Syntax.sigopts = uu____23227;_},binders,t,quals1)
                                  ->
                                  let t1 =
-                                   let uu____23062 =
+                                   let uu____23289 =
                                      typars_of_binders env1 binders  in
-                                   match uu____23062 with
+                                   match uu____23289 with
                                    | (env2,tpars1) ->
-                                       let uu____23089 =
+                                       let uu____23316 =
                                          push_tparams env2 tpars1  in
-                                       (match uu____23089 with
+                                       (match uu____23316 with
                                         | (env_tps,tpars2) ->
                                             let t1 = desugar_typ env_tps t
                                                in
@@ -6131,26 +6251,26 @@ let rec (desugar_tycon :
                                             FStar_Syntax_Subst.close tpars3
                                               t1)
                                     in
-                                 let uu____23118 =
-                                   let uu____23129 =
+                                 let uu____23345 =
+                                   let uu____23356 =
                                      mk_typ_abbrev env1 d id uvs tpars
                                        (FStar_Pervasives_Native.Some k) t1
                                        [id] quals1 rng
                                       in
-                                   ([], uu____23129)  in
-                                 [uu____23118]
+                                   ([], uu____23356)  in
+                                 [uu____23345]
                              | FStar_Util.Inl
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (tname,univs,tpars,k,mutuals1,uu____23165);
-                                    FStar_Syntax_Syntax.sigrng = uu____23166;
+                                      (tname,univs,tpars,k,mutuals1,uu____23392);
+                                    FStar_Syntax_Syntax.sigrng = uu____23393;
                                     FStar_Syntax_Syntax.sigquals =
                                       tname_quals;
-                                    FStar_Syntax_Syntax.sigmeta = uu____23168;
+                                    FStar_Syntax_Syntax.sigmeta = uu____23395;
                                     FStar_Syntax_Syntax.sigattrs =
-                                      uu____23169;
-                                    FStar_Syntax_Syntax.sigopts = uu____23170;_},constrs,tconstr,quals1)
+                                      uu____23396;
+                                    FStar_Syntax_Syntax.sigopts = uu____23397;_},constrs,tconstr,quals1)
                                  ->
                                  let mk_tot t =
                                    let tot1 =
@@ -6167,15 +6287,15 @@ let rec (desugar_tycon :
                                      t.FStar_Parser_AST.level
                                     in
                                  let tycon = (tname, tpars, k)  in
-                                 let uu____23261 = push_tparams env1 tpars
+                                 let uu____23488 = push_tparams env1 tpars
                                     in
-                                 (match uu____23261 with
+                                 (match uu____23488 with
                                   | (env_tps,tps) ->
                                       let data_tpars =
                                         FStar_List.map
-                                          (fun uu____23320  ->
-                                             match uu____23320 with
-                                             | (x,uu____23332) ->
+                                          (fun uu____23547  ->
+                                             match uu____23547 with
+                                             | (x,uu____23559) ->
                                                  (x,
                                                    (FStar_Pervasives_Native.Some
                                                       (FStar_Syntax_Syntax.Implicit
@@ -6187,19 +6307,19 @@ let rec (desugar_tycon :
                                           d.FStar_Parser_AST.attrs
                                          in
                                       let val_attrs =
-                                        let uu____23343 =
+                                        let uu____23570 =
                                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                             env1 tname
                                            in
-                                        FStar_All.pipe_right uu____23343
+                                        FStar_All.pipe_right uu____23570
                                           FStar_Pervasives_Native.snd
                                          in
-                                      let uu____23366 =
-                                        let uu____23385 =
+                                      let uu____23593 =
+                                        let uu____23612 =
                                           FStar_All.pipe_right constrs
                                             (FStar_List.map
-                                               (fun uu____23462  ->
-                                                  match uu____23462 with
+                                               (fun uu____23689  ->
+                                                  match uu____23689 with
                                                   | (id,topt,of_notation) ->
                                                       let t =
                                                         if of_notation
@@ -6231,10 +6351,10 @@ let rec (desugar_tycon :
                                                                t -> t)
                                                          in
                                                       let t1 =
-                                                        let uu____23505 =
+                                                        let uu____23732 =
                                                           close env_tps t  in
                                                         desugar_term env_tps
-                                                          uu____23505
+                                                          uu____23732
                                                          in
                                                       let name =
                                                         FStar_Syntax_DsEnv.qualify
@@ -6245,54 +6365,54 @@ let rec (desugar_tycon :
                                                           tname_quals
                                                           (FStar_List.collect
                                                              (fun
-                                                                uu___23_23516
+                                                                uu___23_23743
                                                                  ->
-                                                                match uu___23_23516
+                                                                match uu___23_23743
                                                                 with
                                                                 | FStar_Syntax_Syntax.RecordType
                                                                     fns ->
                                                                     [
                                                                     FStar_Syntax_Syntax.RecordConstructor
                                                                     fns]
-                                                                | uu____23528
+                                                                | uu____23755
                                                                     -> []))
                                                          in
                                                       let ntps =
                                                         FStar_List.length
                                                           data_tpars
                                                          in
-                                                      let uu____23536 =
-                                                        let uu____23547 =
-                                                          let uu____23548 =
-                                                            let uu____23549 =
-                                                              let uu____23565
+                                                      let uu____23763 =
+                                                        let uu____23774 =
+                                                          let uu____23775 =
+                                                            let uu____23776 =
+                                                              let uu____23792
                                                                 =
-                                                                let uu____23566
+                                                                let uu____23793
                                                                   =
-                                                                  let uu____23569
+                                                                  let uu____23796
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Util.name_function_binders
                                                                      in
                                                                   FStar_Syntax_Syntax.mk_Total
-                                                                    uu____23569
+                                                                    uu____23796
                                                                    in
                                                                 FStar_Syntax_Util.arrow
                                                                   data_tpars
-                                                                  uu____23566
+                                                                  uu____23793
                                                                  in
                                                               (name, univs,
-                                                                uu____23565,
+                                                                uu____23792,
                                                                 tname, ntps,
                                                                 mutuals1)
                                                                in
                                                             FStar_Syntax_Syntax.Sig_datacon
-                                                              uu____23549
+                                                              uu____23776
                                                              in
                                                           {
                                                             FStar_Syntax_Syntax.sigel
-                                                              = uu____23548;
+                                                              = uu____23775;
                                                             FStar_Syntax_Syntax.sigrng
                                                               = rng;
                                                             FStar_Syntax_Syntax.sigquals
@@ -6309,14 +6429,14 @@ let rec (desugar_tycon :
                                                               =
                                                               FStar_Pervasives_Native.None
                                                           }  in
-                                                        (tps, uu____23547)
+                                                        (tps, uu____23774)
                                                          in
-                                                      (name, uu____23536)))
+                                                      (name, uu____23763)))
                                            in
                                         FStar_All.pipe_left FStar_List.split
-                                          uu____23385
+                                          uu____23612
                                          in
-                                      (match uu____23366 with
+                                      (match uu____23593 with
                                        | (constrNames,constrs1) ->
                                            ([],
                                              {
@@ -6337,23 +6457,23 @@ let rec (desugar_tycon :
                                                  FStar_Pervasives_Native.None
                                              })
                                            :: constrs1))
-                             | uu____23701 -> failwith "impossible"))
+                             | uu____23928 -> failwith "impossible"))
                       in
                    let sigelts =
                      FStar_All.pipe_right tps_sigelts
                        (FStar_List.map
-                          (fun uu____23782  ->
-                             match uu____23782 with | (uu____23793,se) -> se))
+                          (fun uu____24009  ->
+                             match uu____24009 with | (uu____24020,se) -> se))
                       in
-                   let uu____23807 =
-                     let uu____23814 =
+                   let uu____24034 =
+                     let uu____24041 =
                        FStar_List.collect FStar_Syntax_Util.lids_of_sigelt
                          sigelts
                         in
                      FStar_Syntax_MutRecTy.disentangle_abbrevs_from_bundle
-                       sigelts quals uu____23814 rng
+                       sigelts quals uu____24041 rng
                       in
-                   (match uu____23807 with
+                   (match uu____24034 with
                     | (bundle,abbrevs) ->
                         let env2 = FStar_Syntax_DsEnv.push_sigelt env0 bundle
                            in
@@ -6364,8 +6484,8 @@ let rec (desugar_tycon :
                         let data_ops =
                           FStar_All.pipe_right tps_sigelts
                             (FStar_List.collect
-                               (fun uu____23859  ->
-                                  match uu____23859 with
+                               (fun uu____24086  ->
+                                  match uu____24086 with
                                   | (tps,se) ->
                                       mk_data_projector_names quals env3 se))
                            in
@@ -6375,7 +6495,7 @@ let rec (desugar_tycon :
                                (fun se  ->
                                   match se.FStar_Syntax_Syntax.sigel with
                                   | FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (tname,uu____23907,tps,k,uu____23910,constrs)
+                                      (tname,uu____24134,tps,k,uu____24137,constrs)
                                       ->
                                       let quals1 =
                                         se.FStar_Syntax_Syntax.sigquals  in
@@ -6392,13 +6512,13 @@ let rec (desugar_tycon :
                                         then FStar_Syntax_Syntax.Private ::
                                           quals1
                                         else quals1  in
-                                      let uu____23931 =
+                                      let uu____24158 =
                                         FStar_All.pipe_right constrs
                                           (FStar_List.filter
                                              (fun data_lid  ->
                                                 let data_quals =
                                                   let data_se =
-                                                    let uu____23946 =
+                                                    let uu____24173 =
                                                       FStar_All.pipe_right
                                                         sigelts
                                                         (FStar_List.find
@@ -6406,38 +6526,38 @@ let rec (desugar_tycon :
                                                               match se1.FStar_Syntax_Syntax.sigel
                                                               with
                                                               | FStar_Syntax_Syntax.Sig_datacon
-                                                                  (name,uu____23963,uu____23964,uu____23965,uu____23966,uu____23967)
+                                                                  (name,uu____24190,uu____24191,uu____24192,uu____24193,uu____24194)
                                                                   ->
                                                                   FStar_Ident.lid_equals
                                                                     name
                                                                     data_lid
-                                                              | uu____23974
+                                                              | uu____24201
                                                                   -> false))
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____23946
+                                                      uu____24173
                                                       FStar_Util.must
                                                      in
                                                   data_se.FStar_Syntax_Syntax.sigquals
                                                    in
-                                                let uu____23978 =
+                                                let uu____24205 =
                                                   FStar_All.pipe_right
                                                     data_quals
                                                     (FStar_List.existsb
-                                                       (fun uu___25_23985  ->
-                                                          match uu___25_23985
+                                                       (fun uu___25_24212  ->
+                                                          match uu___25_24212
                                                           with
                                                           | FStar_Syntax_Syntax.RecordConstructor
-                                                              uu____23987 ->
+                                                              uu____24214 ->
                                                               true
-                                                          | uu____23997 ->
+                                                          | uu____24224 ->
                                                               false))
                                                    in
-                                                Prims.op_Negation uu____23978))
+                                                Prims.op_Negation uu____24205))
                                          in
                                       mk_data_discriminators quals2 env3
-                                        uu____23931
-                                  | uu____23999 -> []))
+                                        uu____24158
+                                  | uu____24226 -> []))
                            in
                         let ops = FStar_List.append discs data_ops  in
                         let env4 =
@@ -6458,28 +6578,28 @@ let (desugar_binders :
   =
   fun env  ->
     fun binders  ->
-      let uu____24036 =
+      let uu____24263 =
         FStar_List.fold_left
-          (fun uu____24071  ->
+          (fun uu____24298  ->
              fun b  ->
-               match uu____24071 with
+               match uu____24298 with
                | (env1,binders1) ->
-                   let uu____24115 = desugar_binder env1 b  in
-                   (match uu____24115 with
+                   let uu____24342 = desugar_binder env1 b  in
+                   (match uu____24342 with
                     | (FStar_Pervasives_Native.Some a,k) ->
-                        let uu____24138 =
+                        let uu____24365 =
                           as_binder env1 b.FStar_Parser_AST.aqual
                             ((FStar_Pervasives_Native.Some a), k)
                            in
-                        (match uu____24138 with
+                        (match uu____24365 with
                          | (binder,env2) -> (env2, (binder :: binders1)))
-                    | uu____24191 ->
+                    | uu____24418 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_MissingNameInBinder,
                             "Missing name in binder")
                           b.FStar_Parser_AST.brange)) (env, []) binders
          in
-      match uu____24036 with
+      match uu____24263 with
       | (env1,binders1) -> (env1, (FStar_List.rev binders1))
   
 let (push_reflect_effect :
@@ -6491,23 +6611,22 @@ let (push_reflect_effect :
     fun quals  ->
       fun effect_name  ->
         fun range  ->
-          let uu____24295 =
+          let uu____24522 =
             FStar_All.pipe_right quals
               (FStar_Util.for_some
-                 (fun uu___26_24302  ->
-                    match uu___26_24302 with
-                    | FStar_Syntax_Syntax.Reflectable uu____24304 -> true
-                    | uu____24306 -> false))
+                 (fun uu___26_24529  ->
+                    match uu___26_24529 with
+                    | FStar_Syntax_Syntax.Reflectable uu____24531 -> true
+                    | uu____24533 -> false))
              in
-          if uu____24295
+          if uu____24522
           then
             let monad_env =
-              FStar_Syntax_DsEnv.enter_monad_scope env
-                effect_name.FStar_Ident.ident
-               in
+              let uu____24537 = FStar_Ident.ident_of_lid effect_name  in
+              FStar_Syntax_DsEnv.enter_monad_scope env uu____24537  in
             let reflect_lid =
-              let uu____24311 = FStar_Ident.id_of_text "reflect"  in
-              FStar_All.pipe_right uu____24311
+              let uu____24539 = FStar_Ident.id_of_text "reflect"  in
+              FStar_All.pipe_right uu____24539
                 (FStar_Syntax_DsEnv.qualify monad_env)
                in
             let quals1 =
@@ -6537,52 +6656,52 @@ let (parse_attr_with_list :
   fun warn  ->
     fun at  ->
       fun head  ->
-        let warn1 uu____24362 =
+        let warn1 uu____24590 =
           if warn
           then
-            let uu____24364 =
-              let uu____24370 =
-                let uu____24372 = FStar_Ident.string_of_lid head  in
+            let uu____24592 =
+              let uu____24598 =
+                let uu____24600 = FStar_Ident.string_of_lid head  in
                 FStar_Util.format1
                   "Found ill-applied '%s', argument should be a non-empty list of integer literals"
-                  uu____24372
+                  uu____24600
                  in
-              (FStar_Errors.Warning_UnappliedFail, uu____24370)  in
-            FStar_Errors.log_issue at.FStar_Syntax_Syntax.pos uu____24364
+              (FStar_Errors.Warning_UnappliedFail, uu____24598)  in
+            FStar_Errors.log_issue at.FStar_Syntax_Syntax.pos uu____24592
           else ()  in
-        let uu____24378 = FStar_Syntax_Util.head_and_args at  in
-        match uu____24378 with
+        let uu____24606 = FStar_Syntax_Util.head_and_args at  in
+        match uu____24606 with
         | (hd,args) ->
-            let uu____24431 =
-              let uu____24432 = FStar_Syntax_Subst.compress hd  in
-              uu____24432.FStar_Syntax_Syntax.n  in
-            (match uu____24431 with
+            let uu____24659 =
+              let uu____24660 = FStar_Syntax_Subst.compress hd  in
+              uu____24660.FStar_Syntax_Syntax.n  in
+            (match uu____24659 with
              | FStar_Syntax_Syntax.Tm_fvar fv when
                  FStar_Syntax_Syntax.fv_eq_lid fv head ->
                  (match args with
                   | [] -> ((FStar_Pervasives_Native.Some []), true)
-                  | (a1,uu____24476)::[] ->
-                      let uu____24501 =
-                        let uu____24506 =
-                          let uu____24515 =
+                  | (a1,uu____24704)::[] ->
+                      let uu____24729 =
+                        let uu____24734 =
+                          let uu____24743 =
                             FStar_Syntax_Embeddings.e_list
                               FStar_Syntax_Embeddings.e_int
                              in
-                          FStar_Syntax_Embeddings.unembed uu____24515 a1  in
-                        uu____24506 true FStar_Syntax_Embeddings.id_norm_cb
+                          FStar_Syntax_Embeddings.unembed uu____24743 a1  in
+                        uu____24734 true FStar_Syntax_Embeddings.id_norm_cb
                          in
-                      (match uu____24501 with
+                      (match uu____24729 with
                        | FStar_Pervasives_Native.Some es ->
-                           let uu____24538 =
-                             let uu____24544 =
+                           let uu____24766 =
+                             let uu____24772 =
                                FStar_List.map FStar_BigInt.to_int_fs es  in
-                             FStar_Pervasives_Native.Some uu____24544  in
-                           (uu____24538, true)
-                       | uu____24559 ->
+                             FStar_Pervasives_Native.Some uu____24772  in
+                           (uu____24766, true)
+                       | uu____24787 ->
                            (warn1 (); (FStar_Pervasives_Native.None, true)))
-                  | uu____24575 ->
+                  | uu____24803 ->
                       (warn1 (); (FStar_Pervasives_Native.None, true)))
-             | uu____24597 -> (FStar_Pervasives_Native.None, false))
+             | uu____24825 -> (FStar_Pervasives_Native.None, false))
   
 let (get_fail_attr1 :
   Prims.bool ->
@@ -6597,17 +6716,17 @@ let (get_fail_attr1 :
         | FStar_Pervasives_Native.Some l ->
             FStar_Pervasives_Native.Some (l, b)
          in
-      let uu____24714 =
+      let uu____24942 =
         parse_attr_with_list warn at FStar_Parser_Const.fail_attr  in
-      match uu____24714 with
+      match uu____24942 with
       | (res,matched) ->
           if matched
           then rebind res false
           else
-            (let uu____24763 =
+            (let uu____24991 =
                parse_attr_with_list warn at FStar_Parser_Const.fail_lax_attr
                 in
-             match uu____24763 with | (res1,uu____24785) -> rebind res1 true)
+             match uu____24991 with | (res1,uu____25013) -> rebind res1 true)
   
 let (get_fail_attr :
   Prims.bool ->
@@ -6626,12 +6745,12 @@ let (get_fail_attr :
             -> FStar_Pervasives_Native.Some (e, l)
         | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.Some (e,l))
             -> FStar_Pervasives_Native.Some (e, l)
-        | uu____25112 -> FStar_Pervasives_Native.None  in
+        | uu____25340 -> FStar_Pervasives_Native.None  in
       FStar_List.fold_right
         (fun at  ->
            fun acc  ->
-             let uu____25170 = get_fail_attr1 warn at  in
-             comb uu____25170 acc) ats FStar_Pervasives_Native.None
+             let uu____25398 = get_fail_attr1 warn at  in
+             comb uu____25398 acc) ats FStar_Pervasives_Native.None
   
 let (lookup_effect_lid :
   FStar_Syntax_DsEnv.env ->
@@ -6640,17 +6759,17 @@ let (lookup_effect_lid :
   fun env  ->
     fun l  ->
       fun r  ->
-        let uu____25205 = FStar_Syntax_DsEnv.try_lookup_effect_defn env l  in
-        match uu____25205 with
+        let uu____25433 = FStar_Syntax_DsEnv.try_lookup_effect_defn env l  in
+        match uu____25433 with
         | FStar_Pervasives_Native.None  ->
-            let uu____25208 =
-              let uu____25214 =
-                let uu____25216 =
-                  let uu____25218 = FStar_Syntax_Print.lid_to_string l  in
-                  Prims.op_Hat uu____25218 " not found"  in
-                Prims.op_Hat "Effect name " uu____25216  in
-              (FStar_Errors.Fatal_EffectNotFound, uu____25214)  in
-            FStar_Errors.raise_error uu____25208 r
+            let uu____25436 =
+              let uu____25442 =
+                let uu____25444 =
+                  let uu____25446 = FStar_Syntax_Print.lid_to_string l  in
+                  Prims.op_Hat uu____25446 " not found"  in
+                Prims.op_Hat "Effect name " uu____25444  in
+              (FStar_Errors.Fatal_EffectNotFound, uu____25442)  in
+            FStar_Errors.raise_error uu____25436 r
         | FStar_Pervasives_Native.Some l1 -> l1
   
 let rec (desugar_effect :
@@ -6678,32 +6797,32 @@ let rec (desugar_effect :
                     let env0 = env  in
                     let monad_env =
                       FStar_Syntax_DsEnv.enter_monad_scope env eff_name  in
-                    let uu____25374 = desugar_binders monad_env eff_binders
+                    let uu____25602 = desugar_binders monad_env eff_binders
                        in
-                    match uu____25374 with
+                    match uu____25602 with
                     | (env1,binders) ->
                         let eff_t = desugar_term env1 eff_typ  in
                         let num_indices =
-                          let uu____25413 =
-                            let uu____25422 =
+                          let uu____25641 =
+                            let uu____25650 =
                               FStar_Syntax_Util.arrow_formals eff_t  in
-                            FStar_Pervasives_Native.fst uu____25422  in
-                          FStar_List.length uu____25413  in
+                            FStar_Pervasives_Native.fst uu____25650  in
+                          FStar_List.length uu____25641  in
                         (if is_layered && (num_indices <= Prims.int_one)
                          then
-                           (let uu____25440 =
-                              let uu____25446 =
-                                let uu____25448 =
-                                  let uu____25450 =
+                           (let uu____25668 =
+                              let uu____25674 =
+                                let uu____25676 =
+                                  let uu____25678 =
                                     FStar_Ident.text_of_id eff_name  in
-                                  Prims.op_Hat uu____25450
+                                  Prims.op_Hat uu____25678
                                     "is defined as a layered effect but has no indices"
                                    in
-                                Prims.op_Hat "Effect " uu____25448  in
+                                Prims.op_Hat "Effect " uu____25676  in
                               (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
-                                uu____25446)
+                                uu____25674)
                                in
-                            FStar_Errors.raise_error uu____25440
+                            FStar_Errors.raise_error uu____25668
                               d.FStar_Parser_AST.drange)
                          else ();
                          (let for_free = num_indices = Prims.int_one  in
@@ -6729,41 +6848,41 @@ let rec (desugar_effect :
                           let name_of_eff_decl decl =
                             match decl.FStar_Parser_AST.d with
                             | FStar_Parser_AST.Tycon
-                                (uu____25518,uu____25519,(FStar_Parser_AST.TyconAbbrev
-                                 (name,uu____25521,uu____25522,uu____25523))::[])
+                                (uu____25746,uu____25747,(FStar_Parser_AST.TyconAbbrev
+                                 (name,uu____25749,uu____25750,uu____25751))::[])
                                 -> FStar_Ident.text_of_id name
-                            | uu____25538 ->
+                            | uu____25766 ->
                                 failwith
                                   "Malformed effect member declaration."
                              in
-                          let uu____25541 =
+                          let uu____25769 =
                             FStar_List.partition
                               (fun decl  ->
-                                 let uu____25553 = name_of_eff_decl decl  in
-                                 FStar_List.mem uu____25553 mandatory_members)
+                                 let uu____25781 = name_of_eff_decl decl  in
+                                 FStar_List.mem uu____25781 mandatory_members)
                               eff_decls
                              in
-                          match uu____25541 with
+                          match uu____25769 with
                           | (mandatory_members_decls,actions) ->
-                              let uu____25572 =
+                              let uu____25800 =
                                 FStar_All.pipe_right mandatory_members_decls
                                   (FStar_List.fold_left
-                                     (fun uu____25601  ->
+                                     (fun uu____25829  ->
                                         fun decl  ->
-                                          match uu____25601 with
+                                          match uu____25829 with
                                           | (env2,out) ->
-                                              let uu____25621 =
+                                              let uu____25849 =
                                                 desugar_decl env2 decl  in
-                                              (match uu____25621 with
+                                              (match uu____25849 with
                                                | (env3,ses) ->
-                                                   let uu____25634 =
-                                                     let uu____25637 =
+                                                   let uu____25862 =
+                                                     let uu____25865 =
                                                        FStar_List.hd ses  in
-                                                     uu____25637 :: out  in
-                                                   (env3, uu____25634)))
+                                                     uu____25865 :: out  in
+                                                   (env3, uu____25862)))
                                      (env1, []))
                                  in
-                              (match uu____25572 with
+                              (match uu____25800 with
                                | (env2,decls) ->
                                    let binders1 =
                                      FStar_Syntax_Subst.close_binders binders
@@ -6774,36 +6893,36 @@ let rec (desugar_effect :
                                           (fun d1  ->
                                              match d1.FStar_Parser_AST.d with
                                              | FStar_Parser_AST.Tycon
-                                                 (uu____25683,uu____25684,(FStar_Parser_AST.TyconAbbrev
-                                                  (name,action_params,uu____25687,
+                                                 (uu____25911,uu____25912,(FStar_Parser_AST.TyconAbbrev
+                                                  (name,action_params,uu____25915,
                                                    {
                                                      FStar_Parser_AST.tm =
                                                        FStar_Parser_AST.Construct
-                                                       (uu____25688,(def,uu____25690)::
-                                                        (cps_type,uu____25692)::[]);
+                                                       (uu____25916,(def,uu____25918)::
+                                                        (cps_type,uu____25920)::[]);
                                                      FStar_Parser_AST.range =
-                                                       uu____25693;
+                                                       uu____25921;
                                                      FStar_Parser_AST.level =
-                                                       uu____25694;_}))::[])
+                                                       uu____25922;_}))::[])
                                                  when
                                                  Prims.op_Negation for_free
                                                  ->
-                                                 let uu____25727 =
+                                                 let uu____25955 =
                                                    desugar_binders env2
                                                      action_params
                                                     in
-                                                 (match uu____25727 with
+                                                 (match uu____25955 with
                                                   | (env3,action_params1) ->
                                                       let action_params2 =
                                                         FStar_Syntax_Subst.close_binders
                                                           action_params1
                                                          in
-                                                      let uu____25759 =
+                                                      let uu____25987 =
                                                         FStar_Syntax_DsEnv.qualify
                                                           env3 name
                                                          in
-                                                      let uu____25760 =
-                                                        let uu____25761 =
+                                                      let uu____25988 =
+                                                        let uu____25989 =
                                                           desugar_term env3
                                                             def
                                                            in
@@ -6811,10 +6930,10 @@ let rec (desugar_effect :
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____25761
+                                                          uu____25989
                                                          in
-                                                      let uu____25768 =
-                                                        let uu____25769 =
+                                                      let uu____25996 =
+                                                        let uu____25997 =
                                                           desugar_typ env3
                                                             cps_type
                                                            in
@@ -6822,11 +6941,11 @@ let rec (desugar_effect :
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____25769
+                                                          uu____25997
                                                          in
                                                       {
                                                         FStar_Syntax_Syntax.action_name
-                                                          = uu____25759;
+                                                          = uu____25987;
                                                         FStar_Syntax_Syntax.action_unqualified_name
                                                           = name;
                                                         FStar_Syntax_Syntax.action_univs
@@ -6834,31 +6953,31 @@ let rec (desugar_effect :
                                                         FStar_Syntax_Syntax.action_params
                                                           = action_params2;
                                                         FStar_Syntax_Syntax.action_defn
-                                                          = uu____25760;
+                                                          = uu____25988;
                                                         FStar_Syntax_Syntax.action_typ
-                                                          = uu____25768
+                                                          = uu____25996
                                                       })
                                              | FStar_Parser_AST.Tycon
-                                                 (uu____25776,uu____25777,(FStar_Parser_AST.TyconAbbrev
-                                                  (name,action_params,uu____25780,defn))::[])
+                                                 (uu____26004,uu____26005,(FStar_Parser_AST.TyconAbbrev
+                                                  (name,action_params,uu____26008,defn))::[])
                                                  when for_free || is_layered
                                                  ->
-                                                 let uu____25796 =
+                                                 let uu____26024 =
                                                    desugar_binders env2
                                                      action_params
                                                     in
-                                                 (match uu____25796 with
+                                                 (match uu____26024 with
                                                   | (env3,action_params1) ->
                                                       let action_params2 =
                                                         FStar_Syntax_Subst.close_binders
                                                           action_params1
                                                          in
-                                                      let uu____25828 =
+                                                      let uu____26056 =
                                                         FStar_Syntax_DsEnv.qualify
                                                           env3 name
                                                          in
-                                                      let uu____25829 =
-                                                        let uu____25830 =
+                                                      let uu____26057 =
+                                                        let uu____26058 =
                                                           desugar_term env3
                                                             defn
                                                            in
@@ -6866,11 +6985,11 @@ let rec (desugar_effect :
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____25830
+                                                          uu____26058
                                                          in
                                                       {
                                                         FStar_Syntax_Syntax.action_name
-                                                          = uu____25828;
+                                                          = uu____26056;
                                                         FStar_Syntax_Syntax.action_unqualified_name
                                                           = name;
                                                         FStar_Syntax_Syntax.action_univs
@@ -6878,12 +6997,12 @@ let rec (desugar_effect :
                                                         FStar_Syntax_Syntax.action_params
                                                           = action_params2;
                                                         FStar_Syntax_Syntax.action_defn
-                                                          = uu____25829;
+                                                          = uu____26057;
                                                         FStar_Syntax_Syntax.action_typ
                                                           =
                                                           FStar_Syntax_Syntax.tun
                                                       })
-                                             | uu____25837 ->
+                                             | uu____26065 ->
                                                  FStar_Errors.raise_error
                                                    (FStar_Errors.Fatal_MalformedActionDeclaration,
                                                      "Malformed action declaration; if this is an \"effect for free\", just provide the direct-style declaration. If this is not an \"effect for free\", please provide a pair of the definition and its cps-type with arrows inserted in the right place (see examples).")
@@ -6894,24 +7013,24 @@ let rec (desugar_effect :
                                       in
                                    let lookup s =
                                      let l =
-                                       let uu____25856 =
+                                       let uu____26084 =
                                          FStar_Ident.mk_ident
                                            (s, (d.FStar_Parser_AST.drange))
                                           in
                                        FStar_Syntax_DsEnv.qualify env2
-                                         uu____25856
+                                         uu____26084
                                         in
-                                     let uu____25858 =
-                                       let uu____25859 =
+                                     let uu____26086 =
+                                       let uu____26087 =
                                          FStar_Syntax_DsEnv.fail_or env2
                                            (FStar_Syntax_DsEnv.try_lookup_definition
                                               env2) l
                                           in
                                        FStar_All.pipe_left
                                          (FStar_Syntax_Subst.close binders1)
-                                         uu____25859
+                                         uu____26087
                                         in
-                                     ([], uu____25858)  in
+                                     ([], uu____26086)  in
                                    let mname =
                                      FStar_Syntax_DsEnv.qualify env0 eff_name
                                       in
@@ -6926,24 +7045,24 @@ let rec (desugar_effect :
                                    let combinators =
                                      if for_free
                                      then
-                                       let uu____25881 =
-                                         let uu____25882 =
-                                           let uu____25885 = lookup "repr"
+                                       let uu____26109 =
+                                         let uu____26110 =
+                                           let uu____26113 = lookup "repr"
                                               in
                                            FStar_Pervasives_Native.Some
-                                             uu____25885
+                                             uu____26113
                                             in
-                                         let uu____25887 =
-                                           let uu____25890 = lookup "return"
+                                         let uu____26115 =
+                                           let uu____26118 = lookup "return"
                                               in
                                            FStar_Pervasives_Native.Some
-                                             uu____25890
+                                             uu____26118
                                             in
-                                         let uu____25892 =
-                                           let uu____25895 = lookup "bind"
+                                         let uu____26120 =
+                                           let uu____26123 = lookup "bind"
                                               in
                                            FStar_Pervasives_Native.Some
-                                             uu____25895
+                                             uu____26123
                                             in
                                          {
                                            FStar_Syntax_Syntax.ret_wp =
@@ -6961,156 +7080,156 @@ let rec (desugar_effect :
                                            FStar_Syntax_Syntax.trivial =
                                              dummy_tscheme;
                                            FStar_Syntax_Syntax.repr =
-                                             uu____25882;
+                                             uu____26110;
                                            FStar_Syntax_Syntax.return_repr =
-                                             uu____25887;
+                                             uu____26115;
                                            FStar_Syntax_Syntax.bind_repr =
-                                             uu____25892
+                                             uu____26120
                                          }  in
                                        FStar_Syntax_Syntax.DM4F_eff
-                                         uu____25881
+                                         uu____26109
                                      else
                                        if is_layered
                                        then
-                                         (let to_comb uu____25929 =
-                                            match uu____25929 with
+                                         (let to_comb uu____26157 =
+                                            match uu____26157 with
                                             | (us,t) ->
                                                 ((us, t), dummy_tscheme)
                                              in
-                                          let uu____25976 =
-                                            let uu____25977 =
+                                          let uu____26204 =
+                                            let uu____26205 =
                                               FStar_Ident.lid_of_str ""  in
-                                            let uu____25979 =
-                                              let uu____25984 = lookup "repr"
+                                            let uu____26207 =
+                                              let uu____26212 = lookup "repr"
                                                  in
                                               FStar_All.pipe_right
-                                                uu____25984 to_comb
+                                                uu____26212 to_comb
                                                in
-                                            let uu____26002 =
-                                              let uu____26007 =
+                                            let uu____26230 =
+                                              let uu____26235 =
                                                 lookup "return"  in
                                               FStar_All.pipe_right
-                                                uu____26007 to_comb
+                                                uu____26235 to_comb
                                                in
-                                            let uu____26025 =
-                                              let uu____26030 = lookup "bind"
+                                            let uu____26253 =
+                                              let uu____26258 = lookup "bind"
                                                  in
                                               FStar_All.pipe_right
-                                                uu____26030 to_comb
+                                                uu____26258 to_comb
                                                in
-                                            let uu____26048 =
-                                              let uu____26053 =
+                                            let uu____26276 =
+                                              let uu____26281 =
                                                 lookup "subcomp"  in
                                               FStar_All.pipe_right
-                                                uu____26053 to_comb
+                                                uu____26281 to_comb
                                                in
-                                            let uu____26071 =
-                                              let uu____26076 =
+                                            let uu____26299 =
+                                              let uu____26304 =
                                                 lookup "if_then_else"  in
                                               FStar_All.pipe_right
-                                                uu____26076 to_comb
+                                                uu____26304 to_comb
                                                in
                                             {
                                               FStar_Syntax_Syntax.l_base_effect
-                                                = uu____25977;
+                                                = uu____26205;
                                               FStar_Syntax_Syntax.l_repr =
-                                                uu____25979;
+                                                uu____26207;
                                               FStar_Syntax_Syntax.l_return =
-                                                uu____26002;
+                                                uu____26230;
                                               FStar_Syntax_Syntax.l_bind =
-                                                uu____26025;
+                                                uu____26253;
                                               FStar_Syntax_Syntax.l_subcomp =
-                                                uu____26048;
+                                                uu____26276;
                                               FStar_Syntax_Syntax.l_if_then_else
-                                                = uu____26071
+                                                = uu____26299
                                             }  in
                                           FStar_Syntax_Syntax.Layered_eff
-                                            uu____25976)
+                                            uu____26204)
                                        else
                                          (let rr =
                                             FStar_Util.for_some
-                                              (fun uu___27_26099  ->
-                                                 match uu___27_26099 with
+                                              (fun uu___27_26327  ->
+                                                 match uu___27_26327 with
                                                  | FStar_Syntax_Syntax.Reifiable
                                                       -> true
                                                  | FStar_Syntax_Syntax.Reflectable
-                                                     uu____26102 -> true
-                                                 | uu____26104 -> false)
+                                                     uu____26330 -> true
+                                                 | uu____26332 -> false)
                                               qualifiers
                                              in
-                                          let uu____26106 =
-                                            let uu____26107 =
+                                          let uu____26334 =
+                                            let uu____26335 =
                                               lookup "return_wp"  in
-                                            let uu____26109 =
+                                            let uu____26337 =
                                               lookup "bind_wp"  in
-                                            let uu____26111 =
+                                            let uu____26339 =
                                               lookup "stronger"  in
-                                            let uu____26113 =
+                                            let uu____26341 =
                                               lookup "if_then_else"  in
-                                            let uu____26115 = lookup "ite_wp"
+                                            let uu____26343 = lookup "ite_wp"
                                                in
-                                            let uu____26117 =
+                                            let uu____26345 =
                                               lookup "close_wp"  in
-                                            let uu____26119 =
+                                            let uu____26347 =
                                               lookup "trivial"  in
-                                            let uu____26121 =
+                                            let uu____26349 =
                                               if rr
                                               then
-                                                let uu____26127 =
+                                                let uu____26355 =
                                                   lookup "repr"  in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____26127
+                                                  uu____26355
                                               else
                                                 FStar_Pervasives_Native.None
                                                in
-                                            let uu____26131 =
+                                            let uu____26359 =
                                               if rr
                                               then
-                                                let uu____26137 =
+                                                let uu____26365 =
                                                   lookup "return"  in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____26137
+                                                  uu____26365
                                               else
                                                 FStar_Pervasives_Native.None
                                                in
-                                            let uu____26141 =
+                                            let uu____26369 =
                                               if rr
                                               then
-                                                let uu____26147 =
+                                                let uu____26375 =
                                                   lookup "bind"  in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____26147
+                                                  uu____26375
                                               else
                                                 FStar_Pervasives_Native.None
                                                in
                                             {
                                               FStar_Syntax_Syntax.ret_wp =
-                                                uu____26107;
+                                                uu____26335;
                                               FStar_Syntax_Syntax.bind_wp =
-                                                uu____26109;
+                                                uu____26337;
                                               FStar_Syntax_Syntax.stronger =
-                                                uu____26111;
+                                                uu____26339;
                                               FStar_Syntax_Syntax.if_then_else
-                                                = uu____26113;
+                                                = uu____26341;
                                               FStar_Syntax_Syntax.ite_wp =
-                                                uu____26115;
+                                                uu____26343;
                                               FStar_Syntax_Syntax.close_wp =
-                                                uu____26117;
+                                                uu____26345;
                                               FStar_Syntax_Syntax.trivial =
-                                                uu____26119;
+                                                uu____26347;
                                               FStar_Syntax_Syntax.repr =
-                                                uu____26121;
+                                                uu____26349;
                                               FStar_Syntax_Syntax.return_repr
-                                                = uu____26131;
+                                                = uu____26359;
                                               FStar_Syntax_Syntax.bind_repr =
-                                                uu____26141
+                                                uu____26369
                                             }  in
                                           FStar_Syntax_Syntax.Primitive_eff
-                                            uu____26106)
+                                            uu____26334)
                                       in
                                    let sigel =
-                                     let uu____26152 =
-                                       let uu____26153 =
+                                     let uu____26380 =
+                                       let uu____26381 =
                                          FStar_List.map (desugar_term env2)
                                            attrs
                                           in
@@ -7127,10 +7246,10 @@ let rec (desugar_effect :
                                          FStar_Syntax_Syntax.actions =
                                            actions1;
                                          FStar_Syntax_Syntax.eff_attrs =
-                                           uu____26153
+                                           uu____26381
                                        }  in
                                      FStar_Syntax_Syntax.Sig_new_effect
-                                       uu____26152
+                                       uu____26380
                                       in
                                    let se =
                                      {
@@ -7153,13 +7272,13 @@ let rec (desugar_effect :
                                        (FStar_List.fold_left
                                           (fun env4  ->
                                              fun a  ->
-                                               let uu____26170 =
+                                               let uu____26398 =
                                                  FStar_Syntax_Util.action_as_lb
                                                    mname a
                                                    (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                                   in
                                                FStar_Syntax_DsEnv.push_sigelt
-                                                 env4 uu____26170) env3)
+                                                 env4 uu____26398) env3)
                                       in
                                    let env5 =
                                      push_reflect_effect env4 qualifiers
@@ -7190,30 +7309,30 @@ and (desugar_redefine_effect :
                 let env0 = env  in
                 let env1 = FStar_Syntax_DsEnv.enter_monad_scope env eff_name
                    in
-                let uu____26193 = desugar_binders env1 eff_binders  in
-                match uu____26193 with
+                let uu____26421 = desugar_binders env1 eff_binders  in
+                match uu____26421 with
                 | (env2,binders) ->
-                    let uu____26230 =
-                      let uu____26241 = head_and_args defn  in
-                      match uu____26241 with
+                    let uu____26458 =
+                      let uu____26469 = head_and_args defn  in
+                      match uu____26469 with
                       | (head,args) ->
                           let lid =
                             match head.FStar_Parser_AST.tm with
                             | FStar_Parser_AST.Name l -> l
-                            | uu____26278 ->
-                                let uu____26279 =
-                                  let uu____26285 =
-                                    let uu____26287 =
-                                      let uu____26289 =
+                            | uu____26506 ->
+                                let uu____26507 =
+                                  let uu____26513 =
+                                    let uu____26515 =
+                                      let uu____26517 =
                                         FStar_Parser_AST.term_to_string head
                                          in
-                                      Prims.op_Hat uu____26289 " not found"
+                                      Prims.op_Hat uu____26517 " not found"
                                        in
-                                    Prims.op_Hat "Effect " uu____26287  in
+                                    Prims.op_Hat "Effect " uu____26515  in
                                   (FStar_Errors.Fatal_EffectNotFound,
-                                    uu____26285)
+                                    uu____26513)
                                    in
-                                FStar_Errors.raise_error uu____26279
+                                FStar_Errors.raise_error uu____26507
                                   d.FStar_Parser_AST.drange
                              in
                           let ed =
@@ -7221,25 +7340,25 @@ and (desugar_redefine_effect :
                               (FStar_Syntax_DsEnv.try_lookup_effect_defn env2)
                               lid
                              in
-                          let uu____26295 =
+                          let uu____26523 =
                             match FStar_List.rev args with
-                            | (last_arg,uu____26325)::args_rev ->
-                                let uu____26337 =
-                                  let uu____26338 = unparen last_arg  in
-                                  uu____26338.FStar_Parser_AST.tm  in
-                                (match uu____26337 with
+                            | (last_arg,uu____26553)::args_rev ->
+                                let uu____26565 =
+                                  let uu____26566 = unparen last_arg  in
+                                  uu____26566.FStar_Parser_AST.tm  in
+                                (match uu____26565 with
                                  | FStar_Parser_AST.Attributes ts ->
                                      (ts, (FStar_List.rev args_rev))
-                                 | uu____26366 -> ([], args))
-                            | uu____26375 -> ([], args)  in
-                          (match uu____26295 with
+                                 | uu____26594 -> ([], args))
+                            | uu____26603 -> ([], args)  in
+                          (match uu____26523 with
                            | (cattributes,args1) ->
-                               let uu____26418 = desugar_args env2 args1  in
-                               let uu____26419 =
+                               let uu____26646 = desugar_args env2 args1  in
+                               let uu____26647 =
                                  desugar_attributes env2 cattributes  in
-                               (lid, ed, uu____26418, uu____26419))
+                               (lid, ed, uu____26646, uu____26647))
                        in
-                    (match uu____26230 with
+                    (match uu____26458 with
                      | (ed_lid,ed,args,cattributes) ->
                          let binders1 =
                            FStar_Syntax_Subst.close_binders binders  in
@@ -7253,77 +7372,77 @@ and (desugar_redefine_effect :
                                 "Unexpected number of arguments to effect constructor")
                               defn.FStar_Parser_AST.range
                           else ();
-                          (let uu____26459 =
+                          (let uu____26687 =
                              FStar_Syntax_Subst.open_term'
                                ed.FStar_Syntax_Syntax.binders
                                FStar_Syntax_Syntax.t_unit
                               in
-                           match uu____26459 with
-                           | (ed_binders,uu____26473,ed_binders_opening) ->
-                               let sub' shift_n uu____26492 =
-                                 match uu____26492 with
+                           match uu____26687 with
+                           | (ed_binders,uu____26701,ed_binders_opening) ->
+                               let sub' shift_n uu____26720 =
+                                 match uu____26720 with
                                  | (us,x) ->
                                      let x1 =
-                                       let uu____26507 =
+                                       let uu____26735 =
                                          FStar_Syntax_Subst.shift_subst
                                            (shift_n + (FStar_List.length us))
                                            ed_binders_opening
                                           in
-                                       FStar_Syntax_Subst.subst uu____26507 x
+                                       FStar_Syntax_Subst.subst uu____26735 x
                                         in
                                      let s =
                                        FStar_Syntax_Util.subst_of_list
                                          ed_binders args
                                         in
-                                     let uu____26511 =
-                                       let uu____26512 =
+                                     let uu____26739 =
+                                       let uu____26740 =
                                          FStar_Syntax_Subst.subst s x1  in
-                                       (us, uu____26512)  in
+                                       (us, uu____26740)  in
                                      FStar_Syntax_Subst.close_tscheme
-                                       binders1 uu____26511
+                                       binders1 uu____26739
                                   in
                                let sub = sub' Prims.int_zero  in
                                let mname =
                                  FStar_Syntax_DsEnv.qualify env0 eff_name  in
                                let ed1 =
-                                 let uu____26533 =
+                                 let uu____26761 =
                                    sub ed.FStar_Syntax_Syntax.signature  in
-                                 let uu____26534 =
+                                 let uu____26762 =
                                    FStar_Syntax_Util.apply_eff_combinators
                                      sub ed.FStar_Syntax_Syntax.combinators
                                     in
-                                 let uu____26535 =
+                                 let uu____26763 =
                                    FStar_List.map
                                      (fun action  ->
                                         let nparam =
                                           FStar_List.length
                                             action.FStar_Syntax_Syntax.action_params
                                            in
-                                        let uu____26551 =
+                                        let uu____26779 =
                                           FStar_Syntax_DsEnv.qualify env2
                                             action.FStar_Syntax_Syntax.action_unqualified_name
                                            in
-                                        let uu____26552 =
-                                          let uu____26553 =
+                                        let uu____26780 =
+                                          let uu____26781 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_defn))
                                              in
                                           FStar_Pervasives_Native.snd
-                                            uu____26553
+                                            uu____26781
                                            in
-                                        let uu____26568 =
-                                          let uu____26569 =
+                                        let uu____26796 =
+                                          let uu____26797 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_typ))
                                              in
                                           FStar_Pervasives_Native.snd
-                                            uu____26569
+                                            uu____26797
                                            in
                                         {
                                           FStar_Syntax_Syntax.action_name =
-                                            uu____26551;
+                                            uu____26779;
                                           FStar_Syntax_Syntax.action_unqualified_name
                                             =
                                             (action.FStar_Syntax_Syntax.action_unqualified_name);
@@ -7332,9 +7451,9 @@ and (desugar_redefine_effect :
                                           FStar_Syntax_Syntax.action_params =
                                             (action.FStar_Syntax_Syntax.action_params);
                                           FStar_Syntax_Syntax.action_defn =
-                                            uu____26552;
+                                            uu____26780;
                                           FStar_Syntax_Syntax.action_typ =
-                                            uu____26568
+                                            uu____26796
                                         }) ed.FStar_Syntax_Syntax.actions
                                     in
                                  {
@@ -7345,26 +7464,26 @@ and (desugar_redefine_effect :
                                      (ed.FStar_Syntax_Syntax.univs);
                                    FStar_Syntax_Syntax.binders = binders1;
                                    FStar_Syntax_Syntax.signature =
-                                     uu____26533;
+                                     uu____26761;
                                    FStar_Syntax_Syntax.combinators =
-                                     uu____26534;
-                                   FStar_Syntax_Syntax.actions = uu____26535;
+                                     uu____26762;
+                                   FStar_Syntax_Syntax.actions = uu____26763;
                                    FStar_Syntax_Syntax.eff_attrs =
                                      (ed.FStar_Syntax_Syntax.eff_attrs)
                                  }  in
                                let se =
-                                 let uu____26585 =
-                                   let uu____26588 =
+                                 let uu____26813 =
+                                   let uu____26816 =
                                      trans_qual1
                                        (FStar_Pervasives_Native.Some mname)
                                       in
-                                   FStar_List.map uu____26588 quals  in
+                                   FStar_List.map uu____26816 quals  in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_new_effect ed1);
                                    FStar_Syntax_Syntax.sigrng =
                                      (d.FStar_Parser_AST.drange);
-                                   FStar_Syntax_Syntax.sigquals = uu____26585;
+                                   FStar_Syntax_Syntax.sigquals = uu____26813;
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
                                    FStar_Syntax_Syntax.sigattrs = [];
@@ -7380,26 +7499,26 @@ and (desugar_redefine_effect :
                                    (FStar_List.fold_left
                                       (fun env4  ->
                                          fun a  ->
-                                           let uu____26603 =
+                                           let uu____26831 =
                                              FStar_Syntax_Util.action_as_lb
                                                mname a
                                                (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                               in
                                            FStar_Syntax_DsEnv.push_sigelt
-                                             env4 uu____26603) env3)
+                                             env4 uu____26831) env3)
                                   in
                                let env5 =
-                                 let uu____26605 =
+                                 let uu____26833 =
                                    FStar_All.pipe_right quals
                                      (FStar_List.contains
                                         FStar_Parser_AST.Reflectable)
                                     in
-                                 if uu____26605
+                                 if uu____26833
                                  then
                                    let reflect_lid =
-                                     let uu____26612 =
+                                     let uu____26840 =
                                        FStar_Ident.id_of_text "reflect"  in
-                                     FStar_All.pipe_right uu____26612
+                                     FStar_All.pipe_right uu____26840
                                        (FStar_Syntax_DsEnv.qualify monad_env)
                                       in
                                    let quals1 =
@@ -7435,55 +7554,55 @@ and (desugar_decl_aux :
       let no_fail_attrs ats =
         FStar_List.filter
           (fun at  ->
-             let uu____26645 = get_fail_attr1 false at  in
-             FStar_Option.isNone uu____26645) ats
+             let uu____26873 = get_fail_attr1 false at  in
+             FStar_Option.isNone uu____26873) ats
          in
       let env0 =
-        let uu____26666 = FStar_Syntax_DsEnv.snapshot env  in
-        FStar_All.pipe_right uu____26666 FStar_Pervasives_Native.snd  in
+        let uu____26894 = FStar_Syntax_DsEnv.snapshot env  in
+        FStar_All.pipe_right uu____26894 FStar_Pervasives_Native.snd  in
       let attrs = FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs
          in
-      let uu____26681 =
-        let uu____26688 = get_fail_attr false attrs  in
-        match uu____26688 with
+      let uu____26909 =
+        let uu____26916 = get_fail_attr false attrs  in
+        match uu____26916 with
         | FStar_Pervasives_Native.Some (expected_errs,lax) ->
             let d1 =
-              let uu___3445_26725 = d  in
+              let uu___3413_26953 = d  in
               {
-                FStar_Parser_AST.d = (uu___3445_26725.FStar_Parser_AST.d);
+                FStar_Parser_AST.d = (uu___3413_26953.FStar_Parser_AST.d);
                 FStar_Parser_AST.drange =
-                  (uu___3445_26725.FStar_Parser_AST.drange);
+                  (uu___3413_26953.FStar_Parser_AST.drange);
                 FStar_Parser_AST.quals =
-                  (uu___3445_26725.FStar_Parser_AST.quals);
+                  (uu___3413_26953.FStar_Parser_AST.quals);
                 FStar_Parser_AST.attrs = []
               }  in
-            let uu____26726 =
+            let uu____26954 =
               FStar_Errors.catch_errors
-                (fun uu____26744  ->
+                (fun uu____26972  ->
                    FStar_Options.with_saved_options
-                     (fun uu____26750  -> desugar_decl_noattrs env d1))
+                     (fun uu____26978  -> desugar_decl_noattrs env d1))
                in
-            (match uu____26726 with
+            (match uu____26954 with
              | (errs,r) ->
                  (match (errs, r) with
                   | ([],FStar_Pervasives_Native.Some (env1,ses)) ->
                       let ses1 =
                         FStar_List.map
                           (fun se  ->
-                             let uu___3460_26810 = se  in
-                             let uu____26811 = no_fail_attrs attrs  in
+                             let uu___3428_27038 = se  in
+                             let uu____27039 = no_fail_attrs attrs  in
                              {
                                FStar_Syntax_Syntax.sigel =
-                                 (uu___3460_26810.FStar_Syntax_Syntax.sigel);
+                                 (uu___3428_27038.FStar_Syntax_Syntax.sigel);
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___3460_26810.FStar_Syntax_Syntax.sigrng);
+                                 (uu___3428_27038.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___3460_26810.FStar_Syntax_Syntax.sigquals);
+                                 (uu___3428_27038.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___3460_26810.FStar_Syntax_Syntax.sigmeta);
-                               FStar_Syntax_Syntax.sigattrs = uu____26811;
+                                 (uu___3428_27038.FStar_Syntax_Syntax.sigmeta);
+                               FStar_Syntax_Syntax.sigattrs = uu____27039;
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___3460_26810.FStar_Syntax_Syntax.sigopts)
+                                 (uu___3428_27038.FStar_Syntax_Syntax.sigopts)
                              }) ses
                          in
                       let se =
@@ -7511,128 +7630,128 @@ and (desugar_decl_aux :
                       if expected_errs = []
                       then (env0, [])
                       else
-                        (let uu____26864 =
+                        (let uu____27092 =
                            FStar_Errors.find_multiset_discrepancy
                              expected_errs errnos
                             in
-                         match uu____26864 with
+                         match uu____27092 with
                          | FStar_Pervasives_Native.None  -> (env0, [])
                          | FStar_Pervasives_Native.Some (e,n1,n2) ->
                              (FStar_List.iter FStar_Errors.print_issue errs1;
-                              (let uu____26913 =
-                                 let uu____26919 =
-                                   let uu____26921 =
+                              (let uu____27141 =
+                                 let uu____27147 =
+                                   let uu____27149 =
                                      FStar_Common.string_of_list
                                        FStar_Util.string_of_int expected_errs
                                       in
-                                   let uu____26924 =
+                                   let uu____27152 =
                                      FStar_Common.string_of_list
                                        FStar_Util.string_of_int errnos
                                       in
-                                   let uu____26927 =
+                                   let uu____27155 =
                                      FStar_Util.string_of_int e  in
-                                   let uu____26929 =
+                                   let uu____27157 =
                                      FStar_Util.string_of_int n2  in
-                                   let uu____26931 =
+                                   let uu____27159 =
                                      FStar_Util.string_of_int n1  in
                                    FStar_Util.format5
                                      "This top-level definition was expected to raise error codes %s, but it raised %s (at desugaring time). Error #%s was raised %s times, instead of %s."
-                                     uu____26921 uu____26924 uu____26927
-                                     uu____26929 uu____26931
+                                     uu____27149 uu____27152 uu____27155
+                                     uu____27157 uu____27159
                                     in
-                                 (FStar_Errors.Error_DidNotFail, uu____26919)
+                                 (FStar_Errors.Error_DidNotFail, uu____27147)
                                   in
                                FStar_Errors.log_issue
-                                 d1.FStar_Parser_AST.drange uu____26913);
+                                 d1.FStar_Parser_AST.drange uu____27141);
                               (env0, [])))))
         | FStar_Pervasives_Native.None  -> desugar_decl_noattrs env d  in
-      match uu____26681 with
+      match uu____26909 with
       | (env1,sigelts) ->
           let rec val_attrs ses =
             match ses with
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-                  uu____26969;
-                FStar_Syntax_Syntax.sigrng = uu____26970;
-                FStar_Syntax_Syntax.sigquals = uu____26971;
-                FStar_Syntax_Syntax.sigmeta = uu____26972;
-                FStar_Syntax_Syntax.sigattrs = uu____26973;
-                FStar_Syntax_Syntax.sigopts = uu____26974;_}::[] ->
-                let uu____26987 =
-                  let uu____26990 = FStar_List.hd sigelts  in
-                  FStar_Syntax_Util.lids_of_sigelt uu____26990  in
-                FStar_All.pipe_right uu____26987
+                  uu____27197;
+                FStar_Syntax_Syntax.sigrng = uu____27198;
+                FStar_Syntax_Syntax.sigquals = uu____27199;
+                FStar_Syntax_Syntax.sigmeta = uu____27200;
+                FStar_Syntax_Syntax.sigattrs = uu____27201;
+                FStar_Syntax_Syntax.sigopts = uu____27202;_}::[] ->
+                let uu____27215 =
+                  let uu____27218 = FStar_List.hd sigelts  in
+                  FStar_Syntax_Util.lids_of_sigelt uu____27218  in
+                FStar_All.pipe_right uu____27215
                   (FStar_List.collect
                      (fun nm  ->
-                        let uu____26998 =
+                        let uu____27226 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env0 nm
                            in
-                        FStar_Pervasives_Native.snd uu____26998))
+                        FStar_Pervasives_Native.snd uu____27226))
             | {
                 FStar_Syntax_Syntax.sigel =
-                  FStar_Syntax_Syntax.Sig_inductive_typ uu____27011;
-                FStar_Syntax_Syntax.sigrng = uu____27012;
-                FStar_Syntax_Syntax.sigquals = uu____27013;
-                FStar_Syntax_Syntax.sigmeta = uu____27014;
-                FStar_Syntax_Syntax.sigattrs = uu____27015;
-                FStar_Syntax_Syntax.sigopts = uu____27016;_}::uu____27017 ->
-                let uu____27042 =
-                  let uu____27045 = FStar_List.hd sigelts  in
-                  FStar_Syntax_Util.lids_of_sigelt uu____27045  in
-                FStar_All.pipe_right uu____27042
+                  FStar_Syntax_Syntax.Sig_inductive_typ uu____27239;
+                FStar_Syntax_Syntax.sigrng = uu____27240;
+                FStar_Syntax_Syntax.sigquals = uu____27241;
+                FStar_Syntax_Syntax.sigmeta = uu____27242;
+                FStar_Syntax_Syntax.sigattrs = uu____27243;
+                FStar_Syntax_Syntax.sigopts = uu____27244;_}::uu____27245 ->
+                let uu____27270 =
+                  let uu____27273 = FStar_List.hd sigelts  in
+                  FStar_Syntax_Util.lids_of_sigelt uu____27273  in
+                FStar_All.pipe_right uu____27270
                   (FStar_List.collect
                      (fun nm  ->
-                        let uu____27053 =
+                        let uu____27281 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env0 nm
                            in
-                        FStar_Pervasives_Native.snd uu____27053))
+                        FStar_Pervasives_Native.snd uu____27281))
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_fail
                   (_errs,_lax,ses1);
-                FStar_Syntax_Syntax.sigrng = uu____27069;
-                FStar_Syntax_Syntax.sigquals = uu____27070;
-                FStar_Syntax_Syntax.sigmeta = uu____27071;
-                FStar_Syntax_Syntax.sigattrs = uu____27072;
-                FStar_Syntax_Syntax.sigopts = uu____27073;_}::[] ->
+                FStar_Syntax_Syntax.sigrng = uu____27297;
+                FStar_Syntax_Syntax.sigquals = uu____27298;
+                FStar_Syntax_Syntax.sigmeta = uu____27299;
+                FStar_Syntax_Syntax.sigattrs = uu____27300;
+                FStar_Syntax_Syntax.sigopts = uu____27301;_}::[] ->
                 FStar_List.collect (fun se  -> val_attrs [se]) ses1
-            | uu____27094 -> []  in
+            | uu____27322 -> []  in
           let attrs1 =
-            let uu____27100 = val_attrs sigelts  in
-            FStar_List.append attrs uu____27100  in
-          let uu____27103 =
+            let uu____27328 = val_attrs sigelts  in
+            FStar_List.append attrs uu____27328  in
+          let uu____27331 =
             FStar_List.map
               (fun sigelt  ->
-                 let uu___3520_27107 = sigelt  in
+                 let uu___3488_27335 = sigelt  in
                  {
                    FStar_Syntax_Syntax.sigel =
-                     (uu___3520_27107.FStar_Syntax_Syntax.sigel);
+                     (uu___3488_27335.FStar_Syntax_Syntax.sigel);
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___3520_27107.FStar_Syntax_Syntax.sigrng);
+                     (uu___3488_27335.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
-                     (uu___3520_27107.FStar_Syntax_Syntax.sigquals);
+                     (uu___3488_27335.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___3520_27107.FStar_Syntax_Syntax.sigmeta);
+                     (uu___3488_27335.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs = attrs1;
                    FStar_Syntax_Syntax.sigopts =
-                     (uu___3520_27107.FStar_Syntax_Syntax.sigopts)
+                     (uu___3488_27335.FStar_Syntax_Syntax.sigopts)
                  }) sigelts
              in
-          (env1, uu____27103)
+          (env1, uu____27331)
 
 and (desugar_decl :
   env_t -> FStar_Parser_AST.decl -> (env_t * FStar_Syntax_Syntax.sigelts)) =
   fun env  ->
     fun d  ->
-      let uu____27114 = desugar_decl_aux env d  in
-      match uu____27114 with
+      let uu____27342 = desugar_decl_aux env d  in
+      match uu____27342 with
       | (env1,ses) ->
-          let uu____27125 =
+          let uu____27353 =
             FStar_All.pipe_right ses
               (FStar_List.map generalize_annotated_univs)
              in
-          (env1, uu____27125)
+          (env1, uu____27353)
 
 and (desugar_decl_noattrs :
   FStar_Syntax_DsEnv.env ->
@@ -7661,49 +7780,49 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Open lid ->
           let env1 = FStar_Syntax_DsEnv.push_namespace env lid  in (env1, [])
       | FStar_Parser_AST.Friend lid ->
-          let uu____27157 = FStar_Syntax_DsEnv.iface env  in
-          if uu____27157
+          let uu____27385 = FStar_Syntax_DsEnv.iface env  in
+          if uu____27385
           then
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_FriendInterface,
                 "'friend' declarations are not allowed in interfaces")
               d.FStar_Parser_AST.drange
           else
-            (let uu____27172 =
-               let uu____27174 =
-                 let uu____27176 = FStar_Syntax_DsEnv.dep_graph env  in
-                 let uu____27177 = FStar_Syntax_DsEnv.current_module env  in
-                 FStar_Parser_Dep.module_has_interface uu____27176
-                   uu____27177
+            (let uu____27400 =
+               let uu____27402 =
+                 let uu____27404 = FStar_Syntax_DsEnv.dep_graph env  in
+                 let uu____27405 = FStar_Syntax_DsEnv.current_module env  in
+                 FStar_Parser_Dep.module_has_interface uu____27404
+                   uu____27405
                   in
-               Prims.op_Negation uu____27174  in
-             if uu____27172
+               Prims.op_Negation uu____27402  in
+             if uu____27400
              then
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_FriendInterface,
                    "'friend' declarations are not allowed in modules that lack interfaces")
                  d.FStar_Parser_AST.drange
              else
-               (let uu____27191 =
-                  let uu____27193 =
-                    let uu____27195 = FStar_Syntax_DsEnv.dep_graph env  in
-                    FStar_Parser_Dep.module_has_interface uu____27195 lid  in
-                  Prims.op_Negation uu____27193  in
-                if uu____27191
+               (let uu____27419 =
+                  let uu____27421 =
+                    let uu____27423 = FStar_Syntax_DsEnv.dep_graph env  in
+                    FStar_Parser_Dep.module_has_interface uu____27423 lid  in
+                  Prims.op_Negation uu____27421  in
+                if uu____27419
                 then
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_FriendInterface,
                       "'friend' declarations cannot refer to modules that lack interfaces")
                     d.FStar_Parser_AST.drange
                 else
-                  (let uu____27209 =
-                     let uu____27211 =
-                       let uu____27213 = FStar_Syntax_DsEnv.dep_graph env  in
-                       FStar_Parser_Dep.deps_has_implementation uu____27213
+                  (let uu____27437 =
+                     let uu____27439 =
+                       let uu____27441 = FStar_Syntax_DsEnv.dep_graph env  in
+                       FStar_Parser_Dep.deps_has_implementation uu____27441
                          lid
                         in
-                     Prims.op_Negation uu____27211  in
-                   if uu____27209
+                     Prims.op_Negation uu____27439  in
+                   if uu____27437
                    then
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_FriendInterface,
@@ -7713,8 +7832,8 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Include lid ->
           let env1 = FStar_Syntax_DsEnv.push_include env lid  in (env1, [])
       | FStar_Parser_AST.ModuleAbbrev (x,l) ->
-          let uu____27231 = FStar_Syntax_DsEnv.push_module_abbrev env x l  in
-          (uu____27231, [])
+          let uu____27459 = FStar_Syntax_DsEnv.push_module_abbrev env x l  in
+          (uu____27459, [])
       | FStar_Parser_AST.Tycon (is_effect,typeclass,tcs) ->
           let quals = d.FStar_Parser_AST.quals  in
           let quals1 =
@@ -7725,78 +7844,78 @@ and (desugar_decl_noattrs :
             if typeclass
             then
               match tcs with
-              | (FStar_Parser_AST.TyconRecord uu____27260)::[] ->
+              | (FStar_Parser_AST.TyconRecord uu____27488)::[] ->
                   FStar_Parser_AST.Noeq :: quals1
-              | uu____27279 ->
+              | uu____27507 ->
                   FStar_Errors.raise_error
                     (FStar_Errors.Error_BadClassDecl,
                       "Ill-formed `class` declaration: definition must be a record type")
                     d.FStar_Parser_AST.drange
             else quals1  in
-          let uu____27288 =
-            let uu____27293 =
+          let uu____27516 =
+            let uu____27521 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals2
                in
-            desugar_tycon env d uu____27293 tcs  in
-          (match uu____27288 with
+            desugar_tycon env d uu____27521 tcs  in
+          (match uu____27516 with
            | (env1,ses) ->
                let mkclass lid =
-                 let uu____27310 =
-                   let uu____27311 =
-                     let uu____27318 =
+                 let uu____27538 =
+                   let uu____27539 =
+                     let uu____27546 =
                        FStar_Syntax_Syntax.new_bv
                          FStar_Pervasives_Native.None FStar_Syntax_Syntax.tun
                         in
-                     FStar_Syntax_Syntax.mk_binder uu____27318  in
-                   [uu____27311]  in
-                 let uu____27331 =
-                   let uu____27334 =
+                     FStar_Syntax_Syntax.mk_binder uu____27546  in
+                   [uu____27539]  in
+                 let uu____27559 =
+                   let uu____27562 =
                      FStar_Syntax_Syntax.tabbrev
                        FStar_Parser_Const.mk_class_lid
                       in
-                   let uu____27337 =
-                     let uu____27348 =
-                       let uu____27357 =
-                         let uu____27358 = FStar_Ident.string_of_lid lid  in
-                         FStar_Syntax_Util.exp_string uu____27358  in
-                       FStar_Syntax_Syntax.as_arg uu____27357  in
-                     [uu____27348]  in
-                   FStar_Syntax_Util.mk_app uu____27334 uu____27337  in
-                 FStar_Syntax_Util.abs uu____27310 uu____27331
+                   let uu____27565 =
+                     let uu____27576 =
+                       let uu____27585 =
+                         let uu____27586 = FStar_Ident.string_of_lid lid  in
+                         FStar_Syntax_Util.exp_string uu____27586  in
+                       FStar_Syntax_Syntax.as_arg uu____27585  in
+                     [uu____27576]  in
+                   FStar_Syntax_Util.mk_app uu____27562 uu____27565  in
+                 FStar_Syntax_Util.abs uu____27538 uu____27559
                    FStar_Pervasives_Native.None
                   in
                let get_meths se =
                  let rec get_fname quals3 =
                    match quals3 with
                    | (FStar_Syntax_Syntax.Projector
-                       (uu____27398,id))::uu____27400 ->
+                       (uu____27626,id))::uu____27628 ->
                        FStar_Pervasives_Native.Some id
-                   | uu____27403::quals4 -> get_fname quals4
+                   | uu____27631::quals4 -> get_fname quals4
                    | [] -> FStar_Pervasives_Native.None  in
-                 let uu____27407 = get_fname se.FStar_Syntax_Syntax.sigquals
+                 let uu____27635 = get_fname se.FStar_Syntax_Syntax.sigquals
                     in
-                 match uu____27407 with
+                 match uu____27635 with
                  | FStar_Pervasives_Native.None  -> []
                  | FStar_Pervasives_Native.Some id ->
-                     let uu____27413 = FStar_Syntax_DsEnv.qualify env1 id  in
-                     [uu____27413]
+                     let uu____27641 = FStar_Syntax_DsEnv.qualify env1 id  in
+                     [uu____27641]
                   in
                let rec splice_decl meths se =
                  match se.FStar_Syntax_Syntax.sigel with
-                 | FStar_Syntax_Syntax.Sig_bundle (ses1,uu____27434) ->
+                 | FStar_Syntax_Syntax.Sig_bundle (ses1,uu____27662) ->
                      FStar_List.concatMap (splice_decl meths) ses1
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid,uu____27444,uu____27445,uu____27446,uu____27447,uu____27448)
+                     (lid,uu____27672,uu____27673,uu____27674,uu____27675,uu____27676)
                      ->
-                     let uu____27457 =
-                       let uu____27458 =
-                         let uu____27459 =
-                           let uu____27466 = mkclass lid  in
-                           (meths, uu____27466)  in
-                         FStar_Syntax_Syntax.Sig_splice uu____27459  in
+                     let uu____27685 =
+                       let uu____27686 =
+                         let uu____27687 =
+                           let uu____27694 = mkclass lid  in
+                           (meths, uu____27694)  in
+                         FStar_Syntax_Syntax.Sig_splice uu____27687  in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____27458;
+                         FStar_Syntax_Syntax.sigel = uu____27686;
                          FStar_Syntax_Syntax.sigrng =
                            (d.FStar_Parser_AST.drange);
                          FStar_Syntax_Syntax.sigquals = [];
@@ -7806,8 +7925,8 @@ and (desugar_decl_noattrs :
                          FStar_Syntax_Syntax.sigopts =
                            FStar_Pervasives_Native.None
                        }  in
-                     [uu____27457]
-                 | uu____27469 -> []  in
+                     [uu____27685]
+                 | uu____27697 -> []  in
                let extra =
                  if typeclass
                  then
@@ -7825,34 +7944,34 @@ and (desugar_decl_noattrs :
             (isrec = FStar_Parser_AST.NoLetQualifier) &&
               (match lets with
                | ({
-                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____27503;
-                    FStar_Parser_AST.prange = uu____27504;_},uu____27505)::[]
+                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____27731;
+                    FStar_Parser_AST.prange = uu____27732;_},uu____27733)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                      uu____27515;
-                    FStar_Parser_AST.prange = uu____27516;_},uu____27517)::[]
+                      uu____27743;
+                    FStar_Parser_AST.prange = uu____27744;_},uu____27745)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatOp
-                           uu____27533;
-                         FStar_Parser_AST.prange = uu____27534;_},uu____27535);
-                    FStar_Parser_AST.prange = uu____27536;_},uu____27537)::[]
+                           uu____27761;
+                         FStar_Parser_AST.prange = uu____27762;_},uu____27763);
+                    FStar_Parser_AST.prange = uu____27764;_},uu____27765)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                           uu____27559;
-                         FStar_Parser_AST.prange = uu____27560;_},uu____27561);
-                    FStar_Parser_AST.prange = uu____27562;_},uu____27563)::[]
+                           uu____27787;
+                         FStar_Parser_AST.prange = uu____27788;_},uu____27789);
+                    FStar_Parser_AST.prange = uu____27790;_},uu____27791)::[]
                    -> false
-               | (p,uu____27592)::[] ->
-                   let uu____27601 = is_app_pattern p  in
-                   Prims.op_Negation uu____27601
-               | uu____27603 -> false)
+               | (p,uu____27820)::[] ->
+                   let uu____27829 = is_app_pattern p  in
+                   Prims.op_Negation uu____27829
+               | uu____27831 -> false)
              in
           if Prims.op_Negation expand_toplevel_pattern
           then
@@ -7869,19 +7988,19 @@ and (desugar_decl_noattrs :
                         d.FStar_Parser_AST.drange FStar_Parser_AST.Expr)))
                 d.FStar_Parser_AST.drange FStar_Parser_AST.Expr
                in
-            let uu____27678 = desugar_term_maybe_top true env as_inner_let
+            let uu____27906 = desugar_term_maybe_top true env as_inner_let
                in
-            (match uu____27678 with
+            (match uu____27906 with
              | (ds_lets,aq) ->
                  (check_no_aq aq;
-                  (let uu____27691 =
-                     let uu____27692 =
+                  (let uu____27919 =
+                     let uu____27920 =
                        FStar_All.pipe_left FStar_Syntax_Subst.compress
                          ds_lets
                         in
-                     uu____27692.FStar_Syntax_Syntax.n  in
-                   match uu____27691 with
-                   | FStar_Syntax_Syntax.Tm_let (lbs,uu____27702) ->
+                     uu____27920.FStar_Syntax_Syntax.n  in
+                   match uu____27919 with
+                   | FStar_Syntax_Syntax.Tm_let (lbs,uu____27930) ->
                        let fvs =
                          FStar_All.pipe_right
                            (FStar_Pervasives_Native.snd lbs)
@@ -7890,54 +8009,54 @@ and (desugar_decl_noattrs :
                                  FStar_Util.right
                                    lb.FStar_Syntax_Syntax.lbname))
                           in
-                       let uu____27733 =
+                       let uu____27961 =
                          FStar_List.fold_right
                            (fun fv  ->
-                              fun uu____27758  ->
-                                match uu____27758 with
+                              fun uu____27986  ->
+                                match uu____27986 with
                                 | (qs,ats) ->
-                                    let uu____27785 =
+                                    let uu____28013 =
                                       FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                         env
                                         (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                        in
-                                    (match uu____27785 with
+                                    (match uu____28013 with
                                      | (qs',ats') ->
                                          ((FStar_List.append qs' qs),
                                            (FStar_List.append ats' ats))))
                            fvs ([], [])
                           in
-                       (match uu____27733 with
+                       (match uu____27961 with
                         | (val_quals,val_attrs) ->
                             let quals1 =
                               match quals with
-                              | uu____27839::uu____27840 ->
+                              | uu____28067::uu____28068 ->
                                   FStar_List.map
                                     (trans_qual1 FStar_Pervasives_Native.None)
                                     quals
-                              | uu____27843 -> val_quals  in
+                              | uu____28071 -> val_quals  in
                             let quals2 =
-                              let uu____27847 =
+                              let uu____28075 =
                                 FStar_All.pipe_right lets1
                                   (FStar_Util.for_some
-                                     (fun uu____27880  ->
-                                        match uu____27880 with
-                                        | (uu____27894,(uu____27895,t)) ->
+                                     (fun uu____28108  ->
+                                        match uu____28108 with
+                                        | (uu____28122,(uu____28123,t)) ->
                                             t.FStar_Parser_AST.level =
                                               FStar_Parser_AST.Formula))
                                  in
-                              if uu____27847
+                              if uu____28075
                               then FStar_Syntax_Syntax.Logic :: quals1
                               else quals1  in
                             let lbs1 =
-                              let uu____27915 =
+                              let uu____28143 =
                                 FStar_All.pipe_right quals2
                                   (FStar_List.contains
                                      FStar_Syntax_Syntax.Abstract)
                                  in
-                              if uu____27915
+                              if uu____28143
                               then
-                                let uu____27921 =
+                                let uu____28149 =
                                   FStar_All.pipe_right
                                     (FStar_Pervasives_Native.snd lbs)
                                     (FStar_List.map
@@ -7946,40 +8065,40 @@ and (desugar_decl_noattrs :
                                             FStar_Util.right
                                               lb.FStar_Syntax_Syntax.lbname
                                              in
-                                          let uu___3697_27936 = lb  in
+                                          let uu___3665_28164 = lb  in
                                           {
                                             FStar_Syntax_Syntax.lbname =
                                               (FStar_Util.Inr
-                                                 (let uu___3699_27938 = fv
+                                                 (let uu___3667_28166 = fv
                                                      in
                                                   {
                                                     FStar_Syntax_Syntax.fv_name
                                                       =
-                                                      (uu___3699_27938.FStar_Syntax_Syntax.fv_name);
+                                                      (uu___3667_28166.FStar_Syntax_Syntax.fv_name);
                                                     FStar_Syntax_Syntax.fv_delta
                                                       =
                                                       (FStar_Syntax_Syntax.Delta_abstract
                                                          (fv.FStar_Syntax_Syntax.fv_delta));
                                                     FStar_Syntax_Syntax.fv_qual
                                                       =
-                                                      (uu___3699_27938.FStar_Syntax_Syntax.fv_qual)
+                                                      (uu___3667_28166.FStar_Syntax_Syntax.fv_qual)
                                                   }));
                                             FStar_Syntax_Syntax.lbunivs =
-                                              (uu___3697_27936.FStar_Syntax_Syntax.lbunivs);
+                                              (uu___3665_28164.FStar_Syntax_Syntax.lbunivs);
                                             FStar_Syntax_Syntax.lbtyp =
-                                              (uu___3697_27936.FStar_Syntax_Syntax.lbtyp);
+                                              (uu___3665_28164.FStar_Syntax_Syntax.lbtyp);
                                             FStar_Syntax_Syntax.lbeff =
-                                              (uu___3697_27936.FStar_Syntax_Syntax.lbeff);
+                                              (uu___3665_28164.FStar_Syntax_Syntax.lbeff);
                                             FStar_Syntax_Syntax.lbdef =
-                                              (uu___3697_27936.FStar_Syntax_Syntax.lbdef);
+                                              (uu___3665_28164.FStar_Syntax_Syntax.lbdef);
                                             FStar_Syntax_Syntax.lbattrs =
-                                              (uu___3697_27936.FStar_Syntax_Syntax.lbattrs);
+                                              (uu___3665_28164.FStar_Syntax_Syntax.lbattrs);
                                             FStar_Syntax_Syntax.lbpos =
-                                              (uu___3697_27936.FStar_Syntax_Syntax.lbpos)
+                                              (uu___3665_28164.FStar_Syntax_Syntax.lbpos)
                                           }))
                                    in
                                 ((FStar_Pervasives_Native.fst lbs),
-                                  uu____27921)
+                                  uu____28149)
                               else lbs  in
                             let names =
                               FStar_All.pipe_right fvs
@@ -8008,17 +8127,17 @@ and (desugar_decl_noattrs :
                             let env1 = FStar_Syntax_DsEnv.push_sigelt env s
                                in
                             (env1, [s]))
-                   | uu____27963 ->
+                   | uu____28191 ->
                        failwith "Desugaring a let did not produce a let")))
           else
-            (let uu____27971 =
+            (let uu____28199 =
                match lets with
                | (pat,body)::[] -> (pat, body)
-               | uu____27990 ->
+               | uu____28218 ->
                    failwith
                      "expand_toplevel_pattern should only allow single definition lets"
                 in
-             match uu____27971 with
+             match uu____28199 with
              | (pat,body) ->
                  let fresh_toplevel_name =
                    FStar_Ident.gen FStar_Range.dummyRange  in
@@ -8031,58 +8150,58 @@ and (desugar_decl_noattrs :
                       in
                    match pat.FStar_Parser_AST.pat with
                    | FStar_Parser_AST.PatAscribed (pat1,ty) ->
-                       let uu___3722_28027 = pat1  in
+                       let uu___3690_28255 = pat1  in
                        {
                          FStar_Parser_AST.pat =
                            (FStar_Parser_AST.PatAscribed (var_pat, ty));
                          FStar_Parser_AST.prange =
-                           (uu___3722_28027.FStar_Parser_AST.prange)
+                           (uu___3690_28255.FStar_Parser_AST.prange)
                        }
-                   | uu____28034 -> var_pat  in
+                   | uu____28262 -> var_pat  in
                  let main_let =
                    desugar_decl env
-                     (let uu___3726_28041 = d  in
+                     (let uu___3694_28269 = d  in
                       {
                         FStar_Parser_AST.d =
                           (FStar_Parser_AST.TopLevelLet
                              (isrec, [(fresh_pat, body)]));
                         FStar_Parser_AST.drange =
-                          (uu___3726_28041.FStar_Parser_AST.drange);
+                          (uu___3694_28269.FStar_Parser_AST.drange);
                         FStar_Parser_AST.quals = (FStar_Parser_AST.Private ::
                           (d.FStar_Parser_AST.quals));
                         FStar_Parser_AST.attrs =
-                          (uu___3726_28041.FStar_Parser_AST.attrs)
+                          (uu___3694_28269.FStar_Parser_AST.attrs)
                       })
                     in
                  let main =
-                   let uu____28057 =
-                     let uu____28058 =
+                   let uu____28285 =
+                     let uu____28286 =
                        FStar_Ident.lid_of_ids [fresh_toplevel_name]  in
-                     FStar_Parser_AST.Var uu____28058  in
-                   FStar_Parser_AST.mk_term uu____28057
+                     FStar_Parser_AST.Var uu____28286  in
+                   FStar_Parser_AST.mk_term uu____28285
                      pat.FStar_Parser_AST.prange FStar_Parser_AST.Expr
                     in
-                 let build_generic_projection uu____28082 id_opt =
-                   match uu____28082 with
+                 let build_generic_projection uu____28310 id_opt =
+                   match uu____28310 with
                    | (env1,ses) ->
-                       let uu____28104 =
+                       let uu____28332 =
                          match id_opt with
                          | FStar_Pervasives_Native.Some id ->
                              let lid = FStar_Ident.lid_of_ids [id]  in
                              let branch =
-                               let uu____28116 = FStar_Ident.range_of_lid lid
+                               let uu____28344 = FStar_Ident.range_of_lid lid
                                   in
                                FStar_Parser_AST.mk_term
-                                 (FStar_Parser_AST.Var lid) uu____28116
+                                 (FStar_Parser_AST.Var lid) uu____28344
                                  FStar_Parser_AST.Expr
                                 in
                              let bv_pat =
-                               let uu____28118 = FStar_Ident.range_of_id id
+                               let uu____28346 = FStar_Ident.range_of_id id
                                   in
                                FStar_Parser_AST.mk_pattern
                                  (FStar_Parser_AST.PatVar
                                     (id, FStar_Pervasives_Native.None))
-                                 uu____28118
+                                 uu____28346
                                 in
                              (bv_pat, branch)
                          | FStar_Pervasives_Native.None  ->
@@ -8095,25 +8214,25 @@ and (desugar_decl_noattrs :
                                  FStar_Range.dummyRange FStar_Parser_AST.Expr
                                 in
                              let bv_pat =
-                               let uu____28124 = FStar_Ident.range_of_id id
+                               let uu____28352 = FStar_Ident.range_of_id id
                                   in
                                FStar_Parser_AST.mk_pattern
                                  (FStar_Parser_AST.PatVar
                                     (id, FStar_Pervasives_Native.None))
-                                 uu____28124
+                                 uu____28352
                                 in
                              let bv_pat1 =
-                               let uu____28128 = FStar_Ident.range_of_id id
+                               let uu____28356 = FStar_Ident.range_of_id id
                                   in
                                FStar_Parser_AST.mk_pattern
                                  (FStar_Parser_AST.PatAscribed
                                     (bv_pat,
                                       (unit_ty, FStar_Pervasives_Native.None)))
-                                 uu____28128
+                                 uu____28356
                                 in
                              (bv_pat1, branch)
                           in
-                       (match uu____28104 with
+                       (match uu____28332 with
                         | (bv_pat,branch) ->
                             let body1 =
                               FStar_Parser_AST.mk_term
@@ -8131,33 +8250,33 @@ and (desugar_decl_noattrs :
                                      [(bv_pat, body1)]))
                                 FStar_Range.dummyRange []
                                in
-                            let uu____28189 = desugar_decl env1 id_decl  in
-                            (match uu____28189 with
+                            let uu____28417 = desugar_decl env1 id_decl  in
+                            (match uu____28417 with
                              | (env2,ses') ->
                                  (env2, (FStar_List.append ses ses'))))
                     in
-                 let build_projection uu____28225 id =
-                   match uu____28225 with
+                 let build_projection uu____28453 id =
+                   match uu____28453 with
                    | (env1,ses) ->
                        build_generic_projection (env1, ses)
                          (FStar_Pervasives_Native.Some id)
                     in
-                 let build_coverage_check uu____28264 =
-                   match uu____28264 with
+                 let build_coverage_check uu____28492 =
+                   match uu____28492 with
                    | (env1,ses) ->
                        build_generic_projection (env1, ses)
                          FStar_Pervasives_Native.None
                     in
                  let bvs =
-                   let uu____28288 = gather_pattern_bound_vars pat  in
-                   FStar_All.pipe_right uu____28288 FStar_Util.set_elements
+                   let uu____28516 = gather_pattern_bound_vars pat  in
+                   FStar_All.pipe_right uu____28516 FStar_Util.set_elements
                     in
-                 let uu____28295 =
+                 let uu____28523 =
                    (FStar_List.isEmpty bvs) &&
-                     (let uu____28298 = is_var_pattern pat  in
-                      Prims.op_Negation uu____28298)
+                     (let uu____28526 = is_var_pattern pat  in
+                      Prims.op_Negation uu____28526)
                     in
-                 if uu____28295
+                 if uu____28523
                  then build_coverage_check main_let
                  else FStar_List.fold_left build_projection main_let bvs)
       | FStar_Parser_AST.Main t ->
@@ -8191,21 +8310,21 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Val (id,t) ->
           let quals = d.FStar_Parser_AST.quals  in
           let t1 =
-            let uu____28322 = close_fun env t  in
-            desugar_term env uu____28322  in
+            let uu____28550 = close_fun env t  in
+            desugar_term env uu____28550  in
           let quals1 =
-            let uu____28326 =
+            let uu____28554 =
               (FStar_Syntax_DsEnv.iface env) &&
                 (FStar_Syntax_DsEnv.admitted_iface env)
                in
-            if uu____28326
+            if uu____28554
             then FStar_Parser_AST.Assumption :: quals
             else quals  in
           let lid = FStar_Syntax_DsEnv.qualify env id  in
           let attrs =
             FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs  in
           let se =
-            let uu____28338 =
+            let uu____28566 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals1
                in
@@ -8213,7 +8332,7 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, [], t1));
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
-              FStar_Syntax_Syntax.sigquals = uu____28338;
+              FStar_Syntax_Syntax.sigquals = uu____28566;
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
               FStar_Syntax_Syntax.sigattrs = attrs;
@@ -8229,19 +8348,19 @@ and (desugar_decl_noattrs :
                   FStar_Parser_Const.exn_lid
             | FStar_Pervasives_Native.Some term ->
                 let t = desugar_term env term  in
-                let uu____28351 =
-                  let uu____28360 = FStar_Syntax_Syntax.null_binder t  in
-                  [uu____28360]  in
-                let uu____28379 =
-                  let uu____28382 =
+                let uu____28579 =
+                  let uu____28588 = FStar_Syntax_Syntax.null_binder t  in
+                  [uu____28588]  in
+                let uu____28607 =
+                  let uu____28610 =
                     FStar_Syntax_DsEnv.fail_or env
                       (FStar_Syntax_DsEnv.try_lookup_lid env)
                       FStar_Parser_Const.exn_lid
                      in
                   FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total
-                    uu____28382
+                    uu____28610
                    in
-                FStar_Syntax_Util.arrow uu____28351 uu____28379
+                FStar_Syntax_Util.arrow uu____28579 uu____28607
              in
           let l = FStar_Syntax_DsEnv.qualify env id  in
           let qual = [FStar_Syntax_Syntax.ExceptionConstructor]  in
@@ -8295,7 +8414,7 @@ and (desugar_decl_noattrs :
           desugar_effect env d quals true eff_name eff_binders eff_typ
             eff_decls attrs
       | FStar_Parser_AST.LayeredEffect (FStar_Parser_AST.RedefineEffect
-          uu____28445) ->
+          uu____28673) ->
           failwith
             "Impossible: LayeredEffect (RedefineEffect _) (should not be parseable)"
       | FStar_Parser_AST.SubEffect l ->
@@ -8307,44 +8426,44 @@ and (desugar_decl_noattrs :
             lookup_effect_lid env l.FStar_Parser_AST.mdest
               d.FStar_Parser_AST.drange
              in
-          let uu____28462 =
-            let uu____28464 =
+          let uu____28690 =
+            let uu____28692 =
               (FStar_Syntax_Util.is_layered src_ed) ||
                 (FStar_Syntax_Util.is_layered dst_ed)
                in
-            Prims.op_Negation uu____28464  in
-          if uu____28462
+            Prims.op_Negation uu____28692  in
+          if uu____28690
           then
-            let uu____28471 =
+            let uu____28699 =
               match l.FStar_Parser_AST.lift_op with
               | FStar_Parser_AST.NonReifiableLift t ->
-                  let uu____28489 =
-                    let uu____28492 =
-                      let uu____28493 = desugar_term env t  in
-                      ([], uu____28493)  in
-                    FStar_Pervasives_Native.Some uu____28492  in
-                  (uu____28489, FStar_Pervasives_Native.None)
+                  let uu____28717 =
+                    let uu____28720 =
+                      let uu____28721 = desugar_term env t  in
+                      ([], uu____28721)  in
+                    FStar_Pervasives_Native.Some uu____28720  in
+                  (uu____28717, FStar_Pervasives_Native.None)
               | FStar_Parser_AST.ReifiableLift (wp,t) ->
-                  let uu____28506 =
-                    let uu____28509 =
-                      let uu____28510 = desugar_term env wp  in
-                      ([], uu____28510)  in
-                    FStar_Pervasives_Native.Some uu____28509  in
-                  let uu____28517 =
-                    let uu____28520 =
-                      let uu____28521 = desugar_term env t  in
-                      ([], uu____28521)  in
-                    FStar_Pervasives_Native.Some uu____28520  in
-                  (uu____28506, uu____28517)
+                  let uu____28734 =
+                    let uu____28737 =
+                      let uu____28738 = desugar_term env wp  in
+                      ([], uu____28738)  in
+                    FStar_Pervasives_Native.Some uu____28737  in
+                  let uu____28745 =
+                    let uu____28748 =
+                      let uu____28749 = desugar_term env t  in
+                      ([], uu____28749)  in
+                    FStar_Pervasives_Native.Some uu____28748  in
+                  (uu____28734, uu____28745)
               | FStar_Parser_AST.LiftForFree t ->
-                  let uu____28533 =
-                    let uu____28536 =
-                      let uu____28537 = desugar_term env t  in
-                      ([], uu____28537)  in
-                    FStar_Pervasives_Native.Some uu____28536  in
-                  (FStar_Pervasives_Native.None, uu____28533)
+                  let uu____28761 =
+                    let uu____28764 =
+                      let uu____28765 = desugar_term env t  in
+                      ([], uu____28765)  in
+                    FStar_Pervasives_Native.Some uu____28764  in
+                  (FStar_Pervasives_Native.None, uu____28761)
                in
-            (match uu____28471 with
+            (match uu____28699 with
              | (lift_wp,lift) ->
                  let se =
                    {
@@ -8371,11 +8490,11 @@ and (desugar_decl_noattrs :
             (match l.FStar_Parser_AST.lift_op with
              | FStar_Parser_AST.NonReifiableLift t ->
                  let sub_eff =
-                   let uu____28571 =
-                     let uu____28574 =
-                       let uu____28575 = desugar_term env t  in
-                       ([], uu____28575)  in
-                     FStar_Pervasives_Native.Some uu____28574  in
+                   let uu____28799 =
+                     let uu____28802 =
+                       let uu____28803 = desugar_term env t  in
+                       ([], uu____28803)  in
+                     FStar_Pervasives_Native.Some uu____28802  in
                    {
                      FStar_Syntax_Syntax.source =
                        (src_ed.FStar_Syntax_Syntax.mname);
@@ -8383,7 +8502,7 @@ and (desugar_decl_noattrs :
                        (dst_ed.FStar_Syntax_Syntax.mname);
                      FStar_Syntax_Syntax.lift_wp =
                        FStar_Pervasives_Native.None;
-                     FStar_Syntax_Syntax.lift = uu____28571
+                     FStar_Syntax_Syntax.lift = uu____28799
                    }  in
                  (env,
                    [{
@@ -8398,28 +8517,28 @@ and (desugar_decl_noattrs :
                       FStar_Syntax_Syntax.sigopts =
                         FStar_Pervasives_Native.None
                     }])
-             | uu____28582 ->
+             | uu____28810 ->
                  failwith
                    "Impossible! unexpected lift_op for lift to a layered effect")
       | FStar_Parser_AST.Polymonadic_bind (m_eff,n_eff,p_eff,bind) ->
           let m = lookup_effect_lid env m_eff d.FStar_Parser_AST.drange  in
           let n = lookup_effect_lid env n_eff d.FStar_Parser_AST.drange  in
           let p = lookup_effect_lid env p_eff d.FStar_Parser_AST.drange  in
-          let uu____28595 =
-            let uu____28596 =
-              let uu____28597 =
-                let uu____28598 =
-                  let uu____28609 =
-                    let uu____28610 = desugar_term env bind  in
-                    ([], uu____28610)  in
+          let uu____28823 =
+            let uu____28824 =
+              let uu____28825 =
+                let uu____28826 =
+                  let uu____28837 =
+                    let uu____28838 = desugar_term env bind  in
+                    ([], uu____28838)  in
                   ((m.FStar_Syntax_Syntax.mname),
                     (n.FStar_Syntax_Syntax.mname),
-                    (p.FStar_Syntax_Syntax.mname), uu____28609,
+                    (p.FStar_Syntax_Syntax.mname), uu____28837,
                     ([], FStar_Syntax_Syntax.tun))
                    in
-                FStar_Syntax_Syntax.Sig_polymonadic_bind uu____28598  in
+                FStar_Syntax_Syntax.Sig_polymonadic_bind uu____28826  in
               {
-                FStar_Syntax_Syntax.sigel = uu____28597;
+                FStar_Syntax_Syntax.sigel = uu____28825;
                 FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
                 FStar_Syntax_Syntax.sigquals = [];
                 FStar_Syntax_Syntax.sigmeta =
@@ -8427,19 +8546,19 @@ and (desugar_decl_noattrs :
                 FStar_Syntax_Syntax.sigattrs = [];
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               }  in
-            [uu____28596]  in
-          (env, uu____28595)
+            [uu____28824]  in
+          (env, uu____28823)
       | FStar_Parser_AST.Splice (ids,t) ->
           let t1 = desugar_term env t  in
           let se =
-            let uu____28629 =
-              let uu____28630 =
-                let uu____28637 =
+            let uu____28857 =
+              let uu____28858 =
+                let uu____28865 =
                   FStar_List.map (FStar_Syntax_DsEnv.qualify env) ids  in
-                (uu____28637, t1)  in
-              FStar_Syntax_Syntax.Sig_splice uu____28630  in
+                (uu____28865, t1)  in
+              FStar_Syntax_Syntax.Sig_splice uu____28858  in
             {
-              FStar_Syntax_Syntax.sigel = uu____28629;
+              FStar_Syntax_Syntax.sigel = uu____28857;
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
               FStar_Syntax_Syntax.sigquals = [];
               FStar_Syntax_Syntax.sigmeta =
@@ -8456,18 +8575,18 @@ let (desugar_decls :
   =
   fun env  ->
     fun decls  ->
-      let uu____28664 =
+      let uu____28892 =
         FStar_List.fold_left
-          (fun uu____28684  ->
+          (fun uu____28912  ->
              fun d  ->
-               match uu____28684 with
+               match uu____28912 with
                | (env1,sigelts) ->
-                   let uu____28704 = desugar_decl env1 d  in
-                   (match uu____28704 with
+                   let uu____28932 = desugar_decl env1 d  in
+                   (match uu____28932 with
                     | (env2,se) -> (env2, (FStar_List.append sigelts se))))
           (env, []) decls
          in
-      match uu____28664 with | (env1,sigelts) -> (env1, sigelts)
+      match uu____28892 with | (env1,sigelts) -> (env1, sigelts)
   
 let (open_prims_all :
   (FStar_Parser_AST.decoration Prims.list -> FStar_Parser_AST.decl)
@@ -8490,41 +8609,41 @@ let (desugar_modul_common :
       fun m  ->
         let env1 =
           match (curmod, m) with
-          | (FStar_Pervasives_Native.None ,uu____28795) -> env
+          | (FStar_Pervasives_Native.None ,uu____29023) -> env
           | (FStar_Pervasives_Native.Some
              { FStar_Syntax_Syntax.name = prev_lid;
-               FStar_Syntax_Syntax.declarations = uu____28799;
-               FStar_Syntax_Syntax.exports = uu____28800;
-               FStar_Syntax_Syntax.is_interface = uu____28801;_},FStar_Parser_AST.Module
-             (current_lid,uu____28803)) when
+               FStar_Syntax_Syntax.declarations = uu____29027;
+               FStar_Syntax_Syntax.exports = uu____29028;
+               FStar_Syntax_Syntax.is_interface = uu____29029;_},FStar_Parser_AST.Module
+             (current_lid,uu____29031)) when
               (FStar_Ident.lid_equals prev_lid current_lid) &&
                 (FStar_Options.interactive ())
               -> env
-          | (FStar_Pervasives_Native.Some prev_mod,uu____28812) ->
-              let uu____28815 =
+          | (FStar_Pervasives_Native.Some prev_mod,uu____29040) ->
+              let uu____29043 =
                 FStar_Syntax_DsEnv.finish_module_or_interface env prev_mod
                  in
-              FStar_Pervasives_Native.fst uu____28815
+              FStar_Pervasives_Native.fst uu____29043
            in
-        let uu____28820 =
+        let uu____29048 =
           match m with
           | FStar_Parser_AST.Interface (mname,decls,admitted) ->
-              let uu____28862 =
+              let uu____29090 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface true admitted
                   env1 mname FStar_Syntax_DsEnv.default_mii
                  in
-              (uu____28862, mname, decls, true)
+              (uu____29090, mname, decls, true)
           | FStar_Parser_AST.Module (mname,decls) ->
-              let uu____28884 =
+              let uu____29112 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface false false
                   env1 mname FStar_Syntax_DsEnv.default_mii
                  in
-              (uu____28884, mname, decls, false)
+              (uu____29112, mname, decls, false)
            in
-        match uu____28820 with
+        match uu____29048 with
         | ((env2,pop_when_done),mname,decls,intf) ->
-            let uu____28926 = desugar_decls env2 decls  in
-            (match uu____28926 with
+            let uu____29154 = desugar_decls env2 decls  in
+            (match uu____29154 with
              | (env3,sigelts) ->
                  let modul =
                    {
@@ -8550,23 +8669,23 @@ let (desugar_partial_modul :
     fun env  ->
       fun m  ->
         let m1 =
-          let uu____28994 =
+          let uu____29222 =
             (FStar_Options.interactive ()) &&
-              (let uu____28997 =
-                 let uu____28999 =
-                   let uu____29001 = FStar_Options.file_list ()  in
-                   FStar_List.hd uu____29001  in
-                 FStar_Util.get_file_extension uu____28999  in
-               FStar_List.mem uu____28997 ["fsti"; "fsi"])
+              (let uu____29225 =
+                 let uu____29227 =
+                   let uu____29229 = FStar_Options.file_list ()  in
+                   FStar_List.hd uu____29229  in
+                 FStar_Util.get_file_extension uu____29227  in
+               FStar_List.mem uu____29225 ["fsti"; "fsi"])
              in
-          if uu____28994 then as_interface m else m  in
-        let uu____29015 = desugar_modul_common curmod env m1  in
-        match uu____29015 with
+          if uu____29222 then as_interface m else m  in
+        let uu____29243 = desugar_modul_common curmod env m1  in
+        match uu____29243 with
         | (env1,modul,pop_when_done) ->
             if pop_when_done
             then
-              let uu____29037 = FStar_Syntax_DsEnv.pop ()  in
-              (uu____29037, modul)
+              let uu____29265 = FStar_Syntax_DsEnv.pop ()  in
+              (uu____29265, modul)
             else (env1, modul)
   
 let (desugar_modul :
@@ -8575,32 +8694,34 @@ let (desugar_modul :
   =
   fun env  ->
     fun m  ->
-      let uu____29059 =
+      let uu____29287 =
         desugar_modul_common FStar_Pervasives_Native.None env m  in
-      match uu____29059 with
+      match uu____29287 with
       | (env1,modul,pop_when_done) ->
-          let uu____29076 =
+          let uu____29304 =
             FStar_Syntax_DsEnv.finish_module_or_interface env1 modul  in
-          (match uu____29076 with
+          (match uu____29304 with
            | (env2,modul1) ->
-               ((let uu____29088 =
-                   FStar_Options.dump_module
-                     (modul1.FStar_Syntax_Syntax.name).FStar_Ident.str
-                    in
-                 if uu____29088
+               ((let uu____29316 =
+                   let uu____29318 =
+                     FStar_Ident.string_of_lid
+                       modul1.FStar_Syntax_Syntax.name
+                      in
+                   FStar_Options.dump_module uu____29318  in
+                 if uu____29316
                  then
-                   let uu____29091 =
+                   let uu____29321 =
                      FStar_Syntax_Print.modul_to_string modul1  in
                    FStar_Util.print1 "Module after desugaring:\n%s\n"
-                     uu____29091
+                     uu____29321
                  else ());
-                (let uu____29096 =
+                (let uu____29326 =
                    if pop_when_done
                    then
                      FStar_Syntax_DsEnv.export_interface
                        modul1.FStar_Syntax_Syntax.name env2
                    else env2  in
-                 (uu____29096, modul1))))
+                 (uu____29326, modul1))))
   
 let with_options : 'a . (unit -> 'a) -> 'a =
   fun f  ->
@@ -8618,9 +8739,9 @@ let (ast_modul_to_modul :
   fun modul  ->
     fun env  ->
       with_options
-        (fun uu____29146  ->
-           let uu____29147 = desugar_modul env modul  in
-           match uu____29147 with | (e,m) -> (m, e))
+        (fun uu____29376  ->
+           let uu____29377 = desugar_modul env modul  in
+           match uu____29377 with | (e,m) -> (m, e))
   
 let (decls_to_sigelts :
   FStar_Parser_AST.decl Prims.list ->
@@ -8629,9 +8750,9 @@ let (decls_to_sigelts :
   fun decls  ->
     fun env  ->
       with_options
-        (fun uu____29185  ->
-           let uu____29186 = desugar_decls env decls  in
-           match uu____29186 with | (env1,sigelts) -> (sigelts, env1))
+        (fun uu____29415  ->
+           let uu____29416 = desugar_decls env decls  in
+           match uu____29416 with | (env1,sigelts) -> (sigelts, env1))
   
 let (partial_ast_modul_to_modul :
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
@@ -8642,9 +8763,9 @@ let (partial_ast_modul_to_modul :
     fun a_modul  ->
       fun env  ->
         with_options
-          (fun uu____29237  ->
-             let uu____29238 = desugar_partial_modul modul env a_modul  in
-             match uu____29238 with | (env1,modul1) -> (modul1, env1))
+          (fun uu____29467  ->
+             let uu____29468 = desugar_partial_modul modul env a_modul  in
+             match uu____29468 with | (env1,modul1) -> (modul1, env1))
   
 let (add_modul_to_env :
   FStar_Syntax_Syntax.modul ->
@@ -8660,51 +8781,51 @@ let (add_modul_to_env :
             let erase_binders bs =
               match bs with
               | [] -> []
-              | uu____29333 ->
+              | uu____29563 ->
                   let t =
-                    let uu____29343 =
+                    let uu____29573 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_abs
                            (bs, FStar_Syntax_Syntax.t_unit,
                              FStar_Pervasives_Native.None))
                         FStar_Pervasives_Native.None FStar_Range.dummyRange
                        in
-                    erase_univs uu____29343  in
-                  let uu____29356 =
-                    let uu____29357 = FStar_Syntax_Subst.compress t  in
-                    uu____29357.FStar_Syntax_Syntax.n  in
-                  (match uu____29356 with
-                   | FStar_Syntax_Syntax.Tm_abs (bs1,uu____29369,uu____29370)
+                    erase_univs uu____29573  in
+                  let uu____29586 =
+                    let uu____29587 = FStar_Syntax_Subst.compress t  in
+                    uu____29587.FStar_Syntax_Syntax.n  in
+                  (match uu____29586 with
+                   | FStar_Syntax_Syntax.Tm_abs (bs1,uu____29599,uu____29600)
                        -> bs1
-                   | uu____29395 -> failwith "Impossible")
+                   | uu____29625 -> failwith "Impossible")
                in
-            let uu____29405 =
-              let uu____29412 = erase_binders ed.FStar_Syntax_Syntax.binders
+            let uu____29635 =
+              let uu____29642 = erase_binders ed.FStar_Syntax_Syntax.binders
                  in
-              FStar_Syntax_Subst.open_term' uu____29412
+              FStar_Syntax_Subst.open_term' uu____29642
                 FStar_Syntax_Syntax.t_unit
                in
-            match uu____29405 with
-            | (binders,uu____29414,binders_opening) ->
+            match uu____29635 with
+            | (binders,uu____29644,binders_opening) ->
                 let erase_term t =
-                  let uu____29422 =
-                    let uu____29423 =
+                  let uu____29652 =
+                    let uu____29653 =
                       FStar_Syntax_Subst.subst binders_opening t  in
-                    erase_univs uu____29423  in
-                  FStar_Syntax_Subst.close binders uu____29422  in
-                let erase_tscheme uu____29441 =
-                  match uu____29441 with
+                    erase_univs uu____29653  in
+                  FStar_Syntax_Subst.close binders uu____29652  in
+                let erase_tscheme uu____29671 =
+                  match uu____29671 with
                   | (us,t) ->
                       let t1 =
-                        let uu____29461 =
+                        let uu____29691 =
                           FStar_Syntax_Subst.shift_subst
                             (FStar_List.length us) binders_opening
                            in
-                        FStar_Syntax_Subst.subst uu____29461 t  in
-                      let uu____29464 =
-                        let uu____29465 = erase_univs t1  in
-                        FStar_Syntax_Subst.close binders uu____29465  in
-                      ([], uu____29464)
+                        FStar_Syntax_Subst.subst uu____29691 t  in
+                      let uu____29694 =
+                        let uu____29695 = erase_univs t1  in
+                        FStar_Syntax_Subst.close binders uu____29695  in
+                      ([], uu____29694)
                    in
                 let erase_action action =
                   let opening =
@@ -8716,13 +8837,13 @@ let (add_modul_to_env :
                   let erased_action_params =
                     match action.FStar_Syntax_Syntax.action_params with
                     | [] -> []
-                    | uu____29488 ->
+                    | uu____29718 ->
                         let bs =
-                          let uu____29498 =
+                          let uu____29728 =
                             FStar_Syntax_Subst.subst_binders opening
                               action.FStar_Syntax_Syntax.action_params
                              in
-                          FStar_All.pipe_left erase_binders uu____29498  in
+                          FStar_All.pipe_left erase_binders uu____29728  in
                         let t =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_abs
@@ -8731,109 +8852,109 @@ let (add_modul_to_env :
                             FStar_Pervasives_Native.None
                             FStar_Range.dummyRange
                            in
-                        let uu____29538 =
-                          let uu____29539 =
-                            let uu____29542 =
+                        let uu____29768 =
+                          let uu____29769 =
+                            let uu____29772 =
                               FStar_Syntax_Subst.close binders t  in
-                            FStar_Syntax_Subst.compress uu____29542  in
-                          uu____29539.FStar_Syntax_Syntax.n  in
-                        (match uu____29538 with
+                            FStar_Syntax_Subst.compress uu____29772  in
+                          uu____29769.FStar_Syntax_Syntax.n  in
+                        (match uu____29768 with
                          | FStar_Syntax_Syntax.Tm_abs
-                             (bs1,uu____29544,uu____29545) -> bs1
-                         | uu____29570 -> failwith "Impossible")
+                             (bs1,uu____29774,uu____29775) -> bs1
+                         | uu____29800 -> failwith "Impossible")
                      in
                   let erase_term1 t =
-                    let uu____29578 =
-                      let uu____29579 = FStar_Syntax_Subst.subst opening t
+                    let uu____29808 =
+                      let uu____29809 = FStar_Syntax_Subst.subst opening t
                          in
-                      erase_univs uu____29579  in
-                    FStar_Syntax_Subst.close binders uu____29578  in
-                  let uu___4022_29580 = action  in
-                  let uu____29581 =
+                      erase_univs uu____29809  in
+                    FStar_Syntax_Subst.close binders uu____29808  in
+                  let uu___3990_29810 = action  in
+                  let uu____29811 =
                     erase_term1 action.FStar_Syntax_Syntax.action_defn  in
-                  let uu____29582 =
+                  let uu____29812 =
                     erase_term1 action.FStar_Syntax_Syntax.action_typ  in
                   {
                     FStar_Syntax_Syntax.action_name =
-                      (uu___4022_29580.FStar_Syntax_Syntax.action_name);
+                      (uu___3990_29810.FStar_Syntax_Syntax.action_name);
                     FStar_Syntax_Syntax.action_unqualified_name =
-                      (uu___4022_29580.FStar_Syntax_Syntax.action_unqualified_name);
+                      (uu___3990_29810.FStar_Syntax_Syntax.action_unqualified_name);
                     FStar_Syntax_Syntax.action_univs = [];
                     FStar_Syntax_Syntax.action_params = erased_action_params;
-                    FStar_Syntax_Syntax.action_defn = uu____29581;
-                    FStar_Syntax_Syntax.action_typ = uu____29582
+                    FStar_Syntax_Syntax.action_defn = uu____29811;
+                    FStar_Syntax_Syntax.action_typ = uu____29812
                   }  in
-                let uu___4024_29583 = ed  in
-                let uu____29584 = FStar_Syntax_Subst.close_binders binders
+                let uu___3992_29813 = ed  in
+                let uu____29814 = FStar_Syntax_Subst.close_binders binders
                    in
-                let uu____29585 =
+                let uu____29815 =
                   erase_tscheme ed.FStar_Syntax_Syntax.signature  in
-                let uu____29586 =
+                let uu____29816 =
                   FStar_Syntax_Util.apply_eff_combinators erase_tscheme
                     ed.FStar_Syntax_Syntax.combinators
                    in
-                let uu____29587 =
+                let uu____29817 =
                   FStar_List.map erase_action ed.FStar_Syntax_Syntax.actions
                    in
                 {
                   FStar_Syntax_Syntax.mname =
-                    (uu___4024_29583.FStar_Syntax_Syntax.mname);
+                    (uu___3992_29813.FStar_Syntax_Syntax.mname);
                   FStar_Syntax_Syntax.cattributes =
-                    (uu___4024_29583.FStar_Syntax_Syntax.cattributes);
+                    (uu___3992_29813.FStar_Syntax_Syntax.cattributes);
                   FStar_Syntax_Syntax.univs = [];
-                  FStar_Syntax_Syntax.binders = uu____29584;
-                  FStar_Syntax_Syntax.signature = uu____29585;
-                  FStar_Syntax_Syntax.combinators = uu____29586;
-                  FStar_Syntax_Syntax.actions = uu____29587;
+                  FStar_Syntax_Syntax.binders = uu____29814;
+                  FStar_Syntax_Syntax.signature = uu____29815;
+                  FStar_Syntax_Syntax.combinators = uu____29816;
+                  FStar_Syntax_Syntax.actions = uu____29817;
                   FStar_Syntax_Syntax.eff_attrs =
-                    (uu___4024_29583.FStar_Syntax_Syntax.eff_attrs)
+                    (uu___3992_29813.FStar_Syntax_Syntax.eff_attrs)
                 }
              in
           let push_sigelt env se =
             match se.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_new_effect ed ->
                 let se' =
-                  let uu___4031_29603 = se  in
-                  let uu____29604 =
-                    let uu____29605 = erase_univs_ed ed  in
-                    FStar_Syntax_Syntax.Sig_new_effect uu____29605  in
+                  let uu___3999_29833 = se  in
+                  let uu____29834 =
+                    let uu____29835 = erase_univs_ed ed  in
+                    FStar_Syntax_Syntax.Sig_new_effect uu____29835  in
                   {
-                    FStar_Syntax_Syntax.sigel = uu____29604;
+                    FStar_Syntax_Syntax.sigel = uu____29834;
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___4031_29603.FStar_Syntax_Syntax.sigrng);
+                      (uu___3999_29833.FStar_Syntax_Syntax.sigrng);
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___4031_29603.FStar_Syntax_Syntax.sigquals);
+                      (uu___3999_29833.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___4031_29603.FStar_Syntax_Syntax.sigmeta);
+                      (uu___3999_29833.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___4031_29603.FStar_Syntax_Syntax.sigattrs);
+                      (uu___3999_29833.FStar_Syntax_Syntax.sigattrs);
                     FStar_Syntax_Syntax.sigopts =
-                      (uu___4031_29603.FStar_Syntax_Syntax.sigopts)
+                      (uu___3999_29833.FStar_Syntax_Syntax.sigopts)
                   }  in
                 let env1 = FStar_Syntax_DsEnv.push_sigelt env se'  in
                 push_reflect_effect env1 se.FStar_Syntax_Syntax.sigquals
                   ed.FStar_Syntax_Syntax.mname se.FStar_Syntax_Syntax.sigrng
-            | uu____29607 -> FStar_Syntax_DsEnv.push_sigelt env se  in
-          let uu____29608 =
+            | uu____29837 -> FStar_Syntax_DsEnv.push_sigelt env se  in
+          let uu____29838 =
             FStar_Syntax_DsEnv.prepare_module_or_interface false false en
               m.FStar_Syntax_Syntax.name mii
              in
-          match uu____29608 with
+          match uu____29838 with
           | (en1,pop_when_done) ->
               let en2 =
-                let uu____29625 =
+                let uu____29855 =
                   FStar_Syntax_DsEnv.set_current_module en1
                     m.FStar_Syntax_Syntax.name
                    in
-                FStar_List.fold_left push_sigelt uu____29625
+                FStar_List.fold_left push_sigelt uu____29855
                   m.FStar_Syntax_Syntax.exports
                  in
               let env = FStar_Syntax_DsEnv.finish en2 m  in
-              let uu____29627 =
+              let uu____29857 =
                 if pop_when_done
                 then
                   FStar_Syntax_DsEnv.export_interface
                     m.FStar_Syntax_Syntax.name env
                 else env  in
-              ((), uu____29627)
+              ((), uu____29857)
   

--- a/src/ocaml-output/FStar_TypeChecker_Cfg.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Cfg.ml
@@ -1636,7 +1636,7 @@ let (add_step :
   primitive_step -> prim_step_set -> primitive_step FStar_Util.psmap) =
   fun s  ->
     fun ss  ->
-      let uu____3549 = FStar_Ident.text_of_lid s.name  in
+      let uu____3549 = FStar_Ident.string_of_lid s.name  in
       FStar_Util.psmap_add ss uu____3549 s
   
 let (merge_steps : prim_step_set -> prim_step_set -> prim_step_set) =
@@ -1730,7 +1730,7 @@ let (find_prim_step :
   fun cfg1  ->
     fun fv  ->
       let uu____3886 =
-        FStar_Ident.text_of_lid
+        FStar_Ident.string_of_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
          in
       FStar_Util.psmap_try_find cfg1.primitive_steps uu____3886
@@ -1740,7 +1740,7 @@ let (is_prim_step : cfg -> FStar_Syntax_Syntax.fv -> Prims.bool) =
     fun fv  ->
       let uu____3900 =
         let uu____3903 =
-          FStar_Ident.text_of_lid
+          FStar_Ident.string_of_lid
             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
            in
         FStar_Util.psmap_try_find cfg1.primitive_steps uu____3903  in
@@ -1823,7 +1823,7 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
              (match uu____4323 with
               | (FStar_Syntax_Syntax.Tm_fvar fv1,(arg,uu____4360)::[]) when
                   let uu____4395 =
-                    FStar_Ident.text_of_lid
+                    FStar_Ident.string_of_lid
                       (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                      in
                   FStar_Util.ends_with uu____4395 "int_to_t" ->

--- a/src/ocaml-output/FStar_TypeChecker_Common.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Common.ml
@@ -471,50 +471,51 @@ let (check_uvar_ctx_invariant :
                               FStar_Syntax_Print.bv_to_string x  in
                             Prims.op_Hat "Binding_var " uu____1735
                         | FStar_Syntax_Syntax.Binding_univ u ->
-                            Prims.op_Hat "Binding_univ " u.FStar_Ident.idText
-                        | FStar_Syntax_Syntax.Binding_lid (l,uu____1741) ->
-                            let uu____1758 = FStar_Ident.string_of_lid l  in
-                            Prims.op_Hat "Binding_lid " uu____1758))
+                            let uu____1739 = FStar_Ident.text_of_id u  in
+                            Prims.op_Hat "Binding_univ " uu____1739
+                        | FStar_Syntax_Syntax.Binding_lid (l,uu____1743) ->
+                            let uu____1760 = FStar_Ident.string_of_lid l  in
+                            Prims.op_Hat "Binding_lid " uu____1760))
                  in
               FStar_All.pipe_right uu____1719 (FStar_String.concat "::\n")
                in
-            let fail uu____1771 =
-              let uu____1772 =
-                let uu____1774 = FStar_Range.string_of_range r  in
-                let uu____1776 = print_gamma g  in
-                let uu____1778 = FStar_Syntax_Print.binders_to_string ", " bs
+            let fail uu____1773 =
+              let uu____1774 =
+                let uu____1776 = FStar_Range.string_of_range r  in
+                let uu____1778 = print_gamma g  in
+                let uu____1780 = FStar_Syntax_Print.binders_to_string ", " bs
                    in
                 FStar_Util.format5
                   "Invariant violation: gamma and binders are out of sync\n\treason=%s, range=%s, should_check=%s\n\t\n                               gamma=%s\n\tbinders=%s\n"
-                  reason uu____1774
-                  (if should_check then "true" else "false") uu____1776
-                  uu____1778
+                  reason uu____1776
+                  (if should_check then "true" else "false") uu____1778
+                  uu____1780
                  in
-              failwith uu____1772  in
+              failwith uu____1774  in
             if Prims.op_Negation should_check
             then ()
             else
-              (let uu____1791 =
-                 let uu____1816 =
+              (let uu____1793 =
+                 let uu____1818 =
                    FStar_Util.prefix_until
-                     (fun uu___4_1831  ->
-                        match uu___4_1831 with
-                        | FStar_Syntax_Syntax.Binding_var uu____1833 -> true
-                        | uu____1835 -> false) g
+                     (fun uu___4_1833  ->
+                        match uu___4_1833 with
+                        | FStar_Syntax_Syntax.Binding_var uu____1835 -> true
+                        | uu____1837 -> false) g
                     in
-                 (uu____1816, bs)  in
-               match uu____1791 with
+                 (uu____1818, bs)  in
+               match uu____1793 with
                | (FStar_Pervasives_Native.None ,[]) -> ()
                | (FStar_Pervasives_Native.Some
-                  (uu____1893,hd,gamma_tail),uu____1896::uu____1897) ->
-                   let uu____1956 = FStar_Util.prefix bs  in
-                   (match uu____1956 with
-                    | (uu____1981,(x,uu____1983)) ->
+                  (uu____1895,hd,gamma_tail),uu____1898::uu____1899) ->
+                   let uu____1958 = FStar_Util.prefix bs  in
+                   (match uu____1958 with
+                    | (uu____1983,(x,uu____1985)) ->
                         (match hd with
                          | FStar_Syntax_Syntax.Binding_var x' when
                              FStar_Syntax_Syntax.bv_eq x x' -> ()
-                         | uu____2011 -> fail ()))
-               | uu____2012 -> fail ())
+                         | uu____2013 -> fail ()))
+               | uu____2014 -> fail ())
   
 type implicit =
   {
@@ -595,19 +596,19 @@ let (conj_guard_f : guard_formula -> guard_formula -> guard_formula) =
       | (Trivial ,g) -> g
       | (g,Trivial ) -> g
       | (NonTrivial f1,NonTrivial f2) ->
-          let uu____2261 = FStar_Syntax_Util.mk_conj f1 f2  in
-          NonTrivial uu____2261
+          let uu____2263 = FStar_Syntax_Util.mk_conj f1 f2  in
+          NonTrivial uu____2263
   
 let (check_trivial : FStar_Syntax_Syntax.term -> guard_formula) =
   fun t  ->
-    let uu____2268 =
-      let uu____2269 = FStar_Syntax_Util.unmeta t  in
-      uu____2269.FStar_Syntax_Syntax.n  in
-    match uu____2268 with
+    let uu____2270 =
+      let uu____2271 = FStar_Syntax_Util.unmeta t  in
+      uu____2271.FStar_Syntax_Syntax.n  in
+    match uu____2270 with
     | FStar_Syntax_Syntax.Tm_fvar tc when
         FStar_Syntax_Syntax.fv_eq_lid tc FStar_Parser_Const.true_lid ->
         Trivial
-    | uu____2273 -> NonTrivial t
+    | uu____2275 -> NonTrivial t
   
 let (imp_guard_f : guard_formula -> guard_formula -> guard_formula) =
   fun g1  ->
@@ -625,9 +626,9 @@ let (binop_guard :
   fun f  ->
     fun g1  ->
       fun g2  ->
-        let uu____2316 = f g1.guard_f g2.guard_f  in
+        let uu____2318 = f g1.guard_f g2.guard_f  in
         {
-          guard_f = uu____2316;
+          guard_f = uu____2318;
           deferred = (FStar_List.append g1.deferred g2.deferred);
           univ_ineqs =
             ((FStar_List.append (FStar_Pervasives_Native.fst g1.univ_ineqs)
@@ -649,15 +650,15 @@ let (weaken_guard_formula : guard_t -> FStar_Syntax_Syntax.typ -> guard_t) =
       match g.guard_f with
       | Trivial  -> g
       | NonTrivial f ->
-          let uu___302_2386 = g  in
-          let uu____2387 =
-            let uu____2388 = FStar_Syntax_Util.mk_imp fml f  in
-            check_trivial uu____2388  in
+          let uu___302_2388 = g  in
+          let uu____2389 =
+            let uu____2390 = FStar_Syntax_Util.mk_imp fml f  in
+            check_trivial uu____2390  in
           {
-            guard_f = uu____2387;
-            deferred = (uu___302_2386.deferred);
-            univ_ineqs = (uu___302_2386.univ_ineqs);
-            implicits = (uu___302_2386.implicits)
+            guard_f = uu____2389;
+            deferred = (uu___302_2388.deferred);
+            univ_ineqs = (uu___302_2388.univ_ineqs);
+            implicits = (uu___302_2388.implicits)
           }
   
 type lcomp =
@@ -704,16 +705,16 @@ let (mk_lcomp :
     fun res_typ  ->
       fun cflags  ->
         fun comp_thunk  ->
-          let uu____2637 = FStar_Util.mk_ref (FStar_Util.Inl comp_thunk)  in
-          { eff_name; res_typ; cflags; comp_thunk = uu____2637 }
+          let uu____2639 = FStar_Util.mk_ref (FStar_Util.Inl comp_thunk)  in
+          { eff_name; res_typ; cflags; comp_thunk = uu____2639 }
   
 let (lcomp_comp : lcomp -> (FStar_Syntax_Syntax.comp * guard_t)) =
   fun lc  ->
-    let uu____2679 = FStar_ST.op_Bang lc.comp_thunk  in
-    match uu____2679 with
+    let uu____2681 = FStar_ST.op_Bang lc.comp_thunk  in
+    match uu____2681 with
     | FStar_Util.Inl thunk ->
-        let uu____2751 = thunk ()  in
-        (match uu____2751 with
+        let uu____2753 = thunk ()  in
+        (match uu____2753 with
          | (c,g) ->
              (FStar_ST.op_Colon_Equals lc.comp_thunk (FStar_Util.Inr c);
               (c, g)))
@@ -727,26 +728,26 @@ let (apply_lcomp :
     fun fg  ->
       fun lc  ->
         mk_lcomp lc.eff_name lc.res_typ lc.cflags
-          (fun uu____2851  ->
-             let uu____2852 = lcomp_comp lc  in
-             match uu____2852 with
+          (fun uu____2853  ->
+             let uu____2854 = lcomp_comp lc  in
+             match uu____2854 with
              | (c,g) ->
-                 let uu____2863 = fc c  in
-                 let uu____2864 = fg g  in (uu____2863, uu____2864))
+                 let uu____2865 = fc c  in
+                 let uu____2866 = fg g  in (uu____2865, uu____2866))
   
 let (lcomp_to_string : lcomp -> Prims.string) =
   fun lc  ->
-    let uu____2872 = FStar_Options.print_effect_args ()  in
-    if uu____2872
+    let uu____2874 = FStar_Options.print_effect_args ()  in
+    if uu____2874
     then
-      let uu____2876 =
-        let uu____2877 = FStar_All.pipe_right lc lcomp_comp  in
-        FStar_All.pipe_right uu____2877 FStar_Pervasives_Native.fst  in
-      FStar_Syntax_Print.comp_to_string uu____2876
+      let uu____2878 =
+        let uu____2879 = FStar_All.pipe_right lc lcomp_comp  in
+        FStar_All.pipe_right uu____2879 FStar_Pervasives_Native.fst  in
+      FStar_Syntax_Print.comp_to_string uu____2878
     else
-      (let uu____2892 = FStar_Syntax_Print.lid_to_string lc.eff_name  in
-       let uu____2894 = FStar_Syntax_Print.term_to_string lc.res_typ  in
-       FStar_Util.format2 "%s %s" uu____2892 uu____2894)
+      (let uu____2894 = FStar_Syntax_Print.lid_to_string lc.eff_name  in
+       let uu____2896 = FStar_Syntax_Print.term_to_string lc.res_typ  in
+       FStar_Util.format2 "%s %s" uu____2894 uu____2896)
   
 let (lcomp_set_flags :
   lcomp -> FStar_Syntax_Syntax.cflag Prims.list -> lcomp) =
@@ -754,48 +755,48 @@ let (lcomp_set_flags :
     fun fs  ->
       let comp_typ_set_flags c =
         match c.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Total uu____2922 -> c
-        | FStar_Syntax_Syntax.GTotal uu____2931 -> c
+        | FStar_Syntax_Syntax.Total uu____2924 -> c
+        | FStar_Syntax_Syntax.GTotal uu____2933 -> c
         | FStar_Syntax_Syntax.Comp ct ->
             let ct1 =
-              let uu___352_2942 = ct  in
+              let uu___352_2944 = ct  in
               {
                 FStar_Syntax_Syntax.comp_univs =
-                  (uu___352_2942.FStar_Syntax_Syntax.comp_univs);
+                  (uu___352_2944.FStar_Syntax_Syntax.comp_univs);
                 FStar_Syntax_Syntax.effect_name =
-                  (uu___352_2942.FStar_Syntax_Syntax.effect_name);
+                  (uu___352_2944.FStar_Syntax_Syntax.effect_name);
                 FStar_Syntax_Syntax.result_typ =
-                  (uu___352_2942.FStar_Syntax_Syntax.result_typ);
+                  (uu___352_2944.FStar_Syntax_Syntax.result_typ);
                 FStar_Syntax_Syntax.effect_args =
-                  (uu___352_2942.FStar_Syntax_Syntax.effect_args);
+                  (uu___352_2944.FStar_Syntax_Syntax.effect_args);
                 FStar_Syntax_Syntax.flags = fs
               }  in
-            let uu___355_2943 = c  in
+            let uu___355_2945 = c  in
             {
               FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
               FStar_Syntax_Syntax.pos =
-                (uu___355_2943.FStar_Syntax_Syntax.pos);
+                (uu___355_2945.FStar_Syntax_Syntax.pos);
               FStar_Syntax_Syntax.vars =
-                (uu___355_2943.FStar_Syntax_Syntax.vars)
+                (uu___355_2945.FStar_Syntax_Syntax.vars)
             }
          in
       mk_lcomp lc.eff_name lc.res_typ fs
-        (fun uu____2946  ->
-           let uu____2947 = FStar_All.pipe_right lc lcomp_comp  in
-           FStar_All.pipe_right uu____2947
-             (fun uu____2969  ->
-                match uu____2969 with | (c,g) -> ((comp_typ_set_flags c), g)))
+        (fun uu____2948  ->
+           let uu____2949 = FStar_All.pipe_right lc lcomp_comp  in
+           FStar_All.pipe_right uu____2949
+             (fun uu____2971  ->
+                match uu____2971 with | (c,g) -> ((comp_typ_set_flags c), g)))
   
 let (is_total_lcomp : lcomp -> Prims.bool) =
   fun c  ->
     (FStar_Ident.lid_equals c.eff_name FStar_Parser_Const.effect_Tot_lid) ||
       (FStar_All.pipe_right c.cflags
          (FStar_Util.for_some
-            (fun uu___5_2995  ->
-               match uu___5_2995 with
+            (fun uu___5_2997  ->
+               match uu___5_2997 with
                | FStar_Syntax_Syntax.TOTAL  -> true
                | FStar_Syntax_Syntax.RETURN  -> true
-               | uu____2999 -> false)))
+               | uu____3001 -> false)))
   
 let (is_tot_or_gtot_lcomp : lcomp -> Prims.bool) =
   fun c  ->
@@ -804,21 +805,21 @@ let (is_tot_or_gtot_lcomp : lcomp -> Prims.bool) =
       ||
       (FStar_All.pipe_right c.cflags
          (FStar_Util.for_some
-            (fun uu___6_3012  ->
-               match uu___6_3012 with
+            (fun uu___6_3014  ->
+               match uu___6_3014 with
                | FStar_Syntax_Syntax.TOTAL  -> true
                | FStar_Syntax_Syntax.RETURN  -> true
-               | uu____3016 -> false)))
+               | uu____3018 -> false)))
   
 let (is_lcomp_partial_return : lcomp -> Prims.bool) =
   fun c  ->
     FStar_All.pipe_right c.cflags
       (FStar_Util.for_some
-         (fun uu___7_3029  ->
-            match uu___7_3029 with
+         (fun uu___7_3031  ->
+            match uu___7_3031 with
             | FStar_Syntax_Syntax.RETURN  -> true
             | FStar_Syntax_Syntax.PARTIAL_RETURN  -> true
-            | uu____3033 -> false))
+            | uu____3035 -> false))
   
 let (is_pure_lcomp : lcomp -> Prims.bool) =
   fun lc  ->
@@ -826,10 +827,10 @@ let (is_pure_lcomp : lcomp -> Prims.bool) =
       ||
       (FStar_All.pipe_right lc.cflags
          (FStar_Util.for_some
-            (fun uu___8_3046  ->
-               match uu___8_3046 with
+            (fun uu___8_3048  ->
+               match uu___8_3048 with
                | FStar_Syntax_Syntax.LEMMA  -> true
-               | uu____3049 -> false)))
+               | uu____3051 -> false)))
   
 let (is_pure_or_ghost_lcomp : lcomp -> Prims.bool) =
   fun lc  ->
@@ -839,14 +840,14 @@ let (set_result_typ_lc : lcomp -> FStar_Syntax_Syntax.typ -> lcomp) =
   fun lc  ->
     fun t  ->
       mk_lcomp lc.eff_name t lc.cflags
-        (fun uu____3071  ->
-           let uu____3072 = FStar_All.pipe_right lc lcomp_comp  in
-           FStar_All.pipe_right uu____3072
-             (fun uu____3099  ->
-                match uu____3099 with
+        (fun uu____3073  ->
+           let uu____3074 = FStar_All.pipe_right lc lcomp_comp  in
+           FStar_All.pipe_right uu____3074
+             (fun uu____3101  ->
+                match uu____3101 with
                 | (c,g) ->
-                    let uu____3116 = FStar_Syntax_Util.set_result_typ c t  in
-                    (uu____3116, g)))
+                    let uu____3118 = FStar_Syntax_Util.set_result_typ c t  in
+                    (uu____3118, g)))
   
 let (residual_comp_of_lcomp : lcomp -> FStar_Syntax_Syntax.residual_comp) =
   fun lc  ->
@@ -859,167 +860,167 @@ let (residual_comp_of_lcomp : lcomp -> FStar_Syntax_Syntax.residual_comp) =
   
 let (lcomp_of_comp : FStar_Syntax_Syntax.comp -> lcomp) =
   fun c0  ->
-    let uu____3131 =
+    let uu____3133 =
       match c0.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total uu____3144 ->
+      | FStar_Syntax_Syntax.Total uu____3146 ->
           (FStar_Parser_Const.effect_Tot_lid, [FStar_Syntax_Syntax.TOTAL])
-      | FStar_Syntax_Syntax.GTotal uu____3155 ->
+      | FStar_Syntax_Syntax.GTotal uu____3157 ->
           (FStar_Parser_Const.effect_GTot_lid,
             [FStar_Syntax_Syntax.SOMETRIVIAL])
       | FStar_Syntax_Syntax.Comp c ->
           ((c.FStar_Syntax_Syntax.effect_name),
             (c.FStar_Syntax_Syntax.flags))
        in
-    match uu____3131 with
+    match uu____3133 with
     | (eff_name,flags) ->
         mk_lcomp eff_name (FStar_Syntax_Util.comp_result c0) flags
-          (fun uu____3176  -> (c0, trivial_guard))
+          (fun uu____3178  -> (c0, trivial_guard))
   
 let (simplify :
   Prims.bool -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun debug  ->
     fun tm  ->
       let w t =
-        let uu___404_3202 = t  in
+        let uu___404_3204 = t  in
         {
-          FStar_Syntax_Syntax.n = (uu___404_3202.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___404_3204.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (tm.FStar_Syntax_Syntax.pos);
-          FStar_Syntax_Syntax.vars = (uu___404_3202.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___404_3204.FStar_Syntax_Syntax.vars)
         }  in
       let simp_t t =
-        let uu____3214 =
-          let uu____3215 = FStar_Syntax_Util.unmeta t  in
-          uu____3215.FStar_Syntax_Syntax.n  in
-        match uu____3214 with
+        let uu____3216 =
+          let uu____3217 = FStar_Syntax_Util.unmeta t  in
+          uu____3217.FStar_Syntax_Syntax.n  in
+        match uu____3216 with
         | FStar_Syntax_Syntax.Tm_fvar fv when
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.true_lid ->
             FStar_Pervasives_Native.Some true
         | FStar_Syntax_Syntax.Tm_fvar fv when
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.false_lid ->
             FStar_Pervasives_Native.Some false
-        | uu____3227 -> FStar_Pervasives_Native.None  in
+        | uu____3229 -> FStar_Pervasives_Native.None  in
       let rec args_are_binders args bs =
         match (args, bs) with
-        | ((t,uu____3291)::args1,(bv,uu____3294)::bs1) ->
-            let uu____3348 =
-              let uu____3349 = FStar_Syntax_Subst.compress t  in
-              uu____3349.FStar_Syntax_Syntax.n  in
-            (match uu____3348 with
+        | ((t,uu____3293)::args1,(bv,uu____3296)::bs1) ->
+            let uu____3350 =
+              let uu____3351 = FStar_Syntax_Subst.compress t  in
+              uu____3351.FStar_Syntax_Syntax.n  in
+            (match uu____3350 with
              | FStar_Syntax_Syntax.Tm_name bv' ->
                  (FStar_Syntax_Syntax.bv_eq bv bv') &&
                    (args_are_binders args1 bs1)
-             | uu____3354 -> false)
+             | uu____3356 -> false)
         | ([],[]) -> true
-        | (uu____3385,uu____3386) -> false  in
+        | (uu____3387,uu____3388) -> false  in
       let is_applied bs t =
         if debug
         then
-          (let uu____3437 = FStar_Syntax_Print.term_to_string t  in
-           let uu____3439 = FStar_Syntax_Print.tag_of_term t  in
-           FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____3437
-             uu____3439)
+          (let uu____3439 = FStar_Syntax_Print.term_to_string t  in
+           let uu____3441 = FStar_Syntax_Print.tag_of_term t  in
+           FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____3439
+             uu____3441)
         else ();
-        (let uu____3444 = FStar_Syntax_Util.head_and_args' t  in
-         match uu____3444 with
+        (let uu____3446 = FStar_Syntax_Util.head_and_args' t  in
+         match uu____3446 with
          | (hd,args) ->
-             let uu____3483 =
-               let uu____3484 = FStar_Syntax_Subst.compress hd  in
-               uu____3484.FStar_Syntax_Syntax.n  in
-             (match uu____3483 with
+             let uu____3485 =
+               let uu____3486 = FStar_Syntax_Subst.compress hd  in
+               uu____3486.FStar_Syntax_Syntax.n  in
+             (match uu____3485 with
               | FStar_Syntax_Syntax.Tm_name bv when args_are_binders args bs
                   ->
                   (if debug
                    then
-                     (let uu____3492 = FStar_Syntax_Print.term_to_string t
+                     (let uu____3494 = FStar_Syntax_Print.term_to_string t
                          in
-                      let uu____3494 = FStar_Syntax_Print.bv_to_string bv  in
-                      let uu____3496 = FStar_Syntax_Print.term_to_string hd
+                      let uu____3496 = FStar_Syntax_Print.bv_to_string bv  in
+                      let uu____3498 = FStar_Syntax_Print.term_to_string hd
                          in
                       FStar_Util.print3
                         "WPE> got it\n>>>>top = %s\n>>>>b = %s\n>>>>hd = %s\n"
-                        uu____3492 uu____3494 uu____3496)
+                        uu____3494 uu____3496 uu____3498)
                    else ();
                    FStar_Pervasives_Native.Some bv)
-              | uu____3501 -> FStar_Pervasives_Native.None))
+              | uu____3503 -> FStar_Pervasives_Native.None))
          in
       let is_applied_maybe_squashed bs t =
         if debug
         then
-          (let uu____3519 = FStar_Syntax_Print.term_to_string t  in
-           let uu____3521 = FStar_Syntax_Print.tag_of_term t  in
+          (let uu____3521 = FStar_Syntax_Print.term_to_string t  in
+           let uu____3523 = FStar_Syntax_Print.tag_of_term t  in
            FStar_Util.print2 "WPE> is_applied_maybe_squashed %s -- %s\n"
-             uu____3519 uu____3521)
+             uu____3521 uu____3523)
         else ();
-        (let uu____3526 = FStar_Syntax_Util.is_squash t  in
-         match uu____3526 with
-         | FStar_Pervasives_Native.Some (uu____3537,t') -> is_applied bs t'
-         | uu____3549 ->
-             let uu____3558 = FStar_Syntax_Util.is_auto_squash t  in
-             (match uu____3558 with
-              | FStar_Pervasives_Native.Some (uu____3569,t') ->
+        (let uu____3528 = FStar_Syntax_Util.is_squash t  in
+         match uu____3528 with
+         | FStar_Pervasives_Native.Some (uu____3539,t') -> is_applied bs t'
+         | uu____3551 ->
+             let uu____3560 = FStar_Syntax_Util.is_auto_squash t  in
+             (match uu____3560 with
+              | FStar_Pervasives_Native.Some (uu____3571,t') ->
                   is_applied bs t'
-              | uu____3581 -> is_applied bs t))
+              | uu____3583 -> is_applied bs t))
          in
       let is_const_match phi =
-        let uu____3602 =
-          let uu____3603 = FStar_Syntax_Subst.compress phi  in
-          uu____3603.FStar_Syntax_Syntax.n  in
-        match uu____3602 with
-        | FStar_Syntax_Syntax.Tm_match (uu____3609,br::brs) ->
-            let uu____3676 = br  in
-            (match uu____3676 with
-             | (uu____3694,uu____3695,e) ->
+        let uu____3604 =
+          let uu____3605 = FStar_Syntax_Subst.compress phi  in
+          uu____3605.FStar_Syntax_Syntax.n  in
+        match uu____3604 with
+        | FStar_Syntax_Syntax.Tm_match (uu____3611,br::brs) ->
+            let uu____3678 = br  in
+            (match uu____3678 with
+             | (uu____3696,uu____3697,e) ->
                  let r =
-                   let uu____3717 = simp_t e  in
-                   match uu____3717 with
+                   let uu____3719 = simp_t e  in
+                   match uu____3719 with
                    | FStar_Pervasives_Native.None  ->
                        FStar_Pervasives_Native.None
                    | FStar_Pervasives_Native.Some b ->
-                       let uu____3729 =
+                       let uu____3731 =
                          FStar_List.for_all
-                           (fun uu____3748  ->
-                              match uu____3748 with
-                              | (uu____3762,uu____3763,e') ->
-                                  let uu____3777 = simp_t e'  in
-                                  uu____3777 =
+                           (fun uu____3750  ->
+                              match uu____3750 with
+                              | (uu____3764,uu____3765,e') ->
+                                  let uu____3779 = simp_t e'  in
+                                  uu____3779 =
                                     (FStar_Pervasives_Native.Some b)) brs
                           in
-                       if uu____3729
+                       if uu____3731
                        then FStar_Pervasives_Native.Some b
                        else FStar_Pervasives_Native.None
                     in
                  r)
-        | uu____3793 -> FStar_Pervasives_Native.None  in
+        | uu____3795 -> FStar_Pervasives_Native.None  in
       let maybe_auto_squash t =
-        let uu____3803 = FStar_Syntax_Util.is_sub_singleton t  in
-        if uu____3803
+        let uu____3805 = FStar_Syntax_Util.is_sub_singleton t  in
+        if uu____3805
         then t
         else FStar_Syntax_Util.mk_auto_squash FStar_Syntax_Syntax.U_zero t
          in
       let squashed_head_un_auto_squash_args t =
-        let maybe_un_auto_squash_arg uu____3841 =
-          match uu____3841 with
+        let maybe_un_auto_squash_arg uu____3843 =
+          match uu____3843 with
           | (t1,q) ->
-              let uu____3862 = FStar_Syntax_Util.is_auto_squash t1  in
-              (match uu____3862 with
+              let uu____3864 = FStar_Syntax_Util.is_auto_squash t1  in
+              (match uu____3864 with
                | FStar_Pervasives_Native.Some
                    (FStar_Syntax_Syntax.U_zero ,t2) -> (t2, q)
-               | uu____3894 -> (t1, q))
+               | uu____3896 -> (t1, q))
            in
-        let uu____3907 = FStar_Syntax_Util.head_and_args t  in
-        match uu____3907 with
+        let uu____3909 = FStar_Syntax_Util.head_and_args t  in
+        match uu____3909 with
         | (head,args) ->
             let args1 = FStar_List.map maybe_un_auto_squash_arg args  in
             FStar_Syntax_Syntax.mk_Tm_app head args1
               FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
          in
       let rec clearly_inhabited ty =
-        let uu____3987 =
-          let uu____3988 = FStar_Syntax_Util.unmeta ty  in
-          uu____3988.FStar_Syntax_Syntax.n  in
-        match uu____3987 with
-        | FStar_Syntax_Syntax.Tm_uinst (t,uu____3993) -> clearly_inhabited t
-        | FStar_Syntax_Syntax.Tm_arrow (uu____3998,c) ->
+        let uu____3989 =
+          let uu____3990 = FStar_Syntax_Util.unmeta ty  in
+          uu____3990.FStar_Syntax_Syntax.n  in
+        match uu____3989 with
+        | FStar_Syntax_Syntax.Tm_uinst (t,uu____3995) -> clearly_inhabited t
+        | FStar_Syntax_Syntax.Tm_arrow (uu____4000,c) ->
             clearly_inhabited (FStar_Syntax_Util.comp_result c)
         | FStar_Syntax_Syntax.Tm_fvar fv ->
             let l = FStar_Syntax_Syntax.lid_of_fv fv  in
@@ -1027,258 +1028,258 @@ let (simplify :
                 (FStar_Ident.lid_equals l FStar_Parser_Const.bool_lid))
                || (FStar_Ident.lid_equals l FStar_Parser_Const.string_lid))
               || (FStar_Ident.lid_equals l FStar_Parser_Const.exn_lid)
-        | uu____4022 -> false  in
+        | uu____4024 -> false  in
       let simplify arg =
-        let uu____4055 = simp_t (FStar_Pervasives_Native.fst arg)  in
-        (uu____4055, arg)  in
-      let uu____4070 =
-        let uu____4071 = FStar_Syntax_Subst.compress tm  in
-        uu____4071.FStar_Syntax_Syntax.n  in
-      match uu____4070 with
+        let uu____4057 = simp_t (FStar_Pervasives_Native.fst arg)  in
+        (uu____4057, arg)  in
+      let uu____4072 =
+        let uu____4073 = FStar_Syntax_Subst.compress tm  in
+        uu____4073.FStar_Syntax_Syntax.n  in
+      match uu____4072 with
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                  FStar_Syntax_Syntax.pos = uu____4075;
-                  FStar_Syntax_Syntax.vars = uu____4076;_},uu____4077);
-             FStar_Syntax_Syntax.pos = uu____4078;
-             FStar_Syntax_Syntax.vars = uu____4079;_},args)
+                  FStar_Syntax_Syntax.pos = uu____4077;
+                  FStar_Syntax_Syntax.vars = uu____4078;_},uu____4079);
+             FStar_Syntax_Syntax.pos = uu____4080;
+             FStar_Syntax_Syntax.vars = uu____4081;_},args)
           ->
-          let uu____4109 =
+          let uu____4111 =
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.and_lid  in
-          if uu____4109
+          if uu____4111
           then
-            let uu____4112 =
+            let uu____4114 =
               FStar_All.pipe_right args (FStar_List.map simplify)  in
-            (match uu____4112 with
-             | (FStar_Pervasives_Native.Some (true ),uu____4170)::(uu____4171,
-                                                                   (arg,uu____4173))::[]
+            (match uu____4114 with
+             | (FStar_Pervasives_Native.Some (true ),uu____4172)::(uu____4173,
+                                                                   (arg,uu____4175))::[]
                  -> maybe_auto_squash arg
-             | (uu____4246,(arg,uu____4248))::(FStar_Pervasives_Native.Some
-                                               (true ),uu____4249)::[]
+             | (uu____4248,(arg,uu____4250))::(FStar_Pervasives_Native.Some
+                                               (true ),uu____4251)::[]
                  -> maybe_auto_squash arg
-             | (FStar_Pervasives_Native.Some (false ),uu____4322)::uu____4323::[]
+             | (FStar_Pervasives_Native.Some (false ),uu____4324)::uu____4325::[]
                  -> w FStar_Syntax_Util.t_false
-             | uu____4393::(FStar_Pervasives_Native.Some (false ),uu____4394)::[]
+             | uu____4395::(FStar_Pervasives_Native.Some (false ),uu____4396)::[]
                  -> w FStar_Syntax_Util.t_false
-             | uu____4464 -> squashed_head_un_auto_squash_args tm)
+             | uu____4466 -> squashed_head_un_auto_squash_args tm)
           else
-            (let uu____4482 =
+            (let uu____4484 =
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.or_lid  in
-             if uu____4482
+             if uu____4484
              then
-               let uu____4485 =
+               let uu____4487 =
                  FStar_All.pipe_right args (FStar_List.map simplify)  in
-               match uu____4485 with
-               | (FStar_Pervasives_Native.Some (true ),uu____4543)::uu____4544::[]
+               match uu____4487 with
+               | (FStar_Pervasives_Native.Some (true ),uu____4545)::uu____4546::[]
                    -> w FStar_Syntax_Util.t_true
-               | uu____4614::(FStar_Pervasives_Native.Some (true
-                              ),uu____4615)::[]
+               | uu____4616::(FStar_Pervasives_Native.Some (true
+                              ),uu____4617)::[]
                    -> w FStar_Syntax_Util.t_true
-               | (FStar_Pervasives_Native.Some (false ),uu____4685)::
-                   (uu____4686,(arg,uu____4688))::[] -> maybe_auto_squash arg
-               | (uu____4761,(arg,uu____4763))::(FStar_Pervasives_Native.Some
-                                                 (false ),uu____4764)::[]
+               | (FStar_Pervasives_Native.Some (false ),uu____4687)::
+                   (uu____4688,(arg,uu____4690))::[] -> maybe_auto_squash arg
+               | (uu____4763,(arg,uu____4765))::(FStar_Pervasives_Native.Some
+                                                 (false ),uu____4766)::[]
                    -> maybe_auto_squash arg
-               | uu____4837 -> squashed_head_un_auto_squash_args tm
+               | uu____4839 -> squashed_head_un_auto_squash_args tm
              else
-               (let uu____4855 =
+               (let uu____4857 =
                   FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid
                    in
-                if uu____4855
+                if uu____4857
                 then
-                  let uu____4858 =
+                  let uu____4860 =
                     FStar_All.pipe_right args (FStar_List.map simplify)  in
-                  match uu____4858 with
-                  | uu____4916::(FStar_Pervasives_Native.Some (true
-                                 ),uu____4917)::[]
+                  match uu____4860 with
+                  | uu____4918::(FStar_Pervasives_Native.Some (true
+                                 ),uu____4919)::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (false ),uu____4987)::uu____4988::[]
+                  | (FStar_Pervasives_Native.Some (false ),uu____4989)::uu____4990::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (true ),uu____5058)::
-                      (uu____5059,(arg,uu____5061))::[] ->
+                  | (FStar_Pervasives_Native.Some (true ),uu____5060)::
+                      (uu____5061,(arg,uu____5063))::[] ->
                       maybe_auto_squash arg
-                  | (uu____5134,(p,uu____5136))::(uu____5137,(q,uu____5139))::[]
+                  | (uu____5136,(p,uu____5138))::(uu____5139,(q,uu____5141))::[]
                       ->
-                      let uu____5211 = FStar_Syntax_Util.term_eq p q  in
-                      (if uu____5211
+                      let uu____5213 = FStar_Syntax_Util.term_eq p q  in
+                      (if uu____5213
                        then w FStar_Syntax_Util.t_true
                        else squashed_head_un_auto_squash_args tm)
-                  | uu____5216 -> squashed_head_un_auto_squash_args tm
+                  | uu____5218 -> squashed_head_un_auto_squash_args tm
                 else
-                  (let uu____5234 =
+                  (let uu____5236 =
                      FStar_Syntax_Syntax.fv_eq_lid fv
                        FStar_Parser_Const.iff_lid
                       in
-                   if uu____5234
+                   if uu____5236
                    then
-                     let uu____5237 =
+                     let uu____5239 =
                        FStar_All.pipe_right args (FStar_List.map simplify)
                         in
-                     match uu____5237 with
-                     | (FStar_Pervasives_Native.Some (true ),uu____5295)::
-                         (FStar_Pervasives_Native.Some (true ),uu____5296)::[]
+                     match uu____5239 with
+                     | (FStar_Pervasives_Native.Some (true ),uu____5297)::
+                         (FStar_Pervasives_Native.Some (true ),uu____5298)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (false ),uu____5370)::
-                         (FStar_Pervasives_Native.Some (false ),uu____5371)::[]
+                     | (FStar_Pervasives_Native.Some (false ),uu____5372)::
+                         (FStar_Pervasives_Native.Some (false ),uu____5373)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (true ),uu____5445)::
-                         (FStar_Pervasives_Native.Some (false ),uu____5446)::[]
+                     | (FStar_Pervasives_Native.Some (true ),uu____5447)::
+                         (FStar_Pervasives_Native.Some (false ),uu____5448)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (FStar_Pervasives_Native.Some (false ),uu____5520)::
-                         (FStar_Pervasives_Native.Some (true ),uu____5521)::[]
+                     | (FStar_Pervasives_Native.Some (false ),uu____5522)::
+                         (FStar_Pervasives_Native.Some (true ),uu____5523)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (uu____5595,(arg,uu____5597))::(FStar_Pervasives_Native.Some
-                                                       (true ),uu____5598)::[]
+                     | (uu____5597,(arg,uu____5599))::(FStar_Pervasives_Native.Some
+                                                       (true ),uu____5600)::[]
                          -> maybe_auto_squash arg
-                     | (FStar_Pervasives_Native.Some (true ),uu____5671)::
-                         (uu____5672,(arg,uu____5674))::[] ->
+                     | (FStar_Pervasives_Native.Some (true ),uu____5673)::
+                         (uu____5674,(arg,uu____5676))::[] ->
                          maybe_auto_squash arg
-                     | (uu____5747,(arg,uu____5749))::(FStar_Pervasives_Native.Some
-                                                       (false ),uu____5750)::[]
+                     | (uu____5749,(arg,uu____5751))::(FStar_Pervasives_Native.Some
+                                                       (false ),uu____5752)::[]
                          ->
-                         let uu____5823 = FStar_Syntax_Util.mk_neg arg  in
-                         maybe_auto_squash uu____5823
-                     | (FStar_Pervasives_Native.Some (false ),uu____5824)::
-                         (uu____5825,(arg,uu____5827))::[] ->
-                         let uu____5900 = FStar_Syntax_Util.mk_neg arg  in
-                         maybe_auto_squash uu____5900
-                     | (uu____5901,(p,uu____5903))::(uu____5904,(q,uu____5906))::[]
+                         let uu____5825 = FStar_Syntax_Util.mk_neg arg  in
+                         maybe_auto_squash uu____5825
+                     | (FStar_Pervasives_Native.Some (false ),uu____5826)::
+                         (uu____5827,(arg,uu____5829))::[] ->
+                         let uu____5902 = FStar_Syntax_Util.mk_neg arg  in
+                         maybe_auto_squash uu____5902
+                     | (uu____5903,(p,uu____5905))::(uu____5906,(q,uu____5908))::[]
                          ->
-                         let uu____5978 = FStar_Syntax_Util.term_eq p q  in
-                         (if uu____5978
+                         let uu____5980 = FStar_Syntax_Util.term_eq p q  in
+                         (if uu____5980
                           then w FStar_Syntax_Util.t_true
                           else squashed_head_un_auto_squash_args tm)
-                     | uu____5983 -> squashed_head_un_auto_squash_args tm
+                     | uu____5985 -> squashed_head_un_auto_squash_args tm
                    else
-                     (let uu____6001 =
+                     (let uu____6003 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.not_lid
                          in
-                      if uu____6001
+                      if uu____6003
                       then
-                        let uu____6004 =
+                        let uu____6006 =
                           FStar_All.pipe_right args (FStar_List.map simplify)
                            in
-                        match uu____6004 with
-                        | (FStar_Pervasives_Native.Some (true ),uu____6062)::[]
+                        match uu____6006 with
+                        | (FStar_Pervasives_Native.Some (true ),uu____6064)::[]
                             -> w FStar_Syntax_Util.t_false
-                        | (FStar_Pervasives_Native.Some (false ),uu____6106)::[]
+                        | (FStar_Pervasives_Native.Some (false ),uu____6108)::[]
                             -> w FStar_Syntax_Util.t_true
-                        | uu____6150 -> squashed_head_un_auto_squash_args tm
+                        | uu____6152 -> squashed_head_un_auto_squash_args tm
                       else
-                        (let uu____6168 =
+                        (let uu____6170 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.forall_lid
                             in
-                         if uu____6168
+                         if uu____6170
                          then
                            match args with
-                           | (t,uu____6172)::[] ->
-                               let uu____6197 =
-                                 let uu____6198 =
+                           | (t,uu____6174)::[] ->
+                               let uu____6199 =
+                                 let uu____6200 =
                                    FStar_Syntax_Subst.compress t  in
-                                 uu____6198.FStar_Syntax_Syntax.n  in
-                               (match uu____6197 with
+                                 uu____6200.FStar_Syntax_Syntax.n  in
+                               (match uu____6199 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____6201::[],body,uu____6203) ->
-                                    let uu____6238 = simp_t body  in
-                                    (match uu____6238 with
+                                    (uu____6203::[],body,uu____6205) ->
+                                    let uu____6240 = simp_t body  in
+                                    (match uu____6240 with
                                      | FStar_Pervasives_Native.Some (true )
                                          -> w FStar_Syntax_Util.t_true
-                                     | uu____6244 -> tm)
-                                | uu____6248 -> tm)
+                                     | uu____6246 -> tm)
+                                | uu____6250 -> tm)
                            | (ty,FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Implicit uu____6250))::
-                               (t,uu____6252)::[] ->
-                               let uu____6292 =
-                                 let uu____6293 =
+                              (FStar_Syntax_Syntax.Implicit uu____6252))::
+                               (t,uu____6254)::[] ->
+                               let uu____6294 =
+                                 let uu____6295 =
                                    FStar_Syntax_Subst.compress t  in
-                                 uu____6293.FStar_Syntax_Syntax.n  in
-                               (match uu____6292 with
+                                 uu____6295.FStar_Syntax_Syntax.n  in
+                               (match uu____6294 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____6296::[],body,uu____6298) ->
-                                    let uu____6333 = simp_t body  in
-                                    (match uu____6333 with
+                                    (uu____6298::[],body,uu____6300) ->
+                                    let uu____6335 = simp_t body  in
+                                    (match uu____6335 with
                                      | FStar_Pervasives_Native.Some (true )
                                          -> w FStar_Syntax_Util.t_true
                                      | FStar_Pervasives_Native.Some (false )
                                          when clearly_inhabited ty ->
                                          w FStar_Syntax_Util.t_false
-                                     | uu____6341 -> tm)
-                                | uu____6345 -> tm)
-                           | uu____6346 -> tm
+                                     | uu____6343 -> tm)
+                                | uu____6347 -> tm)
+                           | uu____6348 -> tm
                          else
-                           (let uu____6359 =
+                           (let uu____6361 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.exists_lid
                                in
-                            if uu____6359
+                            if uu____6361
                             then
                               match args with
-                              | (t,uu____6363)::[] ->
-                                  let uu____6388 =
-                                    let uu____6389 =
+                              | (t,uu____6365)::[] ->
+                                  let uu____6390 =
+                                    let uu____6391 =
                                       FStar_Syntax_Subst.compress t  in
-                                    uu____6389.FStar_Syntax_Syntax.n  in
-                                  (match uu____6388 with
+                                    uu____6391.FStar_Syntax_Syntax.n  in
+                                  (match uu____6390 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____6392::[],body,uu____6394) ->
-                                       let uu____6429 = simp_t body  in
-                                       (match uu____6429 with
+                                       (uu____6394::[],body,uu____6396) ->
+                                       let uu____6431 = simp_t body  in
+                                       (match uu____6431 with
                                         | FStar_Pervasives_Native.Some (false
                                             ) -> w FStar_Syntax_Util.t_false
-                                        | uu____6435 -> tm)
-                                   | uu____6439 -> tm)
+                                        | uu____6437 -> tm)
+                                   | uu____6441 -> tm)
                               | (ty,FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Implicit uu____6441))::
-                                  (t,uu____6443)::[] ->
-                                  let uu____6483 =
-                                    let uu____6484 =
+                                 (FStar_Syntax_Syntax.Implicit uu____6443))::
+                                  (t,uu____6445)::[] ->
+                                  let uu____6485 =
+                                    let uu____6486 =
                                       FStar_Syntax_Subst.compress t  in
-                                    uu____6484.FStar_Syntax_Syntax.n  in
-                                  (match uu____6483 with
+                                    uu____6486.FStar_Syntax_Syntax.n  in
+                                  (match uu____6485 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____6487::[],body,uu____6489) ->
-                                       let uu____6524 = simp_t body  in
-                                       (match uu____6524 with
+                                       (uu____6489::[],body,uu____6491) ->
+                                       let uu____6526 = simp_t body  in
+                                       (match uu____6526 with
                                         | FStar_Pervasives_Native.Some (false
                                             ) -> w FStar_Syntax_Util.t_false
                                         | FStar_Pervasives_Native.Some (true
                                             ) when clearly_inhabited ty ->
                                             w FStar_Syntax_Util.t_true
-                                        | uu____6532 -> tm)
-                                   | uu____6536 -> tm)
-                              | uu____6537 -> tm
+                                        | uu____6534 -> tm)
+                                   | uu____6538 -> tm)
+                              | uu____6539 -> tm
                             else
-                              (let uu____6550 =
+                              (let uu____6552 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.b2t_lid
                                   in
-                               if uu____6550
+                               if uu____6552
                                then
                                  match args with
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (true ));
-                                      FStar_Syntax_Syntax.pos = uu____6553;
-                                      FStar_Syntax_Syntax.vars = uu____6554;_},uu____6555)::[]
+                                      FStar_Syntax_Syntax.pos = uu____6555;
+                                      FStar_Syntax_Syntax.vars = uu____6556;_},uu____6557)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (false ));
-                                      FStar_Syntax_Syntax.pos = uu____6581;
-                                      FStar_Syntax_Syntax.vars = uu____6582;_},uu____6583)::[]
+                                      FStar_Syntax_Syntax.pos = uu____6583;
+                                      FStar_Syntax_Syntax.vars = uu____6584;_},uu____6585)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | uu____6609 -> tm
+                                 | uu____6611 -> tm
                                else
-                                 (let uu____6622 =
+                                 (let uu____6624 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.haseq_lid
                                      in
-                                  if uu____6622
+                                  if uu____6624
                                   then
                                     let t_has_eq_for_sure t =
                                       let haseq_lids =
@@ -1286,11 +1287,11 @@ let (simplify :
                                         FStar_Parser_Const.bool_lid;
                                         FStar_Parser_Const.unit_lid;
                                         FStar_Parser_Const.string_lid]  in
-                                      let uu____6636 =
-                                        let uu____6637 =
+                                      let uu____6638 =
+                                        let uu____6639 =
                                           FStar_Syntax_Subst.compress t  in
-                                        uu____6637.FStar_Syntax_Syntax.n  in
-                                      match uu____6636 with
+                                        uu____6639.FStar_Syntax_Syntax.n  in
+                                      match uu____6638 with
                                       | FStar_Syntax_Syntax.Tm_fvar fv1 when
                                           FStar_All.pipe_right haseq_lids
                                             (FStar_List.existsb
@@ -1298,129 +1299,129 @@ let (simplify :
                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                     fv1 l))
                                           -> true
-                                      | uu____6648 -> false  in
+                                      | uu____6650 -> false  in
                                     (if
                                        (FStar_List.length args) =
                                          Prims.int_one
                                      then
                                        let t =
-                                         let uu____6662 =
+                                         let uu____6664 =
                                            FStar_All.pipe_right args
                                              FStar_List.hd
                                             in
-                                         FStar_All.pipe_right uu____6662
+                                         FStar_All.pipe_right uu____6664
                                            FStar_Pervasives_Native.fst
                                           in
-                                       let uu____6701 =
+                                       let uu____6703 =
                                          FStar_All.pipe_right t
                                            t_has_eq_for_sure
                                           in
-                                       (if uu____6701
+                                       (if uu____6703
                                         then w FStar_Syntax_Util.t_true
                                         else
-                                          (let uu____6707 =
-                                             let uu____6708 =
+                                          (let uu____6709 =
+                                             let uu____6710 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____6708.FStar_Syntax_Syntax.n
+                                             uu____6710.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____6707 with
+                                           match uu____6709 with
                                            | FStar_Syntax_Syntax.Tm_refine
-                                               uu____6711 ->
+                                               uu____6713 ->
                                                let t1 =
                                                  FStar_Syntax_Util.unrefine t
                                                   in
-                                               let uu____6719 =
+                                               let uu____6721 =
                                                  FStar_All.pipe_right t1
                                                    t_has_eq_for_sure
                                                   in
-                                               if uu____6719
+                                               if uu____6721
                                                then
                                                  w FStar_Syntax_Util.t_true
                                                else
                                                  (let haseq_tm =
-                                                    let uu____6728 =
-                                                      let uu____6729 =
+                                                    let uu____6730 =
+                                                      let uu____6731 =
                                                         FStar_Syntax_Subst.compress
                                                           tm
                                                          in
-                                                      uu____6729.FStar_Syntax_Syntax.n
+                                                      uu____6731.FStar_Syntax_Syntax.n
                                                        in
-                                                    match uu____6728 with
+                                                    match uu____6730 with
                                                     | FStar_Syntax_Syntax.Tm_app
-                                                        (hd,uu____6735) -> hd
-                                                    | uu____6760 ->
+                                                        (hd,uu____6737) -> hd
+                                                    | uu____6762 ->
                                                         failwith
                                                           "Impossible! We have already checked that this is a Tm_app"
                                                      in
-                                                  let uu____6764 =
-                                                    let uu____6775 =
+                                                  let uu____6766 =
+                                                    let uu____6777 =
                                                       FStar_All.pipe_right t1
                                                         FStar_Syntax_Syntax.as_arg
                                                        in
-                                                    [uu____6775]  in
+                                                    [uu____6777]  in
                                                   FStar_Syntax_Util.mk_app
-                                                    haseq_tm uu____6764)
-                                           | uu____6808 -> tm))
+                                                    haseq_tm uu____6766)
+                                           | uu____6810 -> tm))
                                      else tm)
                                   else
-                                    (let uu____6813 =
+                                    (let uu____6815 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.eq2_lid
                                         in
-                                     if uu____6813
+                                     if uu____6815
                                      then
                                        match args with
-                                       | (_typ,uu____6817)::(a1,uu____6819)::
-                                           (a2,uu____6821)::[] ->
-                                           let uu____6878 =
+                                       | (_typ,uu____6819)::(a1,uu____6821)::
+                                           (a2,uu____6823)::[] ->
+                                           let uu____6880 =
                                              FStar_Syntax_Util.eq_tm a1 a2
                                               in
-                                           (match uu____6878 with
+                                           (match uu____6880 with
                                             | FStar_Syntax_Util.Equal  ->
                                                 w FStar_Syntax_Util.t_true
                                             | FStar_Syntax_Util.NotEqual  ->
                                                 w FStar_Syntax_Util.t_false
-                                            | uu____6879 -> tm)
-                                       | uu____6880 -> tm
+                                            | uu____6881 -> tm)
+                                       | uu____6882 -> tm
                                      else
-                                       (let uu____6893 =
+                                       (let uu____6895 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.eq3_lid
                                            in
-                                        if uu____6893
+                                        if uu____6895
                                         then
                                           match args with
-                                          | (t1,uu____6897)::(t2,uu____6899)::
-                                              (a1,uu____6901)::(a2,uu____6903)::[]
+                                          | (t1,uu____6899)::(t2,uu____6901)::
+                                              (a1,uu____6903)::(a2,uu____6905)::[]
                                               ->
-                                              let uu____6976 =
-                                                let uu____6977 =
+                                              let uu____6978 =
+                                                let uu____6979 =
                                                   FStar_Syntax_Util.eq_tm t1
                                                     t2
                                                    in
-                                                let uu____6978 =
+                                                let uu____6980 =
                                                   FStar_Syntax_Util.eq_tm a1
                                                     a2
                                                    in
                                                 FStar_Syntax_Util.eq_inj
-                                                  uu____6977 uu____6978
+                                                  uu____6979 uu____6980
                                                  in
-                                              (match uu____6976 with
+                                              (match uu____6978 with
                                                | FStar_Syntax_Util.Equal  ->
                                                    w FStar_Syntax_Util.t_true
                                                | FStar_Syntax_Util.NotEqual 
                                                    ->
                                                    w
                                                      FStar_Syntax_Util.t_false
-                                               | uu____6979 -> tm)
-                                          | uu____6980 -> tm
+                                               | uu____6981 -> tm)
+                                          | uu____6982 -> tm
                                         else
-                                          (let uu____6993 =
+                                          (let uu____6995 =
                                              FStar_Syntax_Util.is_auto_squash
                                                tm
                                               in
-                                           match uu____6993 with
+                                           match uu____6995 with
                                            | FStar_Pervasives_Native.Some
                                                (FStar_Syntax_Syntax.U_zero
                                                 ,t)
@@ -1428,247 +1429,247 @@ let (simplify :
                                                FStar_Syntax_Util.is_sub_singleton
                                                  t
                                                -> t
-                                           | uu____7013 -> tm)))))))))))
+                                           | uu____7015 -> tm)))))))))))
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____7023;
-             FStar_Syntax_Syntax.vars = uu____7024;_},args)
+             FStar_Syntax_Syntax.pos = uu____7025;
+             FStar_Syntax_Syntax.vars = uu____7026;_},args)
           ->
-          let uu____7050 =
+          let uu____7052 =
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.and_lid  in
-          if uu____7050
+          if uu____7052
           then
-            let uu____7053 =
+            let uu____7055 =
               FStar_All.pipe_right args (FStar_List.map simplify)  in
-            (match uu____7053 with
-             | (FStar_Pervasives_Native.Some (true ),uu____7111)::(uu____7112,
-                                                                   (arg,uu____7114))::[]
+            (match uu____7055 with
+             | (FStar_Pervasives_Native.Some (true ),uu____7113)::(uu____7114,
+                                                                   (arg,uu____7116))::[]
                  -> maybe_auto_squash arg
-             | (uu____7187,(arg,uu____7189))::(FStar_Pervasives_Native.Some
-                                               (true ),uu____7190)::[]
+             | (uu____7189,(arg,uu____7191))::(FStar_Pervasives_Native.Some
+                                               (true ),uu____7192)::[]
                  -> maybe_auto_squash arg
-             | (FStar_Pervasives_Native.Some (false ),uu____7263)::uu____7264::[]
+             | (FStar_Pervasives_Native.Some (false ),uu____7265)::uu____7266::[]
                  -> w FStar_Syntax_Util.t_false
-             | uu____7334::(FStar_Pervasives_Native.Some (false ),uu____7335)::[]
+             | uu____7336::(FStar_Pervasives_Native.Some (false ),uu____7337)::[]
                  -> w FStar_Syntax_Util.t_false
-             | uu____7405 -> squashed_head_un_auto_squash_args tm)
+             | uu____7407 -> squashed_head_un_auto_squash_args tm)
           else
-            (let uu____7423 =
+            (let uu____7425 =
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.or_lid  in
-             if uu____7423
+             if uu____7425
              then
-               let uu____7426 =
+               let uu____7428 =
                  FStar_All.pipe_right args (FStar_List.map simplify)  in
-               match uu____7426 with
-               | (FStar_Pervasives_Native.Some (true ),uu____7484)::uu____7485::[]
+               match uu____7428 with
+               | (FStar_Pervasives_Native.Some (true ),uu____7486)::uu____7487::[]
                    -> w FStar_Syntax_Util.t_true
-               | uu____7555::(FStar_Pervasives_Native.Some (true
-                              ),uu____7556)::[]
+               | uu____7557::(FStar_Pervasives_Native.Some (true
+                              ),uu____7558)::[]
                    -> w FStar_Syntax_Util.t_true
-               | (FStar_Pervasives_Native.Some (false ),uu____7626)::
-                   (uu____7627,(arg,uu____7629))::[] -> maybe_auto_squash arg
-               | (uu____7702,(arg,uu____7704))::(FStar_Pervasives_Native.Some
-                                                 (false ),uu____7705)::[]
+               | (FStar_Pervasives_Native.Some (false ),uu____7628)::
+                   (uu____7629,(arg,uu____7631))::[] -> maybe_auto_squash arg
+               | (uu____7704,(arg,uu____7706))::(FStar_Pervasives_Native.Some
+                                                 (false ),uu____7707)::[]
                    -> maybe_auto_squash arg
-               | uu____7778 -> squashed_head_un_auto_squash_args tm
+               | uu____7780 -> squashed_head_un_auto_squash_args tm
              else
-               (let uu____7796 =
+               (let uu____7798 =
                   FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid
                    in
-                if uu____7796
+                if uu____7798
                 then
-                  let uu____7799 =
+                  let uu____7801 =
                     FStar_All.pipe_right args (FStar_List.map simplify)  in
-                  match uu____7799 with
-                  | uu____7857::(FStar_Pervasives_Native.Some (true
-                                 ),uu____7858)::[]
+                  match uu____7801 with
+                  | uu____7859::(FStar_Pervasives_Native.Some (true
+                                 ),uu____7860)::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (false ),uu____7928)::uu____7929::[]
+                  | (FStar_Pervasives_Native.Some (false ),uu____7930)::uu____7931::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (true ),uu____7999)::
-                      (uu____8000,(arg,uu____8002))::[] ->
+                  | (FStar_Pervasives_Native.Some (true ),uu____8001)::
+                      (uu____8002,(arg,uu____8004))::[] ->
                       maybe_auto_squash arg
-                  | (uu____8075,(p,uu____8077))::(uu____8078,(q,uu____8080))::[]
+                  | (uu____8077,(p,uu____8079))::(uu____8080,(q,uu____8082))::[]
                       ->
-                      let uu____8152 = FStar_Syntax_Util.term_eq p q  in
-                      (if uu____8152
+                      let uu____8154 = FStar_Syntax_Util.term_eq p q  in
+                      (if uu____8154
                        then w FStar_Syntax_Util.t_true
                        else squashed_head_un_auto_squash_args tm)
-                  | uu____8157 -> squashed_head_un_auto_squash_args tm
+                  | uu____8159 -> squashed_head_un_auto_squash_args tm
                 else
-                  (let uu____8175 =
+                  (let uu____8177 =
                      FStar_Syntax_Syntax.fv_eq_lid fv
                        FStar_Parser_Const.iff_lid
                       in
-                   if uu____8175
+                   if uu____8177
                    then
-                     let uu____8178 =
+                     let uu____8180 =
                        FStar_All.pipe_right args (FStar_List.map simplify)
                         in
-                     match uu____8178 with
-                     | (FStar_Pervasives_Native.Some (true ),uu____8236)::
-                         (FStar_Pervasives_Native.Some (true ),uu____8237)::[]
+                     match uu____8180 with
+                     | (FStar_Pervasives_Native.Some (true ),uu____8238)::
+                         (FStar_Pervasives_Native.Some (true ),uu____8239)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (false ),uu____8311)::
-                         (FStar_Pervasives_Native.Some (false ),uu____8312)::[]
+                     | (FStar_Pervasives_Native.Some (false ),uu____8313)::
+                         (FStar_Pervasives_Native.Some (false ),uu____8314)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (true ),uu____8386)::
-                         (FStar_Pervasives_Native.Some (false ),uu____8387)::[]
+                     | (FStar_Pervasives_Native.Some (true ),uu____8388)::
+                         (FStar_Pervasives_Native.Some (false ),uu____8389)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (FStar_Pervasives_Native.Some (false ),uu____8461)::
-                         (FStar_Pervasives_Native.Some (true ),uu____8462)::[]
+                     | (FStar_Pervasives_Native.Some (false ),uu____8463)::
+                         (FStar_Pervasives_Native.Some (true ),uu____8464)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (uu____8536,(arg,uu____8538))::(FStar_Pervasives_Native.Some
-                                                       (true ),uu____8539)::[]
+                     | (uu____8538,(arg,uu____8540))::(FStar_Pervasives_Native.Some
+                                                       (true ),uu____8541)::[]
                          -> maybe_auto_squash arg
-                     | (FStar_Pervasives_Native.Some (true ),uu____8612)::
-                         (uu____8613,(arg,uu____8615))::[] ->
+                     | (FStar_Pervasives_Native.Some (true ),uu____8614)::
+                         (uu____8615,(arg,uu____8617))::[] ->
                          maybe_auto_squash arg
-                     | (uu____8688,(arg,uu____8690))::(FStar_Pervasives_Native.Some
-                                                       (false ),uu____8691)::[]
+                     | (uu____8690,(arg,uu____8692))::(FStar_Pervasives_Native.Some
+                                                       (false ),uu____8693)::[]
                          ->
-                         let uu____8764 = FStar_Syntax_Util.mk_neg arg  in
-                         maybe_auto_squash uu____8764
-                     | (FStar_Pervasives_Native.Some (false ),uu____8765)::
-                         (uu____8766,(arg,uu____8768))::[] ->
-                         let uu____8841 = FStar_Syntax_Util.mk_neg arg  in
-                         maybe_auto_squash uu____8841
-                     | (uu____8842,(p,uu____8844))::(uu____8845,(q,uu____8847))::[]
+                         let uu____8766 = FStar_Syntax_Util.mk_neg arg  in
+                         maybe_auto_squash uu____8766
+                     | (FStar_Pervasives_Native.Some (false ),uu____8767)::
+                         (uu____8768,(arg,uu____8770))::[] ->
+                         let uu____8843 = FStar_Syntax_Util.mk_neg arg  in
+                         maybe_auto_squash uu____8843
+                     | (uu____8844,(p,uu____8846))::(uu____8847,(q,uu____8849))::[]
                          ->
-                         let uu____8919 = FStar_Syntax_Util.term_eq p q  in
-                         (if uu____8919
+                         let uu____8921 = FStar_Syntax_Util.term_eq p q  in
+                         (if uu____8921
                           then w FStar_Syntax_Util.t_true
                           else squashed_head_un_auto_squash_args tm)
-                     | uu____8924 -> squashed_head_un_auto_squash_args tm
+                     | uu____8926 -> squashed_head_un_auto_squash_args tm
                    else
-                     (let uu____8942 =
+                     (let uu____8944 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.not_lid
                          in
-                      if uu____8942
+                      if uu____8944
                       then
-                        let uu____8945 =
+                        let uu____8947 =
                           FStar_All.pipe_right args (FStar_List.map simplify)
                            in
-                        match uu____8945 with
-                        | (FStar_Pervasives_Native.Some (true ),uu____9003)::[]
+                        match uu____8947 with
+                        | (FStar_Pervasives_Native.Some (true ),uu____9005)::[]
                             -> w FStar_Syntax_Util.t_false
-                        | (FStar_Pervasives_Native.Some (false ),uu____9047)::[]
+                        | (FStar_Pervasives_Native.Some (false ),uu____9049)::[]
                             -> w FStar_Syntax_Util.t_true
-                        | uu____9091 -> squashed_head_un_auto_squash_args tm
+                        | uu____9093 -> squashed_head_un_auto_squash_args tm
                       else
-                        (let uu____9109 =
+                        (let uu____9111 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.forall_lid
                             in
-                         if uu____9109
+                         if uu____9111
                          then
                            match args with
-                           | (t,uu____9113)::[] ->
-                               let uu____9138 =
-                                 let uu____9139 =
+                           | (t,uu____9115)::[] ->
+                               let uu____9140 =
+                                 let uu____9141 =
                                    FStar_Syntax_Subst.compress t  in
-                                 uu____9139.FStar_Syntax_Syntax.n  in
-                               (match uu____9138 with
+                                 uu____9141.FStar_Syntax_Syntax.n  in
+                               (match uu____9140 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____9142::[],body,uu____9144) ->
-                                    let uu____9179 = simp_t body  in
-                                    (match uu____9179 with
+                                    (uu____9144::[],body,uu____9146) ->
+                                    let uu____9181 = simp_t body  in
+                                    (match uu____9181 with
                                      | FStar_Pervasives_Native.Some (true )
                                          -> w FStar_Syntax_Util.t_true
-                                     | uu____9185 -> tm)
-                                | uu____9189 -> tm)
+                                     | uu____9187 -> tm)
+                                | uu____9191 -> tm)
                            | (ty,FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Implicit uu____9191))::
-                               (t,uu____9193)::[] ->
-                               let uu____9233 =
-                                 let uu____9234 =
+                              (FStar_Syntax_Syntax.Implicit uu____9193))::
+                               (t,uu____9195)::[] ->
+                               let uu____9235 =
+                                 let uu____9236 =
                                    FStar_Syntax_Subst.compress t  in
-                                 uu____9234.FStar_Syntax_Syntax.n  in
-                               (match uu____9233 with
+                                 uu____9236.FStar_Syntax_Syntax.n  in
+                               (match uu____9235 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____9237::[],body,uu____9239) ->
-                                    let uu____9274 = simp_t body  in
-                                    (match uu____9274 with
+                                    (uu____9239::[],body,uu____9241) ->
+                                    let uu____9276 = simp_t body  in
+                                    (match uu____9276 with
                                      | FStar_Pervasives_Native.Some (true )
                                          -> w FStar_Syntax_Util.t_true
                                      | FStar_Pervasives_Native.Some (false )
                                          when clearly_inhabited ty ->
                                          w FStar_Syntax_Util.t_false
-                                     | uu____9282 -> tm)
-                                | uu____9286 -> tm)
-                           | uu____9287 -> tm
+                                     | uu____9284 -> tm)
+                                | uu____9288 -> tm)
+                           | uu____9289 -> tm
                          else
-                           (let uu____9300 =
+                           (let uu____9302 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.exists_lid
                                in
-                            if uu____9300
+                            if uu____9302
                             then
                               match args with
-                              | (t,uu____9304)::[] ->
-                                  let uu____9329 =
-                                    let uu____9330 =
+                              | (t,uu____9306)::[] ->
+                                  let uu____9331 =
+                                    let uu____9332 =
                                       FStar_Syntax_Subst.compress t  in
-                                    uu____9330.FStar_Syntax_Syntax.n  in
-                                  (match uu____9329 with
+                                    uu____9332.FStar_Syntax_Syntax.n  in
+                                  (match uu____9331 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____9333::[],body,uu____9335) ->
-                                       let uu____9370 = simp_t body  in
-                                       (match uu____9370 with
+                                       (uu____9335::[],body,uu____9337) ->
+                                       let uu____9372 = simp_t body  in
+                                       (match uu____9372 with
                                         | FStar_Pervasives_Native.Some (false
                                             ) -> w FStar_Syntax_Util.t_false
-                                        | uu____9376 -> tm)
-                                   | uu____9380 -> tm)
+                                        | uu____9378 -> tm)
+                                   | uu____9382 -> tm)
                               | (ty,FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Implicit uu____9382))::
-                                  (t,uu____9384)::[] ->
-                                  let uu____9424 =
-                                    let uu____9425 =
+                                 (FStar_Syntax_Syntax.Implicit uu____9384))::
+                                  (t,uu____9386)::[] ->
+                                  let uu____9426 =
+                                    let uu____9427 =
                                       FStar_Syntax_Subst.compress t  in
-                                    uu____9425.FStar_Syntax_Syntax.n  in
-                                  (match uu____9424 with
+                                    uu____9427.FStar_Syntax_Syntax.n  in
+                                  (match uu____9426 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____9428::[],body,uu____9430) ->
-                                       let uu____9465 = simp_t body  in
-                                       (match uu____9465 with
+                                       (uu____9430::[],body,uu____9432) ->
+                                       let uu____9467 = simp_t body  in
+                                       (match uu____9467 with
                                         | FStar_Pervasives_Native.Some (false
                                             ) -> w FStar_Syntax_Util.t_false
                                         | FStar_Pervasives_Native.Some (true
                                             ) when clearly_inhabited ty ->
                                             w FStar_Syntax_Util.t_true
-                                        | uu____9473 -> tm)
-                                   | uu____9477 -> tm)
-                              | uu____9478 -> tm
+                                        | uu____9475 -> tm)
+                                   | uu____9479 -> tm)
+                              | uu____9480 -> tm
                             else
-                              (let uu____9491 =
+                              (let uu____9493 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.b2t_lid
                                   in
-                               if uu____9491
+                               if uu____9493
                                then
                                  match args with
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (true ));
-                                      FStar_Syntax_Syntax.pos = uu____9494;
-                                      FStar_Syntax_Syntax.vars = uu____9495;_},uu____9496)::[]
+                                      FStar_Syntax_Syntax.pos = uu____9496;
+                                      FStar_Syntax_Syntax.vars = uu____9497;_},uu____9498)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (false ));
-                                      FStar_Syntax_Syntax.pos = uu____9522;
-                                      FStar_Syntax_Syntax.vars = uu____9523;_},uu____9524)::[]
+                                      FStar_Syntax_Syntax.pos = uu____9524;
+                                      FStar_Syntax_Syntax.vars = uu____9525;_},uu____9526)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | uu____9550 -> tm
+                                 | uu____9552 -> tm
                                else
-                                 (let uu____9563 =
+                                 (let uu____9565 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.haseq_lid
                                      in
-                                  if uu____9563
+                                  if uu____9565
                                   then
                                     let t_has_eq_for_sure t =
                                       let haseq_lids =
@@ -1676,11 +1677,11 @@ let (simplify :
                                         FStar_Parser_Const.bool_lid;
                                         FStar_Parser_Const.unit_lid;
                                         FStar_Parser_Const.string_lid]  in
-                                      let uu____9577 =
-                                        let uu____9578 =
+                                      let uu____9579 =
+                                        let uu____9580 =
                                           FStar_Syntax_Subst.compress t  in
-                                        uu____9578.FStar_Syntax_Syntax.n  in
-                                      match uu____9577 with
+                                        uu____9580.FStar_Syntax_Syntax.n  in
+                                      match uu____9579 with
                                       | FStar_Syntax_Syntax.Tm_fvar fv1 when
                                           FStar_All.pipe_right haseq_lids
                                             (FStar_List.existsb
@@ -1688,129 +1689,129 @@ let (simplify :
                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                     fv1 l))
                                           -> true
-                                      | uu____9589 -> false  in
+                                      | uu____9591 -> false  in
                                     (if
                                        (FStar_List.length args) =
                                          Prims.int_one
                                      then
                                        let t =
-                                         let uu____9603 =
+                                         let uu____9605 =
                                            FStar_All.pipe_right args
                                              FStar_List.hd
                                             in
-                                         FStar_All.pipe_right uu____9603
+                                         FStar_All.pipe_right uu____9605
                                            FStar_Pervasives_Native.fst
                                           in
-                                       let uu____9638 =
+                                       let uu____9640 =
                                          FStar_All.pipe_right t
                                            t_has_eq_for_sure
                                           in
-                                       (if uu____9638
+                                       (if uu____9640
                                         then w FStar_Syntax_Util.t_true
                                         else
-                                          (let uu____9644 =
-                                             let uu____9645 =
+                                          (let uu____9646 =
+                                             let uu____9647 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____9645.FStar_Syntax_Syntax.n
+                                             uu____9647.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____9644 with
+                                           match uu____9646 with
                                            | FStar_Syntax_Syntax.Tm_refine
-                                               uu____9648 ->
+                                               uu____9650 ->
                                                let t1 =
                                                  FStar_Syntax_Util.unrefine t
                                                   in
-                                               let uu____9656 =
+                                               let uu____9658 =
                                                  FStar_All.pipe_right t1
                                                    t_has_eq_for_sure
                                                   in
-                                               if uu____9656
+                                               if uu____9658
                                                then
                                                  w FStar_Syntax_Util.t_true
                                                else
                                                  (let haseq_tm =
-                                                    let uu____9665 =
-                                                      let uu____9666 =
+                                                    let uu____9667 =
+                                                      let uu____9668 =
                                                         FStar_Syntax_Subst.compress
                                                           tm
                                                          in
-                                                      uu____9666.FStar_Syntax_Syntax.n
+                                                      uu____9668.FStar_Syntax_Syntax.n
                                                        in
-                                                    match uu____9665 with
+                                                    match uu____9667 with
                                                     | FStar_Syntax_Syntax.Tm_app
-                                                        (hd,uu____9672) -> hd
-                                                    | uu____9697 ->
+                                                        (hd,uu____9674) -> hd
+                                                    | uu____9699 ->
                                                         failwith
                                                           "Impossible! We have already checked that this is a Tm_app"
                                                      in
-                                                  let uu____9701 =
-                                                    let uu____9712 =
+                                                  let uu____9703 =
+                                                    let uu____9714 =
                                                       FStar_All.pipe_right t1
                                                         FStar_Syntax_Syntax.as_arg
                                                        in
-                                                    [uu____9712]  in
+                                                    [uu____9714]  in
                                                   FStar_Syntax_Util.mk_app
-                                                    haseq_tm uu____9701)
-                                           | uu____9745 -> tm))
+                                                    haseq_tm uu____9703)
+                                           | uu____9747 -> tm))
                                      else tm)
                                   else
-                                    (let uu____9750 =
+                                    (let uu____9752 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.eq2_lid
                                         in
-                                     if uu____9750
+                                     if uu____9752
                                      then
                                        match args with
-                                       | (_typ,uu____9754)::(a1,uu____9756)::
-                                           (a2,uu____9758)::[] ->
-                                           let uu____9815 =
+                                       | (_typ,uu____9756)::(a1,uu____9758)::
+                                           (a2,uu____9760)::[] ->
+                                           let uu____9817 =
                                              FStar_Syntax_Util.eq_tm a1 a2
                                               in
-                                           (match uu____9815 with
+                                           (match uu____9817 with
                                             | FStar_Syntax_Util.Equal  ->
                                                 w FStar_Syntax_Util.t_true
                                             | FStar_Syntax_Util.NotEqual  ->
                                                 w FStar_Syntax_Util.t_false
-                                            | uu____9816 -> tm)
-                                       | uu____9817 -> tm
+                                            | uu____9818 -> tm)
+                                       | uu____9819 -> tm
                                      else
-                                       (let uu____9830 =
+                                       (let uu____9832 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.eq3_lid
                                            in
-                                        if uu____9830
+                                        if uu____9832
                                         then
                                           match args with
-                                          | (t1,uu____9834)::(t2,uu____9836)::
-                                              (a1,uu____9838)::(a2,uu____9840)::[]
+                                          | (t1,uu____9836)::(t2,uu____9838)::
+                                              (a1,uu____9840)::(a2,uu____9842)::[]
                                               ->
-                                              let uu____9913 =
-                                                let uu____9914 =
+                                              let uu____9915 =
+                                                let uu____9916 =
                                                   FStar_Syntax_Util.eq_tm t1
                                                     t2
                                                    in
-                                                let uu____9915 =
+                                                let uu____9917 =
                                                   FStar_Syntax_Util.eq_tm a1
                                                     a2
                                                    in
                                                 FStar_Syntax_Util.eq_inj
-                                                  uu____9914 uu____9915
+                                                  uu____9916 uu____9917
                                                  in
-                                              (match uu____9913 with
+                                              (match uu____9915 with
                                                | FStar_Syntax_Util.Equal  ->
                                                    w FStar_Syntax_Util.t_true
                                                | FStar_Syntax_Util.NotEqual 
                                                    ->
                                                    w
                                                      FStar_Syntax_Util.t_false
-                                               | uu____9916 -> tm)
-                                          | uu____9917 -> tm
+                                               | uu____9918 -> tm)
+                                          | uu____9919 -> tm
                                         else
-                                          (let uu____9930 =
+                                          (let uu____9932 =
                                              FStar_Syntax_Util.is_auto_squash
                                                tm
                                               in
-                                           match uu____9930 with
+                                           match uu____9932 with
                                            | FStar_Pervasives_Native.Some
                                                (FStar_Syntax_Syntax.U_zero
                                                 ,t)
@@ -1818,21 +1819,21 @@ let (simplify :
                                                FStar_Syntax_Util.is_sub_singleton
                                                  t
                                                -> t
-                                           | uu____9950 -> tm)))))))))))
+                                           | uu____9952 -> tm)))))))))))
       | FStar_Syntax_Syntax.Tm_refine (bv,t) ->
-          let uu____9965 = simp_t t  in
-          (match uu____9965 with
+          let uu____9967 = simp_t t  in
+          (match uu____9967 with
            | FStar_Pervasives_Native.Some (true ) ->
                bv.FStar_Syntax_Syntax.sort
            | FStar_Pervasives_Native.Some (false ) -> tm
            | FStar_Pervasives_Native.None  -> tm)
-      | FStar_Syntax_Syntax.Tm_match uu____9974 ->
-          let uu____9997 = is_const_match tm  in
-          (match uu____9997 with
+      | FStar_Syntax_Syntax.Tm_match uu____9976 ->
+          let uu____9999 = is_const_match tm  in
+          (match uu____9999 with
            | FStar_Pervasives_Native.Some (true ) ->
                w FStar_Syntax_Util.t_true
            | FStar_Pervasives_Native.Some (false ) ->
                w FStar_Syntax_Util.t_false
            | FStar_Pervasives_Native.None  -> tm)
-      | uu____10006 -> tm
+      | uu____10008 -> tm
   

--- a/src/ocaml-output/FStar_TypeChecker_DMFF.ml
+++ b/src/ocaml-output/FStar_TypeChecker_DMFF.ml
@@ -2353,86 +2353,89 @@ and (infer :
                        if uu____7303
                        then
                          let xw =
-                           let uu____7313 = star_type' env3 c  in
-                           FStar_Syntax_Syntax.gen_bv
-                             (Prims.op_Hat
-                                (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                "__w") FStar_Pervasives_Native.None
-                             uu____7313
+                           let uu____7313 =
+                             let uu____7315 =
+                               FStar_Ident.text_of_id
+                                 bv.FStar_Syntax_Syntax.ppname
+                                in
+                             Prims.op_Hat uu____7315 "__w"  in
+                           let uu____7318 = star_type' env3 c  in
+                           FStar_Syntax_Syntax.gen_bv uu____7313
+                             FStar_Pervasives_Native.None uu____7318
                             in
                          let x =
-                           let uu___795_7316 = bv  in
-                           let uu____7317 =
-                             let uu____7320 =
+                           let uu___795_7320 = bv  in
+                           let uu____7321 =
+                             let uu____7324 =
                                FStar_Syntax_Syntax.bv_to_name xw  in
-                             trans_F_ env3 c uu____7320  in
+                             trans_F_ env3 c uu____7324  in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___795_7316.FStar_Syntax_Syntax.ppname);
+                               (uu___795_7320.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___795_7316.FStar_Syntax_Syntax.index);
-                             FStar_Syntax_Syntax.sort = uu____7317
+                               (uu___795_7320.FStar_Syntax_Syntax.index);
+                             FStar_Syntax_Syntax.sort = uu____7321
                            }  in
                          let env4 =
-                           let uu___798_7322 = env3  in
-                           let uu____7323 =
-                             let uu____7326 =
-                               let uu____7327 =
-                                 let uu____7334 =
+                           let uu___798_7326 = env3  in
+                           let uu____7327 =
+                             let uu____7330 =
+                               let uu____7331 =
+                                 let uu____7338 =
                                    FStar_Syntax_Syntax.bv_to_name xw  in
-                                 (bv, uu____7334)  in
-                               FStar_Syntax_Syntax.NT uu____7327  in
-                             uu____7326 :: (env3.subst)  in
+                                 (bv, uu____7338)  in
+                               FStar_Syntax_Syntax.NT uu____7331  in
+                             uu____7330 :: (env3.subst)  in
                            {
-                             tcenv = (uu___798_7322.tcenv);
-                             subst = uu____7323;
-                             tc_const = (uu___798_7322.tc_const)
+                             tcenv = (uu___798_7326.tcenv);
+                             subst = uu____7327;
+                             tc_const = (uu___798_7326.tc_const)
                            }  in
-                         let uu____7339 =
-                           let uu____7342 = FStar_Syntax_Syntax.mk_binder x
+                         let uu____7343 =
+                           let uu____7346 = FStar_Syntax_Syntax.mk_binder x
                               in
-                           let uu____7343 =
-                             let uu____7346 =
+                           let uu____7347 =
+                             let uu____7350 =
                                FStar_Syntax_Syntax.mk_binder xw  in
-                             uu____7346 :: acc  in
-                           uu____7342 :: uu____7343  in
-                         (env4, uu____7339)
+                             uu____7350 :: acc  in
+                           uu____7346 :: uu____7347  in
+                         (env4, uu____7343)
                        else
                          (let x =
-                            let uu___801_7352 = bv  in
-                            let uu____7353 =
+                            let uu___801_7356 = bv  in
+                            let uu____7357 =
                               star_type' env3 bv.FStar_Syntax_Syntax.sort  in
                             {
                               FStar_Syntax_Syntax.ppname =
-                                (uu___801_7352.FStar_Syntax_Syntax.ppname);
+                                (uu___801_7356.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
-                                (uu___801_7352.FStar_Syntax_Syntax.index);
-                              FStar_Syntax_Syntax.sort = uu____7353
+                                (uu___801_7356.FStar_Syntax_Syntax.index);
+                              FStar_Syntax_Syntax.sort = uu____7357
                             }  in
-                          let uu____7356 =
-                            let uu____7359 = FStar_Syntax_Syntax.mk_binder x
+                          let uu____7360 =
+                            let uu____7363 = FStar_Syntax_Syntax.mk_binder x
                                in
-                            uu____7359 :: acc  in
-                          (env3, uu____7356))) (env2, []) binders1
+                            uu____7363 :: acc  in
+                          (env3, uu____7360))) (env2, []) binders1
              in
           (match uu____7213 with
            | (env3,u_binders) ->
                let u_binders1 = FStar_List.rev u_binders  in
-               let uu____7379 =
+               let uu____7383 =
                  let check_what =
-                   let uu____7405 = is_monadic rc_opt1  in
-                   if uu____7405 then check_m else check_n  in
-                 let uu____7422 = check_what env3 body1  in
-                 match uu____7422 with
+                   let uu____7409 = is_monadic rc_opt1  in
+                   if uu____7409 then check_m else check_n  in
+                 let uu____7426 = check_what env3 body1  in
+                 match uu____7426 with
                  | (t,s_body,u_body) ->
-                     let uu____7442 =
-                       let uu____7445 =
-                         let uu____7446 = is_monadic rc_opt1  in
-                         if uu____7446 then M t else N t  in
-                       comp_of_nm uu____7445  in
-                     (uu____7442, s_body, u_body)
+                     let uu____7446 =
+                       let uu____7449 =
+                         let uu____7450 = is_monadic rc_opt1  in
+                         if uu____7450 then M t else N t  in
+                       comp_of_nm uu____7449  in
+                     (uu____7446, s_body, u_body)
                   in
-               (match uu____7379 with
+               (match uu____7383 with
                 | (comp,s_body,u_body) ->
                     let t = FStar_Syntax_Util.arrow binders1 comp  in
                     let s_rc_opt =
@@ -2443,157 +2446,157 @@ and (infer :
                           (match rc.FStar_Syntax_Syntax.residual_typ with
                            | FStar_Pervasives_Native.None  ->
                                let rc1 =
-                                 let uu____7486 =
+                                 let uu____7490 =
                                    FStar_All.pipe_right
                                      rc.FStar_Syntax_Syntax.residual_flags
                                      (FStar_Util.for_some
-                                        (fun uu___6_7492  ->
-                                           match uu___6_7492 with
+                                        (fun uu___6_7496  ->
+                                           match uu___6_7496 with
                                            | FStar_Syntax_Syntax.CPS  -> true
-                                           | uu____7495 -> false))
+                                           | uu____7499 -> false))
                                     in
-                                 if uu____7486
+                                 if uu____7490
                                  then
-                                   let uu____7498 =
+                                   let uu____7502 =
                                      FStar_List.filter
-                                       (fun uu___7_7502  ->
-                                          match uu___7_7502 with
+                                       (fun uu___7_7506  ->
+                                          match uu___7_7506 with
                                           | FStar_Syntax_Syntax.CPS  -> false
-                                          | uu____7505 -> true)
+                                          | uu____7509 -> true)
                                        rc.FStar_Syntax_Syntax.residual_flags
                                       in
                                    FStar_Syntax_Util.mk_residual_comp
                                      FStar_Parser_Const.effect_Tot_lid
-                                     FStar_Pervasives_Native.None uu____7498
+                                     FStar_Pervasives_Native.None uu____7502
                                  else rc  in
                                FStar_Pervasives_Native.Some rc1
                            | FStar_Pervasives_Native.Some rt ->
-                               let uu____7516 =
+                               let uu____7520 =
                                  FStar_All.pipe_right
                                    rc.FStar_Syntax_Syntax.residual_flags
                                    (FStar_Util.for_some
-                                      (fun uu___8_7522  ->
-                                         match uu___8_7522 with
+                                      (fun uu___8_7526  ->
+                                         match uu___8_7526 with
                                          | FStar_Syntax_Syntax.CPS  -> true
-                                         | uu____7525 -> false))
+                                         | uu____7529 -> false))
                                   in
-                               if uu____7516
+                               if uu____7520
                                then
                                  let flags =
                                    FStar_List.filter
-                                     (fun uu___9_7534  ->
-                                        match uu___9_7534 with
+                                     (fun uu___9_7538  ->
+                                        match uu___9_7538 with
                                         | FStar_Syntax_Syntax.CPS  -> false
-                                        | uu____7537 -> true)
+                                        | uu____7541 -> true)
                                      rc.FStar_Syntax_Syntax.residual_flags
                                     in
-                                 let uu____7539 =
-                                   let uu____7540 =
-                                     let uu____7545 = double_star rt  in
-                                     FStar_Pervasives_Native.Some uu____7545
+                                 let uu____7543 =
+                                   let uu____7544 =
+                                     let uu____7549 = double_star rt  in
+                                     FStar_Pervasives_Native.Some uu____7549
                                       in
                                    FStar_Syntax_Util.mk_residual_comp
                                      FStar_Parser_Const.effect_Tot_lid
-                                     uu____7540 flags
+                                     uu____7544 flags
                                     in
-                                 FStar_Pervasives_Native.Some uu____7539
+                                 FStar_Pervasives_Native.Some uu____7543
                                else
-                                 (let uu____7552 =
-                                    let uu___842_7553 = rc  in
-                                    let uu____7554 =
-                                      let uu____7559 = star_type' env3 rt  in
-                                      FStar_Pervasives_Native.Some uu____7559
+                                 (let uu____7556 =
+                                    let uu___842_7557 = rc  in
+                                    let uu____7558 =
+                                      let uu____7563 = star_type' env3 rt  in
+                                      FStar_Pervasives_Native.Some uu____7563
                                        in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___842_7553.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___842_7557.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ =
-                                        uu____7554;
+                                        uu____7558;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___842_7553.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___842_7557.FStar_Syntax_Syntax.residual_flags)
                                     }  in
-                                  FStar_Pervasives_Native.Some uu____7552))
+                                  FStar_Pervasives_Native.Some uu____7556))
                        in
-                    let uu____7564 =
+                    let uu____7568 =
                       let comp1 =
-                        let uu____7572 = is_monadic rc_opt1  in
-                        let uu____7574 =
+                        let uu____7576 = is_monadic rc_opt1  in
+                        let uu____7578 =
                           FStar_Syntax_Subst.subst env3.subst s_body  in
                         trans_G env3 (FStar_Syntax_Util.comp_result comp)
-                          uu____7572 uu____7574
+                          uu____7576 uu____7578
                          in
-                      let uu____7575 =
+                      let uu____7579 =
                         FStar_Syntax_Util.ascribe u_body
                           ((FStar_Util.Inr comp1),
                             FStar_Pervasives_Native.None)
                          in
-                      (uu____7575,
+                      (uu____7579,
                         (FStar_Pervasives_Native.Some
                            (FStar_Syntax_Util.residual_comp_of_comp comp1)))
                        in
-                    (match uu____7564 with
+                    (match uu____7568 with
                      | (u_body1,u_rc_opt) ->
                          let s_body1 =
                            FStar_Syntax_Subst.close s_binders s_body  in
                          let s_binders1 =
                            FStar_Syntax_Subst.close_binders s_binders  in
                          let s_term =
-                           let uu____7613 =
-                             let uu____7614 =
-                               let uu____7633 =
-                                 let uu____7636 =
+                           let uu____7617 =
+                             let uu____7618 =
+                               let uu____7637 =
+                                 let uu____7640 =
                                    FStar_Syntax_Subst.closing_of_binders
                                      s_binders1
                                     in
-                                 subst_rc_opt uu____7636 s_rc_opt  in
-                               (s_binders1, s_body1, uu____7633)  in
-                             FStar_Syntax_Syntax.Tm_abs uu____7614  in
-                           mk uu____7613  in
+                                 subst_rc_opt uu____7640 s_rc_opt  in
+                               (s_binders1, s_body1, uu____7637)  in
+                             FStar_Syntax_Syntax.Tm_abs uu____7618  in
+                           mk uu____7617  in
                          let u_body2 =
                            FStar_Syntax_Subst.close u_binders1 u_body1  in
                          let u_binders2 =
                            FStar_Syntax_Subst.close_binders u_binders1  in
                          let u_term =
-                           let uu____7656 =
-                             let uu____7657 =
-                               let uu____7676 =
-                                 let uu____7679 =
+                           let uu____7660 =
+                             let uu____7661 =
+                               let uu____7680 =
+                                 let uu____7683 =
                                    FStar_Syntax_Subst.closing_of_binders
                                      u_binders2
                                     in
-                                 subst_rc_opt uu____7679 u_rc_opt  in
-                               (u_binders2, u_body2, uu____7676)  in
-                             FStar_Syntax_Syntax.Tm_abs uu____7657  in
-                           mk uu____7656  in
+                                 subst_rc_opt uu____7683 u_rc_opt  in
+                               (u_binders2, u_body2, uu____7680)  in
+                             FStar_Syntax_Syntax.Tm_abs uu____7661  in
+                           mk uu____7660  in
                          ((N t), s_term, u_term))))
       | FStar_Syntax_Syntax.Tm_fvar
           {
             FStar_Syntax_Syntax.fv_name =
               { FStar_Syntax_Syntax.v = lid;
-                FStar_Syntax_Syntax.p = uu____7695;_};
-            FStar_Syntax_Syntax.fv_delta = uu____7696;
-            FStar_Syntax_Syntax.fv_qual = uu____7697;_}
+                FStar_Syntax_Syntax.p = uu____7699;_};
+            FStar_Syntax_Syntax.fv_delta = uu____7700;
+            FStar_Syntax_Syntax.fv_qual = uu____7701;_}
           ->
-          let uu____7700 =
-            let uu____7705 = FStar_TypeChecker_Env.lookup_lid env1.tcenv lid
+          let uu____7704 =
+            let uu____7709 = FStar_TypeChecker_Env.lookup_lid env1.tcenv lid
                in
-            FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7705  in
-          (match uu____7700 with
-           | (uu____7736,t) ->
-               let uu____7738 = let uu____7739 = normalize t  in N uu____7739
+            FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7709  in
+          (match uu____7704 with
+           | (uu____7740,t) ->
+               let uu____7742 = let uu____7743 = normalize t  in N uu____7743
                   in
-               (uu____7738, e, e))
+               (uu____7742, e, e))
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____7740;
-             FStar_Syntax_Syntax.vars = uu____7741;_},a::hd::rest)
+             FStar_Syntax_Syntax.pos = uu____7744;
+             FStar_Syntax_Syntax.vars = uu____7745;_},a::hd::rest)
           ->
           let rest1 = hd :: rest  in
-          let uu____7820 = FStar_Syntax_Util.head_and_args e  in
-          (match uu____7820 with
-           | (unary_op,uu____7844) ->
+          let uu____7824 = FStar_Syntax_Util.head_and_args e  in
+          (match uu____7824 with
+           | (unary_op,uu____7848) ->
                let head = mk (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))  in
                let t = mk (FStar_Syntax_Syntax.Tm_app (head, rest1))  in
                infer env1 t)
@@ -2601,13 +2604,13 @@ and (infer :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____7915;
-             FStar_Syntax_Syntax.vars = uu____7916;_},a1::a2::hd::rest)
+             FStar_Syntax_Syntax.pos = uu____7919;
+             FStar_Syntax_Syntax.vars = uu____7920;_},a1::a2::hd::rest)
           ->
           let rest1 = hd :: rest  in
-          let uu____8012 = FStar_Syntax_Util.head_and_args e  in
-          (match uu____8012 with
-           | (unary_op,uu____8036) ->
+          let uu____8016 = FStar_Syntax_Util.head_and_args e  in
+          (match uu____8016 with
+           | (unary_op,uu____8040) ->
                let head =
                  mk (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))  in
                let t = mk (FStar_Syntax_Syntax.Tm_app (head, rest1))  in
@@ -2616,216 +2619,216 @@ and (infer :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____8115;
-             FStar_Syntax_Syntax.vars = uu____8116;_},(a,FStar_Pervasives_Native.None
+             FStar_Syntax_Syntax.pos = uu____8119;
+             FStar_Syntax_Syntax.vars = uu____8120;_},(a,FStar_Pervasives_Native.None
                                                        )::[])
           ->
-          let uu____8154 = infer env1 a  in
-          (match uu____8154 with
+          let uu____8158 = infer env1 a  in
+          (match uu____8158 with
            | (t,s,u) ->
-               let uu____8170 = FStar_Syntax_Util.head_and_args e  in
-               (match uu____8170 with
-                | (head,uu____8194) ->
-                    let uu____8219 =
-                      let uu____8220 =
+               let uu____8174 = FStar_Syntax_Util.head_and_args e  in
+               (match uu____8174 with
+                | (head,uu____8198) ->
+                    let uu____8223 =
+                      let uu____8224 =
                         FStar_Syntax_Syntax.tabbrev
                           FStar_Parser_Const.range_lid
                          in
-                      N uu____8220  in
-                    let uu____8221 =
-                      let uu____8222 =
-                        let uu____8223 =
-                          let uu____8240 =
-                            let uu____8251 = FStar_Syntax_Syntax.as_arg s  in
-                            [uu____8251]  in
-                          (head, uu____8240)  in
-                        FStar_Syntax_Syntax.Tm_app uu____8223  in
-                      mk uu____8222  in
-                    let uu____8288 =
-                      let uu____8289 =
-                        let uu____8290 =
-                          let uu____8307 =
-                            let uu____8318 = FStar_Syntax_Syntax.as_arg u  in
-                            [uu____8318]  in
-                          (head, uu____8307)  in
-                        FStar_Syntax_Syntax.Tm_app uu____8290  in
-                      mk uu____8289  in
-                    (uu____8219, uu____8221, uu____8288)))
+                      N uu____8224  in
+                    let uu____8225 =
+                      let uu____8226 =
+                        let uu____8227 =
+                          let uu____8244 =
+                            let uu____8255 = FStar_Syntax_Syntax.as_arg s  in
+                            [uu____8255]  in
+                          (head, uu____8244)  in
+                        FStar_Syntax_Syntax.Tm_app uu____8227  in
+                      mk uu____8226  in
+                    let uu____8292 =
+                      let uu____8293 =
+                        let uu____8294 =
+                          let uu____8311 =
+                            let uu____8322 = FStar_Syntax_Syntax.as_arg u  in
+                            [uu____8322]  in
+                          (head, uu____8311)  in
+                        FStar_Syntax_Syntax.Tm_app uu____8294  in
+                      mk uu____8293  in
+                    (uu____8223, uu____8225, uu____8292)))
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____8355;
-             FStar_Syntax_Syntax.vars = uu____8356;_},(a1,uu____8358)::a2::[])
+             FStar_Syntax_Syntax.pos = uu____8359;
+             FStar_Syntax_Syntax.vars = uu____8360;_},(a1,uu____8362)::a2::[])
           ->
-          let uu____8414 = infer env1 a1  in
-          (match uu____8414 with
+          let uu____8418 = infer env1 a1  in
+          (match uu____8418 with
            | (t,s,u) ->
-               let uu____8430 = FStar_Syntax_Util.head_and_args e  in
-               (match uu____8430 with
-                | (head,uu____8454) ->
-                    let uu____8479 =
-                      let uu____8480 =
-                        let uu____8481 =
-                          let uu____8498 =
-                            let uu____8509 = FStar_Syntax_Syntax.as_arg s  in
-                            [uu____8509; a2]  in
-                          (head, uu____8498)  in
-                        FStar_Syntax_Syntax.Tm_app uu____8481  in
-                      mk uu____8480  in
-                    let uu____8554 =
-                      let uu____8555 =
-                        let uu____8556 =
-                          let uu____8573 =
-                            let uu____8584 = FStar_Syntax_Syntax.as_arg u  in
-                            [uu____8584; a2]  in
-                          (head, uu____8573)  in
-                        FStar_Syntax_Syntax.Tm_app uu____8556  in
-                      mk uu____8555  in
-                    (t, uu____8479, uu____8554)))
+               let uu____8434 = FStar_Syntax_Util.head_and_args e  in
+               (match uu____8434 with
+                | (head,uu____8458) ->
+                    let uu____8483 =
+                      let uu____8484 =
+                        let uu____8485 =
+                          let uu____8502 =
+                            let uu____8513 = FStar_Syntax_Syntax.as_arg s  in
+                            [uu____8513; a2]  in
+                          (head, uu____8502)  in
+                        FStar_Syntax_Syntax.Tm_app uu____8485  in
+                      mk uu____8484  in
+                    let uu____8558 =
+                      let uu____8559 =
+                        let uu____8560 =
+                          let uu____8577 =
+                            let uu____8588 = FStar_Syntax_Syntax.as_arg u  in
+                            [uu____8588; a2]  in
+                          (head, uu____8577)  in
+                        FStar_Syntax_Syntax.Tm_app uu____8560  in
+                      mk uu____8559  in
+                    (t, uu____8483, uu____8558)))
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____8629;
-             FStar_Syntax_Syntax.vars = uu____8630;_},uu____8631)
+             FStar_Syntax_Syntax.pos = uu____8633;
+             FStar_Syntax_Syntax.vars = uu____8634;_},uu____8635)
           ->
-          let uu____8656 =
-            let uu____8662 =
-              let uu____8664 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____8664
+          let uu____8660 =
+            let uu____8666 =
+              let uu____8668 = FStar_Syntax_Print.term_to_string e  in
+              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____8668
                in
-            (FStar_Errors.Fatal_IllAppliedConstant, uu____8662)  in
-          FStar_Errors.raise_error uu____8656 e.FStar_Syntax_Syntax.pos
+            (FStar_Errors.Fatal_IllAppliedConstant, uu____8666)  in
+          FStar_Errors.raise_error uu____8660 e.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____8674;
-             FStar_Syntax_Syntax.vars = uu____8675;_},uu____8676)
+             FStar_Syntax_Syntax.pos = uu____8678;
+             FStar_Syntax_Syntax.vars = uu____8679;_},uu____8680)
           ->
-          let uu____8701 =
-            let uu____8707 =
-              let uu____8709 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____8709
+          let uu____8705 =
+            let uu____8711 =
+              let uu____8713 = FStar_Syntax_Print.term_to_string e  in
+              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____8713
                in
-            (FStar_Errors.Fatal_IllAppliedConstant, uu____8707)  in
-          FStar_Errors.raise_error uu____8701 e.FStar_Syntax_Syntax.pos
+            (FStar_Errors.Fatal_IllAppliedConstant, uu____8711)  in
+          FStar_Errors.raise_error uu____8705 e.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_app (head,args) ->
-          let uu____8745 = check_n env1 head  in
-          (match uu____8745 with
+          let uu____8749 = check_n env1 head  in
+          (match uu____8749 with
            | (t_head,s_head,u_head) ->
                let is_arrow t =
-                 let uu____8768 =
-                   let uu____8769 = FStar_Syntax_Subst.compress t  in
-                   uu____8769.FStar_Syntax_Syntax.n  in
-                 match uu____8768 with
-                 | FStar_Syntax_Syntax.Tm_arrow uu____8773 -> true
-                 | uu____8789 -> false  in
+                 let uu____8772 =
+                   let uu____8773 = FStar_Syntax_Subst.compress t  in
+                   uu____8773.FStar_Syntax_Syntax.n  in
+                 match uu____8772 with
+                 | FStar_Syntax_Syntax.Tm_arrow uu____8777 -> true
+                 | uu____8793 -> false  in
                let rec flatten t =
-                 let uu____8811 =
-                   let uu____8812 = FStar_Syntax_Subst.compress t  in
-                   uu____8812.FStar_Syntax_Syntax.n  in
-                 match uu____8811 with
+                 let uu____8815 =
+                   let uu____8816 = FStar_Syntax_Subst.compress t  in
+                   uu____8816.FStar_Syntax_Syntax.n  in
+                 match uu____8815 with
                  | FStar_Syntax_Syntax.Tm_arrow
                      (binders,{
                                 FStar_Syntax_Syntax.n =
-                                  FStar_Syntax_Syntax.Total (t1,uu____8831);
-                                FStar_Syntax_Syntax.pos = uu____8832;
-                                FStar_Syntax_Syntax.vars = uu____8833;_})
+                                  FStar_Syntax_Syntax.Total (t1,uu____8835);
+                                FStar_Syntax_Syntax.pos = uu____8836;
+                                FStar_Syntax_Syntax.vars = uu____8837;_})
                      when is_arrow t1 ->
-                     let uu____8862 = flatten t1  in
-                     (match uu____8862 with
+                     let uu____8866 = flatten t1  in
+                     (match uu____8866 with
                       | (binders',comp) ->
                           ((FStar_List.append binders binders'), comp))
                  | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
                      (binders, comp)
-                 | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____8962,uu____8963)
+                 | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____8966,uu____8967)
                      -> flatten e1
-                 | uu____9004 ->
-                     let uu____9005 =
-                       let uu____9011 =
-                         let uu____9013 =
+                 | uu____9008 ->
+                     let uu____9009 =
+                       let uu____9015 =
+                         let uu____9017 =
                            FStar_Syntax_Print.term_to_string t_head  in
                          FStar_Util.format1 "%s: not a function type"
-                           uu____9013
+                           uu____9017
                           in
-                       (FStar_Errors.Fatal_NotFunctionType, uu____9011)  in
-                     FStar_Errors.raise_err uu____9005
+                       (FStar_Errors.Fatal_NotFunctionType, uu____9015)  in
+                     FStar_Errors.raise_err uu____9009
                   in
-               let uu____9031 = flatten t_head  in
-               (match uu____9031 with
+               let uu____9035 = flatten t_head  in
+               (match uu____9035 with
                 | (binders,comp) ->
                     let n = FStar_List.length binders  in
                     let n' = FStar_List.length args  in
                     (if
                        (FStar_List.length binders) < (FStar_List.length args)
                      then
-                       (let uu____9106 =
-                          let uu____9112 =
-                            let uu____9114 = FStar_Util.string_of_int n  in
-                            let uu____9116 =
-                              FStar_Util.string_of_int (n' - n)  in
+                       (let uu____9110 =
+                          let uu____9116 =
                             let uu____9118 = FStar_Util.string_of_int n  in
+                            let uu____9120 =
+                              FStar_Util.string_of_int (n' - n)  in
+                            let uu____9122 = FStar_Util.string_of_int n  in
                             FStar_Util.format3
                               "The head of this application, after being applied to %s arguments, is an effectful computation (leaving %s arguments to be applied). Please let-bind the head applied to the %s first arguments."
-                              uu____9114 uu____9116 uu____9118
+                              uu____9118 uu____9120 uu____9122
                              in
                           (FStar_Errors.Fatal_BinderAndArgsLengthMismatch,
-                            uu____9112)
+                            uu____9116)
                            in
-                        FStar_Errors.raise_err uu____9106)
+                        FStar_Errors.raise_err uu____9110)
                      else ();
-                     (let uu____9124 =
+                     (let uu____9128 =
                         FStar_Syntax_Subst.open_comp binders comp  in
-                      match uu____9124 with
+                      match uu____9128 with
                       | (binders1,comp1) ->
-                          let rec final_type subst uu____9177 args1 =
-                            match uu____9177 with
+                          let rec final_type subst uu____9181 args1 =
+                            match uu____9181 with
                             | (binders2,comp2) ->
                                 (match (binders2, args1) with
                                  | ([],[]) ->
-                                     let uu____9277 =
+                                     let uu____9281 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          comp2
                                         in
-                                     nm_of_comp uu____9277
+                                     nm_of_comp uu____9281
                                  | (binders3,[]) ->
-                                     let uu____9315 =
-                                       let uu____9316 =
-                                         let uu____9319 =
-                                           let uu____9320 =
+                                     let uu____9319 =
+                                       let uu____9320 =
+                                         let uu____9323 =
+                                           let uu____9324 =
                                              mk
                                                (FStar_Syntax_Syntax.Tm_arrow
                                                   (binders3, comp2))
                                               in
                                            FStar_Syntax_Subst.subst subst
-                                             uu____9320
+                                             uu____9324
                                             in
                                          FStar_Syntax_Subst.compress
-                                           uu____9319
+                                           uu____9323
                                           in
-                                       uu____9316.FStar_Syntax_Syntax.n  in
-                                     (match uu____9315 with
+                                       uu____9320.FStar_Syntax_Syntax.n  in
+                                     (match uu____9319 with
                                       | FStar_Syntax_Syntax.Tm_arrow
                                           (binders4,comp3) ->
-                                          let uu____9353 =
-                                            let uu____9354 =
-                                              let uu____9355 =
-                                                let uu____9370 =
+                                          let uu____9357 =
+                                            let uu____9358 =
+                                              let uu____9359 =
+                                                let uu____9374 =
                                                   FStar_Syntax_Subst.close_comp
                                                     binders4 comp3
                                                    in
-                                                (binders4, uu____9370)  in
+                                                (binders4, uu____9374)  in
                                               FStar_Syntax_Syntax.Tm_arrow
-                                                uu____9355
+                                                uu____9359
                                                in
-                                            mk uu____9354  in
-                                          N uu____9353
-                                      | uu____9383 -> failwith "wat?")
-                                 | ([],uu____9385::uu____9386) ->
+                                            mk uu____9358  in
+                                          N uu____9357
+                                      | uu____9387 -> failwith "wat?")
+                                 | ([],uu____9389::uu____9390) ->
                                      failwith "just checked that?!"
-                                 | ((bv,uu____9439)::binders3,(arg,uu____9442)::args2)
+                                 | ((bv,uu____9443)::binders3,(arg,uu____9446)::args2)
                                      ->
                                      final_type
                                        ((FStar_Syntax_Syntax.NT (bv, arg)) ::
@@ -2833,118 +2836,118 @@ and (infer :
                              in
                           let final_type1 =
                             final_type [] (binders1, comp1) args  in
-                          let uu____9529 = FStar_List.splitAt n' binders1  in
-                          (match uu____9529 with
-                           | (binders2,uu____9563) ->
-                               let uu____9596 =
-                                 let uu____9619 =
+                          let uu____9533 = FStar_List.splitAt n' binders1  in
+                          (match uu____9533 with
+                           | (binders2,uu____9567) ->
+                               let uu____9600 =
+                                 let uu____9623 =
                                    FStar_List.map2
-                                     (fun uu____9681  ->
-                                        fun uu____9682  ->
-                                          match (uu____9681, uu____9682) with
-                                          | ((bv,uu____9730),(arg,q)) ->
-                                              let uu____9759 =
-                                                let uu____9760 =
+                                     (fun uu____9685  ->
+                                        fun uu____9686  ->
+                                          match (uu____9685, uu____9686) with
+                                          | ((bv,uu____9734),(arg,q)) ->
+                                              let uu____9763 =
+                                                let uu____9764 =
                                                   FStar_Syntax_Subst.compress
                                                     bv.FStar_Syntax_Syntax.sort
                                                    in
-                                                uu____9760.FStar_Syntax_Syntax.n
+                                                uu____9764.FStar_Syntax_Syntax.n
                                                  in
-                                              (match uu____9759 with
+                                              (match uu____9763 with
                                                | FStar_Syntax_Syntax.Tm_type
-                                                   uu____9781 ->
-                                                   let uu____9782 =
-                                                     let uu____9789 =
+                                                   uu____9785 ->
+                                                   let uu____9786 =
+                                                     let uu____9793 =
                                                        star_type' env1 arg
                                                         in
-                                                     (uu____9789, q)  in
-                                                   (uu____9782, [(arg, q)])
-                                               | uu____9826 ->
-                                                   let uu____9827 =
+                                                     (uu____9793, q)  in
+                                                   (uu____9786, [(arg, q)])
+                                               | uu____9830 ->
+                                                   let uu____9831 =
                                                      check_n env1 arg  in
-                                                   (match uu____9827 with
-                                                    | (uu____9852,s_arg,u_arg)
+                                                   (match uu____9831 with
+                                                    | (uu____9856,s_arg,u_arg)
                                                         ->
-                                                        let uu____9855 =
-                                                          let uu____9864 =
+                                                        let uu____9859 =
+                                                          let uu____9868 =
                                                             is_C
                                                               bv.FStar_Syntax_Syntax.sort
                                                              in
-                                                          if uu____9864
+                                                          if uu____9868
                                                           then
-                                                            let uu____9875 =
-                                                              let uu____9882
+                                                            let uu____9879 =
+                                                              let uu____9886
                                                                 =
                                                                 FStar_Syntax_Subst.subst
                                                                   env1.subst
                                                                   s_arg
                                                                  in
-                                                              (uu____9882, q)
+                                                              (uu____9886, q)
                                                                in
-                                                            [uu____9875;
+                                                            [uu____9879;
                                                             (u_arg, q)]
                                                           else [(u_arg, q)]
                                                            in
                                                         ((s_arg, q),
-                                                          uu____9855))))
+                                                          uu____9859))))
                                      binders2 args
                                     in
-                                 FStar_List.split uu____9619  in
-                               (match uu____9596 with
+                                 FStar_List.split uu____9623  in
+                               (match uu____9600 with
                                 | (s_args,u_args) ->
                                     let u_args1 = FStar_List.flatten u_args
                                        in
-                                    let uu____10010 =
+                                    let uu____10014 =
                                       mk
                                         (FStar_Syntax_Syntax.Tm_app
                                            (s_head, s_args))
                                        in
-                                    let uu____10023 =
+                                    let uu____10027 =
                                       mk
                                         (FStar_Syntax_Syntax.Tm_app
                                            (u_head, u_args1))
                                        in
-                                    (final_type1, uu____10010, uu____10023)))))))
+                                    (final_type1, uu____10014, uu____10027)))))))
       | FStar_Syntax_Syntax.Tm_let ((false ,binding::[]),e2) ->
           mk_let env1 binding e2 infer check_m
       | FStar_Syntax_Syntax.Tm_match (e0,branches) ->
           mk_match env1 e0 branches infer
-      | FStar_Syntax_Syntax.Tm_uinst (e1,uu____10092) -> infer env1 e1
-      | FStar_Syntax_Syntax.Tm_meta (e1,uu____10098) -> infer env1 e1
-      | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____10104,uu____10105) ->
+      | FStar_Syntax_Syntax.Tm_uinst (e1,uu____10096) -> infer env1 e1
+      | FStar_Syntax_Syntax.Tm_meta (e1,uu____10102) -> infer env1 e1
+      | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____10108,uu____10109) ->
           infer env1 e1
       | FStar_Syntax_Syntax.Tm_constant c ->
-          let uu____10147 =
-            let uu____10148 = env1.tc_const c  in N uu____10148  in
-          (uu____10147, e, e)
+          let uu____10151 =
+            let uu____10152 = env1.tc_const c  in N uu____10152  in
+          (uu____10151, e, e)
       | FStar_Syntax_Syntax.Tm_quoted (tm,qt) ->
           ((N FStar_Syntax_Syntax.t_term), e, e)
-      | FStar_Syntax_Syntax.Tm_let uu____10155 ->
-          let uu____10169 =
-            let uu____10171 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_let %s" uu____10171  in
-          failwith uu____10169
-      | FStar_Syntax_Syntax.Tm_type uu____10180 ->
+      | FStar_Syntax_Syntax.Tm_let uu____10159 ->
+          let uu____10173 =
+            let uu____10175 = FStar_Syntax_Print.term_to_string e  in
+            FStar_Util.format1 "[infer]: Tm_let %s" uu____10175  in
+          failwith uu____10173
+      | FStar_Syntax_Syntax.Tm_type uu____10184 ->
           failwith "impossible (DM stratification)"
-      | FStar_Syntax_Syntax.Tm_arrow uu____10188 ->
+      | FStar_Syntax_Syntax.Tm_arrow uu____10192 ->
           failwith "impossible (DM stratification)"
-      | FStar_Syntax_Syntax.Tm_refine uu____10210 ->
-          let uu____10217 =
-            let uu____10219 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_refine %s" uu____10219  in
-          failwith uu____10217
-      | FStar_Syntax_Syntax.Tm_uvar uu____10228 ->
-          let uu____10241 =
-            let uu____10243 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_uvar %s" uu____10243  in
-          failwith uu____10241
-      | FStar_Syntax_Syntax.Tm_delayed uu____10252 ->
+      | FStar_Syntax_Syntax.Tm_refine uu____10214 ->
+          let uu____10221 =
+            let uu____10223 = FStar_Syntax_Print.term_to_string e  in
+            FStar_Util.format1 "[infer]: Tm_refine %s" uu____10223  in
+          failwith uu____10221
+      | FStar_Syntax_Syntax.Tm_uvar uu____10232 ->
+          let uu____10245 =
+            let uu____10247 = FStar_Syntax_Print.term_to_string e  in
+            FStar_Util.format1 "[infer]: Tm_uvar %s" uu____10247  in
+          failwith uu____10245
+      | FStar_Syntax_Syntax.Tm_delayed uu____10256 ->
           failwith "impossible (compressed)"
       | FStar_Syntax_Syntax.Tm_unknown  ->
-          let uu____10274 =
-            let uu____10276 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_unknown %s" uu____10276  in
-          failwith uu____10274
+          let uu____10278 =
+            let uu____10280 = FStar_Syntax_Print.term_to_string e  in
+            FStar_Util.format1 "[infer]: Tm_unknown %s" uu____10280  in
+          failwith uu____10278
 
 and (mk_match :
   env ->
@@ -2966,61 +2969,61 @@ and (mk_match :
             FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
               e0.FStar_Syntax_Syntax.pos
              in
-          let uu____10325 = check_n env1 e0  in
-          match uu____10325 with
-          | (uu____10338,s_e0,u_e0) ->
-              let uu____10341 =
-                let uu____10370 =
+          let uu____10329 = check_n env1 e0  in
+          match uu____10329 with
+          | (uu____10342,s_e0,u_e0) ->
+              let uu____10345 =
+                let uu____10374 =
                   FStar_List.map
                     (fun b  ->
-                       let uu____10431 = FStar_Syntax_Subst.open_branch b  in
-                       match uu____10431 with
+                       let uu____10435 = FStar_Syntax_Subst.open_branch b  in
+                       match uu____10435 with
                        | (pat,FStar_Pervasives_Native.None ,body) ->
                            let env2 =
-                             let uu___1117_10473 = env1  in
-                             let uu____10474 =
-                               let uu____10475 =
+                             let uu___1117_10477 = env1  in
+                             let uu____10478 =
+                               let uu____10479 =
                                  FStar_Syntax_Syntax.pat_bvs pat  in
                                FStar_List.fold_left
                                  FStar_TypeChecker_Env.push_bv env1.tcenv
-                                 uu____10475
+                                 uu____10479
                                 in
                              {
-                               tcenv = uu____10474;
-                               subst = (uu___1117_10473.subst);
-                               tc_const = (uu___1117_10473.tc_const)
+                               tcenv = uu____10478;
+                               subst = (uu___1117_10477.subst);
+                               tc_const = (uu___1117_10477.tc_const)
                              }  in
-                           let uu____10478 = f env2 body  in
-                           (match uu____10478 with
+                           let uu____10482 = f env2 body  in
+                           (match uu____10482 with
                             | (nm1,s_body,u_body) ->
                                 (nm1,
                                   (pat, FStar_Pervasives_Native.None,
                                     (s_body, u_body, body))))
-                       | uu____10550 ->
+                       | uu____10554 ->
                            FStar_Errors.raise_err
                              (FStar_Errors.Fatal_WhenClauseNotSupported,
                                "No when clauses in the definition language"))
                     branches
                    in
-                FStar_List.split uu____10370  in
-              (match uu____10341 with
+                FStar_List.split uu____10374  in
+              (match uu____10345 with
                | (nms,branches1) ->
                    let t1 =
-                     let uu____10656 = FStar_List.hd nms  in
-                     match uu____10656 with | M t1 -> t1 | N t1 -> t1  in
+                     let uu____10660 = FStar_List.hd nms  in
+                     match uu____10660 with | M t1 -> t1 | N t1 -> t1  in
                    let has_m =
                      FStar_List.existsb
-                       (fun uu___10_10665  ->
-                          match uu___10_10665 with
-                          | M uu____10667 -> true
-                          | uu____10669 -> false) nms
+                       (fun uu___10_10669  ->
+                          match uu___10_10669 with
+                          | M uu____10671 -> true
+                          | uu____10673 -> false) nms
                       in
-                   let uu____10671 =
-                     let uu____10708 =
+                   let uu____10675 =
+                     let uu____10712 =
                        FStar_List.map2
                          (fun nm1  ->
-                            fun uu____10798  ->
-                              match uu____10798 with
+                            fun uu____10802  ->
+                              match uu____10802 with
                               | (pat,guard,(s_body,u_body,original_body)) ->
                                   (match (nm1, has_m) with
                                    | (N t2,false ) ->
@@ -3030,17 +3033,17 @@ and (mk_match :
                                        (nm1, (pat, guard, s_body),
                                          (pat, guard, u_body))
                                    | (N t2,true ) ->
-                                       let uu____10982 =
+                                       let uu____10986 =
                                          check env1 original_body (M t2)  in
-                                       (match uu____10982 with
-                                        | (uu____11019,s_body1,u_body1) ->
+                                       (match uu____10986 with
+                                        | (uu____11023,s_body1,u_body1) ->
                                             ((M t2), (pat, guard, s_body1),
                                               (pat, guard, u_body1)))
-                                   | (M uu____11058,false ) ->
+                                   | (M uu____11062,false ) ->
                                        failwith "impossible")) nms branches1
                         in
-                     FStar_List.unzip3 uu____10708  in
-                   (match uu____10671 with
+                     FStar_List.unzip3 uu____10712  in
+                   (match uu____10675 with
                     | (nms1,s_branches,u_branches) ->
                         if has_m
                         then
@@ -3051,29 +3054,29 @@ and (mk_match :
                              in
                           let s_branches1 =
                             FStar_List.map
-                              (fun uu____11247  ->
-                                 match uu____11247 with
+                              (fun uu____11251  ->
+                                 match uu____11251 with
                                  | (pat,guard,s_body) ->
                                      let s_body1 =
-                                       let uu____11298 =
-                                         let uu____11299 =
-                                           let uu____11316 =
-                                             let uu____11327 =
-                                               let uu____11336 =
+                                       let uu____11302 =
+                                         let uu____11303 =
+                                           let uu____11320 =
+                                             let uu____11331 =
+                                               let uu____11340 =
                                                  FStar_Syntax_Syntax.bv_to_name
                                                    p
                                                   in
-                                               let uu____11339 =
+                                               let uu____11343 =
                                                  FStar_Syntax_Syntax.as_implicit
                                                    false
                                                   in
-                                               (uu____11336, uu____11339)  in
-                                             [uu____11327]  in
-                                           (s_body, uu____11316)  in
+                                               (uu____11340, uu____11343)  in
+                                             [uu____11331]  in
+                                           (s_body, uu____11320)  in
                                          FStar_Syntax_Syntax.Tm_app
-                                           uu____11299
+                                           uu____11303
                                           in
-                                       mk uu____11298  in
+                                       mk uu____11302  in
                                      (pat, guard, s_body1)) s_branches
                              in
                           let s_branches2 =
@@ -3085,38 +3088,38 @@ and (mk_match :
                               u_branches
                              in
                           let s_e =
-                            let uu____11474 =
-                              let uu____11475 =
+                            let uu____11478 =
+                              let uu____11479 =
                                 FStar_Syntax_Syntax.mk_binder p  in
-                              [uu____11475]  in
-                            let uu____11494 =
+                              [uu____11479]  in
+                            let uu____11498 =
                               mk
                                 (FStar_Syntax_Syntax.Tm_match
                                    (s_e0, s_branches2))
                                in
-                            FStar_Syntax_Util.abs uu____11474 uu____11494
+                            FStar_Syntax_Util.abs uu____11478 uu____11498
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_tot
                                     FStar_Syntax_Util.ktype0))
                              in
                           let t1_star =
-                            let uu____11518 =
-                              let uu____11527 =
-                                let uu____11534 =
+                            let uu____11522 =
+                              let uu____11531 =
+                                let uu____11538 =
                                   FStar_Syntax_Syntax.new_bv
                                     FStar_Pervasives_Native.None p_type
                                    in
                                 FStar_All.pipe_left
-                                  FStar_Syntax_Syntax.mk_binder uu____11534
+                                  FStar_Syntax_Syntax.mk_binder uu____11538
                                  in
-                              [uu____11527]  in
-                            let uu____11553 =
+                              [uu____11531]  in
+                            let uu____11557 =
                               FStar_Syntax_Syntax.mk_Total
                                 FStar_Syntax_Util.ktype0
                                in
-                            FStar_Syntax_Util.arrow uu____11518 uu____11553
+                            FStar_Syntax_Util.arrow uu____11522 uu____11557
                              in
-                          let uu____11556 =
+                          let uu____11560 =
                             mk
                               (FStar_Syntax_Syntax.Tm_ascribed
                                  (s_e,
@@ -3124,12 +3127,12 @@ and (mk_match :
                                      FStar_Pervasives_Native.None),
                                    FStar_Pervasives_Native.None))
                              in
-                          let uu____11595 =
+                          let uu____11599 =
                             mk
                               (FStar_Syntax_Syntax.Tm_match
                                  (u_e0, u_branches1))
                              in
-                          ((M t1), uu____11556, uu____11595)
+                          ((M t1), uu____11560, uu____11599)
                         else
                           (let s_branches1 =
                              FStar_List.map FStar_Syntax_Subst.close_branch
@@ -3140,28 +3143,28 @@ and (mk_match :
                                u_branches
                               in
                            let t1_star = t1  in
-                           let uu____11705 =
-                             let uu____11706 =
-                               let uu____11707 =
-                                 let uu____11734 =
+                           let uu____11709 =
+                             let uu____11710 =
+                               let uu____11711 =
+                                 let uu____11738 =
                                    mk
                                      (FStar_Syntax_Syntax.Tm_match
                                         (s_e0, s_branches1))
                                     in
-                                 (uu____11734,
+                                 (uu____11738,
                                    ((FStar_Util.Inl t1_star),
                                      FStar_Pervasives_Native.None),
                                    FStar_Pervasives_Native.None)
                                   in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____11707
+                               FStar_Syntax_Syntax.Tm_ascribed uu____11711
                                 in
-                             mk uu____11706  in
-                           let uu____11793 =
+                             mk uu____11710  in
+                           let uu____11797 =
                              mk
                                (FStar_Syntax_Syntax.Tm_match
                                   (u_e0, u_branches1))
                               in
-                           ((N t1), uu____11705, uu____11793))))
+                           ((N t1), uu____11709, uu____11797))))
 
 and (mk_let :
   env_ ->
@@ -3189,172 +3192,172 @@ and (mk_let :
             let e1 = binding.FStar_Syntax_Syntax.lbdef  in
             let x = FStar_Util.left binding.FStar_Syntax_Syntax.lbname  in
             let x_binders =
-              let uu____11858 = FStar_Syntax_Syntax.mk_binder x  in
-              [uu____11858]  in
-            let uu____11877 = FStar_Syntax_Subst.open_term x_binders e2  in
-            match uu____11877 with
+              let uu____11862 = FStar_Syntax_Syntax.mk_binder x  in
+              [uu____11862]  in
+            let uu____11881 = FStar_Syntax_Subst.open_term x_binders e2  in
+            match uu____11881 with
             | (x_binders1,e21) ->
-                let uu____11890 = infer env1 e1  in
-                (match uu____11890 with
+                let uu____11894 = infer env1 e1  in
+                (match uu____11894 with
                  | (N t1,s_e1,u_e1) ->
                      let u_binding =
-                       let uu____11907 = is_C t1  in
-                       if uu____11907
+                       let uu____11911 = is_C t1  in
+                       if uu____11911
                        then
-                         let uu___1203_11910 = binding  in
-                         let uu____11911 =
-                           let uu____11914 =
+                         let uu___1203_11914 = binding  in
+                         let uu____11915 =
+                           let uu____11918 =
                              FStar_Syntax_Subst.subst env1.subst s_e1  in
-                           trans_F_ env1 t1 uu____11914  in
+                           trans_F_ env1 t1 uu____11918  in
                          {
                            FStar_Syntax_Syntax.lbname =
-                             (uu___1203_11910.FStar_Syntax_Syntax.lbname);
+                             (uu___1203_11914.FStar_Syntax_Syntax.lbname);
                            FStar_Syntax_Syntax.lbunivs =
-                             (uu___1203_11910.FStar_Syntax_Syntax.lbunivs);
-                           FStar_Syntax_Syntax.lbtyp = uu____11911;
+                             (uu___1203_11914.FStar_Syntax_Syntax.lbunivs);
+                           FStar_Syntax_Syntax.lbtyp = uu____11915;
                            FStar_Syntax_Syntax.lbeff =
-                             (uu___1203_11910.FStar_Syntax_Syntax.lbeff);
+                             (uu___1203_11914.FStar_Syntax_Syntax.lbeff);
                            FStar_Syntax_Syntax.lbdef =
-                             (uu___1203_11910.FStar_Syntax_Syntax.lbdef);
+                             (uu___1203_11914.FStar_Syntax_Syntax.lbdef);
                            FStar_Syntax_Syntax.lbattrs =
-                             (uu___1203_11910.FStar_Syntax_Syntax.lbattrs);
+                             (uu___1203_11914.FStar_Syntax_Syntax.lbattrs);
                            FStar_Syntax_Syntax.lbpos =
-                             (uu___1203_11910.FStar_Syntax_Syntax.lbpos)
+                             (uu___1203_11914.FStar_Syntax_Syntax.lbpos)
                          }
                        else binding  in
                      let env2 =
-                       let uu___1206_11918 = env1  in
-                       let uu____11919 =
+                       let uu___1206_11922 = env1  in
+                       let uu____11923 =
                          FStar_TypeChecker_Env.push_bv env1.tcenv
-                           (let uu___1208_11921 = x  in
+                           (let uu___1208_11925 = x  in
                             {
                               FStar_Syntax_Syntax.ppname =
-                                (uu___1208_11921.FStar_Syntax_Syntax.ppname);
+                                (uu___1208_11925.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
-                                (uu___1208_11921.FStar_Syntax_Syntax.index);
+                                (uu___1208_11925.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = t1
                             })
                           in
                        {
-                         tcenv = uu____11919;
-                         subst = (uu___1206_11918.subst);
-                         tc_const = (uu___1206_11918.tc_const)
+                         tcenv = uu____11923;
+                         subst = (uu___1206_11922.subst);
+                         tc_const = (uu___1206_11922.tc_const)
                        }  in
-                     let uu____11922 = proceed env2 e21  in
-                     (match uu____11922 with
+                     let uu____11926 = proceed env2 e21  in
+                     (match uu____11926 with
                       | (nm_rec,s_e2,u_e2) ->
                           let s_binding =
-                            let uu___1215_11939 = binding  in
-                            let uu____11940 =
+                            let uu___1215_11943 = binding  in
+                            let uu____11944 =
                               star_type' env2
                                 binding.FStar_Syntax_Syntax.lbtyp
                                in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___1215_11939.FStar_Syntax_Syntax.lbname);
+                                (uu___1215_11943.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___1215_11939.FStar_Syntax_Syntax.lbunivs);
-                              FStar_Syntax_Syntax.lbtyp = uu____11940;
+                                (uu___1215_11943.FStar_Syntax_Syntax.lbunivs);
+                              FStar_Syntax_Syntax.lbtyp = uu____11944;
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___1215_11939.FStar_Syntax_Syntax.lbeff);
+                                (uu___1215_11943.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef =
-                                (uu___1215_11939.FStar_Syntax_Syntax.lbdef);
+                                (uu___1215_11943.FStar_Syntax_Syntax.lbdef);
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___1215_11939.FStar_Syntax_Syntax.lbattrs);
+                                (uu___1215_11943.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___1215_11939.FStar_Syntax_Syntax.lbpos)
+                                (uu___1215_11943.FStar_Syntax_Syntax.lbpos)
                             }  in
-                          let uu____11943 =
-                            let uu____11944 =
-                              let uu____11945 =
-                                let uu____11959 =
+                          let uu____11947 =
+                            let uu____11948 =
+                              let uu____11949 =
+                                let uu____11963 =
                                   FStar_Syntax_Subst.close x_binders1 s_e2
                                    in
                                 ((false,
-                                   [(let uu___1218_11976 = s_binding  in
+                                   [(let uu___1218_11980 = s_binding  in
                                      {
                                        FStar_Syntax_Syntax.lbname =
-                                         (uu___1218_11976.FStar_Syntax_Syntax.lbname);
+                                         (uu___1218_11980.FStar_Syntax_Syntax.lbname);
                                        FStar_Syntax_Syntax.lbunivs =
-                                         (uu___1218_11976.FStar_Syntax_Syntax.lbunivs);
+                                         (uu___1218_11980.FStar_Syntax_Syntax.lbunivs);
                                        FStar_Syntax_Syntax.lbtyp =
-                                         (uu___1218_11976.FStar_Syntax_Syntax.lbtyp);
+                                         (uu___1218_11980.FStar_Syntax_Syntax.lbtyp);
                                        FStar_Syntax_Syntax.lbeff =
-                                         (uu___1218_11976.FStar_Syntax_Syntax.lbeff);
+                                         (uu___1218_11980.FStar_Syntax_Syntax.lbeff);
                                        FStar_Syntax_Syntax.lbdef = s_e1;
                                        FStar_Syntax_Syntax.lbattrs =
-                                         (uu___1218_11976.FStar_Syntax_Syntax.lbattrs);
+                                         (uu___1218_11980.FStar_Syntax_Syntax.lbattrs);
                                        FStar_Syntax_Syntax.lbpos =
-                                         (uu___1218_11976.FStar_Syntax_Syntax.lbpos)
-                                     })]), uu____11959)
+                                         (uu___1218_11980.FStar_Syntax_Syntax.lbpos)
+                                     })]), uu____11963)
                                  in
-                              FStar_Syntax_Syntax.Tm_let uu____11945  in
-                            mk uu____11944  in
-                          let uu____11977 =
-                            let uu____11978 =
-                              let uu____11979 =
-                                let uu____11993 =
+                              FStar_Syntax_Syntax.Tm_let uu____11949  in
+                            mk uu____11948  in
+                          let uu____11981 =
+                            let uu____11982 =
+                              let uu____11983 =
+                                let uu____11997 =
                                   FStar_Syntax_Subst.close x_binders1 u_e2
                                    in
                                 ((false,
-                                   [(let uu___1220_12010 = u_binding  in
+                                   [(let uu___1220_12014 = u_binding  in
                                      {
                                        FStar_Syntax_Syntax.lbname =
-                                         (uu___1220_12010.FStar_Syntax_Syntax.lbname);
+                                         (uu___1220_12014.FStar_Syntax_Syntax.lbname);
                                        FStar_Syntax_Syntax.lbunivs =
-                                         (uu___1220_12010.FStar_Syntax_Syntax.lbunivs);
+                                         (uu___1220_12014.FStar_Syntax_Syntax.lbunivs);
                                        FStar_Syntax_Syntax.lbtyp =
-                                         (uu___1220_12010.FStar_Syntax_Syntax.lbtyp);
+                                         (uu___1220_12014.FStar_Syntax_Syntax.lbtyp);
                                        FStar_Syntax_Syntax.lbeff =
-                                         (uu___1220_12010.FStar_Syntax_Syntax.lbeff);
+                                         (uu___1220_12014.FStar_Syntax_Syntax.lbeff);
                                        FStar_Syntax_Syntax.lbdef = u_e1;
                                        FStar_Syntax_Syntax.lbattrs =
-                                         (uu___1220_12010.FStar_Syntax_Syntax.lbattrs);
+                                         (uu___1220_12014.FStar_Syntax_Syntax.lbattrs);
                                        FStar_Syntax_Syntax.lbpos =
-                                         (uu___1220_12010.FStar_Syntax_Syntax.lbpos)
-                                     })]), uu____11993)
+                                         (uu___1220_12014.FStar_Syntax_Syntax.lbpos)
+                                     })]), uu____11997)
                                  in
-                              FStar_Syntax_Syntax.Tm_let uu____11979  in
-                            mk uu____11978  in
-                          (nm_rec, uu____11943, uu____11977))
+                              FStar_Syntax_Syntax.Tm_let uu____11983  in
+                            mk uu____11982  in
+                          (nm_rec, uu____11947, uu____11981))
                  | (M t1,s_e1,u_e1) ->
                      let u_binding =
-                       let uu___1227_12015 = binding  in
+                       let uu___1227_12019 = binding  in
                        {
                          FStar_Syntax_Syntax.lbname =
-                           (uu___1227_12015.FStar_Syntax_Syntax.lbname);
+                           (uu___1227_12019.FStar_Syntax_Syntax.lbname);
                          FStar_Syntax_Syntax.lbunivs =
-                           (uu___1227_12015.FStar_Syntax_Syntax.lbunivs);
+                           (uu___1227_12019.FStar_Syntax_Syntax.lbunivs);
                          FStar_Syntax_Syntax.lbtyp = t1;
                          FStar_Syntax_Syntax.lbeff =
                            FStar_Parser_Const.effect_PURE_lid;
                          FStar_Syntax_Syntax.lbdef =
-                           (uu___1227_12015.FStar_Syntax_Syntax.lbdef);
+                           (uu___1227_12019.FStar_Syntax_Syntax.lbdef);
                          FStar_Syntax_Syntax.lbattrs =
-                           (uu___1227_12015.FStar_Syntax_Syntax.lbattrs);
+                           (uu___1227_12019.FStar_Syntax_Syntax.lbattrs);
                          FStar_Syntax_Syntax.lbpos =
-                           (uu___1227_12015.FStar_Syntax_Syntax.lbpos)
+                           (uu___1227_12019.FStar_Syntax_Syntax.lbpos)
                        }  in
                      let env2 =
-                       let uu___1230_12017 = env1  in
-                       let uu____12018 =
+                       let uu___1230_12021 = env1  in
+                       let uu____12022 =
                          FStar_TypeChecker_Env.push_bv env1.tcenv
-                           (let uu___1232_12020 = x  in
+                           (let uu___1232_12024 = x  in
                             {
                               FStar_Syntax_Syntax.ppname =
-                                (uu___1232_12020.FStar_Syntax_Syntax.ppname);
+                                (uu___1232_12024.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
-                                (uu___1232_12020.FStar_Syntax_Syntax.index);
+                                (uu___1232_12024.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = t1
                             })
                           in
                        {
-                         tcenv = uu____12018;
-                         subst = (uu___1230_12017.subst);
-                         tc_const = (uu___1230_12017.tc_const)
+                         tcenv = uu____12022;
+                         subst = (uu___1230_12021.subst);
+                         tc_const = (uu___1230_12021.tc_const)
                        }  in
-                     let uu____12021 = ensure_m env2 e21  in
-                     (match uu____12021 with
+                     let uu____12025 = ensure_m env2 e21  in
+                     (match uu____12025 with
                       | (t2,s_e2,u_e2) ->
                           let p_type = mk_star_to_type mk env2 t2  in
                           let p =
@@ -3362,20 +3365,20 @@ and (mk_let :
                               FStar_Pervasives_Native.None p_type
                              in
                           let s_e21 =
-                            let uu____12045 =
-                              let uu____12046 =
-                                let uu____12063 =
-                                  let uu____12074 =
-                                    let uu____12083 =
+                            let uu____12049 =
+                              let uu____12050 =
+                                let uu____12067 =
+                                  let uu____12078 =
+                                    let uu____12087 =
                                       FStar_Syntax_Syntax.bv_to_name p  in
-                                    let uu____12086 =
+                                    let uu____12090 =
                                       FStar_Syntax_Syntax.as_implicit false
                                        in
-                                    (uu____12083, uu____12086)  in
-                                  [uu____12074]  in
-                                (s_e2, uu____12063)  in
-                              FStar_Syntax_Syntax.Tm_app uu____12046  in
-                            mk uu____12045  in
+                                    (uu____12087, uu____12090)  in
+                                  [uu____12078]  in
+                                (s_e2, uu____12067)  in
+                              FStar_Syntax_Syntax.Tm_app uu____12050  in
+                            mk uu____12049  in
                           let s_e22 =
                             FStar_Syntax_Util.abs x_binders1 s_e21
                               (FStar_Pervasives_Native.Some
@@ -3383,55 +3386,55 @@ and (mk_let :
                                     FStar_Syntax_Util.ktype0))
                              in
                           let body =
-                            let uu____12128 =
-                              let uu____12129 =
-                                let uu____12146 =
-                                  let uu____12157 =
-                                    let uu____12166 =
+                            let uu____12132 =
+                              let uu____12133 =
+                                let uu____12150 =
+                                  let uu____12161 =
+                                    let uu____12170 =
                                       FStar_Syntax_Syntax.as_implicit false
                                        in
-                                    (s_e22, uu____12166)  in
-                                  [uu____12157]  in
-                                (s_e1, uu____12146)  in
-                              FStar_Syntax_Syntax.Tm_app uu____12129  in
-                            mk uu____12128  in
-                          let uu____12202 =
-                            let uu____12203 =
-                              let uu____12204 =
+                                    (s_e22, uu____12170)  in
+                                  [uu____12161]  in
+                                (s_e1, uu____12150)  in
+                              FStar_Syntax_Syntax.Tm_app uu____12133  in
+                            mk uu____12132  in
+                          let uu____12206 =
+                            let uu____12207 =
+                              let uu____12208 =
                                 FStar_Syntax_Syntax.mk_binder p  in
-                              [uu____12204]  in
-                            FStar_Syntax_Util.abs uu____12203 body
+                              [uu____12208]  in
+                            FStar_Syntax_Util.abs uu____12207 body
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_tot
                                     FStar_Syntax_Util.ktype0))
                              in
-                          let uu____12223 =
-                            let uu____12224 =
-                              let uu____12225 =
-                                let uu____12239 =
+                          let uu____12227 =
+                            let uu____12228 =
+                              let uu____12229 =
+                                let uu____12243 =
                                   FStar_Syntax_Subst.close x_binders1 u_e2
                                    in
                                 ((false,
-                                   [(let uu___1244_12256 = u_binding  in
+                                   [(let uu___1244_12260 = u_binding  in
                                      {
                                        FStar_Syntax_Syntax.lbname =
-                                         (uu___1244_12256.FStar_Syntax_Syntax.lbname);
+                                         (uu___1244_12260.FStar_Syntax_Syntax.lbname);
                                        FStar_Syntax_Syntax.lbunivs =
-                                         (uu___1244_12256.FStar_Syntax_Syntax.lbunivs);
+                                         (uu___1244_12260.FStar_Syntax_Syntax.lbunivs);
                                        FStar_Syntax_Syntax.lbtyp =
-                                         (uu___1244_12256.FStar_Syntax_Syntax.lbtyp);
+                                         (uu___1244_12260.FStar_Syntax_Syntax.lbtyp);
                                        FStar_Syntax_Syntax.lbeff =
-                                         (uu___1244_12256.FStar_Syntax_Syntax.lbeff);
+                                         (uu___1244_12260.FStar_Syntax_Syntax.lbeff);
                                        FStar_Syntax_Syntax.lbdef = u_e1;
                                        FStar_Syntax_Syntax.lbattrs =
-                                         (uu___1244_12256.FStar_Syntax_Syntax.lbattrs);
+                                         (uu___1244_12260.FStar_Syntax_Syntax.lbattrs);
                                        FStar_Syntax_Syntax.lbpos =
-                                         (uu___1244_12256.FStar_Syntax_Syntax.lbpos)
-                                     })]), uu____12239)
+                                         (uu___1244_12260.FStar_Syntax_Syntax.lbpos)
+                                     })]), uu____12243)
                                  in
-                              FStar_Syntax_Syntax.Tm_let uu____12225  in
-                            mk uu____12224  in
-                          ((M t2), uu____12202, uu____12223)))
+                              FStar_Syntax_Syntax.Tm_let uu____12229  in
+                            mk uu____12228  in
+                          ((M t2), uu____12206, uu____12227)))
 
 and (check_n :
   env_ ->
@@ -3442,15 +3445,15 @@ and (check_n :
   fun env1  ->
     fun e  ->
       let mn =
-        let uu____12266 =
+        let uu____12270 =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
             FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
            in
-        N uu____12266  in
-      let uu____12267 = check env1 e mn  in
-      match uu____12267 with
+        N uu____12270  in
+      let uu____12271 = check env1 e mn  in
+      match uu____12271 with
       | (N t,s_e,u_e) -> (t, s_e, u_e)
-      | uu____12283 -> failwith "[check_n]: impossible"
+      | uu____12287 -> failwith "[check_n]: impossible"
 
 and (check_m :
   env_ ->
@@ -3461,15 +3464,15 @@ and (check_m :
   fun env1  ->
     fun e  ->
       let mn =
-        let uu____12306 =
+        let uu____12310 =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
             FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
            in
-        M uu____12306  in
-      let uu____12307 = check env1 e mn  in
-      match uu____12307 with
+        M uu____12310  in
+      let uu____12311 = check env1 e mn  in
+      match uu____12311 with
       | (M t,s_e,u_e) -> (t, s_e, u_e)
-      | uu____12323 -> failwith "[check_m]: impossible"
+      | uu____12327 -> failwith "[check_m]: impossible"
 
 and (comp_of_nm : nm_ -> FStar_Syntax_Syntax.comp) =
   fun nm1  ->
@@ -3500,181 +3503,188 @@ and (trans_F_ :
   fun env1  ->
     fun c  ->
       fun wp  ->
-        (let uu____12356 =
-           let uu____12358 = is_C c  in Prims.op_Negation uu____12358  in
-         if uu____12356
+        (let uu____12360 =
+           let uu____12362 = is_C c  in Prims.op_Negation uu____12362  in
+         if uu____12360
          then
-           let uu____12361 =
-             let uu____12367 =
-               let uu____12369 = FStar_Syntax_Print.term_to_string c  in
-               FStar_Util.format1 "Not a DM4F C-type: %s" uu____12369  in
-             (FStar_Errors.Error_UnexpectedDM4FType, uu____12367)  in
-           FStar_Errors.raise_error uu____12361 c.FStar_Syntax_Syntax.pos
+           let uu____12365 =
+             let uu____12371 =
+               let uu____12373 = FStar_Syntax_Print.term_to_string c  in
+               FStar_Util.format1 "Not a DM4F C-type: %s" uu____12373  in
+             (FStar_Errors.Error_UnexpectedDM4FType, uu____12371)  in
+           FStar_Errors.raise_error uu____12365 c.FStar_Syntax_Syntax.pos
          else ());
         (let mk x =
            FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
              c.FStar_Syntax_Syntax.pos
             in
-         let uu____12383 =
-           let uu____12384 = FStar_Syntax_Subst.compress c  in
-           uu____12384.FStar_Syntax_Syntax.n  in
-         match uu____12383 with
+         let uu____12387 =
+           let uu____12388 = FStar_Syntax_Subst.compress c  in
+           uu____12388.FStar_Syntax_Syntax.n  in
+         match uu____12387 with
          | FStar_Syntax_Syntax.Tm_app (head,args) ->
-             let uu____12413 = FStar_Syntax_Util.head_and_args wp  in
-             (match uu____12413 with
+             let uu____12417 = FStar_Syntax_Util.head_and_args wp  in
+             (match uu____12417 with
               | (wp_head,wp_args) ->
-                  ((let uu____12457 =
+                  ((let uu____12461 =
                       (Prims.op_Negation
                          ((FStar_List.length wp_args) =
                             (FStar_List.length args)))
                         ||
-                        (let uu____12476 =
-                           let uu____12478 =
+                        (let uu____12480 =
+                           let uu____12482 =
                              FStar_Parser_Const.mk_tuple_data_lid
                                (FStar_List.length wp_args)
                                FStar_Range.dummyRange
                               in
                            FStar_Syntax_Util.is_constructor wp_head
-                             uu____12478
+                             uu____12482
                             in
-                         Prims.op_Negation uu____12476)
+                         Prims.op_Negation uu____12480)
                        in
-                    if uu____12457 then failwith "mismatch" else ());
-                   (let uu____12491 =
-                      let uu____12492 =
-                        let uu____12509 =
+                    if uu____12461 then failwith "mismatch" else ());
+                   (let uu____12495 =
+                      let uu____12496 =
+                        let uu____12513 =
                           FStar_List.map2
-                            (fun uu____12547  ->
-                               fun uu____12548  ->
-                                 match (uu____12547, uu____12548) with
+                            (fun uu____12551  ->
+                               fun uu____12552  ->
+                                 match (uu____12551, uu____12552) with
                                  | ((arg,q),(wp_arg,q')) ->
                                      let print_implicit q1 =
-                                       let uu____12610 =
+                                       let uu____12614 =
                                          FStar_Syntax_Syntax.is_implicit q1
                                           in
-                                       if uu____12610
+                                       if uu____12614
                                        then "implicit"
                                        else "explicit"  in
-                                     ((let uu____12619 =
-                                         let uu____12621 =
+                                     ((let uu____12623 =
+                                         let uu____12625 =
                                            FStar_Syntax_Util.eq_aqual q q'
                                             in
-                                         uu____12621 <>
+                                         uu____12625 <>
                                            FStar_Syntax_Util.Equal
                                           in
-                                       if uu____12619
+                                       if uu____12623
                                        then
-                                         let uu____12623 =
-                                           let uu____12629 =
-                                             let uu____12631 =
+                                         let uu____12627 =
+                                           let uu____12633 =
+                                             let uu____12635 =
                                                print_implicit q  in
-                                             let uu____12633 =
+                                             let uu____12637 =
                                                print_implicit q'  in
                                              FStar_Util.format2
                                                "Incoherent implicit qualifiers %s %s\n"
-                                               uu____12631 uu____12633
+                                               uu____12635 uu____12637
                                               in
                                            (FStar_Errors.Warning_IncoherentImplicitQualifier,
-                                             uu____12629)
+                                             uu____12633)
                                             in
                                          FStar_Errors.log_issue
                                            head.FStar_Syntax_Syntax.pos
-                                           uu____12623
+                                           uu____12627
                                        else ());
-                                      (let uu____12639 =
+                                      (let uu____12643 =
                                          trans_F_ env1 arg wp_arg  in
-                                       (uu____12639, q)))) args wp_args
+                                       (uu____12643, q)))) args wp_args
                            in
-                        (head, uu____12509)  in
-                      FStar_Syntax_Syntax.Tm_app uu____12492  in
-                    mk uu____12491)))
+                        (head, uu____12513)  in
+                      FStar_Syntax_Syntax.Tm_app uu____12496  in
+                    mk uu____12495)))
          | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
              let binders1 = FStar_Syntax_Util.name_binders binders  in
-             let uu____12685 = FStar_Syntax_Subst.open_comp binders1 comp  in
-             (match uu____12685 with
+             let uu____12689 = FStar_Syntax_Subst.open_comp binders1 comp  in
+             (match uu____12689 with
               | (binders_orig,comp1) ->
-                  let uu____12692 =
-                    let uu____12709 =
+                  let uu____12696 =
+                    let uu____12713 =
                       FStar_List.map
-                        (fun uu____12749  ->
-                           match uu____12749 with
+                        (fun uu____12753  ->
+                           match uu____12753 with
                            | (bv,q) ->
                                let h = bv.FStar_Syntax_Syntax.sort  in
-                               let uu____12777 = is_C h  in
-                               if uu____12777
+                               let uu____12781 = is_C h  in
+                               if uu____12781
                                then
                                  let w' =
-                                   let uu____12793 = star_type' env1 h  in
-                                   FStar_Syntax_Syntax.gen_bv
-                                     (Prims.op_Hat
-                                        (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                        "__w'") FStar_Pervasives_Native.None
-                                     uu____12793
+                                   let uu____12797 =
+                                     let uu____12799 =
+                                       FStar_Ident.text_of_id
+                                         bv.FStar_Syntax_Syntax.ppname
+                                        in
+                                     Prims.op_Hat uu____12799 "__w'"  in
+                                   let uu____12802 = star_type' env1 h  in
+                                   FStar_Syntax_Syntax.gen_bv uu____12797
+                                     FStar_Pervasives_Native.None uu____12802
                                     in
-                                 let uu____12795 =
-                                   let uu____12804 =
-                                     let uu____12813 =
-                                       let uu____12820 =
-                                         let uu____12821 =
-                                           let uu____12822 =
+                                 let uu____12803 =
+                                   let uu____12812 =
+                                     let uu____12821 =
+                                       let uu____12828 =
+                                         let uu____12829 =
+                                           let uu____12830 =
                                              FStar_Syntax_Syntax.bv_to_name
                                                w'
                                               in
-                                           trans_F_ env1 h uu____12822  in
+                                           trans_F_ env1 h uu____12830  in
                                          FStar_Syntax_Syntax.null_bv
-                                           uu____12821
+                                           uu____12829
                                           in
-                                       (uu____12820, q)  in
-                                     [uu____12813]  in
-                                   (w', q) :: uu____12804  in
-                                 (w', uu____12795)
+                                       (uu____12828, q)  in
+                                     [uu____12821]  in
+                                   (w', q) :: uu____12812  in
+                                 (w', uu____12803)
                                else
                                  (let x =
-                                    let uu____12856 = star_type' env1 h  in
-                                    FStar_Syntax_Syntax.gen_bv
-                                      (Prims.op_Hat
-                                         (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                         "__x") FStar_Pervasives_Native.None
-                                      uu____12856
+                                    let uu____12864 =
+                                      let uu____12866 =
+                                        FStar_Ident.text_of_id
+                                          bv.FStar_Syntax_Syntax.ppname
+                                         in
+                                      Prims.op_Hat uu____12866 "__x"  in
+                                    let uu____12869 = star_type' env1 h  in
+                                    FStar_Syntax_Syntax.gen_bv uu____12864
+                                      FStar_Pervasives_Native.None
+                                      uu____12869
                                      in
                                   (x, [(x, q)]))) binders_orig
                        in
-                    FStar_List.split uu____12709  in
-                  (match uu____12692 with
+                    FStar_List.split uu____12713  in
+                  (match uu____12696 with
                    | (bvs,binders2) ->
                        let binders3 = FStar_List.flatten binders2  in
                        let comp2 =
-                         let uu____12930 =
-                           let uu____12933 =
+                         let uu____12942 =
+                           let uu____12945 =
                              FStar_Syntax_Syntax.binders_of_list bvs  in
                            FStar_Syntax_Util.rename_binders binders_orig
-                             uu____12933
+                             uu____12945
                             in
-                         FStar_Syntax_Subst.subst_comp uu____12930 comp1  in
+                         FStar_Syntax_Subst.subst_comp uu____12942 comp1  in
                        let app =
-                         let uu____12937 =
-                           let uu____12938 =
-                             let uu____12955 =
+                         let uu____12949 =
+                           let uu____12950 =
+                             let uu____12967 =
                                FStar_List.map
                                  (fun bv  ->
-                                    let uu____12974 =
+                                    let uu____12986 =
                                       FStar_Syntax_Syntax.bv_to_name bv  in
-                                    let uu____12975 =
+                                    let uu____12987 =
                                       FStar_Syntax_Syntax.as_implicit false
                                        in
-                                    (uu____12974, uu____12975)) bvs
+                                    (uu____12986, uu____12987)) bvs
                                 in
-                             (wp, uu____12955)  in
-                           FStar_Syntax_Syntax.Tm_app uu____12938  in
-                         mk uu____12937  in
+                             (wp, uu____12967)  in
+                           FStar_Syntax_Syntax.Tm_app uu____12950  in
+                         mk uu____12949  in
                        let comp3 =
-                         let uu____12990 = type_of_comp comp2  in
-                         let uu____12991 = is_monadic_comp comp2  in
-                         trans_G env1 uu____12990 uu____12991 app  in
+                         let uu____13002 = type_of_comp comp2  in
+                         let uu____13003 = is_monadic_comp comp2  in
+                         trans_G env1 uu____13002 uu____13003 app  in
                        FStar_Syntax_Util.arrow binders3 comp3))
-         | FStar_Syntax_Syntax.Tm_ascribed (e,uu____12994,uu____12995) ->
+         | FStar_Syntax_Syntax.Tm_ascribed (e,uu____13006,uu____13007) ->
              trans_F_ env1 e wp
-         | uu____13036 -> failwith "impossible trans_F_")
+         | uu____13048 -> failwith "impossible trans_F_")
 
 and (trans_G :
   env_ ->
@@ -3687,26 +3697,26 @@ and (trans_G :
         fun wp  ->
           if is_monadic1
           then
-            let uu____13044 =
-              let uu____13045 = star_type' env1 h  in
-              let uu____13048 =
-                let uu____13059 =
-                  let uu____13068 = FStar_Syntax_Syntax.as_implicit false  in
-                  (wp, uu____13068)  in
-                [uu____13059]  in
+            let uu____13056 =
+              let uu____13057 = star_type' env1 h  in
+              let uu____13060 =
+                let uu____13071 =
+                  let uu____13080 = FStar_Syntax_Syntax.as_implicit false  in
+                  (wp, uu____13080)  in
+                [uu____13071]  in
               {
                 FStar_Syntax_Syntax.comp_univs =
                   [FStar_Syntax_Syntax.U_unknown];
                 FStar_Syntax_Syntax.effect_name =
                   FStar_Parser_Const.effect_PURE_lid;
-                FStar_Syntax_Syntax.result_typ = uu____13045;
-                FStar_Syntax_Syntax.effect_args = uu____13048;
+                FStar_Syntax_Syntax.result_typ = uu____13057;
+                FStar_Syntax_Syntax.effect_args = uu____13060;
                 FStar_Syntax_Syntax.flags = []
               }  in
-            FStar_Syntax_Syntax.mk_Comp uu____13044
+            FStar_Syntax_Syntax.mk_Comp uu____13056
           else
-            (let uu____13094 = trans_F_ env1 h wp  in
-             FStar_Syntax_Syntax.mk_Total uu____13094)
+            (let uu____13106 = trans_F_ env1 h wp  in
+             FStar_Syntax_Syntax.mk_Total uu____13106)
 
 let (n :
   FStar_TypeChecker_Env.env ->
@@ -3722,7 +3732,7 @@ let (n :
 let (star_type : env -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) =
   fun env1  ->
     fun t  ->
-      let uu____13115 = n env1.tcenv t  in star_type' env1 uu____13115
+      let uu____13127 = n env1.tcenv t  in star_type' env1 uu____13127
   
 let (star_expr :
   env ->
@@ -3731,7 +3741,7 @@ let (star_expr :
         FStar_Syntax_Syntax.term))
   =
   fun env1  ->
-    fun t  -> let uu____13135 = n env1.tcenv t  in check_n env1 uu____13135
+    fun t  -> let uu____13147 = n env1.tcenv t  in check_n env1 uu____13147
   
 let (trans_F :
   env ->
@@ -3741,9 +3751,9 @@ let (trans_F :
   fun env1  ->
     fun c  ->
       fun wp  ->
-        let uu____13152 = n env1.tcenv c  in
-        let uu____13153 = n env1.tcenv wp  in
-        trans_F_ env1 uu____13152 uu____13153
+        let uu____13164 = n env1.tcenv c  in
+        let uu____13165 = n env1.tcenv wp  in
+        trans_F_ env1 uu____13164 uu____13165
   
 let (recheck_debug :
   Prims.string ->
@@ -3753,26 +3763,26 @@ let (recheck_debug :
   fun s  ->
     fun env1  ->
       fun t  ->
-        (let uu____13173 =
+        (let uu____13185 =
            FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "ED")  in
-         if uu____13173
+         if uu____13185
          then
-           let uu____13177 = FStar_Syntax_Print.term_to_string t  in
+           let uu____13189 = FStar_Syntax_Print.term_to_string t  in
            FStar_Util.print2
              "Term has been %s-transformed to:\n%s\n----------\n" s
-             uu____13177
+             uu____13189
          else ());
-        (let uu____13182 = FStar_TypeChecker_TcTerm.tc_term env1 t  in
-         match uu____13182 with
-         | (t',uu____13190,uu____13191) ->
-             ((let uu____13193 =
+        (let uu____13194 = FStar_TypeChecker_TcTerm.tc_term env1 t  in
+         match uu____13194 with
+         | (t',uu____13202,uu____13203) ->
+             ((let uu____13205 =
                  FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "ED")
                   in
-               if uu____13193
+               if uu____13205
                then
-                 let uu____13197 = FStar_Syntax_Print.term_to_string t'  in
+                 let uu____13209 = FStar_Syntax_Print.term_to_string t'  in
                  FStar_Util.print1 "Re-checked; got:\n%s\n----------\n"
-                   uu____13197
+                   uu____13209
                else ());
               t'))
   
@@ -3784,74 +3794,74 @@ let (cps_and_elaborate :
   =
   fun env1  ->
     fun ed  ->
-      let uu____13233 =
+      let uu____13245 =
         FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders
           (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.signature)
          in
-      match uu____13233 with
+      match uu____13245 with
       | (effect_binders_un,signature_un) ->
-          let uu____13254 =
+          let uu____13266 =
             FStar_TypeChecker_TcTerm.tc_tparams env1 effect_binders_un  in
-          (match uu____13254 with
-           | (effect_binders,env2,uu____13273) ->
-               let uu____13274 =
+          (match uu____13266 with
+           | (effect_binders,env2,uu____13285) ->
+               let uu____13286 =
                  FStar_TypeChecker_TcTerm.tc_trivial_guard env2 signature_un
                   in
-               (match uu____13274 with
-                | (signature,uu____13290) ->
-                    let raise_error uu____13306 =
-                      match uu____13306 with
+               (match uu____13286 with
+                | (signature,uu____13302) ->
+                    let raise_error uu____13318 =
+                      match uu____13318 with
                       | (e,err_msg) ->
                           FStar_Errors.raise_error (e, err_msg)
                             signature.FStar_Syntax_Syntax.pos
                        in
                     let effect_binders1 =
                       FStar_List.map
-                        (fun uu____13342  ->
-                           match uu____13342 with
+                        (fun uu____13354  ->
+                           match uu____13354 with
                            | (bv,qual) ->
-                               let uu____13361 =
-                                 let uu___1370_13362 = bv  in
-                                 let uu____13363 =
+                               let uu____13373 =
+                                 let uu___1370_13374 = bv  in
+                                 let uu____13375 =
                                    FStar_TypeChecker_Normalize.normalize
                                      [FStar_TypeChecker_Env.EraseUniverses]
                                      env2 bv.FStar_Syntax_Syntax.sort
                                     in
                                  {
                                    FStar_Syntax_Syntax.ppname =
-                                     (uu___1370_13362.FStar_Syntax_Syntax.ppname);
+                                     (uu___1370_13374.FStar_Syntax_Syntax.ppname);
                                    FStar_Syntax_Syntax.index =
-                                     (uu___1370_13362.FStar_Syntax_Syntax.index);
-                                   FStar_Syntax_Syntax.sort = uu____13363
+                                     (uu___1370_13374.FStar_Syntax_Syntax.index);
+                                   FStar_Syntax_Syntax.sort = uu____13375
                                  }  in
-                               (uu____13361, qual)) effect_binders
+                               (uu____13373, qual)) effect_binders
                        in
-                    let uu____13368 =
-                      let uu____13375 =
-                        let uu____13376 =
+                    let uu____13380 =
+                      let uu____13387 =
+                        let uu____13388 =
                           FStar_Syntax_Subst.compress signature_un  in
-                        uu____13376.FStar_Syntax_Syntax.n  in
-                      match uu____13375 with
+                        uu____13388.FStar_Syntax_Syntax.n  in
+                      match uu____13387 with
                       | FStar_Syntax_Syntax.Tm_arrow
-                          ((a,uu____13386)::[],effect_marker) ->
+                          ((a,uu____13398)::[],effect_marker) ->
                           (a, effect_marker)
-                      | uu____13418 ->
+                      | uu____13430 ->
                           raise_error
                             (FStar_Errors.Fatal_BadSignatureShape,
                               "bad shape for effect-for-free signature")
                        in
-                    (match uu____13368 with
+                    (match uu____13380 with
                      | (a,effect_marker) ->
                          let a1 =
-                           let uu____13444 = FStar_Syntax_Syntax.is_null_bv a
+                           let uu____13456 = FStar_Syntax_Syntax.is_null_bv a
                               in
-                           if uu____13444
+                           if uu____13456
                            then
-                             let uu____13447 =
-                               let uu____13450 =
+                             let uu____13459 =
+                               let uu____13462 =
                                  FStar_Syntax_Syntax.range_of_bv a  in
-                               FStar_Pervasives_Native.Some uu____13450  in
-                             FStar_Syntax_Syntax.gen_bv "a" uu____13447
+                               FStar_Pervasives_Native.Some uu____13462  in
+                             FStar_Syntax_Syntax.gen_bv "a" uu____13459
                                a.FStar_Syntax_Syntax.sort
                            else a  in
                          let open_and_check env3 other_binders t =
@@ -3861,42 +3871,42 @@ let (cps_and_elaborate :
                                   other_binders)
                               in
                            let t1 = FStar_Syntax_Subst.subst subst t  in
-                           let uu____13498 =
+                           let uu____13510 =
                              FStar_TypeChecker_TcTerm.tc_term env3 t1  in
-                           match uu____13498 with
-                           | (t2,comp,uu____13511) -> (t2, comp)  in
+                           match uu____13510 with
+                           | (t2,comp,uu____13523) -> (t2, comp)  in
                          let mk x =
                            FStar_Syntax_Syntax.mk x
                              FStar_Pervasives_Native.None
                              signature.FStar_Syntax_Syntax.pos
                             in
-                         let uu____13520 =
-                           let uu____13525 =
-                             let uu____13526 =
-                               let uu____13535 =
+                         let uu____13532 =
+                           let uu____13537 =
+                             let uu____13538 =
+                               let uu____13547 =
                                  FStar_All.pipe_right ed
                                    FStar_Syntax_Util.get_eff_repr
                                   in
-                               FStar_All.pipe_right uu____13535
+                               FStar_All.pipe_right uu____13547
                                  FStar_Util.must
                                 in
-                             FStar_All.pipe_right uu____13526
+                             FStar_All.pipe_right uu____13538
                                FStar_Pervasives_Native.snd
                               in
-                           open_and_check env2 [] uu____13525  in
-                         (match uu____13520 with
+                           open_and_check env2 [] uu____13537  in
+                         (match uu____13532 with
                           | (repr,_comp) ->
-                              ((let uu____13581 =
+                              ((let uu____13593 =
                                   FStar_TypeChecker_Env.debug env2
                                     (FStar_Options.Other "ED")
                                    in
-                                if uu____13581
+                                if uu____13593
                                 then
-                                  let uu____13585 =
+                                  let uu____13597 =
                                     FStar_Syntax_Print.term_to_string repr
                                      in
                                   FStar_Util.print1 "Representation is: %s\n"
-                                    uu____13585
+                                    uu____13597
                                 else ());
                                (let dmff_env =
                                   empty env2
@@ -3904,51 +3914,51 @@ let (cps_and_elaborate :
                                        env2 FStar_Range.dummyRange)
                                    in
                                 let wp_type = star_type dmff_env repr  in
-                                let uu____13592 =
+                                let uu____13604 =
                                   recheck_debug "*" env2 wp_type  in
                                 let wp_a =
-                                  let uu____13595 =
-                                    let uu____13596 =
-                                      let uu____13597 =
-                                        let uu____13614 =
-                                          let uu____13625 =
-                                            let uu____13634 =
+                                  let uu____13607 =
+                                    let uu____13608 =
+                                      let uu____13609 =
+                                        let uu____13626 =
+                                          let uu____13637 =
+                                            let uu____13646 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 a1
                                                in
-                                            let uu____13637 =
+                                            let uu____13649 =
                                               FStar_Syntax_Syntax.as_implicit
                                                 false
                                                in
-                                            (uu____13634, uu____13637)  in
-                                          [uu____13625]  in
-                                        (wp_type, uu____13614)  in
-                                      FStar_Syntax_Syntax.Tm_app uu____13597
+                                            (uu____13646, uu____13649)  in
+                                          [uu____13637]  in
+                                        (wp_type, uu____13626)  in
+                                      FStar_Syntax_Syntax.Tm_app uu____13609
                                        in
-                                    mk uu____13596  in
+                                    mk uu____13608  in
                                   FStar_TypeChecker_Normalize.normalize
                                     [FStar_TypeChecker_Env.Beta] env2
-                                    uu____13595
+                                    uu____13607
                                    in
                                 let effect_signature =
                                   let binders =
-                                    let uu____13685 =
-                                      let uu____13692 =
+                                    let uu____13697 =
+                                      let uu____13704 =
                                         FStar_Syntax_Syntax.as_implicit false
                                          in
-                                      (a1, uu____13692)  in
-                                    let uu____13698 =
-                                      let uu____13707 =
-                                        let uu____13714 =
+                                      (a1, uu____13704)  in
+                                    let uu____13710 =
+                                      let uu____13719 =
+                                        let uu____13726 =
                                           FStar_Syntax_Syntax.gen_bv
                                             "dijkstra_wp"
                                             FStar_Pervasives_Native.None wp_a
                                            in
-                                        FStar_All.pipe_right uu____13714
+                                        FStar_All.pipe_right uu____13726
                                           FStar_Syntax_Syntax.mk_binder
                                          in
-                                      [uu____13707]  in
-                                    uu____13685 :: uu____13698  in
+                                      [uu____13719]  in
+                                    uu____13697 :: uu____13710  in
                                   let binders1 =
                                     FStar_Syntax_Subst.close_binders binders
                                      in
@@ -3956,7 +3966,7 @@ let (cps_and_elaborate :
                                     (FStar_Syntax_Syntax.Tm_arrow
                                        (binders1, effect_marker))
                                    in
-                                let uu____13751 =
+                                let uu____13763 =
                                   recheck_debug
                                     "turned into the effect signature" env2
                                     effect_signature
@@ -3967,87 +3977,87 @@ let (cps_and_elaborate :
                                 let elaborate_and_star dmff_env1
                                   other_binders item =
                                   let env3 = get_env dmff_env1  in
-                                  let uu____13817 = item  in
-                                  match uu____13817 with
+                                  let uu____13829 = item  in
+                                  match uu____13829 with
                                   | (u_item,item1) ->
-                                      let uu____13832 =
+                                      let uu____13844 =
                                         open_and_check env3 other_binders
                                           item1
                                          in
-                                      (match uu____13832 with
+                                      (match uu____13844 with
                                        | (item2,item_comp) ->
-                                           ((let uu____13848 =
-                                               let uu____13850 =
+                                           ((let uu____13860 =
+                                               let uu____13862 =
                                                  FStar_TypeChecker_Common.is_total_lcomp
                                                    item_comp
                                                   in
-                                               Prims.op_Negation uu____13850
+                                               Prims.op_Negation uu____13862
                                                 in
-                                             if uu____13848
+                                             if uu____13860
                                              then
-                                               let uu____13853 =
-                                                 let uu____13859 =
-                                                   let uu____13861 =
+                                               let uu____13865 =
+                                                 let uu____13871 =
+                                                   let uu____13873 =
                                                      FStar_Syntax_Print.term_to_string
                                                        item2
                                                       in
-                                                   let uu____13863 =
+                                                   let uu____13875 =
                                                      FStar_TypeChecker_Common.lcomp_to_string
                                                        item_comp
                                                       in
                                                    FStar_Util.format2
                                                      "Computation for [%s] is not total : %s !"
-                                                     uu____13861 uu____13863
+                                                     uu____13873 uu____13875
                                                     in
                                                  (FStar_Errors.Fatal_ComputationNotTotal,
-                                                   uu____13859)
+                                                   uu____13871)
                                                   in
                                                FStar_Errors.raise_err
-                                                 uu____13853
+                                                 uu____13865
                                              else ());
-                                            (let uu____13869 =
+                                            (let uu____13881 =
                                                star_expr dmff_env1 item2  in
-                                             match uu____13869 with
+                                             match uu____13881 with
                                              | (item_t,item_wp,item_elab) ->
-                                                 let uu____13887 =
+                                                 let uu____13899 =
                                                    recheck_debug "*" env3
                                                      item_wp
                                                     in
-                                                 let uu____13889 =
+                                                 let uu____13901 =
                                                    recheck_debug "_" env3
                                                      item_elab
                                                     in
                                                  (dmff_env1, item_t, item_wp,
                                                    item_elab))))
                                    in
-                                let uu____13891 =
-                                  let uu____13900 =
-                                    let uu____13905 =
+                                let uu____13903 =
+                                  let uu____13912 =
+                                    let uu____13917 =
                                       FStar_All.pipe_right ed
                                         FStar_Syntax_Util.get_bind_repr
                                        in
-                                    FStar_All.pipe_right uu____13905
+                                    FStar_All.pipe_right uu____13917
                                       FStar_Util.must
                                      in
-                                  elaborate_and_star dmff_env [] uu____13900
+                                  elaborate_and_star dmff_env [] uu____13912
                                    in
-                                match uu____13891 with
-                                | (dmff_env1,uu____13933,bind_wp,bind_elab)
+                                match uu____13903 with
+                                | (dmff_env1,uu____13945,bind_wp,bind_elab)
                                     ->
-                                    let uu____13936 =
-                                      let uu____13945 =
-                                        let uu____13950 =
+                                    let uu____13948 =
+                                      let uu____13957 =
+                                        let uu____13962 =
                                           FStar_All.pipe_right ed
                                             FStar_Syntax_Util.get_return_repr
                                            in
-                                        FStar_All.pipe_right uu____13950
+                                        FStar_All.pipe_right uu____13962
                                           FStar_Util.must
                                          in
                                       elaborate_and_star dmff_env1 []
-                                        uu____13945
+                                        uu____13957
                                        in
-                                    (match uu____13936 with
-                                     | (dmff_env2,uu____13994,return_wp,return_elab)
+                                    (match uu____13948 with
+                                     | (dmff_env2,uu____14006,return_wp,return_elab)
                                          ->
                                          let rc_gtot =
                                            {
@@ -4060,102 +4070,102 @@ let (cps_and_elaborate :
                                                = []
                                            }  in
                                          let lift_from_pure_wp =
-                                           let uu____14003 =
-                                             let uu____14004 =
+                                           let uu____14015 =
+                                             let uu____14016 =
                                                FStar_Syntax_Subst.compress
                                                  return_wp
                                                 in
-                                             uu____14004.FStar_Syntax_Syntax.n
+                                             uu____14016.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____14003 with
+                                           match uu____14015 with
                                            | FStar_Syntax_Syntax.Tm_abs
                                                (b1::b2::bs,body,what) ->
-                                               let uu____14062 =
-                                                 let uu____14081 =
-                                                   let uu____14086 =
+                                               let uu____14074 =
+                                                 let uu____14093 =
+                                                   let uu____14098 =
                                                      FStar_Syntax_Util.abs bs
                                                        body
                                                        FStar_Pervasives_Native.None
                                                       in
                                                    FStar_Syntax_Subst.open_term
-                                                     [b1; b2] uu____14086
+                                                     [b1; b2] uu____14098
                                                     in
-                                                 match uu____14081 with
+                                                 match uu____14093 with
                                                  | (b11::b21::[],body1) ->
                                                      (b11, b21, body1)
-                                                 | uu____14168 ->
+                                                 | uu____14180 ->
                                                      failwith
                                                        "Impossible : open_term not preserving binders arity"
                                                   in
-                                               (match uu____14062 with
+                                               (match uu____14074 with
                                                 | (b11,b21,body1) ->
                                                     let env0 =
-                                                      let uu____14222 =
+                                                      let uu____14234 =
                                                         get_env dmff_env2  in
                                                       FStar_TypeChecker_Env.push_binders
-                                                        uu____14222
+                                                        uu____14234
                                                         [b11; b21]
                                                        in
                                                     let wp_b1 =
                                                       let raw_wp_b1 =
-                                                        let uu____14245 =
-                                                          let uu____14246 =
-                                                            let uu____14263 =
-                                                              let uu____14274
+                                                        let uu____14257 =
+                                                          let uu____14258 =
+                                                            let uu____14275 =
+                                                              let uu____14286
                                                                 =
-                                                                let uu____14283
+                                                                let uu____14295
                                                                   =
                                                                   FStar_Syntax_Syntax.bv_to_name
                                                                     (
                                                                     FStar_Pervasives_Native.fst
                                                                     b11)
                                                                    in
-                                                                let uu____14288
+                                                                let uu____14300
                                                                   =
                                                                   FStar_Syntax_Syntax.as_implicit
                                                                     false
                                                                    in
-                                                                (uu____14283,
-                                                                  uu____14288)
+                                                                (uu____14295,
+                                                                  uu____14300)
                                                                  in
-                                                              [uu____14274]
+                                                              [uu____14286]
                                                                in
                                                             (wp_type,
-                                                              uu____14263)
+                                                              uu____14275)
                                                              in
                                                           FStar_Syntax_Syntax.Tm_app
-                                                            uu____14246
+                                                            uu____14258
                                                            in
-                                                        mk uu____14245  in
+                                                        mk uu____14257  in
                                                       FStar_TypeChecker_Normalize.normalize
                                                         [FStar_TypeChecker_Env.Beta]
                                                         env0 raw_wp_b1
                                                        in
-                                                    let uu____14324 =
-                                                      let uu____14333 =
-                                                        let uu____14334 =
+                                                    let uu____14336 =
+                                                      let uu____14345 =
+                                                        let uu____14346 =
                                                           FStar_Syntax_Util.unascribe
                                                             wp_b1
                                                            in
                                                         FStar_TypeChecker_Normalize.eta_expand_with_type
                                                           env0 body1
-                                                          uu____14334
+                                                          uu____14346
                                                          in
                                                       FStar_All.pipe_left
                                                         FStar_Syntax_Util.abs_formals
-                                                        uu____14333
+                                                        uu____14345
                                                        in
-                                                    (match uu____14324 with
+                                                    (match uu____14336 with
                                                      | (bs1,body2,what') ->
-                                                         let fail uu____14357
+                                                         let fail uu____14369
                                                            =
                                                            let error_msg =
-                                                             let uu____14360
+                                                             let uu____14372
                                                                =
                                                                FStar_Syntax_Print.term_to_string
                                                                  body2
                                                                 in
-                                                             let uu____14362
+                                                             let uu____14374
                                                                =
                                                                match what'
                                                                with
@@ -4163,13 +4173,13 @@ let (cps_and_elaborate :
                                                                     -> "None"
                                                                | FStar_Pervasives_Native.Some
                                                                    rc ->
-                                                                   FStar_Ident.text_of_lid
+                                                                   FStar_Ident.string_of_lid
                                                                     rc.FStar_Syntax_Syntax.residual_effect
                                                                 in
                                                              FStar_Util.format2
                                                                "The body of return_wp (%s) should be of type Type0 but is of type %s"
-                                                               uu____14360
-                                                               uu____14362
+                                                               uu____14372
+                                                               uu____14374
                                                               in
                                                            raise_error
                                                              (FStar_Errors.Fatal_WrongBodyTypeForReturnWP,
@@ -4180,21 +4190,21 @@ let (cps_and_elaborate :
                                                                 -> fail ()
                                                            | FStar_Pervasives_Native.Some
                                                                rc ->
-                                                               ((let uu____14372
+                                                               ((let uu____14384
                                                                    =
-                                                                   let uu____14374
+                                                                   let uu____14386
                                                                     =
                                                                     FStar_Syntax_Util.is_pure_effect
                                                                     rc.FStar_Syntax_Syntax.residual_effect
                                                                      in
                                                                    Prims.op_Negation
-                                                                    uu____14374
+                                                                    uu____14386
                                                                     in
                                                                  if
-                                                                   uu____14372
+                                                                   uu____14384
                                                                  then fail ()
                                                                  else ());
-                                                                (let uu____14379
+                                                                (let uu____14391
                                                                    =
                                                                    FStar_Util.map_opt
                                                                     rc.FStar_Syntax_Syntax.residual_typ
@@ -4220,9 +4230,9 @@ let (cps_and_elaborate :
                                                                     fail ())
                                                                     in
                                                                  FStar_All.pipe_right
-                                                                   uu____14379
+                                                                   uu____14391
                                                                    (fun
-                                                                    uu____14397
+                                                                    uu____14409
                                                                      -> ()))));
                                                           (let wp =
                                                              let t2 =
@@ -4239,96 +4249,96 @@ let (cps_and_elaborate :
                                                                pure_wp_type
                                                               in
                                                            let body3 =
-                                                             let uu____14409
+                                                             let uu____14421
                                                                =
-                                                               let uu____14414
+                                                               let uu____14426
                                                                  =
                                                                  FStar_Syntax_Syntax.bv_to_name
                                                                    wp
                                                                   in
-                                                               let uu____14415
+                                                               let uu____14427
                                                                  =
-                                                                 let uu____14416
+                                                                 let uu____14428
                                                                    =
-                                                                   let uu____14425
+                                                                   let uu____14437
                                                                     =
                                                                     FStar_Syntax_Util.abs
                                                                     [b21]
                                                                     body2
                                                                     what'  in
-                                                                   (uu____14425,
+                                                                   (uu____14437,
                                                                     FStar_Pervasives_Native.None)
                                                                     in
-                                                                 [uu____14416]
+                                                                 [uu____14428]
                                                                   in
                                                                FStar_Syntax_Syntax.mk_Tm_app
-                                                                 uu____14414
-                                                                 uu____14415
+                                                                 uu____14426
+                                                                 uu____14427
                                                                 in
-                                                             uu____14409
+                                                             uu____14421
                                                                FStar_Pervasives_Native.None
                                                                FStar_Range.dummyRange
                                                               in
-                                                           let uu____14460 =
-                                                             let uu____14461
+                                                           let uu____14472 =
+                                                             let uu____14473
                                                                =
-                                                               let uu____14470
+                                                               let uu____14482
                                                                  =
                                                                  FStar_Syntax_Syntax.mk_binder
                                                                    wp
                                                                   in
-                                                               [uu____14470]
+                                                               [uu____14482]
                                                                 in
                                                              b11 ::
-                                                               uu____14461
+                                                               uu____14473
                                                               in
-                                                           let uu____14495 =
+                                                           let uu____14507 =
                                                              FStar_Syntax_Util.abs
                                                                bs1 body3 what
                                                               in
                                                            FStar_Syntax_Util.abs
-                                                             uu____14460
-                                                             uu____14495
+                                                             uu____14472
+                                                             uu____14507
                                                              (FStar_Pervasives_Native.Some
                                                                 rc_gtot)))))
-                                           | uu____14498 ->
+                                           | uu____14510 ->
                                                raise_error
                                                  (FStar_Errors.Fatal_UnexpectedReturnShape,
                                                    "unexpected shape for return")
                                             in
                                          let return_wp1 =
-                                           let uu____14506 =
-                                             let uu____14507 =
+                                           let uu____14518 =
+                                             let uu____14519 =
                                                FStar_Syntax_Subst.compress
                                                  return_wp
                                                 in
-                                             uu____14507.FStar_Syntax_Syntax.n
+                                             uu____14519.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____14506 with
+                                           match uu____14518 with
                                            | FStar_Syntax_Syntax.Tm_abs
                                                (b1::b2::bs,body,what) ->
-                                               let uu____14565 =
+                                               let uu____14577 =
                                                  FStar_Syntax_Util.abs bs
                                                    body what
                                                   in
                                                FStar_Syntax_Util.abs 
-                                                 [b1; b2] uu____14565
+                                                 [b1; b2] uu____14577
                                                  (FStar_Pervasives_Native.Some
                                                     rc_gtot)
-                                           | uu____14586 ->
+                                           | uu____14598 ->
                                                raise_error
                                                  (FStar_Errors.Fatal_UnexpectedReturnShape,
                                                    "unexpected shape for return")
                                             in
                                          let bind_wp1 =
-                                           let uu____14594 =
-                                             let uu____14595 =
+                                           let uu____14606 =
+                                             let uu____14607 =
                                                FStar_Syntax_Subst.compress
                                                  bind_wp
                                                 in
-                                             uu____14595.FStar_Syntax_Syntax.n
+                                             uu____14607.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____14594 with
+                                           match uu____14606 with
                                            | FStar_Syntax_Syntax.Tm_abs
                                                (binders,body,what) ->
                                                let r =
@@ -4338,24 +4348,24 @@ let (cps_and_elaborate :
                                                       Prims.int_one)
                                                    FStar_Pervasives_Native.None
                                                   in
-                                               let uu____14629 =
-                                                 let uu____14630 =
-                                                   let uu____14639 =
-                                                     let uu____14646 =
+                                               let uu____14641 =
+                                                 let uu____14642 =
+                                                   let uu____14651 =
+                                                     let uu____14658 =
                                                        mk
                                                          (FStar_Syntax_Syntax.Tm_fvar
                                                             r)
                                                         in
                                                      FStar_Syntax_Syntax.null_binder
-                                                       uu____14646
+                                                       uu____14658
                                                       in
-                                                   [uu____14639]  in
+                                                   [uu____14651]  in
                                                  FStar_List.append
-                                                   uu____14630 binders
+                                                   uu____14642 binders
                                                   in
                                                FStar_Syntax_Util.abs
-                                                 uu____14629 body what
-                                           | uu____14665 ->
+                                                 uu____14641 body what
+                                           | uu____14677 ->
                                                raise_error
                                                  (FStar_Errors.Fatal_UnexpectedBindShape,
                                                    "unexpected shape for bind")
@@ -4367,24 +4377,24 @@ let (cps_and_elaborate :
                                                = Prims.int_zero
                                            then t
                                            else
-                                             (let uu____14695 =
-                                                let uu____14696 =
-                                                  let uu____14697 =
-                                                    let uu____14714 =
-                                                      let uu____14725 =
+                                             (let uu____14707 =
+                                                let uu____14708 =
+                                                  let uu____14709 =
+                                                    let uu____14726 =
+                                                      let uu____14737 =
                                                         FStar_Syntax_Util.args_of_binders
                                                           effect_binders1
                                                          in
                                                       FStar_Pervasives_Native.snd
-                                                        uu____14725
+                                                        uu____14737
                                                        in
-                                                    (t, uu____14714)  in
+                                                    (t, uu____14726)  in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____14697
+                                                    uu____14709
                                                    in
-                                                mk uu____14696  in
+                                                mk uu____14708  in
                                               FStar_Syntax_Subst.close
-                                                effect_binders1 uu____14695)
+                                                effect_binders1 uu____14707)
                                             in
                                          let rec apply_last f l =
                                            match l with
@@ -4392,12 +4402,12 @@ let (cps_and_elaborate :
                                                failwith
                                                  "impossible: empty path.."
                                            | a2::[] ->
-                                               let uu____14783 = f a2  in
-                                               [uu____14783]
+                                               let uu____14795 = f a2  in
+                                               [uu____14795]
                                            | x::xs ->
-                                               let uu____14794 =
+                                               let uu____14806 =
                                                  apply_last f xs  in
-                                               x :: uu____14794
+                                               x :: uu____14806
                                             in
                                          let register name item =
                                            let p =
@@ -4417,58 +4427,58 @@ let (cps_and_elaborate :
                                              FStar_Ident.lid_of_path p'
                                                FStar_Range.dummyRange
                                               in
-                                           let uu____14828 =
+                                           let uu____14840 =
                                              FStar_TypeChecker_Env.try_lookup_lid
                                                env2 l'
                                               in
-                                           match uu____14828 with
+                                           match uu____14840 with
                                            | FStar_Pervasives_Native.Some
                                                (_us,_t) ->
-                                               ((let uu____14858 =
+                                               ((let uu____14870 =
                                                    FStar_Options.debug_any ()
                                                     in
-                                                 if uu____14858
+                                                 if uu____14870
                                                  then
-                                                   let uu____14861 =
+                                                   let uu____14873 =
                                                      FStar_Ident.string_of_lid
                                                        l'
                                                       in
                                                    FStar_Util.print1
                                                      "DM4F: Applying override %s\n"
-                                                     uu____14861
+                                                     uu____14873
                                                  else ());
-                                                (let uu____14866 =
+                                                (let uu____14878 =
                                                    FStar_Syntax_Syntax.lid_as_fv
                                                      l'
                                                      FStar_Syntax_Syntax.delta_equational
                                                      FStar_Pervasives_Native.None
                                                     in
                                                  FStar_Syntax_Syntax.fv_to_tm
-                                                   uu____14866))
+                                                   uu____14878))
                                            | FStar_Pervasives_Native.None  ->
-                                               let uu____14875 =
-                                                 let uu____14880 =
+                                               let uu____14887 =
+                                                 let uu____14892 =
                                                    mk_lid name  in
-                                                 let uu____14881 =
+                                                 let uu____14893 =
                                                    FStar_Syntax_Util.abs
                                                      effect_binders1 item
                                                      FStar_Pervasives_Native.None
                                                     in
                                                  FStar_TypeChecker_Util.mk_toplevel_definition
-                                                   env2 uu____14880
-                                                   uu____14881
+                                                   env2 uu____14892
+                                                   uu____14893
                                                   in
-                                               (match uu____14875 with
+                                               (match uu____14887 with
                                                 | (sigelt,fv) ->
-                                                    ((let uu____14885 =
-                                                        let uu____14888 =
+                                                    ((let uu____14897 =
+                                                        let uu____14900 =
                                                           FStar_ST.op_Bang
                                                             sigelts
                                                            in
-                                                        sigelt :: uu____14888
+                                                        sigelt :: uu____14900
                                                          in
                                                       FStar_ST.op_Colon_Equals
-                                                        sigelts uu____14885);
+                                                        sigelts uu____14897);
                                                      fv))
                                             in
                                          let lift_from_pure_wp1 =
@@ -4478,107 +4488,107 @@ let (cps_and_elaborate :
                                          let return_wp2 =
                                            register "return_wp" return_wp1
                                             in
-                                         ((let uu____14942 =
-                                             let uu____14945 =
+                                         ((let uu____14954 =
+                                             let uu____14957 =
                                                FStar_Syntax_Syntax.mk_sigelt
                                                  (FStar_Syntax_Syntax.Sig_pragma
                                                     (FStar_Syntax_Syntax.PushOptions
                                                        (FStar_Pervasives_Native.Some
                                                           "--admit_smt_queries true")))
                                                 in
-                                             let uu____14948 =
+                                             let uu____14960 =
                                                FStar_ST.op_Bang sigelts  in
-                                             uu____14945 :: uu____14948  in
+                                             uu____14957 :: uu____14960  in
                                            FStar_ST.op_Colon_Equals sigelts
-                                             uu____14942);
+                                             uu____14954);
                                           (let return_elab1 =
                                              register "return_elab"
                                                return_elab
                                               in
-                                           (let uu____15000 =
-                                              let uu____15003 =
+                                           (let uu____15012 =
+                                              let uu____15015 =
                                                 FStar_Syntax_Syntax.mk_sigelt
                                                   (FStar_Syntax_Syntax.Sig_pragma
                                                      FStar_Syntax_Syntax.PopOptions)
                                                  in
-                                              let uu____15004 =
+                                              let uu____15016 =
                                                 FStar_ST.op_Bang sigelts  in
-                                              uu____15003 :: uu____15004  in
+                                              uu____15015 :: uu____15016  in
                                             FStar_ST.op_Colon_Equals sigelts
-                                              uu____15000);
+                                              uu____15012);
                                            (let bind_wp2 =
                                               register "bind_wp" bind_wp1  in
-                                            (let uu____15056 =
-                                               let uu____15059 =
+                                            (let uu____15068 =
+                                               let uu____15071 =
                                                  FStar_Syntax_Syntax.mk_sigelt
                                                    (FStar_Syntax_Syntax.Sig_pragma
                                                       (FStar_Syntax_Syntax.PushOptions
                                                          (FStar_Pervasives_Native.Some
                                                             "--admit_smt_queries true")))
                                                   in
-                                               let uu____15062 =
+                                               let uu____15074 =
                                                  FStar_ST.op_Bang sigelts  in
-                                               uu____15059 :: uu____15062  in
+                                               uu____15071 :: uu____15074  in
                                              FStar_ST.op_Colon_Equals sigelts
-                                               uu____15056);
+                                               uu____15068);
                                             (let bind_elab1 =
                                                register "bind_elab" bind_elab
                                                 in
-                                             (let uu____15114 =
-                                                let uu____15117 =
+                                             (let uu____15126 =
+                                                let uu____15129 =
                                                   FStar_Syntax_Syntax.mk_sigelt
                                                     (FStar_Syntax_Syntax.Sig_pragma
                                                        FStar_Syntax_Syntax.PopOptions)
                                                    in
-                                                let uu____15118 =
+                                                let uu____15130 =
                                                   FStar_ST.op_Bang sigelts
                                                    in
-                                                uu____15117 :: uu____15118
+                                                uu____15129 :: uu____15130
                                                  in
                                               FStar_ST.op_Colon_Equals
-                                                sigelts uu____15114);
-                                             (let uu____15167 =
+                                                sigelts uu____15126);
+                                             (let uu____15179 =
                                                 FStar_List.fold_left
-                                                  (fun uu____15207  ->
+                                                  (fun uu____15219  ->
                                                      fun action  ->
-                                                       match uu____15207 with
+                                                       match uu____15219 with
                                                        | (dmff_env3,actions)
                                                            ->
                                                            let params_un =
                                                              FStar_Syntax_Subst.open_binders
                                                                action.FStar_Syntax_Syntax.action_params
                                                               in
-                                                           let uu____15228 =
-                                                             let uu____15235
+                                                           let uu____15240 =
+                                                             let uu____15247
                                                                =
                                                                get_env
                                                                  dmff_env3
                                                                 in
                                                              FStar_TypeChecker_TcTerm.tc_tparams
-                                                               uu____15235
+                                                               uu____15247
                                                                params_un
                                                               in
-                                                           (match uu____15228
+                                                           (match uu____15240
                                                             with
-                                                            | (action_params,env',uu____15244)
+                                                            | (action_params,env',uu____15256)
                                                                 ->
                                                                 let action_params1
                                                                   =
                                                                   FStar_List.map
                                                                     (
                                                                     fun
-                                                                    uu____15270
+                                                                    uu____15282
                                                                      ->
-                                                                    match uu____15270
+                                                                    match uu____15282
                                                                     with
                                                                     | 
                                                                     (bv,qual)
                                                                     ->
-                                                                    let uu____15289
+                                                                    let uu____15301
                                                                     =
-                                                                    let uu___1563_15290
+                                                                    let uu___1563_15302
                                                                     = bv  in
-                                                                    let uu____15291
+                                                                    let uu____15303
                                                                     =
                                                                     FStar_TypeChecker_Normalize.normalize
                                                                     [FStar_TypeChecker_Env.EraseUniverses]
@@ -4588,15 +4598,15 @@ let (cps_and_elaborate :
                                                                     {
                                                                     FStar_Syntax_Syntax.ppname
                                                                     =
-                                                                    (uu___1563_15290.FStar_Syntax_Syntax.ppname);
+                                                                    (uu___1563_15302.FStar_Syntax_Syntax.ppname);
                                                                     FStar_Syntax_Syntax.index
                                                                     =
-                                                                    (uu___1563_15290.FStar_Syntax_Syntax.index);
+                                                                    (uu___1563_15302.FStar_Syntax_Syntax.index);
                                                                     FStar_Syntax_Syntax.sort
                                                                     =
-                                                                    uu____15291
+                                                                    uu____15303
                                                                     }  in
-                                                                    (uu____15289,
+                                                                    (uu____15301,
                                                                     qual))
                                                                     action_params
                                                                    in
@@ -4606,7 +4616,7 @@ let (cps_and_elaborate :
                                                                     dmff_env3
                                                                     env'
                                                                    in
-                                                                let uu____15297
+                                                                let uu____15309
                                                                   =
                                                                   elaborate_and_star
                                                                     dmff_env'
@@ -4614,13 +4624,19 @@ let (cps_and_elaborate :
                                                                     ((action.FStar_Syntax_Syntax.action_univs),
                                                                     (action.FStar_Syntax_Syntax.action_defn))
                                                                    in
-                                                                (match uu____15297
+                                                                (match uu____15309
                                                                  with
                                                                  | (dmff_env4,action_t,action_wp,action_elab)
                                                                     ->
                                                                     let name
                                                                     =
-                                                                    ((action.FStar_Syntax_Syntax.action_name).FStar_Ident.ident).FStar_Ident.idText
+                                                                    let uu____15330
+                                                                    =
+                                                                    FStar_Ident.ident_of_lid
+                                                                    action.FStar_Syntax_Syntax.action_name
+                                                                     in
+                                                                    FStar_Ident.text_of_id
+                                                                    uu____15330
                                                                      in
                                                                     let action_typ_with_wp
                                                                     =
@@ -4661,19 +4677,19 @@ let (cps_and_elaborate :
                                                                     [] ->
                                                                     action_typ_with_wp1
                                                                     | 
-                                                                    uu____15336
+                                                                    uu____15349
                                                                     ->
-                                                                    let uu____15337
+                                                                    let uu____15350
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     action_typ_with_wp1
                                                                      in
                                                                     FStar_Syntax_Util.flat_arrow
                                                                     action_params2
-                                                                    uu____15337
+                                                                    uu____15350
                                                                      in
                                                                     ((
-                                                                    let uu____15341
+                                                                    let uu____15354
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -4681,36 +4697,36 @@ let (cps_and_elaborate :
                                                                     (FStar_Options.Other
                                                                     "ED")  in
                                                                     if
-                                                                    uu____15341
+                                                                    uu____15354
                                                                     then
-                                                                    let uu____15346
+                                                                    let uu____15359
                                                                     =
                                                                     FStar_Syntax_Print.binders_to_string
                                                                     ","
                                                                     params_un
                                                                      in
-                                                                    let uu____15349
+                                                                    let uu____15362
                                                                     =
                                                                     FStar_Syntax_Print.binders_to_string
                                                                     ","
                                                                     action_params2
                                                                      in
-                                                                    let uu____15352
+                                                                    let uu____15365
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     action_typ_with_wp2
                                                                      in
-                                                                    let uu____15354
+                                                                    let uu____15367
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     action_elab2
                                                                      in
                                                                     FStar_Util.print4
                                                                     "original action_params %s, end action_params %s, type %s, term %s\n"
-                                                                    uu____15346
-                                                                    uu____15349
-                                                                    uu____15352
-                                                                    uu____15354
+                                                                    uu____15359
+                                                                    uu____15362
+                                                                    uu____15365
+                                                                    uu____15367
                                                                     else ());
                                                                     (let action_elab3
                                                                     =
@@ -4728,19 +4744,19 @@ let (cps_and_elaborate :
                                                                     "_complete_type")
                                                                     action_typ_with_wp2
                                                                      in
-                                                                    let uu____15363
+                                                                    let uu____15376
                                                                     =
-                                                                    let uu____15366
+                                                                    let uu____15379
                                                                     =
-                                                                    let uu___1585_15367
+                                                                    let uu___1585_15380
                                                                     = action
                                                                      in
-                                                                    let uu____15368
+                                                                    let uu____15381
                                                                     =
                                                                     apply_close
                                                                     action_elab3
                                                                      in
-                                                                    let uu____15369
+                                                                    let uu____15382
                                                                     =
                                                                     apply_close
                                                                     action_typ_with_wp3
@@ -4748,32 +4764,32 @@ let (cps_and_elaborate :
                                                                     {
                                                                     FStar_Syntax_Syntax.action_name
                                                                     =
-                                                                    (uu___1585_15367.FStar_Syntax_Syntax.action_name);
+                                                                    (uu___1585_15380.FStar_Syntax_Syntax.action_name);
                                                                     FStar_Syntax_Syntax.action_unqualified_name
                                                                     =
-                                                                    (uu___1585_15367.FStar_Syntax_Syntax.action_unqualified_name);
+                                                                    (uu___1585_15380.FStar_Syntax_Syntax.action_unqualified_name);
                                                                     FStar_Syntax_Syntax.action_univs
                                                                     =
-                                                                    (uu___1585_15367.FStar_Syntax_Syntax.action_univs);
+                                                                    (uu___1585_15380.FStar_Syntax_Syntax.action_univs);
                                                                     FStar_Syntax_Syntax.action_params
                                                                     = [];
                                                                     FStar_Syntax_Syntax.action_defn
                                                                     =
-                                                                    uu____15368;
+                                                                    uu____15381;
                                                                     FStar_Syntax_Syntax.action_typ
                                                                     =
-                                                                    uu____15369
+                                                                    uu____15382
                                                                     }  in
-                                                                    uu____15366
+                                                                    uu____15379
                                                                     ::
                                                                     actions
                                                                      in
                                                                     (dmff_env4,
-                                                                    uu____15363))))))
+                                                                    uu____15376))))))
                                                   (dmff_env2, [])
                                                   ed.FStar_Syntax_Syntax.actions
                                                  in
-                                              match uu____15167 with
+                                              match uu____15179 with
                                               | (dmff_env3,actions) ->
                                                   let actions1 =
                                                     FStar_List.rev actions
@@ -4786,162 +4802,162 @@ let (cps_and_elaborate :
                                                         wp_a
                                                        in
                                                     let binders =
-                                                      let uu____15413 =
+                                                      let uu____15426 =
                                                         FStar_Syntax_Syntax.mk_binder
                                                           a1
                                                          in
-                                                      let uu____15420 =
-                                                        let uu____15429 =
+                                                      let uu____15433 =
+                                                        let uu____15442 =
                                                           FStar_Syntax_Syntax.mk_binder
                                                             wp
                                                            in
-                                                        [uu____15429]  in
-                                                      uu____15413 ::
-                                                        uu____15420
+                                                        [uu____15442]  in
+                                                      uu____15426 ::
+                                                        uu____15433
                                                        in
-                                                    let uu____15454 =
-                                                      let uu____15457 =
-                                                        let uu____15458 =
-                                                          let uu____15459 =
-                                                            let uu____15476 =
-                                                              let uu____15487
+                                                    let uu____15467 =
+                                                      let uu____15470 =
+                                                        let uu____15471 =
+                                                          let uu____15472 =
+                                                            let uu____15489 =
+                                                              let uu____15500
                                                                 =
-                                                                let uu____15496
+                                                                let uu____15509
                                                                   =
                                                                   FStar_Syntax_Syntax.bv_to_name
                                                                     a1
                                                                    in
-                                                                let uu____15499
+                                                                let uu____15512
                                                                   =
                                                                   FStar_Syntax_Syntax.as_implicit
                                                                     false
                                                                    in
-                                                                (uu____15496,
-                                                                  uu____15499)
+                                                                (uu____15509,
+                                                                  uu____15512)
                                                                  in
-                                                              [uu____15487]
+                                                              [uu____15500]
                                                                in
                                                             (repr,
-                                                              uu____15476)
+                                                              uu____15489)
                                                              in
                                                           FStar_Syntax_Syntax.Tm_app
-                                                            uu____15459
+                                                            uu____15472
                                                            in
-                                                        mk uu____15458  in
-                                                      let uu____15535 =
+                                                        mk uu____15471  in
+                                                      let uu____15548 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           wp
                                                          in
                                                       trans_F dmff_env3
-                                                        uu____15457
-                                                        uu____15535
+                                                        uu____15470
+                                                        uu____15548
                                                        in
                                                     FStar_Syntax_Util.abs
-                                                      binders uu____15454
+                                                      binders uu____15467
                                                       FStar_Pervasives_Native.None
                                                      in
-                                                  let uu____15536 =
+                                                  let uu____15549 =
                                                     recheck_debug "FC" env2
                                                       repr1
                                                      in
                                                   let repr2 =
                                                     register "repr" repr1  in
-                                                  let uu____15540 =
-                                                    let uu____15549 =
-                                                      let uu____15550 =
-                                                        let uu____15553 =
+                                                  let uu____15553 =
+                                                    let uu____15562 =
+                                                      let uu____15563 =
+                                                        let uu____15566 =
                                                           FStar_Syntax_Subst.compress
                                                             wp_type
                                                            in
                                                         FStar_All.pipe_left
                                                           FStar_Syntax_Util.unascribe
-                                                          uu____15553
+                                                          uu____15566
                                                          in
-                                                      uu____15550.FStar_Syntax_Syntax.n
+                                                      uu____15563.FStar_Syntax_Syntax.n
                                                        in
-                                                    match uu____15549 with
+                                                    match uu____15562 with
                                                     | FStar_Syntax_Syntax.Tm_abs
-                                                        (type_param::effect_param,arrow,uu____15567)
+                                                        (type_param::effect_param,arrow,uu____15580)
                                                         ->
-                                                        let uu____15604 =
-                                                          let uu____15625 =
+                                                        let uu____15617 =
+                                                          let uu____15638 =
                                                             FStar_Syntax_Subst.open_term
                                                               (type_param ::
                                                               effect_param)
                                                               arrow
                                                              in
-                                                          match uu____15625
+                                                          match uu____15638
                                                           with
                                                           | (b::bs,body) ->
                                                               (b, bs, body)
-                                                          | uu____15693 ->
+                                                          | uu____15706 ->
                                                               failwith
                                                                 "Impossible : open_term nt preserving binders arity"
                                                            in
-                                                        (match uu____15604
+                                                        (match uu____15617
                                                          with
                                                          | (type_param1,effect_param1,arrow1)
                                                              ->
-                                                             let uu____15758
+                                                             let uu____15771
                                                                =
-                                                               let uu____15759
+                                                               let uu____15772
                                                                  =
-                                                                 let uu____15762
+                                                                 let uu____15775
                                                                    =
                                                                    FStar_Syntax_Subst.compress
                                                                     arrow1
                                                                     in
                                                                  FStar_All.pipe_left
                                                                    FStar_Syntax_Util.unascribe
-                                                                   uu____15762
+                                                                   uu____15775
                                                                   in
-                                                               uu____15759.FStar_Syntax_Syntax.n
+                                                               uu____15772.FStar_Syntax_Syntax.n
                                                                 in
-                                                             (match uu____15758
+                                                             (match uu____15771
                                                               with
                                                               | FStar_Syntax_Syntax.Tm_arrow
                                                                   (wp_binders,c)
                                                                   ->
-                                                                  let uu____15795
+                                                                  let uu____15808
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     wp_binders
                                                                     c  in
-                                                                  (match uu____15795
+                                                                  (match uu____15808
                                                                    with
                                                                    | 
                                                                    (wp_binders1,c1)
                                                                     ->
-                                                                    let uu____15810
+                                                                    let uu____15823
                                                                     =
                                                                     FStar_List.partition
                                                                     (fun
-                                                                    uu____15841
+                                                                    uu____15854
                                                                      ->
-                                                                    match uu____15841
+                                                                    match uu____15854
                                                                     with
                                                                     | 
-                                                                    (bv,uu____15850)
+                                                                    (bv,uu____15863)
                                                                     ->
-                                                                    let uu____15855
+                                                                    let uu____15868
                                                                     =
-                                                                    let uu____15857
+                                                                    let uu____15870
                                                                     =
                                                                     FStar_Syntax_Free.names
                                                                     bv.FStar_Syntax_Syntax.sort
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____15857
+                                                                    uu____15870
                                                                     (FStar_Util.set_mem
                                                                     (FStar_Pervasives_Native.fst
                                                                     type_param1))
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____15855
+                                                                    uu____15868
                                                                     Prims.op_Negation)
                                                                     wp_binders1
                                                                      in
-                                                                    (match uu____15810
+                                                                    (match uu____15823
                                                                     with
                                                                     | 
                                                                     (pre_args,post_args)
@@ -4957,42 +4973,42 @@ let (cps_and_elaborate :
                                                                     [] ->
                                                                     let err_msg
                                                                     =
-                                                                    let uu____15949
+                                                                    let uu____15962
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     arrow1
                                                                      in
                                                                     FStar_Util.format1
                                                                     "Impossible to generate DM effect: no post candidate %s (Type variable does not appear)"
-                                                                    uu____15949
+                                                                    uu____15962
                                                                      in
                                                                     FStar_Errors.raise_err
                                                                     (FStar_Errors.Fatal_ImpossibleToGenerateDMEffect,
                                                                     err_msg)
                                                                     | 
-                                                                    uu____15959
+                                                                    uu____15972
                                                                     ->
                                                                     let err_msg
                                                                     =
-                                                                    let uu____15970
+                                                                    let uu____15983
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     arrow1
                                                                      in
                                                                     FStar_Util.format1
                                                                     "Impossible to generate DM effect: multiple post candidates %s"
-                                                                    uu____15970
+                                                                    uu____15983
                                                                      in
                                                                     FStar_Errors.raise_err
                                                                     (FStar_Errors.Fatal_ImpossibleToGenerateDMEffect,
                                                                     err_msg)
                                                                      in
-                                                                    let uu____15980
+                                                                    let uu____15993
                                                                     =
                                                                     FStar_Syntax_Util.arrow
                                                                     pre_args
                                                                     c1  in
-                                                                    let uu____15983
+                                                                    let uu____15996
                                                                     =
                                                                     FStar_Syntax_Util.abs
                                                                     (type_param1
@@ -5002,57 +5018,57 @@ let (cps_and_elaborate :
                                                                     post).FStar_Syntax_Syntax.sort
                                                                     FStar_Pervasives_Native.None
                                                                      in
-                                                                    (uu____15980,
-                                                                    uu____15983)))
-                                                              | uu____15998
+                                                                    (uu____15993,
+                                                                    uu____15996)))
+                                                              | uu____16011
                                                                   ->
-                                                                  let uu____15999
+                                                                  let uu____16012
                                                                     =
-                                                                    let uu____16005
+                                                                    let uu____16018
                                                                     =
-                                                                    let uu____16007
+                                                                    let uu____16020
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     arrow1
                                                                      in
                                                                     FStar_Util.format1
                                                                     "Impossible: pre/post arrow %s"
-                                                                    uu____16007
+                                                                    uu____16020
                                                                      in
                                                                     (FStar_Errors.Fatal_ImpossiblePrePostArrow,
-                                                                    uu____16005)
+                                                                    uu____16018)
                                                                      in
                                                                   raise_error
-                                                                    uu____15999))
-                                                    | uu____16019 ->
-                                                        let uu____16020 =
-                                                          let uu____16026 =
-                                                            let uu____16028 =
+                                                                    uu____16012))
+                                                    | uu____16032 ->
+                                                        let uu____16033 =
+                                                          let uu____16039 =
+                                                            let uu____16041 =
                                                               FStar_Syntax_Print.term_to_string
                                                                 wp_type
                                                                in
                                                             FStar_Util.format1
                                                               "Impossible: pre/post abs %s"
-                                                              uu____16028
+                                                              uu____16041
                                                              in
                                                           (FStar_Errors.Fatal_ImpossiblePrePostAbs,
-                                                            uu____16026)
+                                                            uu____16039)
                                                            in
                                                         raise_error
-                                                          uu____16020
+                                                          uu____16033
                                                      in
-                                                  (match uu____15540 with
+                                                  (match uu____15553 with
                                                    | (pre,post) ->
-                                                       ((let uu____16061 =
+                                                       ((let uu____16074 =
                                                            register "pre" pre
                                                             in
                                                          ());
-                                                        (let uu____16064 =
+                                                        (let uu____16077 =
                                                            register "post"
                                                              post
                                                             in
                                                          ());
-                                                        (let uu____16067 =
+                                                        (let uu____16080 =
                                                            register "wp"
                                                              wp_type
                                                             in
@@ -5062,177 +5078,177 @@ let (cps_and_elaborate :
                                                            with
                                                            | FStar_Syntax_Syntax.DM4F_eff
                                                                combs ->
-                                                               let uu____16071
+                                                               let uu____16084
                                                                  =
-                                                                 let uu___1643_16072
+                                                                 let uu___1643_16085
                                                                    = combs
                                                                     in
-                                                                 let uu____16073
+                                                                 let uu____16086
                                                                    =
-                                                                   let uu____16074
+                                                                   let uu____16087
                                                                     =
                                                                     apply_close
                                                                     return_wp2
                                                                      in
                                                                    ([],
-                                                                    uu____16074)
+                                                                    uu____16087)
                                                                     in
-                                                                 let uu____16081
+                                                                 let uu____16094
                                                                    =
-                                                                   let uu____16082
+                                                                   let uu____16095
                                                                     =
                                                                     apply_close
                                                                     bind_wp2
                                                                      in
                                                                    ([],
-                                                                    uu____16082)
+                                                                    uu____16095)
                                                                     in
-                                                                 let uu____16089
+                                                                 let uu____16102
                                                                    =
-                                                                   let uu____16092
+                                                                   let uu____16105
                                                                     =
-                                                                    let uu____16093
+                                                                    let uu____16106
                                                                     =
                                                                     apply_close
                                                                     repr2  in
                                                                     ([],
-                                                                    uu____16093)
+                                                                    uu____16106)
                                                                      in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____16092
+                                                                    uu____16105
                                                                     in
-                                                                 let uu____16100
+                                                                 let uu____16113
                                                                    =
-                                                                   let uu____16103
+                                                                   let uu____16116
                                                                     =
-                                                                    let uu____16104
+                                                                    let uu____16117
                                                                     =
                                                                     apply_close
                                                                     return_elab1
                                                                      in
                                                                     ([],
-                                                                    uu____16104)
+                                                                    uu____16117)
                                                                      in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____16103
+                                                                    uu____16116
                                                                     in
-                                                                 let uu____16111
+                                                                 let uu____16124
                                                                    =
-                                                                   let uu____16114
+                                                                   let uu____16127
                                                                     =
-                                                                    let uu____16115
+                                                                    let uu____16128
                                                                     =
                                                                     apply_close
                                                                     bind_elab1
                                                                      in
                                                                     ([],
-                                                                    uu____16115)
+                                                                    uu____16128)
                                                                      in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____16114
+                                                                    uu____16127
                                                                     in
                                                                  {
                                                                    FStar_Syntax_Syntax.ret_wp
                                                                     =
-                                                                    uu____16073;
+                                                                    uu____16086;
                                                                    FStar_Syntax_Syntax.bind_wp
                                                                     =
-                                                                    uu____16081;
+                                                                    uu____16094;
                                                                    FStar_Syntax_Syntax.stronger
                                                                     =
-                                                                    (uu___1643_16072.FStar_Syntax_Syntax.stronger);
+                                                                    (uu___1643_16085.FStar_Syntax_Syntax.stronger);
                                                                    FStar_Syntax_Syntax.if_then_else
                                                                     =
-                                                                    (uu___1643_16072.FStar_Syntax_Syntax.if_then_else);
+                                                                    (uu___1643_16085.FStar_Syntax_Syntax.if_then_else);
                                                                    FStar_Syntax_Syntax.ite_wp
                                                                     =
-                                                                    (uu___1643_16072.FStar_Syntax_Syntax.ite_wp);
+                                                                    (uu___1643_16085.FStar_Syntax_Syntax.ite_wp);
                                                                    FStar_Syntax_Syntax.close_wp
                                                                     =
-                                                                    (uu___1643_16072.FStar_Syntax_Syntax.close_wp);
+                                                                    (uu___1643_16085.FStar_Syntax_Syntax.close_wp);
                                                                    FStar_Syntax_Syntax.trivial
                                                                     =
-                                                                    (uu___1643_16072.FStar_Syntax_Syntax.trivial);
+                                                                    (uu___1643_16085.FStar_Syntax_Syntax.trivial);
                                                                    FStar_Syntax_Syntax.repr
                                                                     =
-                                                                    uu____16089;
+                                                                    uu____16102;
                                                                    FStar_Syntax_Syntax.return_repr
                                                                     =
-                                                                    uu____16100;
+                                                                    uu____16113;
                                                                    FStar_Syntax_Syntax.bind_repr
                                                                     =
-                                                                    uu____16111
+                                                                    uu____16124
                                                                  }  in
                                                                FStar_Syntax_Syntax.DM4F_eff
-                                                                 uu____16071
-                                                           | uu____16122 ->
+                                                                 uu____16084
+                                                           | uu____16135 ->
                                                                failwith
                                                                  "Impossible! For a DM4F effect combinators must be in DM4f_eff"
                                                             in
                                                          let ed1 =
-                                                           let uu___1647_16125
+                                                           let uu___1647_16138
                                                              = ed  in
-                                                           let uu____16126 =
+                                                           let uu____16139 =
                                                              FStar_Syntax_Subst.close_binders
                                                                effect_binders1
                                                               in
-                                                           let uu____16127 =
-                                                             let uu____16128
+                                                           let uu____16140 =
+                                                             let uu____16141
                                                                =
                                                                FStar_Syntax_Subst.close
                                                                  effect_binders1
                                                                  effect_signature
                                                                 in
                                                              ([],
-                                                               uu____16128)
+                                                               uu____16141)
                                                               in
                                                            {
                                                              FStar_Syntax_Syntax.mname
                                                                =
-                                                               (uu___1647_16125.FStar_Syntax_Syntax.mname);
+                                                               (uu___1647_16138.FStar_Syntax_Syntax.mname);
                                                              FStar_Syntax_Syntax.cattributes
                                                                =
-                                                               (uu___1647_16125.FStar_Syntax_Syntax.cattributes);
+                                                               (uu___1647_16138.FStar_Syntax_Syntax.cattributes);
                                                              FStar_Syntax_Syntax.univs
                                                                =
-                                                               (uu___1647_16125.FStar_Syntax_Syntax.univs);
+                                                               (uu___1647_16138.FStar_Syntax_Syntax.univs);
                                                              FStar_Syntax_Syntax.binders
-                                                               = uu____16126;
+                                                               = uu____16139;
                                                              FStar_Syntax_Syntax.signature
-                                                               = uu____16127;
+                                                               = uu____16140;
                                                              FStar_Syntax_Syntax.combinators
                                                                = ed_combs;
                                                              FStar_Syntax_Syntax.actions
                                                                = actions1;
                                                              FStar_Syntax_Syntax.eff_attrs
                                                                =
-                                                               (uu___1647_16125.FStar_Syntax_Syntax.eff_attrs)
+                                                               (uu___1647_16138.FStar_Syntax_Syntax.eff_attrs)
                                                            }  in
-                                                         let uu____16135 =
+                                                         let uu____16148 =
                                                            gen_wps_for_free
                                                              env2
                                                              effect_binders1
                                                              a1 wp_a ed1
                                                             in
-                                                         match uu____16135
+                                                         match uu____16148
                                                          with
                                                          | (sigelts',ed2) ->
-                                                             ((let uu____16153
+                                                             ((let uu____16166
                                                                  =
                                                                  FStar_TypeChecker_Env.debug
                                                                    env2
                                                                    (FStar_Options.Other
                                                                     "ED")
                                                                   in
-                                                               if uu____16153
+                                                               if uu____16166
                                                                then
-                                                                 let uu____16157
+                                                                 let uu____16170
                                                                    =
                                                                    FStar_Syntax_Print.eff_decl_to_string
                                                                     true ed2
                                                                     in
                                                                  FStar_Util.print_string
-                                                                   uu____16157
+                                                                   uu____16170
                                                                else ());
                                                               (let lift_from_pure_opt
                                                                  =
@@ -5244,20 +5260,20 @@ let (cps_and_elaborate :
                                                                  then
                                                                    let lift_from_pure
                                                                     =
-                                                                    let uu____16177
+                                                                    let uu____16190
                                                                     =
-                                                                    let uu____16180
+                                                                    let uu____16193
                                                                     =
-                                                                    let uu____16181
+                                                                    let uu____16194
                                                                     =
                                                                     apply_close
                                                                     lift_from_pure_wp1
                                                                      in
                                                                     ([],
-                                                                    uu____16181)
+                                                                    uu____16194)
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____16180
+                                                                    uu____16193
                                                                      in
                                                                     {
                                                                     FStar_Syntax_Syntax.source
@@ -5268,39 +5284,39 @@ let (cps_and_elaborate :
                                                                     (ed2.FStar_Syntax_Syntax.mname);
                                                                     FStar_Syntax_Syntax.lift_wp
                                                                     =
-                                                                    uu____16177;
+                                                                    uu____16190;
                                                                     FStar_Syntax_Syntax.lift
                                                                     =
                                                                     FStar_Pervasives_Native.None
                                                                     }  in
-                                                                   let uu____16188
+                                                                   let uu____16201
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_sigelt
                                                                     (FStar_Syntax_Syntax.Sig_sub_effect
                                                                     lift_from_pure)
                                                                      in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____16188
+                                                                    uu____16201
                                                                  else
                                                                    FStar_Pervasives_Native.None
                                                                   in
-                                                               let uu____16191
+                                                               let uu____16204
                                                                  =
-                                                                 let uu____16194
+                                                                 let uu____16207
                                                                    =
-                                                                   let uu____16197
+                                                                   let uu____16210
                                                                     =
                                                                     FStar_ST.op_Bang
                                                                     sigelts
                                                                      in
                                                                    FStar_List.rev
-                                                                    uu____16197
+                                                                    uu____16210
                                                                     in
                                                                  FStar_List.append
-                                                                   uu____16194
+                                                                   uu____16207
                                                                    sigelts'
                                                                   in
-                                                               (uu____16191,
+                                                               (uu____16204,
                                                                  ed2,
                                                                  lift_from_pure_opt))))))))))))))))))
   

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -1489,28 +1489,29 @@ type sigtable = FStar_Syntax_Syntax.sigelt FStar_Util.smap
 let (should_verify : env -> Prims.bool) =
   fun env1  ->
     ((Prims.op_Negation env1.lax) && (Prims.op_Negation env1.admit)) &&
-      (FStar_Options.should_verify (env1.curmodule).FStar_Ident.str)
+      (let uu____14464 = FStar_Ident.string_of_lid env1.curmodule  in
+       FStar_Options.should_verify uu____14464)
   
 let (visible_at : delta_level -> FStar_Syntax_Syntax.qualifier -> Prims.bool)
   =
   fun d  ->
     fun q  ->
       match (d, q) with
-      | (NoDelta ,uu____14476) -> true
+      | (NoDelta ,uu____14479) -> true
       | (Eager_unfolding_only
          ,FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen ) -> true
       | (Unfold
-         uu____14479,FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen )
+         uu____14482,FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen )
           -> true
-      | (Unfold uu____14481,FStar_Syntax_Syntax.Visible_default ) -> true
+      | (Unfold uu____14484,FStar_Syntax_Syntax.Visible_default ) -> true
       | (InliningDelta ,FStar_Syntax_Syntax.Inline_for_extraction ) -> true
-      | uu____14484 -> false
+      | uu____14487 -> false
   
 let (default_table_size : Prims.int) = (Prims.of_int (200)) 
-let new_sigtab : 'uuuuuu14498 . unit -> 'uuuuuu14498 FStar_Util.smap =
-  fun uu____14505  -> FStar_Util.smap_create default_table_size 
-let new_gamma_cache : 'uuuuuu14511 . unit -> 'uuuuuu14511 FStar_Util.smap =
-  fun uu____14518  -> FStar_Util.smap_create (Prims.of_int (100)) 
+let new_sigtab : 'uuuuuu14501 . unit -> 'uuuuuu14501 FStar_Util.smap =
+  fun uu____14508  -> FStar_Util.smap_create default_table_size 
+let new_gamma_cache : 'uuuuuu14514 . unit -> 'uuuuuu14514 FStar_Util.smap =
+  fun uu____14521  -> FStar_Util.smap_create (Prims.of_int (100)) 
 let (initial_env :
   FStar_Parser_Dep.deps ->
     (env ->
@@ -1542,26 +1543,26 @@ let (initial_env :
             fun solver  ->
               fun module_lid  ->
                 fun nbe  ->
-                  let uu____14656 = new_gamma_cache ()  in
-                  let uu____14659 = new_sigtab ()  in
+                  let uu____14659 = new_gamma_cache ()  in
                   let uu____14662 = new_sigtab ()  in
-                  let uu____14669 =
-                    let uu____14684 =
+                  let uu____14665 = new_sigtab ()  in
+                  let uu____14672 =
+                    let uu____14687 =
                       FStar_Util.smap_create (Prims.of_int (10))  in
-                    (uu____14684, FStar_Pervasives_Native.None)  in
-                  let uu____14705 =
+                    (uu____14687, FStar_Pervasives_Native.None)  in
+                  let uu____14708 =
                     FStar_Util.smap_create (Prims.of_int (20))  in
-                  let uu____14709 =
+                  let uu____14712 =
                     FStar_Util.smap_create (Prims.of_int (50))  in
-                  let uu____14713 = FStar_Options.using_facts_from ()  in
-                  let uu____14714 =
+                  let uu____14716 = FStar_Options.using_facts_from ()  in
+                  let uu____14717 =
                     FStar_Util.mk_ref
                       FStar_TypeChecker_Common.id_info_table_empty
                      in
-                  let uu____14717 = FStar_Syntax_DsEnv.empty_env deps  in
-                  let uu____14718 =
+                  let uu____14720 = FStar_Syntax_DsEnv.empty_env deps  in
+                  let uu____14721 =
                     FStar_Util.smap_create (Prims.of_int (20))  in
-                  let uu____14732 =
+                  let uu____14735 =
                     FStar_Util.smap_create (Prims.of_int (20))  in
                   {
                     solver;
@@ -1569,11 +1570,11 @@ let (initial_env :
                     curmodule = module_lid;
                     gamma = [];
                     gamma_sig = [];
-                    gamma_cache = uu____14656;
+                    gamma_cache = uu____14659;
                     modules = [];
                     expected_typ = FStar_Pervasives_Native.None;
-                    sigtab = uu____14659;
-                    attrtab = uu____14662;
+                    sigtab = uu____14662;
+                    attrtab = uu____14665;
                     instantiate_imp = true;
                     effects =
                       {
@@ -1601,10 +1602,10 @@ let (initial_env :
                     universe_of;
                     check_type_of;
                     use_bv_sorts = false;
-                    qtbl_name_and_index = uu____14669;
-                    normalized_eff_names = uu____14705;
-                    fv_delta_depths = uu____14709;
-                    proof_ns = uu____14713;
+                    qtbl_name_and_index = uu____14672;
+                    normalized_eff_names = uu____14708;
+                    fv_delta_depths = uu____14712;
+                    proof_ns = uu____14716;
                     synth_hook =
                       (fun e  ->
                          fun g  ->
@@ -1624,13 +1625,13 @@ let (initial_env :
                          fun tau  ->
                            fun typ  ->
                              fun tm  -> failwith "no postprocessor available");
-                    is_native_tactic = (fun uu____14847  -> false);
-                    identifier_info = uu____14714;
+                    is_native_tactic = (fun uu____14850  -> false);
+                    identifier_info = uu____14717;
                     tc_hooks = default_tc_hooks;
-                    dsenv = uu____14717;
+                    dsenv = uu____14720;
                     nbe;
-                    strict_args_tab = uu____14718;
-                    erasable_types_tab = uu____14732
+                    strict_args_tab = uu____14721;
+                    erasable_types_tab = uu____14735
                   }
   
 let (dsenv : env -> FStar_Syntax_DsEnv.env) = fun env1  -> env1.dsenv 
@@ -1644,135 +1645,135 @@ let (query_indices :
   (FStar_Ident.lident * Prims.int) Prims.list Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref [[]] 
 let (push_query_indices : unit -> unit) =
-  fun uu____14926  ->
-    let uu____14927 = FStar_ST.op_Bang query_indices  in
-    match uu____14927 with
+  fun uu____14929  ->
+    let uu____14930 = FStar_ST.op_Bang query_indices  in
+    match uu____14930 with
     | [] -> failwith "Empty query indices!"
-    | uu____14982 ->
-        let uu____14992 =
-          let uu____15002 =
-            let uu____15010 = FStar_ST.op_Bang query_indices  in
-            FStar_List.hd uu____15010  in
-          let uu____15064 = FStar_ST.op_Bang query_indices  in uu____15002 ::
-            uu____15064
+    | uu____14985 ->
+        let uu____14995 =
+          let uu____15005 =
+            let uu____15013 = FStar_ST.op_Bang query_indices  in
+            FStar_List.hd uu____15013  in
+          let uu____15067 = FStar_ST.op_Bang query_indices  in uu____15005 ::
+            uu____15067
            in
-        FStar_ST.op_Colon_Equals query_indices uu____14992
+        FStar_ST.op_Colon_Equals query_indices uu____14995
   
 let (pop_query_indices : unit -> unit) =
-  fun uu____15160  ->
-    let uu____15161 = FStar_ST.op_Bang query_indices  in
-    match uu____15161 with
+  fun uu____15163  ->
+    let uu____15164 = FStar_ST.op_Bang query_indices  in
+    match uu____15164 with
     | [] -> failwith "Empty query indices!"
     | hd::tl -> FStar_ST.op_Colon_Equals query_indices tl
   
 let (snapshot_query_indices : unit -> (Prims.int * unit)) =
-  fun uu____15288  ->
+  fun uu____15291  ->
     FStar_Common.snapshot push_query_indices query_indices ()
   
 let (rollback_query_indices :
   Prims.int FStar_Pervasives_Native.option -> unit) =
   fun depth  -> FStar_Common.rollback pop_query_indices query_indices depth 
 let (add_query_index : (FStar_Ident.lident * Prims.int) -> unit) =
-  fun uu____15325  ->
-    match uu____15325 with
+  fun uu____15328  ->
+    match uu____15328 with
     | (l,n) ->
-        let uu____15335 = FStar_ST.op_Bang query_indices  in
-        (match uu____15335 with
+        let uu____15338 = FStar_ST.op_Bang query_indices  in
+        (match uu____15338 with
          | hd::tl ->
              FStar_ST.op_Colon_Equals query_indices (((l, n) :: hd) :: tl)
-         | uu____15457 -> failwith "Empty query indices")
+         | uu____15460 -> failwith "Empty query indices")
   
 let (peek_query_indices :
   unit -> (FStar_Ident.lident * Prims.int) Prims.list) =
-  fun uu____15480  ->
-    let uu____15481 = FStar_ST.op_Bang query_indices  in
-    FStar_List.hd uu____15481
+  fun uu____15483  ->
+    let uu____15484 = FStar_ST.op_Bang query_indices  in
+    FStar_List.hd uu____15484
   
 let (stack : env Prims.list FStar_ST.ref) = FStar_Util.mk_ref [] 
 let (push_stack : env -> env) =
   fun env1  ->
-    (let uu____15549 =
-       let uu____15552 = FStar_ST.op_Bang stack  in env1 :: uu____15552  in
-     FStar_ST.op_Colon_Equals stack uu____15549);
-    (let uu___418_15601 = env1  in
-     let uu____15602 = FStar_Util.smap_copy (gamma_cache env1)  in
-     let uu____15605 = FStar_Util.smap_copy (sigtab env1)  in
-     let uu____15608 = FStar_Util.smap_copy (attrtab env1)  in
-     let uu____15615 =
-       let uu____15630 =
-         let uu____15634 =
+    (let uu____15552 =
+       let uu____15555 = FStar_ST.op_Bang stack  in env1 :: uu____15555  in
+     FStar_ST.op_Colon_Equals stack uu____15552);
+    (let uu___418_15604 = env1  in
+     let uu____15605 = FStar_Util.smap_copy (gamma_cache env1)  in
+     let uu____15608 = FStar_Util.smap_copy (sigtab env1)  in
+     let uu____15611 = FStar_Util.smap_copy (attrtab env1)  in
+     let uu____15618 =
+       let uu____15633 =
+         let uu____15637 =
            FStar_All.pipe_right env1.qtbl_name_and_index
              FStar_Pervasives_Native.fst
             in
-         FStar_Util.smap_copy uu____15634  in
-       let uu____15666 =
+         FStar_Util.smap_copy uu____15637  in
+       let uu____15669 =
          FStar_All.pipe_right env1.qtbl_name_and_index
            FStar_Pervasives_Native.snd
           in
-       (uu____15630, uu____15666)  in
-     let uu____15715 = FStar_Util.smap_copy env1.normalized_eff_names  in
-     let uu____15718 = FStar_Util.smap_copy env1.fv_delta_depths  in
-     let uu____15721 =
-       let uu____15724 = FStar_ST.op_Bang env1.identifier_info  in
-       FStar_Util.mk_ref uu____15724  in
-     let uu____15744 = FStar_Util.smap_copy env1.strict_args_tab  in
-     let uu____15757 = FStar_Util.smap_copy env1.erasable_types_tab  in
+       (uu____15633, uu____15669)  in
+     let uu____15718 = FStar_Util.smap_copy env1.normalized_eff_names  in
+     let uu____15721 = FStar_Util.smap_copy env1.fv_delta_depths  in
+     let uu____15724 =
+       let uu____15727 = FStar_ST.op_Bang env1.identifier_info  in
+       FStar_Util.mk_ref uu____15727  in
+     let uu____15747 = FStar_Util.smap_copy env1.strict_args_tab  in
+     let uu____15760 = FStar_Util.smap_copy env1.erasable_types_tab  in
      {
-       solver = (uu___418_15601.solver);
-       range = (uu___418_15601.range);
-       curmodule = (uu___418_15601.curmodule);
-       gamma = (uu___418_15601.gamma);
-       gamma_sig = (uu___418_15601.gamma_sig);
-       gamma_cache = uu____15602;
-       modules = (uu___418_15601.modules);
-       expected_typ = (uu___418_15601.expected_typ);
-       sigtab = uu____15605;
-       attrtab = uu____15608;
-       instantiate_imp = (uu___418_15601.instantiate_imp);
-       effects = (uu___418_15601.effects);
-       generalize = (uu___418_15601.generalize);
-       letrecs = (uu___418_15601.letrecs);
-       top_level = (uu___418_15601.top_level);
-       check_uvars = (uu___418_15601.check_uvars);
-       use_eq = (uu___418_15601.use_eq);
-       use_eq_strict = (uu___418_15601.use_eq_strict);
-       is_iface = (uu___418_15601.is_iface);
-       admit = (uu___418_15601.admit);
-       lax = (uu___418_15601.lax);
-       lax_universes = (uu___418_15601.lax_universes);
-       phase1 = (uu___418_15601.phase1);
-       failhard = (uu___418_15601.failhard);
-       nosynth = (uu___418_15601.nosynth);
-       uvar_subtyping = (uu___418_15601.uvar_subtyping);
-       tc_term = (uu___418_15601.tc_term);
-       type_of = (uu___418_15601.type_of);
-       universe_of = (uu___418_15601.universe_of);
-       check_type_of = (uu___418_15601.check_type_of);
-       use_bv_sorts = (uu___418_15601.use_bv_sorts);
-       qtbl_name_and_index = uu____15615;
-       normalized_eff_names = uu____15715;
-       fv_delta_depths = uu____15718;
-       proof_ns = (uu___418_15601.proof_ns);
-       synth_hook = (uu___418_15601.synth_hook);
-       try_solve_implicits_hook = (uu___418_15601.try_solve_implicits_hook);
-       splice = (uu___418_15601.splice);
-       mpreprocess = (uu___418_15601.mpreprocess);
-       postprocess = (uu___418_15601.postprocess);
-       is_native_tactic = (uu___418_15601.is_native_tactic);
-       identifier_info = uu____15721;
-       tc_hooks = (uu___418_15601.tc_hooks);
-       dsenv = (uu___418_15601.dsenv);
-       nbe = (uu___418_15601.nbe);
-       strict_args_tab = uu____15744;
-       erasable_types_tab = uu____15757
+       solver = (uu___418_15604.solver);
+       range = (uu___418_15604.range);
+       curmodule = (uu___418_15604.curmodule);
+       gamma = (uu___418_15604.gamma);
+       gamma_sig = (uu___418_15604.gamma_sig);
+       gamma_cache = uu____15605;
+       modules = (uu___418_15604.modules);
+       expected_typ = (uu___418_15604.expected_typ);
+       sigtab = uu____15608;
+       attrtab = uu____15611;
+       instantiate_imp = (uu___418_15604.instantiate_imp);
+       effects = (uu___418_15604.effects);
+       generalize = (uu___418_15604.generalize);
+       letrecs = (uu___418_15604.letrecs);
+       top_level = (uu___418_15604.top_level);
+       check_uvars = (uu___418_15604.check_uvars);
+       use_eq = (uu___418_15604.use_eq);
+       use_eq_strict = (uu___418_15604.use_eq_strict);
+       is_iface = (uu___418_15604.is_iface);
+       admit = (uu___418_15604.admit);
+       lax = (uu___418_15604.lax);
+       lax_universes = (uu___418_15604.lax_universes);
+       phase1 = (uu___418_15604.phase1);
+       failhard = (uu___418_15604.failhard);
+       nosynth = (uu___418_15604.nosynth);
+       uvar_subtyping = (uu___418_15604.uvar_subtyping);
+       tc_term = (uu___418_15604.tc_term);
+       type_of = (uu___418_15604.type_of);
+       universe_of = (uu___418_15604.universe_of);
+       check_type_of = (uu___418_15604.check_type_of);
+       use_bv_sorts = (uu___418_15604.use_bv_sorts);
+       qtbl_name_and_index = uu____15618;
+       normalized_eff_names = uu____15718;
+       fv_delta_depths = uu____15721;
+       proof_ns = (uu___418_15604.proof_ns);
+       synth_hook = (uu___418_15604.synth_hook);
+       try_solve_implicits_hook = (uu___418_15604.try_solve_implicits_hook);
+       splice = (uu___418_15604.splice);
+       mpreprocess = (uu___418_15604.mpreprocess);
+       postprocess = (uu___418_15604.postprocess);
+       is_native_tactic = (uu___418_15604.is_native_tactic);
+       identifier_info = uu____15724;
+       tc_hooks = (uu___418_15604.tc_hooks);
+       dsenv = (uu___418_15604.dsenv);
+       nbe = (uu___418_15604.nbe);
+       strict_args_tab = uu____15747;
+       erasable_types_tab = uu____15760
      })
   
 let (pop_stack : unit -> env) =
-  fun uu____15767  ->
-    let uu____15768 = FStar_ST.op_Bang stack  in
-    match uu____15768 with
+  fun uu____15770  ->
+    let uu____15771 = FStar_ST.op_Bang stack  in
+    match uu____15771 with
     | env1::tl -> (FStar_ST.op_Colon_Equals stack tl; env1)
-    | uu____15822 -> failwith "Impossible: Too many pops"
+    | uu____15825 -> failwith "Impossible: Too many pops"
   
 let (snapshot_stack : env -> (Prims.int * env)) =
   fun env1  -> FStar_Common.snapshot push_stack stack env1 
@@ -1783,86 +1784,86 @@ let (snapshot : env -> Prims.string -> (tcenv_depth_t * env)) =
   fun env1  ->
     fun msg  ->
       FStar_Util.atomically
-        (fun uu____15912  ->
-           let uu____15913 = snapshot_stack env1  in
-           match uu____15913 with
+        (fun uu____15915  ->
+           let uu____15916 = snapshot_stack env1  in
+           match uu____15916 with
            | (stack_depth,env2) ->
-               let uu____15947 = snapshot_query_indices ()  in
-               (match uu____15947 with
+               let uu____15950 = snapshot_query_indices ()  in
+               (match uu____15950 with
                 | (query_indices_depth,()) ->
-                    let uu____15980 = (env2.solver).snapshot msg  in
-                    (match uu____15980 with
+                    let uu____15983 = (env2.solver).snapshot msg  in
+                    (match uu____15983 with
                      | (solver_depth,()) ->
-                         let uu____16037 =
+                         let uu____16040 =
                            FStar_Syntax_DsEnv.snapshot env2.dsenv  in
-                         (match uu____16037 with
+                         (match uu____16040 with
                           | (dsenv_depth,dsenv1) ->
                               ((stack_depth, query_indices_depth,
                                  solver_depth, dsenv_depth),
-                                (let uu___443_16104 = env2  in
+                                (let uu___443_16107 = env2  in
                                  {
-                                   solver = (uu___443_16104.solver);
-                                   range = (uu___443_16104.range);
-                                   curmodule = (uu___443_16104.curmodule);
-                                   gamma = (uu___443_16104.gamma);
-                                   gamma_sig = (uu___443_16104.gamma_sig);
-                                   gamma_cache = (uu___443_16104.gamma_cache);
-                                   modules = (uu___443_16104.modules);
+                                   solver = (uu___443_16107.solver);
+                                   range = (uu___443_16107.range);
+                                   curmodule = (uu___443_16107.curmodule);
+                                   gamma = (uu___443_16107.gamma);
+                                   gamma_sig = (uu___443_16107.gamma_sig);
+                                   gamma_cache = (uu___443_16107.gamma_cache);
+                                   modules = (uu___443_16107.modules);
                                    expected_typ =
-                                     (uu___443_16104.expected_typ);
-                                   sigtab = (uu___443_16104.sigtab);
-                                   attrtab = (uu___443_16104.attrtab);
+                                     (uu___443_16107.expected_typ);
+                                   sigtab = (uu___443_16107.sigtab);
+                                   attrtab = (uu___443_16107.attrtab);
                                    instantiate_imp =
-                                     (uu___443_16104.instantiate_imp);
-                                   effects = (uu___443_16104.effects);
-                                   generalize = (uu___443_16104.generalize);
-                                   letrecs = (uu___443_16104.letrecs);
-                                   top_level = (uu___443_16104.top_level);
-                                   check_uvars = (uu___443_16104.check_uvars);
-                                   use_eq = (uu___443_16104.use_eq);
+                                     (uu___443_16107.instantiate_imp);
+                                   effects = (uu___443_16107.effects);
+                                   generalize = (uu___443_16107.generalize);
+                                   letrecs = (uu___443_16107.letrecs);
+                                   top_level = (uu___443_16107.top_level);
+                                   check_uvars = (uu___443_16107.check_uvars);
+                                   use_eq = (uu___443_16107.use_eq);
                                    use_eq_strict =
-                                     (uu___443_16104.use_eq_strict);
-                                   is_iface = (uu___443_16104.is_iface);
-                                   admit = (uu___443_16104.admit);
-                                   lax = (uu___443_16104.lax);
+                                     (uu___443_16107.use_eq_strict);
+                                   is_iface = (uu___443_16107.is_iface);
+                                   admit = (uu___443_16107.admit);
+                                   lax = (uu___443_16107.lax);
                                    lax_universes =
-                                     (uu___443_16104.lax_universes);
-                                   phase1 = (uu___443_16104.phase1);
-                                   failhard = (uu___443_16104.failhard);
-                                   nosynth = (uu___443_16104.nosynth);
+                                     (uu___443_16107.lax_universes);
+                                   phase1 = (uu___443_16107.phase1);
+                                   failhard = (uu___443_16107.failhard);
+                                   nosynth = (uu___443_16107.nosynth);
                                    uvar_subtyping =
-                                     (uu___443_16104.uvar_subtyping);
-                                   tc_term = (uu___443_16104.tc_term);
-                                   type_of = (uu___443_16104.type_of);
-                                   universe_of = (uu___443_16104.universe_of);
+                                     (uu___443_16107.uvar_subtyping);
+                                   tc_term = (uu___443_16107.tc_term);
+                                   type_of = (uu___443_16107.type_of);
+                                   universe_of = (uu___443_16107.universe_of);
                                    check_type_of =
-                                     (uu___443_16104.check_type_of);
+                                     (uu___443_16107.check_type_of);
                                    use_bv_sorts =
-                                     (uu___443_16104.use_bv_sorts);
+                                     (uu___443_16107.use_bv_sorts);
                                    qtbl_name_and_index =
-                                     (uu___443_16104.qtbl_name_and_index);
+                                     (uu___443_16107.qtbl_name_and_index);
                                    normalized_eff_names =
-                                     (uu___443_16104.normalized_eff_names);
+                                     (uu___443_16107.normalized_eff_names);
                                    fv_delta_depths =
-                                     (uu___443_16104.fv_delta_depths);
-                                   proof_ns = (uu___443_16104.proof_ns);
-                                   synth_hook = (uu___443_16104.synth_hook);
+                                     (uu___443_16107.fv_delta_depths);
+                                   proof_ns = (uu___443_16107.proof_ns);
+                                   synth_hook = (uu___443_16107.synth_hook);
                                    try_solve_implicits_hook =
-                                     (uu___443_16104.try_solve_implicits_hook);
-                                   splice = (uu___443_16104.splice);
-                                   mpreprocess = (uu___443_16104.mpreprocess);
-                                   postprocess = (uu___443_16104.postprocess);
+                                     (uu___443_16107.try_solve_implicits_hook);
+                                   splice = (uu___443_16107.splice);
+                                   mpreprocess = (uu___443_16107.mpreprocess);
+                                   postprocess = (uu___443_16107.postprocess);
                                    is_native_tactic =
-                                     (uu___443_16104.is_native_tactic);
+                                     (uu___443_16107.is_native_tactic);
                                    identifier_info =
-                                     (uu___443_16104.identifier_info);
-                                   tc_hooks = (uu___443_16104.tc_hooks);
+                                     (uu___443_16107.identifier_info);
+                                   tc_hooks = (uu___443_16107.tc_hooks);
                                    dsenv = dsenv1;
-                                   nbe = (uu___443_16104.nbe);
+                                   nbe = (uu___443_16107.nbe);
                                    strict_args_tab =
-                                     (uu___443_16104.strict_args_tab);
+                                     (uu___443_16107.strict_args_tab);
                                    erasable_types_tab =
-                                     (uu___443_16104.erasable_types_tab)
+                                     (uu___443_16107.erasable_types_tab)
                                  }))))))
   
 let (rollback :
@@ -1873,8 +1874,8 @@ let (rollback :
     fun msg  ->
       fun depth  ->
         FStar_Util.atomically
-          (fun uu____16138  ->
-             let uu____16139 =
+          (fun uu____16141  ->
+             let uu____16142 =
                match depth with
                | FStar_Pervasives_Native.Some (s1,s2,s3,s4) ->
                    ((FStar_Pervasives_Native.Some s1),
@@ -1887,7 +1888,7 @@ let (rollback :
                      FStar_Pervasives_Native.None,
                      FStar_Pervasives_Native.None)
                 in
-             match uu____16139 with
+             match uu____16142 with
              | (stack_depth,query_indices_depth,solver_depth,dsenv_depth) ->
                  (solver.rollback msg solver_depth;
                   (match () with
@@ -1898,19 +1899,19 @@ let (rollback :
                              let tcenv = rollback_stack stack_depth  in
                              let dsenv1 =
                                FStar_Syntax_DsEnv.rollback dsenv_depth  in
-                             ((let uu____16319 =
+                             ((let uu____16322 =
                                  FStar_Util.physical_equality tcenv.dsenv
                                    dsenv1
                                   in
-                               FStar_Common.runtime_assert uu____16319
+                               FStar_Common.runtime_assert uu____16322
                                  "Inconsistent stack state");
                               tcenv))))))
   
 let (push : env -> Prims.string -> env) =
   fun env1  ->
     fun msg  ->
-      let uu____16335 = snapshot env1 msg  in
-      FStar_Pervasives_Native.snd uu____16335
+      let uu____16338 = snapshot env1 msg  in
+      FStar_Pervasives_Native.snd uu____16338
   
 let (pop : env -> Prims.string -> env) =
   fun env1  ->
@@ -1920,132 +1921,136 @@ let (incr_query_index : env -> env) =
   fun env1  ->
     let qix = peek_query_indices ()  in
     match env1.qtbl_name_and_index with
-    | (uu____16367,FStar_Pervasives_Native.None ) -> env1
+    | (uu____16370,FStar_Pervasives_Native.None ) -> env1
     | (tbl,FStar_Pervasives_Native.Some (l,n)) ->
-        let uu____16409 =
+        let uu____16412 =
           FStar_All.pipe_right qix
             (FStar_List.tryFind
-               (fun uu____16439  ->
-                  match uu____16439 with
-                  | (m,uu____16447) -> FStar_Ident.lid_equals l m))
+               (fun uu____16442  ->
+                  match uu____16442 with
+                  | (m,uu____16450) -> FStar_Ident.lid_equals l m))
            in
-        (match uu____16409 with
+        (match uu____16412 with
          | FStar_Pervasives_Native.None  ->
              let next = n + Prims.int_one  in
              (add_query_index (l, next);
-              FStar_Util.smap_add tbl l.FStar_Ident.str next;
-              (let uu___488_16462 = env1  in
+              (let uu____16464 = FStar_Ident.string_of_lid l  in
+               FStar_Util.smap_add tbl uu____16464 next);
+              (let uu___488_16467 = env1  in
                {
-                 solver = (uu___488_16462.solver);
-                 range = (uu___488_16462.range);
-                 curmodule = (uu___488_16462.curmodule);
-                 gamma = (uu___488_16462.gamma);
-                 gamma_sig = (uu___488_16462.gamma_sig);
-                 gamma_cache = (uu___488_16462.gamma_cache);
-                 modules = (uu___488_16462.modules);
-                 expected_typ = (uu___488_16462.expected_typ);
-                 sigtab = (uu___488_16462.sigtab);
-                 attrtab = (uu___488_16462.attrtab);
-                 instantiate_imp = (uu___488_16462.instantiate_imp);
-                 effects = (uu___488_16462.effects);
-                 generalize = (uu___488_16462.generalize);
-                 letrecs = (uu___488_16462.letrecs);
-                 top_level = (uu___488_16462.top_level);
-                 check_uvars = (uu___488_16462.check_uvars);
-                 use_eq = (uu___488_16462.use_eq);
-                 use_eq_strict = (uu___488_16462.use_eq_strict);
-                 is_iface = (uu___488_16462.is_iface);
-                 admit = (uu___488_16462.admit);
-                 lax = (uu___488_16462.lax);
-                 lax_universes = (uu___488_16462.lax_universes);
-                 phase1 = (uu___488_16462.phase1);
-                 failhard = (uu___488_16462.failhard);
-                 nosynth = (uu___488_16462.nosynth);
-                 uvar_subtyping = (uu___488_16462.uvar_subtyping);
-                 tc_term = (uu___488_16462.tc_term);
-                 type_of = (uu___488_16462.type_of);
-                 universe_of = (uu___488_16462.universe_of);
-                 check_type_of = (uu___488_16462.check_type_of);
-                 use_bv_sorts = (uu___488_16462.use_bv_sorts);
+                 solver = (uu___488_16467.solver);
+                 range = (uu___488_16467.range);
+                 curmodule = (uu___488_16467.curmodule);
+                 gamma = (uu___488_16467.gamma);
+                 gamma_sig = (uu___488_16467.gamma_sig);
+                 gamma_cache = (uu___488_16467.gamma_cache);
+                 modules = (uu___488_16467.modules);
+                 expected_typ = (uu___488_16467.expected_typ);
+                 sigtab = (uu___488_16467.sigtab);
+                 attrtab = (uu___488_16467.attrtab);
+                 instantiate_imp = (uu___488_16467.instantiate_imp);
+                 effects = (uu___488_16467.effects);
+                 generalize = (uu___488_16467.generalize);
+                 letrecs = (uu___488_16467.letrecs);
+                 top_level = (uu___488_16467.top_level);
+                 check_uvars = (uu___488_16467.check_uvars);
+                 use_eq = (uu___488_16467.use_eq);
+                 use_eq_strict = (uu___488_16467.use_eq_strict);
+                 is_iface = (uu___488_16467.is_iface);
+                 admit = (uu___488_16467.admit);
+                 lax = (uu___488_16467.lax);
+                 lax_universes = (uu___488_16467.lax_universes);
+                 phase1 = (uu___488_16467.phase1);
+                 failhard = (uu___488_16467.failhard);
+                 nosynth = (uu___488_16467.nosynth);
+                 uvar_subtyping = (uu___488_16467.uvar_subtyping);
+                 tc_term = (uu___488_16467.tc_term);
+                 type_of = (uu___488_16467.type_of);
+                 universe_of = (uu___488_16467.universe_of);
+                 check_type_of = (uu___488_16467.check_type_of);
+                 use_bv_sorts = (uu___488_16467.use_bv_sorts);
                  qtbl_name_and_index =
                    (tbl, (FStar_Pervasives_Native.Some (l, next)));
-                 normalized_eff_names = (uu___488_16462.normalized_eff_names);
-                 fv_delta_depths = (uu___488_16462.fv_delta_depths);
-                 proof_ns = (uu___488_16462.proof_ns);
-                 synth_hook = (uu___488_16462.synth_hook);
+                 normalized_eff_names = (uu___488_16467.normalized_eff_names);
+                 fv_delta_depths = (uu___488_16467.fv_delta_depths);
+                 proof_ns = (uu___488_16467.proof_ns);
+                 synth_hook = (uu___488_16467.synth_hook);
                  try_solve_implicits_hook =
-                   (uu___488_16462.try_solve_implicits_hook);
-                 splice = (uu___488_16462.splice);
-                 mpreprocess = (uu___488_16462.mpreprocess);
-                 postprocess = (uu___488_16462.postprocess);
-                 is_native_tactic = (uu___488_16462.is_native_tactic);
-                 identifier_info = (uu___488_16462.identifier_info);
-                 tc_hooks = (uu___488_16462.tc_hooks);
-                 dsenv = (uu___488_16462.dsenv);
-                 nbe = (uu___488_16462.nbe);
-                 strict_args_tab = (uu___488_16462.strict_args_tab);
-                 erasable_types_tab = (uu___488_16462.erasable_types_tab)
+                   (uu___488_16467.try_solve_implicits_hook);
+                 splice = (uu___488_16467.splice);
+                 mpreprocess = (uu___488_16467.mpreprocess);
+                 postprocess = (uu___488_16467.postprocess);
+                 is_native_tactic = (uu___488_16467.is_native_tactic);
+                 identifier_info = (uu___488_16467.identifier_info);
+                 tc_hooks = (uu___488_16467.tc_hooks);
+                 dsenv = (uu___488_16467.dsenv);
+                 nbe = (uu___488_16467.nbe);
+                 strict_args_tab = (uu___488_16467.strict_args_tab);
+                 erasable_types_tab = (uu___488_16467.erasable_types_tab)
                }))
-         | FStar_Pervasives_Native.Some (uu____16479,m) ->
+         | FStar_Pervasives_Native.Some (uu____16484,m) ->
              let next = m + Prims.int_one  in
              (add_query_index (l, next);
-              FStar_Util.smap_add tbl l.FStar_Ident.str next;
-              (let uu___497_16495 = env1  in
+              (let uu____16499 = FStar_Ident.string_of_lid l  in
+               FStar_Util.smap_add tbl uu____16499 next);
+              (let uu___497_16502 = env1  in
                {
-                 solver = (uu___497_16495.solver);
-                 range = (uu___497_16495.range);
-                 curmodule = (uu___497_16495.curmodule);
-                 gamma = (uu___497_16495.gamma);
-                 gamma_sig = (uu___497_16495.gamma_sig);
-                 gamma_cache = (uu___497_16495.gamma_cache);
-                 modules = (uu___497_16495.modules);
-                 expected_typ = (uu___497_16495.expected_typ);
-                 sigtab = (uu___497_16495.sigtab);
-                 attrtab = (uu___497_16495.attrtab);
-                 instantiate_imp = (uu___497_16495.instantiate_imp);
-                 effects = (uu___497_16495.effects);
-                 generalize = (uu___497_16495.generalize);
-                 letrecs = (uu___497_16495.letrecs);
-                 top_level = (uu___497_16495.top_level);
-                 check_uvars = (uu___497_16495.check_uvars);
-                 use_eq = (uu___497_16495.use_eq);
-                 use_eq_strict = (uu___497_16495.use_eq_strict);
-                 is_iface = (uu___497_16495.is_iface);
-                 admit = (uu___497_16495.admit);
-                 lax = (uu___497_16495.lax);
-                 lax_universes = (uu___497_16495.lax_universes);
-                 phase1 = (uu___497_16495.phase1);
-                 failhard = (uu___497_16495.failhard);
-                 nosynth = (uu___497_16495.nosynth);
-                 uvar_subtyping = (uu___497_16495.uvar_subtyping);
-                 tc_term = (uu___497_16495.tc_term);
-                 type_of = (uu___497_16495.type_of);
-                 universe_of = (uu___497_16495.universe_of);
-                 check_type_of = (uu___497_16495.check_type_of);
-                 use_bv_sorts = (uu___497_16495.use_bv_sorts);
+                 solver = (uu___497_16502.solver);
+                 range = (uu___497_16502.range);
+                 curmodule = (uu___497_16502.curmodule);
+                 gamma = (uu___497_16502.gamma);
+                 gamma_sig = (uu___497_16502.gamma_sig);
+                 gamma_cache = (uu___497_16502.gamma_cache);
+                 modules = (uu___497_16502.modules);
+                 expected_typ = (uu___497_16502.expected_typ);
+                 sigtab = (uu___497_16502.sigtab);
+                 attrtab = (uu___497_16502.attrtab);
+                 instantiate_imp = (uu___497_16502.instantiate_imp);
+                 effects = (uu___497_16502.effects);
+                 generalize = (uu___497_16502.generalize);
+                 letrecs = (uu___497_16502.letrecs);
+                 top_level = (uu___497_16502.top_level);
+                 check_uvars = (uu___497_16502.check_uvars);
+                 use_eq = (uu___497_16502.use_eq);
+                 use_eq_strict = (uu___497_16502.use_eq_strict);
+                 is_iface = (uu___497_16502.is_iface);
+                 admit = (uu___497_16502.admit);
+                 lax = (uu___497_16502.lax);
+                 lax_universes = (uu___497_16502.lax_universes);
+                 phase1 = (uu___497_16502.phase1);
+                 failhard = (uu___497_16502.failhard);
+                 nosynth = (uu___497_16502.nosynth);
+                 uvar_subtyping = (uu___497_16502.uvar_subtyping);
+                 tc_term = (uu___497_16502.tc_term);
+                 type_of = (uu___497_16502.type_of);
+                 universe_of = (uu___497_16502.universe_of);
+                 check_type_of = (uu___497_16502.check_type_of);
+                 use_bv_sorts = (uu___497_16502.use_bv_sorts);
                  qtbl_name_and_index =
                    (tbl, (FStar_Pervasives_Native.Some (l, next)));
-                 normalized_eff_names = (uu___497_16495.normalized_eff_names);
-                 fv_delta_depths = (uu___497_16495.fv_delta_depths);
-                 proof_ns = (uu___497_16495.proof_ns);
-                 synth_hook = (uu___497_16495.synth_hook);
+                 normalized_eff_names = (uu___497_16502.normalized_eff_names);
+                 fv_delta_depths = (uu___497_16502.fv_delta_depths);
+                 proof_ns = (uu___497_16502.proof_ns);
+                 synth_hook = (uu___497_16502.synth_hook);
                  try_solve_implicits_hook =
-                   (uu___497_16495.try_solve_implicits_hook);
-                 splice = (uu___497_16495.splice);
-                 mpreprocess = (uu___497_16495.mpreprocess);
-                 postprocess = (uu___497_16495.postprocess);
-                 is_native_tactic = (uu___497_16495.is_native_tactic);
-                 identifier_info = (uu___497_16495.identifier_info);
-                 tc_hooks = (uu___497_16495.tc_hooks);
-                 dsenv = (uu___497_16495.dsenv);
-                 nbe = (uu___497_16495.nbe);
-                 strict_args_tab = (uu___497_16495.strict_args_tab);
-                 erasable_types_tab = (uu___497_16495.erasable_types_tab)
+                   (uu___497_16502.try_solve_implicits_hook);
+                 splice = (uu___497_16502.splice);
+                 mpreprocess = (uu___497_16502.mpreprocess);
+                 postprocess = (uu___497_16502.postprocess);
+                 is_native_tactic = (uu___497_16502.is_native_tactic);
+                 identifier_info = (uu___497_16502.identifier_info);
+                 tc_hooks = (uu___497_16502.tc_hooks);
+                 dsenv = (uu___497_16502.dsenv);
+                 nbe = (uu___497_16502.nbe);
+                 strict_args_tab = (uu___497_16502.strict_args_tab);
+                 erasable_types_tab = (uu___497_16502.erasable_types_tab)
                })))
   
 let (debug : env -> FStar_Options.debug_level_t -> Prims.bool) =
   fun env1  ->
-    fun l  -> FStar_Options.debug_at_level (env1.curmodule).FStar_Ident.str l
+    fun l  ->
+      let uu____16531 = FStar_Ident.string_of_lid env1.curmodule  in
+      FStar_Options.debug_at_level uu____16531 l
   
 let (set_range : env -> FStar_Range.range -> env) =
   fun e  ->
@@ -2053,95 +2058,95 @@ let (set_range : env -> FStar_Range.range -> env) =
       if r = FStar_Range.dummyRange
       then e
       else
-        (let uu___504_16538 = e  in
+        (let uu___504_16547 = e  in
          {
-           solver = (uu___504_16538.solver);
+           solver = (uu___504_16547.solver);
            range = r;
-           curmodule = (uu___504_16538.curmodule);
-           gamma = (uu___504_16538.gamma);
-           gamma_sig = (uu___504_16538.gamma_sig);
-           gamma_cache = (uu___504_16538.gamma_cache);
-           modules = (uu___504_16538.modules);
-           expected_typ = (uu___504_16538.expected_typ);
-           sigtab = (uu___504_16538.sigtab);
-           attrtab = (uu___504_16538.attrtab);
-           instantiate_imp = (uu___504_16538.instantiate_imp);
-           effects = (uu___504_16538.effects);
-           generalize = (uu___504_16538.generalize);
-           letrecs = (uu___504_16538.letrecs);
-           top_level = (uu___504_16538.top_level);
-           check_uvars = (uu___504_16538.check_uvars);
-           use_eq = (uu___504_16538.use_eq);
-           use_eq_strict = (uu___504_16538.use_eq_strict);
-           is_iface = (uu___504_16538.is_iface);
-           admit = (uu___504_16538.admit);
-           lax = (uu___504_16538.lax);
-           lax_universes = (uu___504_16538.lax_universes);
-           phase1 = (uu___504_16538.phase1);
-           failhard = (uu___504_16538.failhard);
-           nosynth = (uu___504_16538.nosynth);
-           uvar_subtyping = (uu___504_16538.uvar_subtyping);
-           tc_term = (uu___504_16538.tc_term);
-           type_of = (uu___504_16538.type_of);
-           universe_of = (uu___504_16538.universe_of);
-           check_type_of = (uu___504_16538.check_type_of);
-           use_bv_sorts = (uu___504_16538.use_bv_sorts);
-           qtbl_name_and_index = (uu___504_16538.qtbl_name_and_index);
-           normalized_eff_names = (uu___504_16538.normalized_eff_names);
-           fv_delta_depths = (uu___504_16538.fv_delta_depths);
-           proof_ns = (uu___504_16538.proof_ns);
-           synth_hook = (uu___504_16538.synth_hook);
+           curmodule = (uu___504_16547.curmodule);
+           gamma = (uu___504_16547.gamma);
+           gamma_sig = (uu___504_16547.gamma_sig);
+           gamma_cache = (uu___504_16547.gamma_cache);
+           modules = (uu___504_16547.modules);
+           expected_typ = (uu___504_16547.expected_typ);
+           sigtab = (uu___504_16547.sigtab);
+           attrtab = (uu___504_16547.attrtab);
+           instantiate_imp = (uu___504_16547.instantiate_imp);
+           effects = (uu___504_16547.effects);
+           generalize = (uu___504_16547.generalize);
+           letrecs = (uu___504_16547.letrecs);
+           top_level = (uu___504_16547.top_level);
+           check_uvars = (uu___504_16547.check_uvars);
+           use_eq = (uu___504_16547.use_eq);
+           use_eq_strict = (uu___504_16547.use_eq_strict);
+           is_iface = (uu___504_16547.is_iface);
+           admit = (uu___504_16547.admit);
+           lax = (uu___504_16547.lax);
+           lax_universes = (uu___504_16547.lax_universes);
+           phase1 = (uu___504_16547.phase1);
+           failhard = (uu___504_16547.failhard);
+           nosynth = (uu___504_16547.nosynth);
+           uvar_subtyping = (uu___504_16547.uvar_subtyping);
+           tc_term = (uu___504_16547.tc_term);
+           type_of = (uu___504_16547.type_of);
+           universe_of = (uu___504_16547.universe_of);
+           check_type_of = (uu___504_16547.check_type_of);
+           use_bv_sorts = (uu___504_16547.use_bv_sorts);
+           qtbl_name_and_index = (uu___504_16547.qtbl_name_and_index);
+           normalized_eff_names = (uu___504_16547.normalized_eff_names);
+           fv_delta_depths = (uu___504_16547.fv_delta_depths);
+           proof_ns = (uu___504_16547.proof_ns);
+           synth_hook = (uu___504_16547.synth_hook);
            try_solve_implicits_hook =
-             (uu___504_16538.try_solve_implicits_hook);
-           splice = (uu___504_16538.splice);
-           mpreprocess = (uu___504_16538.mpreprocess);
-           postprocess = (uu___504_16538.postprocess);
-           is_native_tactic = (uu___504_16538.is_native_tactic);
-           identifier_info = (uu___504_16538.identifier_info);
-           tc_hooks = (uu___504_16538.tc_hooks);
-           dsenv = (uu___504_16538.dsenv);
-           nbe = (uu___504_16538.nbe);
-           strict_args_tab = (uu___504_16538.strict_args_tab);
-           erasable_types_tab = (uu___504_16538.erasable_types_tab)
+             (uu___504_16547.try_solve_implicits_hook);
+           splice = (uu___504_16547.splice);
+           mpreprocess = (uu___504_16547.mpreprocess);
+           postprocess = (uu___504_16547.postprocess);
+           is_native_tactic = (uu___504_16547.is_native_tactic);
+           identifier_info = (uu___504_16547.identifier_info);
+           tc_hooks = (uu___504_16547.tc_hooks);
+           dsenv = (uu___504_16547.dsenv);
+           nbe = (uu___504_16547.nbe);
+           strict_args_tab = (uu___504_16547.strict_args_tab);
+           erasable_types_tab = (uu___504_16547.erasable_types_tab)
          })
   
 let (get_range : env -> FStar_Range.range) = fun e  -> e.range 
 let (toggle_id_info : env -> Prims.bool -> unit) =
   fun env1  ->
     fun enabled  ->
-      let uu____16558 =
-        let uu____16559 = FStar_ST.op_Bang env1.identifier_info  in
-        FStar_TypeChecker_Common.id_info_toggle uu____16559 enabled  in
-      FStar_ST.op_Colon_Equals env1.identifier_info uu____16558
+      let uu____16567 =
+        let uu____16568 = FStar_ST.op_Bang env1.identifier_info  in
+        FStar_TypeChecker_Common.id_info_toggle uu____16568 enabled  in
+      FStar_ST.op_Colon_Equals env1.identifier_info uu____16567
   
 let (insert_bv_info :
   env -> FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.typ -> unit) =
   fun env1  ->
     fun bv  ->
       fun ty  ->
-        let uu____16614 =
-          let uu____16615 = FStar_ST.op_Bang env1.identifier_info  in
-          FStar_TypeChecker_Common.id_info_insert_bv uu____16615 bv ty  in
-        FStar_ST.op_Colon_Equals env1.identifier_info uu____16614
+        let uu____16623 =
+          let uu____16624 = FStar_ST.op_Bang env1.identifier_info  in
+          FStar_TypeChecker_Common.id_info_insert_bv uu____16624 bv ty  in
+        FStar_ST.op_Colon_Equals env1.identifier_info uu____16623
   
 let (insert_fv_info :
   env -> FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.typ -> unit) =
   fun env1  ->
     fun fv  ->
       fun ty  ->
-        let uu____16670 =
-          let uu____16671 = FStar_ST.op_Bang env1.identifier_info  in
-          FStar_TypeChecker_Common.id_info_insert_fv uu____16671 fv ty  in
-        FStar_ST.op_Colon_Equals env1.identifier_info uu____16670
+        let uu____16679 =
+          let uu____16680 = FStar_ST.op_Bang env1.identifier_info  in
+          FStar_TypeChecker_Common.id_info_insert_fv uu____16680 fv ty  in
+        FStar_ST.op_Colon_Equals env1.identifier_info uu____16679
   
 let (promote_id_info :
   env -> (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) -> unit) =
   fun env1  ->
     fun ty_map  ->
-      let uu____16726 =
-        let uu____16727 = FStar_ST.op_Bang env1.identifier_info  in
-        FStar_TypeChecker_Common.id_info_promote uu____16727 ty_map  in
-      FStar_ST.op_Colon_Equals env1.identifier_info uu____16726
+      let uu____16735 =
+        let uu____16736 = FStar_ST.op_Bang env1.identifier_info  in
+        FStar_TypeChecker_Common.id_info_promote uu____16736 ty_map  in
+      FStar_ST.op_Colon_Equals env1.identifier_info uu____16735
   
 let (modules : env -> FStar_Syntax_Syntax.modul Prims.list) =
   fun env1  -> env1.modules 
@@ -2150,55 +2155,55 @@ let (current_module : env -> FStar_Ident.lident) =
 let (set_current_module : env -> FStar_Ident.lident -> env) =
   fun env1  ->
     fun lid  ->
-      let uu___521_16791 = env1  in
+      let uu___521_16800 = env1  in
       {
-        solver = (uu___521_16791.solver);
-        range = (uu___521_16791.range);
+        solver = (uu___521_16800.solver);
+        range = (uu___521_16800.range);
         curmodule = lid;
-        gamma = (uu___521_16791.gamma);
-        gamma_sig = (uu___521_16791.gamma_sig);
-        gamma_cache = (uu___521_16791.gamma_cache);
-        modules = (uu___521_16791.modules);
-        expected_typ = (uu___521_16791.expected_typ);
-        sigtab = (uu___521_16791.sigtab);
-        attrtab = (uu___521_16791.attrtab);
-        instantiate_imp = (uu___521_16791.instantiate_imp);
-        effects = (uu___521_16791.effects);
-        generalize = (uu___521_16791.generalize);
-        letrecs = (uu___521_16791.letrecs);
-        top_level = (uu___521_16791.top_level);
-        check_uvars = (uu___521_16791.check_uvars);
-        use_eq = (uu___521_16791.use_eq);
-        use_eq_strict = (uu___521_16791.use_eq_strict);
-        is_iface = (uu___521_16791.is_iface);
-        admit = (uu___521_16791.admit);
-        lax = (uu___521_16791.lax);
-        lax_universes = (uu___521_16791.lax_universes);
-        phase1 = (uu___521_16791.phase1);
-        failhard = (uu___521_16791.failhard);
-        nosynth = (uu___521_16791.nosynth);
-        uvar_subtyping = (uu___521_16791.uvar_subtyping);
-        tc_term = (uu___521_16791.tc_term);
-        type_of = (uu___521_16791.type_of);
-        universe_of = (uu___521_16791.universe_of);
-        check_type_of = (uu___521_16791.check_type_of);
-        use_bv_sorts = (uu___521_16791.use_bv_sorts);
-        qtbl_name_and_index = (uu___521_16791.qtbl_name_and_index);
-        normalized_eff_names = (uu___521_16791.normalized_eff_names);
-        fv_delta_depths = (uu___521_16791.fv_delta_depths);
-        proof_ns = (uu___521_16791.proof_ns);
-        synth_hook = (uu___521_16791.synth_hook);
-        try_solve_implicits_hook = (uu___521_16791.try_solve_implicits_hook);
-        splice = (uu___521_16791.splice);
-        mpreprocess = (uu___521_16791.mpreprocess);
-        postprocess = (uu___521_16791.postprocess);
-        is_native_tactic = (uu___521_16791.is_native_tactic);
-        identifier_info = (uu___521_16791.identifier_info);
-        tc_hooks = (uu___521_16791.tc_hooks);
-        dsenv = (uu___521_16791.dsenv);
-        nbe = (uu___521_16791.nbe);
-        strict_args_tab = (uu___521_16791.strict_args_tab);
-        erasable_types_tab = (uu___521_16791.erasable_types_tab)
+        gamma = (uu___521_16800.gamma);
+        gamma_sig = (uu___521_16800.gamma_sig);
+        gamma_cache = (uu___521_16800.gamma_cache);
+        modules = (uu___521_16800.modules);
+        expected_typ = (uu___521_16800.expected_typ);
+        sigtab = (uu___521_16800.sigtab);
+        attrtab = (uu___521_16800.attrtab);
+        instantiate_imp = (uu___521_16800.instantiate_imp);
+        effects = (uu___521_16800.effects);
+        generalize = (uu___521_16800.generalize);
+        letrecs = (uu___521_16800.letrecs);
+        top_level = (uu___521_16800.top_level);
+        check_uvars = (uu___521_16800.check_uvars);
+        use_eq = (uu___521_16800.use_eq);
+        use_eq_strict = (uu___521_16800.use_eq_strict);
+        is_iface = (uu___521_16800.is_iface);
+        admit = (uu___521_16800.admit);
+        lax = (uu___521_16800.lax);
+        lax_universes = (uu___521_16800.lax_universes);
+        phase1 = (uu___521_16800.phase1);
+        failhard = (uu___521_16800.failhard);
+        nosynth = (uu___521_16800.nosynth);
+        uvar_subtyping = (uu___521_16800.uvar_subtyping);
+        tc_term = (uu___521_16800.tc_term);
+        type_of = (uu___521_16800.type_of);
+        universe_of = (uu___521_16800.universe_of);
+        check_type_of = (uu___521_16800.check_type_of);
+        use_bv_sorts = (uu___521_16800.use_bv_sorts);
+        qtbl_name_and_index = (uu___521_16800.qtbl_name_and_index);
+        normalized_eff_names = (uu___521_16800.normalized_eff_names);
+        fv_delta_depths = (uu___521_16800.fv_delta_depths);
+        proof_ns = (uu___521_16800.proof_ns);
+        synth_hook = (uu___521_16800.synth_hook);
+        try_solve_implicits_hook = (uu___521_16800.try_solve_implicits_hook);
+        splice = (uu___521_16800.splice);
+        mpreprocess = (uu___521_16800.mpreprocess);
+        postprocess = (uu___521_16800.postprocess);
+        is_native_tactic = (uu___521_16800.is_native_tactic);
+        identifier_info = (uu___521_16800.identifier_info);
+        tc_hooks = (uu___521_16800.tc_hooks);
+        dsenv = (uu___521_16800.dsenv);
+        nbe = (uu___521_16800.nbe);
+        strict_args_tab = (uu___521_16800.strict_args_tab);
+        erasable_types_tab = (uu___521_16800.erasable_types_tab)
       }
   
 let (has_interface : env -> FStar_Ident.lident -> Prims.bool) =
@@ -2217,28 +2222,29 @@ let (find_in_sigtab :
   =
   fun env1  ->
     fun lid  ->
-      let uu____16822 = FStar_Ident.text_of_lid lid  in
-      FStar_Util.smap_try_find (sigtab env1) uu____16822
+      let uu____16831 = FStar_Ident.string_of_lid lid  in
+      FStar_Util.smap_try_find (sigtab env1) uu____16831
   
 let (name_not_found :
   FStar_Ident.lid -> (FStar_Errors.raw_error * Prims.string)) =
   fun l  ->
-    let uu____16835 =
-      FStar_Util.format1 "Name \"%s\" not found" l.FStar_Ident.str  in
-    (FStar_Errors.Fatal_NameNotFound, uu____16835)
+    let uu____16844 =
+      let uu____16846 = FStar_Ident.string_of_lid l  in
+      FStar_Util.format1 "Name \"%s\" not found" uu____16846  in
+    (FStar_Errors.Fatal_NameNotFound, uu____16844)
   
 let (variable_not_found :
   FStar_Syntax_Syntax.bv -> (FStar_Errors.raw_error * Prims.string)) =
   fun v  ->
-    let uu____16850 =
-      let uu____16852 = FStar_Syntax_Print.bv_to_string v  in
-      FStar_Util.format1 "Variable \"%s\" not found" uu____16852  in
-    (FStar_Errors.Fatal_VariableNotFound, uu____16850)
+    let uu____16861 =
+      let uu____16863 = FStar_Syntax_Print.bv_to_string v  in
+      FStar_Util.format1 "Variable \"%s\" not found" uu____16863  in
+    (FStar_Errors.Fatal_VariableNotFound, uu____16861)
   
 let (new_u_univ : unit -> FStar_Syntax_Syntax.universe) =
-  fun uu____16861  ->
-    let uu____16862 = FStar_Syntax_Unionfind.univ_fresh ()  in
-    FStar_Syntax_Syntax.U_unif uu____16862
+  fun uu____16872  ->
+    let uu____16873 = FStar_Syntax_Unionfind.univ_fresh ()  in
+    FStar_Syntax_Syntax.U_unif uu____16873
   
 let (mk_univ_subst :
   FStar_Syntax_Syntax.univ_name Prims.list ->
@@ -2260,22 +2266,22 @@ let (inst_tscheme_with :
     fun us  ->
       match (ts, us) with
       | (([],t),[]) -> ([], t)
-      | ((formals,t),uu____16962) ->
+      | ((formals,t),uu____16973) ->
           let vs = mk_univ_subst formals us  in
-          let uu____16986 = FStar_Syntax_Subst.subst vs t  in
-          (us, uu____16986)
+          let uu____16997 = FStar_Syntax_Subst.subst vs t  in
+          (us, uu____16997)
   
 let (inst_tscheme :
   FStar_Syntax_Syntax.tscheme ->
     (FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.term))
   =
-  fun uu___1_17003  ->
-    match uu___1_17003 with
+  fun uu___1_17014  ->
+    match uu___1_17014 with
     | ([],t) -> ([], t)
     | (us,t) ->
         let us' =
           FStar_All.pipe_right us
-            (FStar_List.map (fun uu____17029  -> new_u_univ ()))
+            (FStar_List.map (fun uu____17040  -> new_u_univ ()))
            in
         inst_tscheme_with (us, t) us'
   
@@ -2286,11 +2292,11 @@ let (inst_tscheme_with_range :
   =
   fun r  ->
     fun t  ->
-      let uu____17049 = inst_tscheme t  in
-      match uu____17049 with
+      let uu____17060 = inst_tscheme t  in
+      match uu____17060 with
       | (us,t1) ->
-          let uu____17060 = FStar_Syntax_Subst.set_use_range r t1  in
-          (us, uu____17060)
+          let uu____17071 = FStar_Syntax_Subst.set_use_range r t1  in
+          (us, uu____17071)
   
 let (check_effect_is_not_a_template :
   FStar_Syntax_Syntax.eff_decl -> FStar_Range.range -> unit) =
@@ -2303,15 +2309,15 @@ let (check_effect_is_not_a_template :
              Prims.int_zero)
       then
         let msg =
-          let uu____17085 =
+          let uu____17096 =
             FStar_Syntax_Print.lid_to_string ed.FStar_Syntax_Syntax.mname  in
-          let uu____17087 =
+          let uu____17098 =
             FStar_Syntax_Print.binders_to_string ", "
               ed.FStar_Syntax_Syntax.binders
              in
           FStar_Util.format2
             "Effect template %s should be applied to arguments for its binders (%s) before it can be used at an effect position"
-            uu____17085 uu____17087
+            uu____17096 uu____17098
            in
         FStar_Errors.raise_error
           (FStar_Errors.Fatal_NotEnoughArgumentsForEffect, msg) rng
@@ -2326,34 +2332,34 @@ let (inst_effect_fun_with :
   fun insts  ->
     fun env1  ->
       fun ed  ->
-        fun uu____17114  ->
-          match uu____17114 with
+        fun uu____17125  ->
+          match uu____17125 with
           | (us,t) ->
               (check_effect_is_not_a_template ed env1.range;
                if (FStar_List.length insts) <> (FStar_List.length us)
                then
-                 (let uu____17128 =
-                    let uu____17130 =
+                 (let uu____17139 =
+                    let uu____17141 =
                       FStar_All.pipe_left FStar_Util.string_of_int
                         (FStar_List.length us)
                        in
-                    let uu____17134 =
+                    let uu____17145 =
                       FStar_All.pipe_left FStar_Util.string_of_int
                         (FStar_List.length insts)
                        in
-                    let uu____17138 =
+                    let uu____17149 =
                       FStar_Syntax_Print.lid_to_string
                         ed.FStar_Syntax_Syntax.mname
                        in
-                    let uu____17140 = FStar_Syntax_Print.term_to_string t  in
+                    let uu____17151 = FStar_Syntax_Print.term_to_string t  in
                     FStar_Util.format4
                       "Expected %s instantiations; got %s; failed universe instantiation in effect %s\n\t%s\n"
-                      uu____17130 uu____17134 uu____17138 uu____17140
+                      uu____17141 uu____17145 uu____17149 uu____17151
                      in
-                  failwith uu____17128)
+                  failwith uu____17139)
                else ();
-               (let uu____17145 = inst_tscheme_with (us, t) insts  in
-                FStar_Pervasives_Native.snd uu____17145))
+               (let uu____17156 = inst_tscheme_with (us, t) insts  in
+                FStar_Pervasives_Native.snd uu____17156))
   
 type tri =
   | Yes 
@@ -2361,36 +2367,54 @@ type tri =
   | Maybe 
 let (uu___is_Yes : tri -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Yes  -> true | uu____17163 -> false
+    match projectee with | Yes  -> true | uu____17174 -> false
   
 let (uu___is_No : tri -> Prims.bool) =
-  fun projectee  -> match projectee with | No  -> true | uu____17174 -> false 
+  fun projectee  -> match projectee with | No  -> true | uu____17185 -> false 
 let (uu___is_Maybe : tri -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Maybe  -> true | uu____17185 -> false
+    match projectee with | Maybe  -> true | uu____17196 -> false
   
 let (in_cur_mod : env -> FStar_Ident.lident -> tri) =
   fun env1  ->
     fun l  ->
       let cur = current_module env1  in
-      if l.FStar_Ident.nsstr = cur.FStar_Ident.str
+      let uu____17210 =
+        let uu____17212 = FStar_Ident.nsstr l  in
+        let uu____17214 = FStar_Ident.string_of_lid cur  in
+        uu____17212 = uu____17214  in
+      if uu____17210
       then Yes
       else
-        if FStar_Util.starts_with l.FStar_Ident.nsstr cur.FStar_Ident.str
-        then
-          (let lns = FStar_List.append l.FStar_Ident.ns [l.FStar_Ident.ident]
-              in
+        (let uu____17220 =
+           let uu____17222 = FStar_Ident.nsstr l  in
+           let uu____17224 = FStar_Ident.string_of_lid cur  in
+           FStar_Util.starts_with uu____17222 uu____17224  in
+         if uu____17220
+         then
+           let lns =
+             let uu____17230 = FStar_Ident.ns_of_lid l  in
+             let uu____17233 =
+               let uu____17236 = FStar_Ident.ident_of_lid l  in [uu____17236]
+                in
+             FStar_List.append uu____17230 uu____17233  in
            let cur1 =
-             FStar_List.append cur.FStar_Ident.ns [cur.FStar_Ident.ident]  in
+             let uu____17240 = FStar_Ident.ns_of_lid cur  in
+             let uu____17243 =
+               let uu____17246 = FStar_Ident.ident_of_lid cur  in
+               [uu____17246]  in
+             FStar_List.append uu____17240 uu____17243  in
            let rec aux c l1 =
              match (c, l1) with
-             | ([],uu____17233) -> Maybe
-             | (uu____17240,[]) -> No
+             | ([],uu____17270) -> Maybe
+             | (uu____17277,[]) -> No
              | (hd::tl,hd'::tl') when
-                 hd.FStar_Ident.idText = hd'.FStar_Ident.idText -> aux tl tl'
-             | uu____17260 -> No  in
-           aux cur1 lns)
-        else No
+                 let uu____17296 = FStar_Ident.text_of_id hd  in
+                 let uu____17298 = FStar_Ident.text_of_id hd'  in
+                 uu____17296 = uu____17298 -> aux tl tl'
+             | uu____17301 -> No  in
+           aux cur1 lns
+         else No)
   
 type qninfo =
   (((FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.typ),(FStar_Syntax_Syntax.sigelt
@@ -2403,63 +2427,64 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
     fun lid  ->
       let cur_mod = in_cur_mod env1 lid  in
       let cache t =
-        FStar_Util.smap_add (gamma_cache env1) lid.FStar_Ident.str t;
+        (let uu____17353 = FStar_Ident.string_of_lid lid  in
+         FStar_Util.smap_add (gamma_cache env1) uu____17353 t);
         FStar_Pervasives_Native.Some t  in
       let found =
         if cur_mod <> No
         then
-          let uu____17354 =
-            FStar_Util.smap_try_find (gamma_cache env1) lid.FStar_Ident.str
-             in
-          match uu____17354 with
+          let uu____17397 =
+            let uu____17400 = FStar_Ident.string_of_lid lid  in
+            FStar_Util.smap_try_find (gamma_cache env1) uu____17400  in
+          match uu____17397 with
           | FStar_Pervasives_Native.None  ->
-              let uu____17377 =
+              let uu____17422 =
                 FStar_Util.find_map env1.gamma
-                  (fun uu___2_17421  ->
-                     match uu___2_17421 with
+                  (fun uu___2_17466  ->
+                     match uu___2_17466 with
                      | FStar_Syntax_Syntax.Binding_lid (l,t) ->
-                         let uu____17460 = FStar_Ident.lid_equals lid l  in
-                         if uu____17460
+                         let uu____17505 = FStar_Ident.lid_equals lid l  in
+                         if uu____17505
                          then
-                           let uu____17483 =
-                             let uu____17502 =
-                               let uu____17517 = inst_tscheme t  in
-                               FStar_Util.Inl uu____17517  in
-                             let uu____17532 = FStar_Ident.range_of_lid l  in
-                             (uu____17502, uu____17532)  in
-                           FStar_Pervasives_Native.Some uu____17483
+                           let uu____17528 =
+                             let uu____17547 =
+                               let uu____17562 = inst_tscheme t  in
+                               FStar_Util.Inl uu____17562  in
+                             let uu____17577 = FStar_Ident.range_of_lid l  in
+                             (uu____17547, uu____17577)  in
+                           FStar_Pervasives_Native.Some uu____17528
                          else FStar_Pervasives_Native.None
-                     | uu____17585 -> FStar_Pervasives_Native.None)
+                     | uu____17630 -> FStar_Pervasives_Native.None)
                  in
-              FStar_Util.catch_opt uu____17377
-                (fun uu____17623  ->
+              FStar_Util.catch_opt uu____17422
+                (fun uu____17668  ->
                    FStar_Util.find_map env1.gamma_sig
-                     (fun uu___3_17633  ->
-                        match uu___3_17633 with
-                        | (uu____17636,{
+                     (fun uu___3_17678  ->
+                        match uu___3_17678 with
+                        | (uu____17681,{
                                          FStar_Syntax_Syntax.sigel =
                                            FStar_Syntax_Syntax.Sig_bundle
-                                           (ses,uu____17638);
+                                           (ses,uu____17683);
                                          FStar_Syntax_Syntax.sigrng =
-                                           uu____17639;
+                                           uu____17684;
                                          FStar_Syntax_Syntax.sigquals =
-                                           uu____17640;
+                                           uu____17685;
                                          FStar_Syntax_Syntax.sigmeta =
-                                           uu____17641;
+                                           uu____17686;
                                          FStar_Syntax_Syntax.sigattrs =
-                                           uu____17642;
+                                           uu____17687;
                                          FStar_Syntax_Syntax.sigopts =
-                                           uu____17643;_})
+                                           uu____17688;_})
                             ->
                             FStar_Util.find_map ses
                               (fun se  ->
-                                 let uu____17665 =
+                                 let uu____17710 =
                                    FStar_All.pipe_right
                                      (FStar_Syntax_Util.lids_of_sigelt se)
                                      (FStar_Util.for_some
                                         (FStar_Ident.lid_equals lid))
                                     in
-                                 if uu____17665
+                                 if uu____17710
                                  then
                                    cache
                                      ((FStar_Util.Inr
@@ -2470,32 +2495,32 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
                             let maybe_cache t =
                               match s.FStar_Syntax_Syntax.sigel with
                               | FStar_Syntax_Syntax.Sig_declare_typ
-                                  uu____17717 ->
+                                  uu____17762 ->
                                   FStar_Pervasives_Native.Some t
-                              | uu____17724 -> cache t  in
-                            let uu____17725 =
+                              | uu____17769 -> cache t  in
+                            let uu____17770 =
                               FStar_List.tryFind (FStar_Ident.lid_equals lid)
                                 lids
                                in
-                            (match uu____17725 with
+                            (match uu____17770 with
                              | FStar_Pervasives_Native.None  ->
                                  FStar_Pervasives_Native.None
                              | FStar_Pervasives_Native.Some l ->
-                                 let uu____17731 =
-                                   let uu____17732 =
+                                 let uu____17776 =
+                                   let uu____17777 =
                                      FStar_Ident.range_of_lid l  in
                                    ((FStar_Util.Inr
                                        (s, FStar_Pervasives_Native.None)),
-                                     uu____17732)
+                                     uu____17777)
                                     in
-                                 maybe_cache uu____17731)))
+                                 maybe_cache uu____17776)))
           | se -> se
         else FStar_Pervasives_Native.None  in
       if FStar_Util.is_some found
       then found
       else
-        (let uu____17803 = find_in_sigtab env1 lid  in
-         match uu____17803 with
+        (let uu____17848 = find_in_sigtab env1 lid  in
+         match uu____17848 with
          | FStar_Pervasives_Native.Some se ->
              FStar_Pervasives_Native.Some
                ((FStar_Util.Inr (se, FStar_Pervasives_Native.None)),
@@ -2509,10 +2534,10 @@ let (lookup_sigelt :
   =
   fun env1  ->
     fun lid  ->
-      let uu____17884 = lookup_qname env1 lid  in
-      match uu____17884 with
+      let uu____17929 = lookup_qname env1 lid  in
+      match uu____17929 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-      | FStar_Pervasives_Native.Some (FStar_Util.Inl uu____17905,rng) ->
+      | FStar_Pervasives_Native.Some (FStar_Util.Inl uu____17950,rng) ->
           FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (FStar_Util.Inr (se,us),rng) ->
           FStar_Pervasives_Native.Some se
@@ -2521,8 +2546,8 @@ let (lookup_attr :
   env -> Prims.string -> FStar_Syntax_Syntax.sigelt Prims.list) =
   fun env1  ->
     fun attr  ->
-      let uu____18019 = FStar_Util.smap_try_find (attrtab env1) attr  in
-      match uu____18019 with
+      let uu____18064 = FStar_Util.smap_try_find (attrtab env1) attr  in
+      match uu____18064 with
       | FStar_Pervasives_Native.Some ses -> ses
       | FStar_Pervasives_Native.None  -> []
   
@@ -2530,33 +2555,34 @@ let (add_se_to_attrtab : env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env1  ->
     fun se  ->
       let add_one env2 se1 attr =
-        let uu____18064 =
-          let uu____18067 = lookup_attr env2 attr  in se1 :: uu____18067  in
-        FStar_Util.smap_add (attrtab env2) attr uu____18064  in
+        let uu____18109 =
+          let uu____18112 = lookup_attr env2 attr  in se1 :: uu____18112  in
+        FStar_Util.smap_add (attrtab env2) attr uu____18109  in
       FStar_List.iter
         (fun attr  ->
-           let uu____18077 =
-             let uu____18078 = FStar_Syntax_Subst.compress attr  in
-             uu____18078.FStar_Syntax_Syntax.n  in
-           match uu____18077 with
+           let uu____18122 =
+             let uu____18123 = FStar_Syntax_Subst.compress attr  in
+             uu____18123.FStar_Syntax_Syntax.n  in
+           match uu____18122 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
-               let uu____18082 =
-                 let uu____18084 = FStar_Syntax_Syntax.lid_of_fv fv  in
-                 uu____18084.FStar_Ident.str  in
-               add_one env1 se uu____18082
-           | uu____18085 -> ()) se.FStar_Syntax_Syntax.sigattrs
+               let uu____18127 =
+                 let uu____18129 = FStar_Syntax_Syntax.lid_of_fv fv  in
+                 FStar_Ident.string_of_lid uu____18129  in
+               add_one env1 se uu____18127
+           | uu____18130 -> ()) se.FStar_Syntax_Syntax.sigattrs
   
 let rec (add_sigelt : env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env1  ->
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle (ses,uu____18108) ->
+      | FStar_Syntax_Syntax.Sig_bundle (ses,uu____18153) ->
           add_sigelts env1 ses
-      | uu____18117 ->
+      | uu____18162 ->
           let lids = FStar_Syntax_Util.lids_of_sigelt se  in
           (FStar_List.iter
              (fun l  ->
-                FStar_Util.smap_add (sigtab env1) l.FStar_Ident.str se) lids;
+                let uu____18170 = FStar_Ident.string_of_lid l  in
+                FStar_Util.smap_add (sigtab env1) uu____18170 se) lids;
            add_se_to_attrtab env1 se)
 
 and (add_sigelts : env -> FStar_Syntax_Syntax.sigelt Prims.list -> unit) =
@@ -2572,14 +2598,16 @@ let (try_lookup_bv :
   fun env1  ->
     fun bv  ->
       FStar_Util.find_map env1.gamma
-        (fun uu___4_18155  ->
-           match uu___4_18155 with
+        (fun uu___4_18204  ->
+           match uu___4_18204 with
            | FStar_Syntax_Syntax.Binding_var id when
                FStar_Syntax_Syntax.bv_eq id bv ->
-               FStar_Pervasives_Native.Some
-                 ((id.FStar_Syntax_Syntax.sort),
-                   ((id.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange))
-           | uu____18173 -> FStar_Pervasives_Native.None)
+               let uu____18214 =
+                 let uu____18221 =
+                   FStar_Ident.range_of_id id.FStar_Syntax_Syntax.ppname  in
+                 ((id.FStar_Syntax_Syntax.sort), uu____18221)  in
+               FStar_Pervasives_Native.Some uu____18214
+           | uu____18230 -> FStar_Pervasives_Native.None)
   
 let (lookup_type_of_let :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
@@ -2596,41 +2624,41 @@ let (lookup_type_of_let :
           | FStar_Pervasives_Native.None  -> inst_tscheme ts
           | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us  in
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_let ((uu____18235,lb::[]),uu____18237) ->
-            let uu____18246 =
-              let uu____18255 =
+        | FStar_Syntax_Syntax.Sig_let ((uu____18292,lb::[]),uu____18294) ->
+            let uu____18303 =
+              let uu____18312 =
                 inst_tscheme1
                   ((lb.FStar_Syntax_Syntax.lbunivs),
                     (lb.FStar_Syntax_Syntax.lbtyp))
                  in
-              let uu____18264 =
+              let uu____18321 =
                 FStar_Syntax_Syntax.range_of_lbname
                   lb.FStar_Syntax_Syntax.lbname
                  in
-              (uu____18255, uu____18264)  in
-            FStar_Pervasives_Native.Some uu____18246
-        | FStar_Syntax_Syntax.Sig_let ((uu____18277,lbs),uu____18279) ->
+              (uu____18312, uu____18321)  in
+            FStar_Pervasives_Native.Some uu____18303
+        | FStar_Syntax_Syntax.Sig_let ((uu____18334,lbs),uu____18336) ->
             FStar_Util.find_map lbs
               (fun lb  ->
                  match lb.FStar_Syntax_Syntax.lbname with
-                 | FStar_Util.Inl uu____18311 -> failwith "impossible"
+                 | FStar_Util.Inl uu____18368 -> failwith "impossible"
                  | FStar_Util.Inr fv ->
-                     let uu____18324 = FStar_Syntax_Syntax.fv_eq_lid fv lid
+                     let uu____18381 = FStar_Syntax_Syntax.fv_eq_lid fv lid
                         in
-                     if uu____18324
+                     if uu____18381
                      then
-                       let uu____18337 =
-                         let uu____18346 =
+                       let uu____18394 =
+                         let uu____18403 =
                            inst_tscheme1
                              ((lb.FStar_Syntax_Syntax.lbunivs),
                                (lb.FStar_Syntax_Syntax.lbtyp))
                             in
-                         let uu____18355 = FStar_Syntax_Syntax.range_of_fv fv
+                         let uu____18412 = FStar_Syntax_Syntax.range_of_fv fv
                             in
-                         (uu____18346, uu____18355)  in
-                       FStar_Pervasives_Native.Some uu____18337
+                         (uu____18403, uu____18412)  in
+                       FStar_Pervasives_Native.Some uu____18394
                      else FStar_Pervasives_Native.None)
-        | uu____18378 -> FStar_Pervasives_Native.None
+        | uu____18435 -> FStar_Pervasives_Native.None
   
 let (effect_signature :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
@@ -2658,54 +2686,55 @@ let (effect_signature :
                          (FStar_Pervasives_Native.fst
                             ne.FStar_Syntax_Syntax.signature))
                   then
-                    let uu____18470 =
-                      let uu____18472 =
-                        let uu____18474 =
-                          let uu____18476 =
-                            let uu____18478 =
+                    let uu____18527 =
+                      let uu____18529 =
+                        let uu____18531 =
+                          FStar_Ident.string_of_lid
+                            ne.FStar_Syntax_Syntax.mname
+                           in
+                        let uu____18533 =
+                          let uu____18535 =
+                            let uu____18537 =
                               FStar_Util.string_of_int
                                 (FStar_List.length
                                    (FStar_Pervasives_Native.fst
                                       ne.FStar_Syntax_Syntax.signature))
                                in
-                            let uu____18484 =
-                              let uu____18486 =
+                            let uu____18543 =
+                              let uu____18545 =
                                 FStar_Util.string_of_int
                                   (FStar_List.length us)
                                  in
-                              Prims.op_Hat ", got " uu____18486  in
-                            Prims.op_Hat uu____18478 uu____18484  in
-                          Prims.op_Hat ", expected " uu____18476  in
-                        Prims.op_Hat
-                          (ne.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                          uu____18474
-                         in
+                              Prims.op_Hat ", got " uu____18545  in
+                            Prims.op_Hat uu____18537 uu____18543  in
+                          Prims.op_Hat ", expected " uu____18535  in
+                        Prims.op_Hat uu____18531 uu____18533  in
                       Prims.op_Hat
                         "effect_signature: incorrect number of universes for the signature of "
-                        uu____18472
+                        uu____18529
                        in
-                    failwith uu____18470
+                    failwith uu____18527
                   else ());
-             (let uu____18493 =
-                let uu____18502 =
+             (let uu____18552 =
+                let uu____18561 =
                   inst_ts us_opt ne.FStar_Syntax_Syntax.signature  in
-                (uu____18502, (se.FStar_Syntax_Syntax.sigrng))  in
-              FStar_Pervasives_Native.Some uu____18493))
+                (uu____18561, (se.FStar_Syntax_Syntax.sigrng))  in
+              FStar_Pervasives_Native.Some uu____18552))
         | FStar_Syntax_Syntax.Sig_effect_abbrev
-            (lid,us,binders,uu____18522,uu____18523) ->
-            let uu____18528 =
-              let uu____18537 =
-                let uu____18542 =
-                  let uu____18543 =
-                    let uu____18546 =
+            (lid,us,binders,uu____18581,uu____18582) ->
+            let uu____18587 =
+              let uu____18596 =
+                let uu____18601 =
+                  let uu____18602 =
+                    let uu____18605 =
                       FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.teff
                        in
-                    FStar_Syntax_Util.arrow binders uu____18546  in
-                  (us, uu____18543)  in
-                inst_ts us_opt uu____18542  in
-              (uu____18537, (se.FStar_Syntax_Syntax.sigrng))  in
-            FStar_Pervasives_Native.Some uu____18528
-        | uu____18565 -> FStar_Pervasives_Native.None
+                    FStar_Syntax_Util.arrow binders uu____18605  in
+                  (us, uu____18602)  in
+                inst_ts us_opt uu____18601  in
+              (uu____18596, (se.FStar_Syntax_Syntax.sigrng))  in
+            FStar_Pervasives_Native.Some uu____18587
+        | uu____18624 -> FStar_Pervasives_Native.None
   
 let (try_lookup_lid_aux :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
@@ -2722,8 +2751,8 @@ let (try_lookup_lid_aux :
           match us_opt with
           | FStar_Pervasives_Native.None  -> inst_tscheme ts
           | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us  in
-        let mapper uu____18654 =
-          match uu____18654 with
+        let mapper uu____18713 =
+          match uu____18713 with
           | (lr,rng) ->
               (match lr with
                | FStar_Util.Inl t -> FStar_Pervasives_Native.Some (t, rng)
@@ -2731,166 +2760,166 @@ let (try_lookup_lid_aux :
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_datacon
-                        (uu____18750,uvs,t,uu____18753,uu____18754,uu____18755);
-                      FStar_Syntax_Syntax.sigrng = uu____18756;
-                      FStar_Syntax_Syntax.sigquals = uu____18757;
-                      FStar_Syntax_Syntax.sigmeta = uu____18758;
-                      FStar_Syntax_Syntax.sigattrs = uu____18759;
-                      FStar_Syntax_Syntax.sigopts = uu____18760;_},FStar_Pervasives_Native.None
+                        (uu____18809,uvs,t,uu____18812,uu____18813,uu____18814);
+                      FStar_Syntax_Syntax.sigrng = uu____18815;
+                      FStar_Syntax_Syntax.sigquals = uu____18816;
+                      FStar_Syntax_Syntax.sigmeta = uu____18817;
+                      FStar_Syntax_Syntax.sigattrs = uu____18818;
+                      FStar_Syntax_Syntax.sigopts = uu____18819;_},FStar_Pervasives_Native.None
                     )
                    ->
-                   let uu____18785 =
-                     let uu____18794 = inst_tscheme1 (uvs, t)  in
-                     (uu____18794, rng)  in
-                   FStar_Pervasives_Native.Some uu____18785
+                   let uu____18844 =
+                     let uu____18853 = inst_tscheme1 (uvs, t)  in
+                     (uu____18853, rng)  in
+                   FStar_Pervasives_Native.Some uu____18844
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_declare_typ (l,uvs,t);
-                      FStar_Syntax_Syntax.sigrng = uu____18818;
+                      FStar_Syntax_Syntax.sigrng = uu____18877;
                       FStar_Syntax_Syntax.sigquals = qs;
-                      FStar_Syntax_Syntax.sigmeta = uu____18820;
-                      FStar_Syntax_Syntax.sigattrs = uu____18821;
-                      FStar_Syntax_Syntax.sigopts = uu____18822;_},FStar_Pervasives_Native.None
+                      FStar_Syntax_Syntax.sigmeta = uu____18879;
+                      FStar_Syntax_Syntax.sigattrs = uu____18880;
+                      FStar_Syntax_Syntax.sigopts = uu____18881;_},FStar_Pervasives_Native.None
                     )
                    ->
-                   let uu____18841 =
-                     let uu____18843 = in_cur_mod env1 l  in
-                     uu____18843 = Yes  in
-                   if uu____18841
+                   let uu____18900 =
+                     let uu____18902 = in_cur_mod env1 l  in
+                     uu____18902 = Yes  in
+                   if uu____18900
                    then
-                     let uu____18855 =
+                     let uu____18914 =
                        (FStar_All.pipe_right qs
                           (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                          || env1.is_iface
                         in
-                     (if uu____18855
+                     (if uu____18914
                       then
-                        let uu____18871 =
-                          let uu____18880 = inst_tscheme1 (uvs, t)  in
-                          (uu____18880, rng)  in
-                        FStar_Pervasives_Native.Some uu____18871
+                        let uu____18930 =
+                          let uu____18939 = inst_tscheme1 (uvs, t)  in
+                          (uu____18939, rng)  in
+                        FStar_Pervasives_Native.Some uu____18930
                       else FStar_Pervasives_Native.None)
                    else
-                     (let uu____18913 =
-                        let uu____18922 = inst_tscheme1 (uvs, t)  in
-                        (uu____18922, rng)  in
-                      FStar_Pervasives_Native.Some uu____18913)
+                     (let uu____18972 =
+                        let uu____18981 = inst_tscheme1 (uvs, t)  in
+                        (uu____18981, rng)  in
+                      FStar_Pervasives_Native.Some uu____18972)
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_inductive_typ
-                        (lid1,uvs,tps,k,uu____18947,uu____18948);
-                      FStar_Syntax_Syntax.sigrng = uu____18949;
-                      FStar_Syntax_Syntax.sigquals = uu____18950;
-                      FStar_Syntax_Syntax.sigmeta = uu____18951;
-                      FStar_Syntax_Syntax.sigattrs = uu____18952;
-                      FStar_Syntax_Syntax.sigopts = uu____18953;_},FStar_Pervasives_Native.None
+                        (lid1,uvs,tps,k,uu____19006,uu____19007);
+                      FStar_Syntax_Syntax.sigrng = uu____19008;
+                      FStar_Syntax_Syntax.sigquals = uu____19009;
+                      FStar_Syntax_Syntax.sigmeta = uu____19010;
+                      FStar_Syntax_Syntax.sigattrs = uu____19011;
+                      FStar_Syntax_Syntax.sigopts = uu____19012;_},FStar_Pervasives_Native.None
                     )
                    ->
                    (match tps with
                     | [] ->
-                        let uu____18996 =
-                          let uu____19005 = inst_tscheme1 (uvs, k)  in
-                          (uu____19005, rng)  in
-                        FStar_Pervasives_Native.Some uu____18996
-                    | uu____19026 ->
-                        let uu____19027 =
-                          let uu____19036 =
-                            let uu____19041 =
-                              let uu____19042 =
-                                let uu____19045 =
+                        let uu____19055 =
+                          let uu____19064 = inst_tscheme1 (uvs, k)  in
+                          (uu____19064, rng)  in
+                        FStar_Pervasives_Native.Some uu____19055
+                    | uu____19085 ->
+                        let uu____19086 =
+                          let uu____19095 =
+                            let uu____19100 =
+                              let uu____19101 =
+                                let uu____19104 =
                                   FStar_Syntax_Syntax.mk_Total k  in
-                                FStar_Syntax_Util.flat_arrow tps uu____19045
+                                FStar_Syntax_Util.flat_arrow tps uu____19104
                                  in
-                              (uvs, uu____19042)  in
-                            inst_tscheme1 uu____19041  in
-                          (uu____19036, rng)  in
-                        FStar_Pervasives_Native.Some uu____19027)
+                              (uvs, uu____19101)  in
+                            inst_tscheme1 uu____19100  in
+                          (uu____19095, rng)  in
+                        FStar_Pervasives_Native.Some uu____19086)
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_inductive_typ
-                        (lid1,uvs,tps,k,uu____19068,uu____19069);
-                      FStar_Syntax_Syntax.sigrng = uu____19070;
-                      FStar_Syntax_Syntax.sigquals = uu____19071;
-                      FStar_Syntax_Syntax.sigmeta = uu____19072;
-                      FStar_Syntax_Syntax.sigattrs = uu____19073;
-                      FStar_Syntax_Syntax.sigopts = uu____19074;_},FStar_Pervasives_Native.Some
+                        (lid1,uvs,tps,k,uu____19127,uu____19128);
+                      FStar_Syntax_Syntax.sigrng = uu____19129;
+                      FStar_Syntax_Syntax.sigquals = uu____19130;
+                      FStar_Syntax_Syntax.sigmeta = uu____19131;
+                      FStar_Syntax_Syntax.sigattrs = uu____19132;
+                      FStar_Syntax_Syntax.sigopts = uu____19133;_},FStar_Pervasives_Native.Some
                     us)
                    ->
                    (match tps with
                     | [] ->
-                        let uu____19118 =
-                          let uu____19127 = inst_tscheme_with (uvs, k) us  in
-                          (uu____19127, rng)  in
-                        FStar_Pervasives_Native.Some uu____19118
-                    | uu____19148 ->
-                        let uu____19149 =
-                          let uu____19158 =
-                            let uu____19163 =
-                              let uu____19164 =
-                                let uu____19167 =
+                        let uu____19177 =
+                          let uu____19186 = inst_tscheme_with (uvs, k) us  in
+                          (uu____19186, rng)  in
+                        FStar_Pervasives_Native.Some uu____19177
+                    | uu____19207 ->
+                        let uu____19208 =
+                          let uu____19217 =
+                            let uu____19222 =
+                              let uu____19223 =
+                                let uu____19226 =
                                   FStar_Syntax_Syntax.mk_Total k  in
-                                FStar_Syntax_Util.flat_arrow tps uu____19167
+                                FStar_Syntax_Util.flat_arrow tps uu____19226
                                  in
-                              (uvs, uu____19164)  in
-                            inst_tscheme_with uu____19163 us  in
-                          (uu____19158, rng)  in
-                        FStar_Pervasives_Native.Some uu____19149)
+                              (uvs, uu____19223)  in
+                            inst_tscheme_with uu____19222 us  in
+                          (uu____19217, rng)  in
+                        FStar_Pervasives_Native.Some uu____19208)
                | FStar_Util.Inr se ->
-                   let uu____19203 =
+                   let uu____19262 =
                      match se with
                      | ({
                           FStar_Syntax_Syntax.sigel =
-                            FStar_Syntax_Syntax.Sig_let uu____19224;
-                          FStar_Syntax_Syntax.sigrng = uu____19225;
-                          FStar_Syntax_Syntax.sigquals = uu____19226;
-                          FStar_Syntax_Syntax.sigmeta = uu____19227;
-                          FStar_Syntax_Syntax.sigattrs = uu____19228;
-                          FStar_Syntax_Syntax.sigopts = uu____19229;_},FStar_Pervasives_Native.None
+                            FStar_Syntax_Syntax.Sig_let uu____19283;
+                          FStar_Syntax_Syntax.sigrng = uu____19284;
+                          FStar_Syntax_Syntax.sigquals = uu____19285;
+                          FStar_Syntax_Syntax.sigmeta = uu____19286;
+                          FStar_Syntax_Syntax.sigattrs = uu____19287;
+                          FStar_Syntax_Syntax.sigopts = uu____19288;_},FStar_Pervasives_Native.None
                         ) ->
                          lookup_type_of_let us_opt
                            (FStar_Pervasives_Native.fst se) lid
-                     | uu____19246 ->
+                     | uu____19305 ->
                          effect_signature us_opt
                            (FStar_Pervasives_Native.fst se) env1.range
                       in
-                   FStar_All.pipe_right uu____19203
+                   FStar_All.pipe_right uu____19262
                      (FStar_Util.map_option
-                        (fun uu____19294  ->
-                           match uu____19294 with
+                        (fun uu____19353  ->
+                           match uu____19353 with
                            | (us_t,rng1) -> (us_t, rng1))))
            in
-        let uu____19325 =
-          let uu____19336 = lookup_qname env1 lid  in
-          FStar_Util.bind_opt uu____19336 mapper  in
-        match uu____19325 with
+        let uu____19384 =
+          let uu____19395 = lookup_qname env1 lid  in
+          FStar_Util.bind_opt uu____19395 mapper  in
+        match uu____19384 with
         | FStar_Pervasives_Native.Some ((us,t),r) ->
-            let uu____19410 =
-              let uu____19421 =
-                let uu____19428 =
-                  let uu___858_19431 = t  in
-                  let uu____19432 = FStar_Ident.range_of_lid lid  in
+            let uu____19469 =
+              let uu____19480 =
+                let uu____19487 =
+                  let uu___858_19490 = t  in
+                  let uu____19491 = FStar_Ident.range_of_lid lid  in
                   {
                     FStar_Syntax_Syntax.n =
-                      (uu___858_19431.FStar_Syntax_Syntax.n);
-                    FStar_Syntax_Syntax.pos = uu____19432;
+                      (uu___858_19490.FStar_Syntax_Syntax.n);
+                    FStar_Syntax_Syntax.pos = uu____19491;
                     FStar_Syntax_Syntax.vars =
-                      (uu___858_19431.FStar_Syntax_Syntax.vars)
+                      (uu___858_19490.FStar_Syntax_Syntax.vars)
                   }  in
-                (us, uu____19428)  in
-              (uu____19421, r)  in
-            FStar_Pervasives_Native.Some uu____19410
+                (us, uu____19487)  in
+              (uu____19480, r)  in
+            FStar_Pervasives_Native.Some uu____19469
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
   
 let (lid_exists : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
     fun l  ->
-      let uu____19481 = lookup_qname env1 l  in
-      match uu____19481 with
+      let uu____19540 = lookup_qname env1 l  in
+      match uu____19540 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some uu____19502 -> true
+      | FStar_Pervasives_Native.Some uu____19561 -> true
   
 let (lookup_bv :
   env ->
@@ -2899,17 +2928,17 @@ let (lookup_bv :
   fun env1  ->
     fun bv  ->
       let bvr = FStar_Syntax_Syntax.range_of_bv bv  in
-      let uu____19556 = try_lookup_bv env1 bv  in
-      match uu____19556 with
+      let uu____19615 = try_lookup_bv env1 bv  in
+      match uu____19615 with
       | FStar_Pervasives_Native.None  ->
-          let uu____19571 = variable_not_found bv  in
-          FStar_Errors.raise_error uu____19571 bvr
+          let uu____19630 = variable_not_found bv  in
+          FStar_Errors.raise_error uu____19630 bvr
       | FStar_Pervasives_Native.Some (t,r) ->
-          let uu____19587 = FStar_Syntax_Subst.set_use_range bvr t  in
-          let uu____19588 =
-            let uu____19589 = FStar_Range.use_range bvr  in
-            FStar_Range.set_use_range r uu____19589  in
-          (uu____19587, uu____19588)
+          let uu____19646 = FStar_Syntax_Subst.set_use_range bvr t  in
+          let uu____19647 =
+            let uu____19648 = FStar_Range.use_range bvr  in
+            FStar_Range.set_use_range r uu____19648  in
+          (uu____19646, uu____19647)
   
 let (try_lookup_lid :
   env ->
@@ -2919,22 +2948,22 @@ let (try_lookup_lid :
   =
   fun env1  ->
     fun l  ->
-      let uu____19611 =
+      let uu____19670 =
         try_lookup_lid_aux FStar_Pervasives_Native.None env1 l  in
-      match uu____19611 with
+      match uu____19670 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some ((us,t),r) ->
           let use_range = FStar_Ident.range_of_lid l  in
           let r1 =
-            let uu____19677 = FStar_Range.use_range use_range  in
-            FStar_Range.set_use_range r uu____19677  in
-          let uu____19678 =
-            let uu____19687 =
-              let uu____19692 = FStar_Syntax_Subst.set_use_range use_range t
+            let uu____19736 = FStar_Range.use_range use_range  in
+            FStar_Range.set_use_range r uu____19736  in
+          let uu____19737 =
+            let uu____19746 =
+              let uu____19751 = FStar_Syntax_Subst.set_use_range use_range t
                  in
-              (us, uu____19692)  in
-            (uu____19687, r1)  in
-          FStar_Pervasives_Native.Some uu____19678
+              (us, uu____19751)  in
+            (uu____19746, r1)  in
+          FStar_Pervasives_Native.Some uu____19737
   
 let (try_lookup_and_inst_lid :
   env ->
@@ -2946,20 +2975,20 @@ let (try_lookup_and_inst_lid :
   fun env1  ->
     fun us  ->
       fun l  ->
-        let uu____19727 =
+        let uu____19786 =
           try_lookup_lid_aux (FStar_Pervasives_Native.Some us) env1 l  in
-        match uu____19727 with
+        match uu____19786 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some ((uu____19760,t),r) ->
+        | FStar_Pervasives_Native.Some ((uu____19819,t),r) ->
             let use_range = FStar_Ident.range_of_lid l  in
             let r1 =
-              let uu____19785 = FStar_Range.use_range use_range  in
-              FStar_Range.set_use_range r uu____19785  in
-            let uu____19786 =
-              let uu____19791 = FStar_Syntax_Subst.set_use_range use_range t
+              let uu____19844 = FStar_Range.use_range use_range  in
+              FStar_Range.set_use_range r uu____19844  in
+            let uu____19845 =
+              let uu____19850 = FStar_Syntax_Subst.set_use_range use_range t
                  in
-              (uu____19791, r1)  in
-            FStar_Pervasives_Native.Some uu____19786
+              (uu____19850, r1)  in
+            FStar_Pervasives_Native.Some uu____19845
   
 let (lookup_lid :
   env ->
@@ -2969,12 +2998,12 @@ let (lookup_lid :
   =
   fun env1  ->
     fun l  ->
-      let uu____19815 = try_lookup_lid env1 l  in
-      match uu____19815 with
+      let uu____19874 = try_lookup_lid env1 l  in
+      match uu____19874 with
       | FStar_Pervasives_Native.None  ->
-          let uu____19842 = name_not_found l  in
-          let uu____19848 = FStar_Ident.range_of_lid l  in
-          FStar_Errors.raise_error uu____19842 uu____19848
+          let uu____19901 = name_not_found l  in
+          let uu____19907 = FStar_Ident.range_of_lid l  in
+          FStar_Errors.raise_error uu____19901 uu____19907
       | FStar_Pervasives_Native.Some v -> v
   
 let (lookup_univ : env -> FStar_Syntax_Syntax.univ_name -> Prims.bool) =
@@ -2982,11 +3011,13 @@ let (lookup_univ : env -> FStar_Syntax_Syntax.univ_name -> Prims.bool) =
     fun x  ->
       FStar_All.pipe_right
         (FStar_List.find
-           (fun uu___5_19891  ->
-              match uu___5_19891 with
+           (fun uu___5_19952  ->
+              match uu___5_19952 with
               | FStar_Syntax_Syntax.Binding_univ y ->
-                  x.FStar_Ident.idText = y.FStar_Ident.idText
-              | uu____19895 -> false) env1.gamma) FStar_Option.isSome
+                  let uu____19955 = FStar_Ident.text_of_id x  in
+                  let uu____19957 = FStar_Ident.text_of_id y  in
+                  uu____19955 = uu____19957
+              | uu____19960 -> false) env1.gamma) FStar_Option.isSome
   
 let (try_lookup_val_decl :
   env ->
@@ -2996,29 +3027,29 @@ let (try_lookup_val_decl :
   =
   fun env1  ->
     fun lid  ->
-      let uu____19916 = lookup_qname env1 lid  in
-      match uu____19916 with
+      let uu____19981 = lookup_qname env1 lid  in
+      match uu____19981 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____19925,uvs,t);
-              FStar_Syntax_Syntax.sigrng = uu____19928;
+                (uu____19990,uvs,t);
+              FStar_Syntax_Syntax.sigrng = uu____19993;
               FStar_Syntax_Syntax.sigquals = q;
-              FStar_Syntax_Syntax.sigmeta = uu____19930;
-              FStar_Syntax_Syntax.sigattrs = uu____19931;
-              FStar_Syntax_Syntax.sigopts = uu____19932;_},FStar_Pervasives_Native.None
-            ),uu____19933)
+              FStar_Syntax_Syntax.sigmeta = uu____19995;
+              FStar_Syntax_Syntax.sigattrs = uu____19996;
+              FStar_Syntax_Syntax.sigopts = uu____19997;_},FStar_Pervasives_Native.None
+            ),uu____19998)
           ->
-          let uu____19984 =
-            let uu____19991 =
-              let uu____19992 =
-                let uu____19995 = FStar_Ident.range_of_lid lid  in
-                FStar_Syntax_Subst.set_use_range uu____19995 t  in
-              (uvs, uu____19992)  in
-            (uu____19991, q)  in
-          FStar_Pervasives_Native.Some uu____19984
-      | uu____20008 -> FStar_Pervasives_Native.None
+          let uu____20049 =
+            let uu____20056 =
+              let uu____20057 =
+                let uu____20060 = FStar_Ident.range_of_lid lid  in
+                FStar_Syntax_Subst.set_use_range uu____20060 t  in
+              (uvs, uu____20057)  in
+            (uu____20056, q)  in
+          FStar_Pervasives_Native.Some uu____20049
+      | uu____20073 -> FStar_Pervasives_Native.None
   
 let (lookup_val_decl :
   env ->
@@ -3027,26 +3058,26 @@ let (lookup_val_decl :
   =
   fun env1  ->
     fun lid  ->
-      let uu____20030 = lookup_qname env1 lid  in
-      match uu____20030 with
+      let uu____20095 = lookup_qname env1 lid  in
+      match uu____20095 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____20035,uvs,t);
-              FStar_Syntax_Syntax.sigrng = uu____20038;
-              FStar_Syntax_Syntax.sigquals = uu____20039;
-              FStar_Syntax_Syntax.sigmeta = uu____20040;
-              FStar_Syntax_Syntax.sigattrs = uu____20041;
-              FStar_Syntax_Syntax.sigopts = uu____20042;_},FStar_Pervasives_Native.None
-            ),uu____20043)
+                (uu____20100,uvs,t);
+              FStar_Syntax_Syntax.sigrng = uu____20103;
+              FStar_Syntax_Syntax.sigquals = uu____20104;
+              FStar_Syntax_Syntax.sigmeta = uu____20105;
+              FStar_Syntax_Syntax.sigattrs = uu____20106;
+              FStar_Syntax_Syntax.sigopts = uu____20107;_},FStar_Pervasives_Native.None
+            ),uu____20108)
           ->
-          let uu____20094 = FStar_Ident.range_of_lid lid  in
-          inst_tscheme_with_range uu____20094 (uvs, t)
-      | uu____20099 ->
-          let uu____20100 = name_not_found lid  in
-          let uu____20106 = FStar_Ident.range_of_lid lid  in
-          FStar_Errors.raise_error uu____20100 uu____20106
+          let uu____20159 = FStar_Ident.range_of_lid lid  in
+          inst_tscheme_with_range uu____20159 (uvs, t)
+      | uu____20164 ->
+          let uu____20165 = name_not_found lid  in
+          let uu____20171 = FStar_Ident.range_of_lid lid  in
+          FStar_Errors.raise_error uu____20165 uu____20171
   
 let (lookup_datacon :
   env ->
@@ -3055,69 +3086,69 @@ let (lookup_datacon :
   =
   fun env1  ->
     fun lid  ->
-      let uu____20126 = lookup_qname env1 lid  in
-      match uu____20126 with
+      let uu____20191 = lookup_qname env1 lid  in
+      match uu____20191 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____20131,uvs,t,uu____20134,uu____20135,uu____20136);
-              FStar_Syntax_Syntax.sigrng = uu____20137;
-              FStar_Syntax_Syntax.sigquals = uu____20138;
-              FStar_Syntax_Syntax.sigmeta = uu____20139;
-              FStar_Syntax_Syntax.sigattrs = uu____20140;
-              FStar_Syntax_Syntax.sigopts = uu____20141;_},FStar_Pervasives_Native.None
-            ),uu____20142)
+                (uu____20196,uvs,t,uu____20199,uu____20200,uu____20201);
+              FStar_Syntax_Syntax.sigrng = uu____20202;
+              FStar_Syntax_Syntax.sigquals = uu____20203;
+              FStar_Syntax_Syntax.sigmeta = uu____20204;
+              FStar_Syntax_Syntax.sigattrs = uu____20205;
+              FStar_Syntax_Syntax.sigopts = uu____20206;_},FStar_Pervasives_Native.None
+            ),uu____20207)
           ->
-          let uu____20199 = FStar_Ident.range_of_lid lid  in
-          inst_tscheme_with_range uu____20199 (uvs, t)
-      | uu____20204 ->
-          let uu____20205 = name_not_found lid  in
-          let uu____20211 = FStar_Ident.range_of_lid lid  in
-          FStar_Errors.raise_error uu____20205 uu____20211
+          let uu____20264 = FStar_Ident.range_of_lid lid  in
+          inst_tscheme_with_range uu____20264 (uvs, t)
+      | uu____20269 ->
+          let uu____20270 = name_not_found lid  in
+          let uu____20276 = FStar_Ident.range_of_lid lid  in
+          FStar_Errors.raise_error uu____20270 uu____20276
   
 let (datacons_of_typ :
   env -> FStar_Ident.lident -> (Prims.bool * FStar_Ident.lident Prims.list))
   =
   fun env1  ->
     fun lid  ->
-      let uu____20234 = lookup_qname env1 lid  in
-      match uu____20234 with
+      let uu____20299 = lookup_qname env1 lid  in
+      match uu____20299 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____20242,uu____20243,uu____20244,uu____20245,uu____20246,dcs);
-              FStar_Syntax_Syntax.sigrng = uu____20248;
-              FStar_Syntax_Syntax.sigquals = uu____20249;
-              FStar_Syntax_Syntax.sigmeta = uu____20250;
-              FStar_Syntax_Syntax.sigattrs = uu____20251;
-              FStar_Syntax_Syntax.sigopts = uu____20252;_},uu____20253),uu____20254)
+                (uu____20307,uu____20308,uu____20309,uu____20310,uu____20311,dcs);
+              FStar_Syntax_Syntax.sigrng = uu____20313;
+              FStar_Syntax_Syntax.sigquals = uu____20314;
+              FStar_Syntax_Syntax.sigmeta = uu____20315;
+              FStar_Syntax_Syntax.sigattrs = uu____20316;
+              FStar_Syntax_Syntax.sigopts = uu____20317;_},uu____20318),uu____20319)
           -> (true, dcs)
-      | uu____20319 -> (false, [])
+      | uu____20384 -> (false, [])
   
 let (typ_of_datacon : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env1  ->
     fun lid  ->
-      let uu____20335 = lookup_qname env1 lid  in
-      match uu____20335 with
+      let uu____20400 = lookup_qname env1 lid  in
+      match uu____20400 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____20336,uu____20337,uu____20338,l,uu____20340,uu____20341);
-              FStar_Syntax_Syntax.sigrng = uu____20342;
-              FStar_Syntax_Syntax.sigquals = uu____20343;
-              FStar_Syntax_Syntax.sigmeta = uu____20344;
-              FStar_Syntax_Syntax.sigattrs = uu____20345;
-              FStar_Syntax_Syntax.sigopts = uu____20346;_},uu____20347),uu____20348)
+                (uu____20401,uu____20402,uu____20403,l,uu____20405,uu____20406);
+              FStar_Syntax_Syntax.sigrng = uu____20407;
+              FStar_Syntax_Syntax.sigquals = uu____20408;
+              FStar_Syntax_Syntax.sigmeta = uu____20409;
+              FStar_Syntax_Syntax.sigattrs = uu____20410;
+              FStar_Syntax_Syntax.sigopts = uu____20411;_},uu____20412),uu____20413)
           -> l
-      | uu____20407 ->
-          let uu____20408 =
-            let uu____20410 = FStar_Syntax_Print.lid_to_string lid  in
-            FStar_Util.format1 "Not a datacon: %s" uu____20410  in
-          failwith uu____20408
+      | uu____20472 ->
+          let uu____20473 =
+            let uu____20475 = FStar_Syntax_Print.lid_to_string lid  in
+            FStar_Util.format1 "Not a datacon: %s" uu____20475  in
+          failwith uu____20473
   
 let (lookup_definition_qninfo_aux :
   Prims.bool ->
@@ -3141,10 +3172,10 @@ let (lookup_definition_qninfo_aux :
              in
           match qninfo1 with
           | FStar_Pervasives_Native.Some
-              (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____20480)
+              (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____20545)
               ->
               (match se.FStar_Syntax_Syntax.sigel with
-               | FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),uu____20537) when
+               | FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),uu____20602) when
                    (visible se.FStar_Syntax_Syntax.sigquals) &&
                      ((Prims.op_Negation is_rec) || rec_ok)
                    ->
@@ -3152,16 +3183,16 @@ let (lookup_definition_qninfo_aux :
                      (fun lb  ->
                         let fv =
                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-                        let uu____20561 =
+                        let uu____20626 =
                           FStar_Syntax_Syntax.fv_eq_lid fv lid  in
-                        if uu____20561
+                        if uu____20626
                         then
                           FStar_Pervasives_Native.Some
                             ((lb.FStar_Syntax_Syntax.lbunivs),
                               (lb.FStar_Syntax_Syntax.lbdef))
                         else FStar_Pervasives_Native.None)
-               | uu____20596 -> FStar_Pervasives_Native.None)
-          | uu____20605 -> FStar_Pervasives_Native.None
+               | uu____20661 -> FStar_Pervasives_Native.None)
+          | uu____20670 -> FStar_Pervasives_Native.None
   
 let (lookup_definition_qninfo :
   delta_level Prims.list ->
@@ -3185,9 +3216,9 @@ let (lookup_definition :
   fun delta_levels  ->
     fun env1  ->
       fun lid  ->
-        let uu____20667 = lookup_qname env1 lid  in
+        let uu____20732 = lookup_qname env1 lid  in
         FStar_All.pipe_left (lookup_definition_qninfo delta_levels lid)
-          uu____20667
+          uu____20732
   
 let (lookup_nonrec_definition :
   delta_level Prims.list ->
@@ -3199,9 +3230,9 @@ let (lookup_nonrec_definition :
   fun delta_levels  ->
     fun env1  ->
       fun lid  ->
-        let uu____20700 = lookup_qname env1 lid  in
+        let uu____20765 = lookup_qname env1 lid  in
         FStar_All.pipe_left
-          (lookup_definition_qninfo_aux false delta_levels lid) uu____20700
+          (lookup_definition_qninfo_aux false delta_levels lid) uu____20765
   
 let (delta_depth_of_qninfo :
   FStar_Syntax_Syntax.fv ->
@@ -3210,7 +3241,9 @@ let (delta_depth_of_qninfo :
   fun fv  ->
     fun qn  ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-      if lid.FStar_Ident.nsstr = "Prims"
+      let uu____20789 =
+        let uu____20791 = FStar_Ident.nsstr lid  in uu____20791 = "Prims"  in
+      if uu____20789
       then FStar_Pervasives_Native.Some (fv.FStar_Syntax_Syntax.fv_delta)
       else
         (match qn with
@@ -3218,60 +3251,60 @@ let (delta_depth_of_qninfo :
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_zero)
          | FStar_Pervasives_Native.Some
-             (FStar_Util.Inl uu____20752,uu____20753) ->
+             (FStar_Util.Inl uu____20821,uu____20822) ->
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_zero)
          | FStar_Pervasives_Native.Some
-             (FStar_Util.Inr (se,uu____20802),uu____20803) ->
+             (FStar_Util.Inr (se,uu____20871),uu____20872) ->
              (match se.FStar_Syntax_Syntax.sigel with
-              | FStar_Syntax_Syntax.Sig_inductive_typ uu____20852 ->
+              | FStar_Syntax_Syntax.Sig_inductive_typ uu____20921 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_bundle uu____20870 ->
+              | FStar_Syntax_Syntax.Sig_bundle uu____20939 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_datacon uu____20880 ->
+              | FStar_Syntax_Syntax.Sig_datacon uu____20949 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_declare_typ uu____20897 ->
-                  let uu____20904 =
+              | FStar_Syntax_Syntax.Sig_declare_typ uu____20966 ->
+                  let uu____20973 =
                     FStar_Syntax_DsEnv.delta_depth_of_declaration lid
                       se.FStar_Syntax_Syntax.sigquals
                      in
-                  FStar_Pervasives_Native.Some uu____20904
-              | FStar_Syntax_Syntax.Sig_let ((uu____20905,lbs),uu____20907)
+                  FStar_Pervasives_Native.Some uu____20973
+              | FStar_Syntax_Syntax.Sig_let ((uu____20974,lbs),uu____20976)
                   ->
                   FStar_Util.find_map lbs
                     (fun lb  ->
                        let fv1 =
                          FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-                       let uu____20923 =
+                       let uu____20992 =
                          FStar_Syntax_Syntax.fv_eq_lid fv1 lid  in
-                       if uu____20923
+                       if uu____20992
                        then
                          FStar_Pervasives_Native.Some
                            (fv1.FStar_Syntax_Syntax.fv_delta)
                        else FStar_Pervasives_Native.None)
-              | FStar_Syntax_Syntax.Sig_fail uu____20930 ->
+              | FStar_Syntax_Syntax.Sig_fail uu____20999 ->
                   failwith "impossible: delta_depth_of_qninfo"
-              | FStar_Syntax_Syntax.Sig_splice uu____20946 ->
+              | FStar_Syntax_Syntax.Sig_splice uu____21015 ->
                   failwith "impossible: delta_depth_of_qninfo"
-              | FStar_Syntax_Syntax.Sig_main uu____20956 ->
+              | FStar_Syntax_Syntax.Sig_main uu____21025 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_assume uu____20957 ->
+              | FStar_Syntax_Syntax.Sig_assume uu____21026 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_new_effect uu____20964 ->
+              | FStar_Syntax_Syntax.Sig_new_effect uu____21033 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_sub_effect uu____20965 ->
+              | FStar_Syntax_Syntax.Sig_sub_effect uu____21034 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_effect_abbrev uu____20966 ->
+              | FStar_Syntax_Syntax.Sig_effect_abbrev uu____21035 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_pragma uu____20979 ->
+              | FStar_Syntax_Syntax.Sig_pragma uu____21048 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____20980 ->
+              | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____21049 ->
                   FStar_Pervasives_Native.None))
   
 let (delta_depth_of_fv :
@@ -3279,56 +3312,59 @@ let (delta_depth_of_fv :
   fun env1  ->
     fun fv  ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-      if lid.FStar_Ident.nsstr = "Prims"
+      let uu____21072 =
+        let uu____21074 = FStar_Ident.nsstr lid  in uu____21074 = "Prims"  in
+      if uu____21072
       then fv.FStar_Syntax_Syntax.fv_delta
       else
-        (let uu____21008 =
-           FStar_All.pipe_right lid.FStar_Ident.str
+        (let uu____21081 =
+           let uu____21084 = FStar_Ident.string_of_lid lid  in
+           FStar_All.pipe_right uu____21084
              (FStar_Util.smap_try_find env1.fv_delta_depths)
             in
-         FStar_All.pipe_right uu____21008
+         FStar_All.pipe_right uu____21081
            (fun d_opt  ->
-              let uu____21021 = FStar_All.pipe_right d_opt FStar_Util.is_some
+              let uu____21096 = FStar_All.pipe_right d_opt FStar_Util.is_some
                  in
-              if uu____21021
+              if uu____21096
               then FStar_All.pipe_right d_opt FStar_Util.must
               else
-                (let uu____21031 =
-                   let uu____21034 =
+                (let uu____21106 =
+                   let uu____21109 =
                      lookup_qname env1
                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                       in
-                   delta_depth_of_qninfo fv uu____21034  in
-                 match uu____21031 with
+                   delta_depth_of_qninfo fv uu____21109  in
+                 match uu____21106 with
                  | FStar_Pervasives_Native.None  ->
-                     let uu____21035 =
-                       let uu____21037 = FStar_Syntax_Print.fv_to_string fv
+                     let uu____21110 =
+                       let uu____21112 = FStar_Syntax_Print.fv_to_string fv
                           in
                        FStar_Util.format1 "Delta depth not found for %s"
-                         uu____21037
+                         uu____21112
                         in
-                     failwith uu____21035
+                     failwith uu____21110
                  | FStar_Pervasives_Native.Some d ->
-                     ((let uu____21042 =
+                     ((let uu____21117 =
                          (d <> fv.FStar_Syntax_Syntax.fv_delta) &&
                            (FStar_Options.debug_any ())
                           in
-                       if uu____21042
+                       if uu____21117
                        then
-                         let uu____21045 = FStar_Syntax_Print.fv_to_string fv
+                         let uu____21120 = FStar_Syntax_Print.fv_to_string fv
                             in
-                         let uu____21047 =
+                         let uu____21122 =
                            FStar_Syntax_Print.delta_depth_to_string
                              fv.FStar_Syntax_Syntax.fv_delta
                             in
-                         let uu____21049 =
+                         let uu____21124 =
                            FStar_Syntax_Print.delta_depth_to_string d  in
                          FStar_Util.print3
                            "WARNING WARNING WARNING fv=%s, delta_depth=%s, env.delta_depth=%s\n"
-                           uu____21045 uu____21047 uu____21049
+                           uu____21120 uu____21122 uu____21124
                        else ());
-                      FStar_Util.smap_add env1.fv_delta_depths
-                        lid.FStar_Ident.str d;
+                      (let uu____21130 = FStar_Ident.string_of_lid lid  in
+                       FStar_Util.smap_add env1.fv_delta_depths uu____21130 d);
                       d))))
   
 let (quals_of_qninfo :
@@ -3338,9 +3374,9 @@ let (quals_of_qninfo :
   fun qninfo1  ->
     match qninfo1 with
     | FStar_Pervasives_Native.Some
-        (FStar_Util.Inr (se,uu____21074),uu____21075) ->
+        (FStar_Util.Inr (se,uu____21151),uu____21152) ->
         FStar_Pervasives_Native.Some (se.FStar_Syntax_Syntax.sigquals)
-    | uu____21124 -> FStar_Pervasives_Native.None
+    | uu____21201 -> FStar_Pervasives_Native.None
   
 let (attrs_of_qninfo :
   qninfo ->
@@ -3349,9 +3385,9 @@ let (attrs_of_qninfo :
   fun qninfo1  ->
     match qninfo1 with
     | FStar_Pervasives_Native.Some
-        (FStar_Util.Inr (se,uu____21146),uu____21147) ->
+        (FStar_Util.Inr (se,uu____21223),uu____21224) ->
         FStar_Pervasives_Native.Some (se.FStar_Syntax_Syntax.sigattrs)
-    | uu____21196 -> FStar_Pervasives_Native.None
+    | uu____21273 -> FStar_Pervasives_Native.None
   
 let (lookup_attrs_of_lid :
   env ->
@@ -3360,8 +3396,8 @@ let (lookup_attrs_of_lid :
   =
   fun env1  ->
     fun lid  ->
-      let uu____21218 = lookup_qname env1 lid  in
-      FStar_All.pipe_left attrs_of_qninfo uu____21218
+      let uu____21295 = lookup_qname env1 lid  in
+      FStar_All.pipe_left attrs_of_qninfo uu____21295
   
 let (fv_exists_and_has_attr :
   env -> FStar_Ident.lid -> FStar_Ident.lident -> (Prims.bool * Prims.bool))
@@ -3369,31 +3405,31 @@ let (fv_exists_and_has_attr :
   fun env1  ->
     fun fv_lid  ->
       fun attr_lid  ->
-        let uu____21251 = lookup_attrs_of_lid env1 fv_lid  in
-        match uu____21251 with
+        let uu____21328 = lookup_attrs_of_lid env1 fv_lid  in
+        match uu____21328 with
         | FStar_Pervasives_Native.None  -> (false, false)
         | FStar_Pervasives_Native.Some attrs ->
-            let uu____21273 =
+            let uu____21350 =
               FStar_All.pipe_right attrs
                 (FStar_Util.for_some
                    (fun tm  ->
-                      let uu____21282 =
-                        let uu____21283 = FStar_Syntax_Util.un_uinst tm  in
-                        uu____21283.FStar_Syntax_Syntax.n  in
-                      match uu____21282 with
+                      let uu____21359 =
+                        let uu____21360 = FStar_Syntax_Util.un_uinst tm  in
+                        uu____21360.FStar_Syntax_Syntax.n  in
+                      match uu____21359 with
                       | FStar_Syntax_Syntax.Tm_fvar fv ->
                           FStar_Syntax_Syntax.fv_eq_lid fv attr_lid
-                      | uu____21288 -> false))
+                      | uu____21365 -> false))
                in
-            (true, uu____21273)
+            (true, uu____21350)
   
 let (fv_with_lid_has_attr :
   env -> FStar_Ident.lid -> FStar_Ident.lid -> Prims.bool) =
   fun env1  ->
     fun fv_lid  ->
       fun attr_lid  ->
-        let uu____21311 = fv_exists_and_has_attr env1 fv_lid attr_lid  in
-        FStar_Pervasives_Native.snd uu____21311
+        let uu____21388 = fv_exists_and_has_attr env1 fv_lid attr_lid  in
+        FStar_Pervasives_Native.snd uu____21388
   
 let (fv_has_attr :
   env -> FStar_Syntax_Syntax.fv -> FStar_Ident.lid -> Prims.bool) =
@@ -3412,13 +3448,13 @@ let cache_in_fv_tab :
     fun fv  ->
       fun f  ->
         let s =
-          let uu____21383 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          uu____21383.FStar_Ident.str  in
-        let uu____21384 = FStar_Util.smap_try_find tab s  in
-        match uu____21384 with
+          let uu____21460 = FStar_Syntax_Syntax.lid_of_fv fv  in
+          FStar_Ident.string_of_lid uu____21460  in
+        let uu____21461 = FStar_Util.smap_try_find tab s  in
+        match uu____21461 with
         | FStar_Pervasives_Native.None  ->
-            let uu____21387 = f ()  in
-            (match uu____21387 with
+            let uu____21464 = f ()  in
+            (match uu____21464 with
              | (should_cache,res) ->
                  (if should_cache then FStar_Util.smap_add tab s res else ();
                   res))
@@ -3427,37 +3463,37 @@ let cache_in_fv_tab :
 let (type_is_erasable : env -> FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun env1  ->
     fun fv  ->
-      let f uu____21425 =
-        let uu____21426 =
+      let f uu____21502 =
+        let uu____21503 =
           fv_exists_and_has_attr env1
             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
             FStar_Parser_Const.erasable_attr
            in
-        match uu____21426 with | (ex,erasable) -> (ex, erasable)  in
+        match uu____21503 with | (ex,erasable) -> (ex, erasable)  in
       cache_in_fv_tab env1.erasable_types_tab fv f
   
 let rec (non_informative : env -> FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun env1  ->
     fun t  ->
-      let uu____21460 =
-        let uu____21461 = FStar_Syntax_Util.unrefine t  in
-        uu____21461.FStar_Syntax_Syntax.n  in
-      match uu____21460 with
-      | FStar_Syntax_Syntax.Tm_type uu____21465 -> true
+      let uu____21537 =
+        let uu____21538 = FStar_Syntax_Util.unrefine t  in
+        uu____21538.FStar_Syntax_Syntax.n  in
+      match uu____21537 with
+      | FStar_Syntax_Syntax.Tm_type uu____21542 -> true
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           (((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.unit_lid) ||
               (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid))
              ||
              (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.erased_lid))
             || (type_is_erasable env1 fv)
-      | FStar_Syntax_Syntax.Tm_app (head,uu____21469) ->
+      | FStar_Syntax_Syntax.Tm_app (head,uu____21546) ->
           non_informative env1 head
-      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____21495) ->
+      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____21572) ->
           non_informative env1 t1
-      | FStar_Syntax_Syntax.Tm_arrow (uu____21500,c) ->
+      | FStar_Syntax_Syntax.Tm_arrow (uu____21577,c) ->
           (FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
             (non_informative env1 (FStar_Syntax_Util.comp_result c))
-      | uu____21522 -> false
+      | uu____21599 -> false
   
 let (fv_has_strict_args :
   env ->
@@ -3466,10 +3502,10 @@ let (fv_has_strict_args :
   =
   fun env1  ->
     fun fv  ->
-      let f uu____21555 =
+      let f uu____21632 =
         let attrs =
-          let uu____21561 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          lookup_attrs_of_lid env1 uu____21561  in
+          let uu____21638 = FStar_Syntax_Syntax.lid_of_fv fv  in
+          lookup_attrs_of_lid env1 uu____21638  in
         match attrs with
         | FStar_Pervasives_Native.None  ->
             (false, FStar_Pervasives_Native.None)
@@ -3477,11 +3513,11 @@ let (fv_has_strict_args :
             let res =
               FStar_Util.find_map attrs1
                 (fun x  ->
-                   let uu____21601 =
+                   let uu____21678 =
                      FStar_ToSyntax_ToSyntax.parse_attr_with_list false x
                        FStar_Parser_Const.strict_on_arguments_attr
                       in
-                   FStar_Pervasives_Native.fst uu____21601)
+                   FStar_Pervasives_Native.fst uu____21678)
                in
             (true, res)
          in
@@ -3494,31 +3530,31 @@ let (try_lookup_effect_lid :
   =
   fun env1  ->
     fun ftv  ->
-      let uu____21646 = lookup_qname env1 ftv  in
-      match uu____21646 with
+      let uu____21723 = lookup_qname env1 ftv  in
+      match uu____21723 with
       | FStar_Pervasives_Native.Some
-          (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____21650) ->
-          let uu____21695 =
+          (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____21727) ->
+          let uu____21772 =
             effect_signature FStar_Pervasives_Native.None se env1.range  in
-          (match uu____21695 with
+          (match uu____21772 with
            | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-           | FStar_Pervasives_Native.Some ((uu____21716,t),r) ->
-               let uu____21731 =
-                 let uu____21732 = FStar_Ident.range_of_lid ftv  in
-                 FStar_Syntax_Subst.set_use_range uu____21732 t  in
-               FStar_Pervasives_Native.Some uu____21731)
-      | uu____21733 -> FStar_Pervasives_Native.None
+           | FStar_Pervasives_Native.Some ((uu____21793,t),r) ->
+               let uu____21808 =
+                 let uu____21809 = FStar_Ident.range_of_lid ftv  in
+                 FStar_Syntax_Subst.set_use_range uu____21809 t  in
+               FStar_Pervasives_Native.Some uu____21808)
+      | uu____21810 -> FStar_Pervasives_Native.None
   
 let (lookup_effect_lid :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun env1  ->
     fun ftv  ->
-      let uu____21745 = try_lookup_effect_lid env1 ftv  in
-      match uu____21745 with
+      let uu____21822 = try_lookup_effect_lid env1 ftv  in
+      match uu____21822 with
       | FStar_Pervasives_Native.None  ->
-          let uu____21748 = name_not_found ftv  in
-          let uu____21754 = FStar_Ident.range_of_lid ftv  in
-          FStar_Errors.raise_error uu____21748 uu____21754
+          let uu____21825 = name_not_found ftv  in
+          let uu____21831 = FStar_Ident.range_of_lid ftv  in
+          FStar_Errors.raise_error uu____21825 uu____21831
       | FStar_Pervasives_Native.Some k -> k
   
 let (lookup_effect_abbrev :
@@ -3531,38 +3567,38 @@ let (lookup_effect_abbrev :
   fun env1  ->
     fun univ_insts  ->
       fun lid0  ->
-        let uu____21778 = lookup_qname env1 lid0  in
-        match uu____21778 with
+        let uu____21855 = lookup_qname env1 lid0  in
+        match uu____21855 with
         | FStar_Pervasives_Native.Some
             (FStar_Util.Inr
              ({
                 FStar_Syntax_Syntax.sigel =
                   FStar_Syntax_Syntax.Sig_effect_abbrev
-                  (lid,univs,binders,c,uu____21789);
-                FStar_Syntax_Syntax.sigrng = uu____21790;
+                  (lid,univs,binders,c,uu____21866);
+                FStar_Syntax_Syntax.sigrng = uu____21867;
                 FStar_Syntax_Syntax.sigquals = quals;
-                FStar_Syntax_Syntax.sigmeta = uu____21792;
-                FStar_Syntax_Syntax.sigattrs = uu____21793;
-                FStar_Syntax_Syntax.sigopts = uu____21794;_},FStar_Pervasives_Native.None
-              ),uu____21795)
+                FStar_Syntax_Syntax.sigmeta = uu____21869;
+                FStar_Syntax_Syntax.sigattrs = uu____21870;
+                FStar_Syntax_Syntax.sigopts = uu____21871;_},FStar_Pervasives_Native.None
+              ),uu____21872)
             ->
             let lid1 =
-              let uu____21851 =
-                let uu____21852 = FStar_Ident.range_of_lid lid  in
-                let uu____21853 =
-                  let uu____21854 = FStar_Ident.range_of_lid lid0  in
-                  FStar_Range.use_range uu____21854  in
-                FStar_Range.set_use_range uu____21852 uu____21853  in
-              FStar_Ident.set_lid_range lid uu____21851  in
-            let uu____21855 =
+              let uu____21928 =
+                let uu____21929 = FStar_Ident.range_of_lid lid  in
+                let uu____21930 =
+                  let uu____21931 = FStar_Ident.range_of_lid lid0  in
+                  FStar_Range.use_range uu____21931  in
+                FStar_Range.set_use_range uu____21929 uu____21930  in
+              FStar_Ident.set_lid_range lid uu____21928  in
+            let uu____21932 =
               FStar_All.pipe_right quals
                 (FStar_Util.for_some
-                   (fun uu___6_21861  ->
-                      match uu___6_21861 with
+                   (fun uu___6_21938  ->
+                      match uu___6_21938 with
                       | FStar_Syntax_Syntax.Irreducible  -> true
-                      | uu____21864 -> false))
+                      | uu____21941 -> false))
                in
-            if uu____21855
+            if uu____21932
             then FStar_Pervasives_Native.None
             else
               (let insts =
@@ -3570,96 +3606,96 @@ let (lookup_effect_abbrev :
                    (FStar_List.length univ_insts) = (FStar_List.length univs)
                  then univ_insts
                  else
-                   (let uu____21883 =
-                      let uu____21885 =
-                        let uu____21887 = get_range env1  in
-                        FStar_Range.string_of_range uu____21887  in
-                      let uu____21888 = FStar_Syntax_Print.lid_to_string lid1
+                   (let uu____21960 =
+                      let uu____21962 =
+                        let uu____21964 = get_range env1  in
+                        FStar_Range.string_of_range uu____21964  in
+                      let uu____21965 = FStar_Syntax_Print.lid_to_string lid1
                          in
-                      let uu____21890 =
+                      let uu____21967 =
                         FStar_All.pipe_right (FStar_List.length univ_insts)
                           FStar_Util.string_of_int
                          in
                       FStar_Util.format3
                         "(%s) Unexpected instantiation of effect %s with %s universes"
-                        uu____21885 uu____21888 uu____21890
+                        uu____21962 uu____21965 uu____21967
                        in
-                    failwith uu____21883)
+                    failwith uu____21960)
                   in
                match (binders, univs) with
-               | ([],uu____21911) ->
+               | ([],uu____21988) ->
                    failwith
                      "Unexpected effect abbreviation with no arguments"
-               | (uu____21937,uu____21938::uu____21939::uu____21940) ->
-                   let uu____21961 =
-                     let uu____21963 = FStar_Syntax_Print.lid_to_string lid1
+               | (uu____22014,uu____22015::uu____22016::uu____22017) ->
+                   let uu____22038 =
+                     let uu____22040 = FStar_Syntax_Print.lid_to_string lid1
                         in
-                     let uu____21965 =
+                     let uu____22042 =
                        FStar_All.pipe_left FStar_Util.string_of_int
                          (FStar_List.length univs)
                         in
                      FStar_Util.format2
                        "Unexpected effect abbreviation %s; polymorphic in %s universes"
-                       uu____21963 uu____21965
+                       uu____22040 uu____22042
                       in
-                   failwith uu____21961
-               | uu____21976 ->
-                   let uu____21991 =
-                     let uu____21996 =
-                       let uu____21997 = FStar_Syntax_Util.arrow binders c
+                   failwith uu____22038
+               | uu____22053 ->
+                   let uu____22068 =
+                     let uu____22073 =
+                       let uu____22074 = FStar_Syntax_Util.arrow binders c
                           in
-                       (univs, uu____21997)  in
-                     inst_tscheme_with uu____21996 insts  in
-                   (match uu____21991 with
-                    | (uu____22010,t) ->
+                       (univs, uu____22074)  in
+                     inst_tscheme_with uu____22073 insts  in
+                   (match uu____22068 with
+                    | (uu____22087,t) ->
                         let t1 =
-                          let uu____22013 = FStar_Ident.range_of_lid lid1  in
-                          FStar_Syntax_Subst.set_use_range uu____22013 t  in
-                        let uu____22014 =
-                          let uu____22015 = FStar_Syntax_Subst.compress t1
+                          let uu____22090 = FStar_Ident.range_of_lid lid1  in
+                          FStar_Syntax_Subst.set_use_range uu____22090 t  in
+                        let uu____22091 =
+                          let uu____22092 = FStar_Syntax_Subst.compress t1
                              in
-                          uu____22015.FStar_Syntax_Syntax.n  in
-                        (match uu____22014 with
+                          uu____22092.FStar_Syntax_Syntax.n  in
+                        (match uu____22091 with
                          | FStar_Syntax_Syntax.Tm_arrow (binders1,c1) ->
                              FStar_Pervasives_Native.Some (binders1, c1)
-                         | uu____22050 -> failwith "Impossible")))
-        | uu____22058 -> FStar_Pervasives_Native.None
+                         | uu____22127 -> failwith "Impossible")))
+        | uu____22135 -> FStar_Pervasives_Native.None
   
 let (norm_eff_name : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env1  ->
     fun l  ->
       let rec find l1 =
-        let uu____22082 =
+        let uu____22159 =
           lookup_effect_abbrev env1 [FStar_Syntax_Syntax.U_unknown] l1  in
-        match uu____22082 with
+        match uu____22159 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some (uu____22095,c) ->
+        | FStar_Pervasives_Native.Some (uu____22172,c) ->
             let l2 = FStar_Syntax_Util.comp_effect_name c  in
-            let uu____22102 = find l2  in
-            (match uu____22102 with
+            let uu____22179 = find l2  in
+            (match uu____22179 with
              | FStar_Pervasives_Native.None  ->
                  FStar_Pervasives_Native.Some l2
              | FStar_Pervasives_Native.Some l' ->
                  FStar_Pervasives_Native.Some l')
          in
       let res =
-        let uu____22109 =
-          FStar_Util.smap_try_find env1.normalized_eff_names
-            l.FStar_Ident.str
-           in
-        match uu____22109 with
+        let uu____22186 =
+          let uu____22189 = FStar_Ident.string_of_lid l  in
+          FStar_Util.smap_try_find env1.normalized_eff_names uu____22189  in
+        match uu____22186 with
         | FStar_Pervasives_Native.Some l1 -> l1
         | FStar_Pervasives_Native.None  ->
-            let uu____22113 = find l  in
-            (match uu____22113 with
+            let uu____22192 = find l  in
+            (match uu____22192 with
              | FStar_Pervasives_Native.None  -> l
              | FStar_Pervasives_Native.Some m ->
-                 (FStar_Util.smap_add env1.normalized_eff_names
-                    l.FStar_Ident.str m;
+                 ((let uu____22197 = FStar_Ident.string_of_lid l  in
+                   FStar_Util.smap_add env1.normalized_eff_names uu____22197
+                     m);
                   m))
          in
-      let uu____22118 = FStar_Ident.range_of_lid l  in
-      FStar_Ident.set_lid_range res uu____22118
+      let uu____22199 = FStar_Ident.range_of_lid l  in
+      FStar_Ident.set_lid_range res uu____22199
   
 let (num_effect_indices :
   env -> FStar_Ident.lident -> FStar_Range.range -> Prims.int) =
@@ -3667,66 +3703,66 @@ let (num_effect_indices :
     fun name  ->
       fun r  ->
         let sig_t =
-          let uu____22139 =
+          let uu____22220 =
             FStar_All.pipe_right name (lookup_effect_lid env1)  in
-          FStar_All.pipe_right uu____22139 FStar_Syntax_Subst.compress  in
+          FStar_All.pipe_right uu____22220 FStar_Syntax_Subst.compress  in
         match sig_t.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_arrow (_a::bs,uu____22145) ->
+        | FStar_Syntax_Syntax.Tm_arrow (_a::bs,uu____22226) ->
             FStar_List.length bs
-        | uu____22184 ->
-            let uu____22185 =
-              let uu____22191 =
-                let uu____22193 = FStar_Ident.string_of_lid name  in
-                let uu____22195 = FStar_Syntax_Print.term_to_string sig_t  in
+        | uu____22265 ->
+            let uu____22266 =
+              let uu____22272 =
+                let uu____22274 = FStar_Ident.string_of_lid name  in
+                let uu____22276 = FStar_Syntax_Print.term_to_string sig_t  in
                 FStar_Util.format2 "Signature for %s not an arrow (%s)"
-                  uu____22193 uu____22195
+                  uu____22274 uu____22276
                  in
-              (FStar_Errors.Fatal_UnexpectedSignatureForMonad, uu____22191)
+              (FStar_Errors.Fatal_UnexpectedSignatureForMonad, uu____22272)
                in
-            FStar_Errors.raise_error uu____22185 r
+            FStar_Errors.raise_error uu____22266 r
   
 let (lookup_effect_quals :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.qualifier Prims.list) =
   fun env1  ->
     fun l  ->
       let l1 = norm_eff_name env1 l  in
-      let uu____22214 = lookup_qname env1 l1  in
-      match uu____22214 with
+      let uu____22295 = lookup_qname env1 l1  in
+      match uu____22295 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect
-                uu____22217;
-              FStar_Syntax_Syntax.sigrng = uu____22218;
+                uu____22298;
+              FStar_Syntax_Syntax.sigrng = uu____22299;
               FStar_Syntax_Syntax.sigquals = q;
-              FStar_Syntax_Syntax.sigmeta = uu____22220;
-              FStar_Syntax_Syntax.sigattrs = uu____22221;
-              FStar_Syntax_Syntax.sigopts = uu____22222;_},uu____22223),uu____22224)
+              FStar_Syntax_Syntax.sigmeta = uu____22301;
+              FStar_Syntax_Syntax.sigattrs = uu____22302;
+              FStar_Syntax_Syntax.sigopts = uu____22303;_},uu____22304),uu____22305)
           -> q
-      | uu____22277 -> []
+      | uu____22358 -> []
   
 let (lookup_projector :
   env -> FStar_Ident.lident -> Prims.int -> FStar_Ident.lident) =
   fun env1  ->
     fun lid  ->
       fun i  ->
-        let fail uu____22301 =
-          let uu____22302 =
-            let uu____22304 = FStar_Util.string_of_int i  in
-            let uu____22306 = FStar_Syntax_Print.lid_to_string lid  in
+        let fail uu____22382 =
+          let uu____22383 =
+            let uu____22385 = FStar_Util.string_of_int i  in
+            let uu____22387 = FStar_Syntax_Print.lid_to_string lid  in
             FStar_Util.format2
               "Impossible: projecting field #%s from constructor %s is undefined"
-              uu____22304 uu____22306
+              uu____22385 uu____22387
              in
-          failwith uu____22302  in
-        let uu____22309 = lookup_datacon env1 lid  in
-        match uu____22309 with
-        | (uu____22314,t) ->
-            let uu____22316 =
-              let uu____22317 = FStar_Syntax_Subst.compress t  in
-              uu____22317.FStar_Syntax_Syntax.n  in
-            (match uu____22316 with
-             | FStar_Syntax_Syntax.Tm_arrow (binders,uu____22321) ->
+          failwith uu____22383  in
+        let uu____22390 = lookup_datacon env1 lid  in
+        match uu____22390 with
+        | (uu____22395,t) ->
+            let uu____22397 =
+              let uu____22398 = FStar_Syntax_Subst.compress t  in
+              uu____22398.FStar_Syntax_Syntax.n  in
+            (match uu____22397 with
+             | FStar_Syntax_Syntax.Tm_arrow (binders,uu____22402) ->
                  if
                    (i < Prims.int_zero) || (i >= (FStar_List.length binders))
                  then fail ()
@@ -3734,73 +3770,73 @@ let (lookup_projector :
                    (let b = FStar_List.nth binders i  in
                     FStar_Syntax_Util.mk_field_projector_name lid
                       (FStar_Pervasives_Native.fst b) i)
-             | uu____22367 -> fail ())
+             | uu____22448 -> fail ())
   
 let (is_projector : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
     fun l  ->
-      let uu____22381 = lookup_qname env1 l  in
-      match uu____22381 with
+      let uu____22462 = lookup_qname env1 l  in
+      match uu____22462 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____22383,uu____22384,uu____22385);
-              FStar_Syntax_Syntax.sigrng = uu____22386;
+                (uu____22464,uu____22465,uu____22466);
+              FStar_Syntax_Syntax.sigrng = uu____22467;
               FStar_Syntax_Syntax.sigquals = quals;
-              FStar_Syntax_Syntax.sigmeta = uu____22388;
-              FStar_Syntax_Syntax.sigattrs = uu____22389;
-              FStar_Syntax_Syntax.sigopts = uu____22390;_},uu____22391),uu____22392)
+              FStar_Syntax_Syntax.sigmeta = uu____22469;
+              FStar_Syntax_Syntax.sigattrs = uu____22470;
+              FStar_Syntax_Syntax.sigopts = uu____22471;_},uu____22472),uu____22473)
           ->
           FStar_Util.for_some
-            (fun uu___7_22447  ->
-               match uu___7_22447 with
-               | FStar_Syntax_Syntax.Projector uu____22449 -> true
-               | uu____22455 -> false) quals
-      | uu____22457 -> false
+            (fun uu___7_22528  ->
+               match uu___7_22528 with
+               | FStar_Syntax_Syntax.Projector uu____22530 -> true
+               | uu____22536 -> false) quals
+      | uu____22538 -> false
   
 let (is_datacon : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
     fun lid  ->
-      let uu____22471 = lookup_qname env1 lid  in
-      match uu____22471 with
+      let uu____22552 = lookup_qname env1 lid  in
+      match uu____22552 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____22473,uu____22474,uu____22475,uu____22476,uu____22477,uu____22478);
-              FStar_Syntax_Syntax.sigrng = uu____22479;
-              FStar_Syntax_Syntax.sigquals = uu____22480;
-              FStar_Syntax_Syntax.sigmeta = uu____22481;
-              FStar_Syntax_Syntax.sigattrs = uu____22482;
-              FStar_Syntax_Syntax.sigopts = uu____22483;_},uu____22484),uu____22485)
+                (uu____22554,uu____22555,uu____22556,uu____22557,uu____22558,uu____22559);
+              FStar_Syntax_Syntax.sigrng = uu____22560;
+              FStar_Syntax_Syntax.sigquals = uu____22561;
+              FStar_Syntax_Syntax.sigmeta = uu____22562;
+              FStar_Syntax_Syntax.sigattrs = uu____22563;
+              FStar_Syntax_Syntax.sigopts = uu____22564;_},uu____22565),uu____22566)
           -> true
-      | uu____22545 -> false
+      | uu____22626 -> false
   
 let (is_record : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
     fun lid  ->
-      let uu____22559 = lookup_qname env1 lid  in
-      match uu____22559 with
+      let uu____22640 = lookup_qname env1 lid  in
+      match uu____22640 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____22561,uu____22562,uu____22563,uu____22564,uu____22565,uu____22566);
-              FStar_Syntax_Syntax.sigrng = uu____22567;
+                (uu____22642,uu____22643,uu____22644,uu____22645,uu____22646,uu____22647);
+              FStar_Syntax_Syntax.sigrng = uu____22648;
               FStar_Syntax_Syntax.sigquals = quals;
-              FStar_Syntax_Syntax.sigmeta = uu____22569;
-              FStar_Syntax_Syntax.sigattrs = uu____22570;
-              FStar_Syntax_Syntax.sigopts = uu____22571;_},uu____22572),uu____22573)
+              FStar_Syntax_Syntax.sigmeta = uu____22650;
+              FStar_Syntax_Syntax.sigattrs = uu____22651;
+              FStar_Syntax_Syntax.sigopts = uu____22652;_},uu____22653),uu____22654)
           ->
           FStar_Util.for_some
-            (fun uu___8_22636  ->
-               match uu___8_22636 with
-               | FStar_Syntax_Syntax.RecordType uu____22638 -> true
-               | FStar_Syntax_Syntax.RecordConstructor uu____22648 -> true
-               | uu____22658 -> false) quals
-      | uu____22660 -> false
+            (fun uu___8_22717  ->
+               match uu___8_22717 with
+               | FStar_Syntax_Syntax.RecordType uu____22719 -> true
+               | FStar_Syntax_Syntax.RecordConstructor uu____22729 -> true
+               | uu____22739 -> false) quals
+      | uu____22741 -> false
   
 let (qninfo_is_action : qninfo -> Prims.bool) =
   fun qninfo1  ->
@@ -3809,25 +3845,25 @@ let (qninfo_is_action : qninfo -> Prims.bool) =
         (FStar_Util.Inr
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-              (uu____22670,uu____22671);
-            FStar_Syntax_Syntax.sigrng = uu____22672;
+              (uu____22751,uu____22752);
+            FStar_Syntax_Syntax.sigrng = uu____22753;
             FStar_Syntax_Syntax.sigquals = quals;
-            FStar_Syntax_Syntax.sigmeta = uu____22674;
-            FStar_Syntax_Syntax.sigattrs = uu____22675;
-            FStar_Syntax_Syntax.sigopts = uu____22676;_},uu____22677),uu____22678)
+            FStar_Syntax_Syntax.sigmeta = uu____22755;
+            FStar_Syntax_Syntax.sigattrs = uu____22756;
+            FStar_Syntax_Syntax.sigopts = uu____22757;_},uu____22758),uu____22759)
         ->
         FStar_Util.for_some
-          (fun uu___9_22737  ->
-             match uu___9_22737 with
-             | FStar_Syntax_Syntax.Action uu____22739 -> true
-             | uu____22741 -> false) quals
-    | uu____22743 -> false
+          (fun uu___9_22818  ->
+             match uu___9_22818 with
+             | FStar_Syntax_Syntax.Action uu____22820 -> true
+             | uu____22822 -> false) quals
+    | uu____22824 -> false
   
 let (is_action : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
     fun lid  ->
-      let uu____22757 = lookup_qname env1 lid  in
-      FStar_All.pipe_left qninfo_is_action uu____22757
+      let uu____22838 = lookup_qname env1 lid  in
+      FStar_All.pipe_left qninfo_is_action uu____22838
   
 let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   let interpreted_symbols =
@@ -3848,51 +3884,51 @@ let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
     FStar_Parser_Const.op_Negation]  in
   fun env1  ->
     fun head  ->
-      let uu____22774 =
-        let uu____22775 = FStar_Syntax_Util.un_uinst head  in
-        uu____22775.FStar_Syntax_Syntax.n  in
-      match uu____22774 with
+      let uu____22855 =
+        let uu____22856 = FStar_Syntax_Util.un_uinst head  in
+        uu____22856.FStar_Syntax_Syntax.n  in
+      match uu____22855 with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           (match fv.FStar_Syntax_Syntax.fv_delta with
-           | FStar_Syntax_Syntax.Delta_equational_at_level uu____22781 ->
+           | FStar_Syntax_Syntax.Delta_equational_at_level uu____22862 ->
                true
-           | uu____22784 -> false)
-      | uu____22786 -> false
+           | uu____22865 -> false)
+      | uu____22867 -> false
   
 let (is_irreducible : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
     fun l  ->
-      let uu____22800 = lookup_qname env1 l  in
-      match uu____22800 with
+      let uu____22881 = lookup_qname env1 l  in
+      match uu____22881 with
       | FStar_Pervasives_Native.Some
-          (FStar_Util.Inr (se,uu____22803),uu____22804) ->
+          (FStar_Util.Inr (se,uu____22884),uu____22885) ->
           FStar_Util.for_some
-            (fun uu___10_22852  ->
-               match uu___10_22852 with
+            (fun uu___10_22933  ->
+               match uu___10_22933 with
                | FStar_Syntax_Syntax.Irreducible  -> true
-               | uu____22855 -> false) se.FStar_Syntax_Syntax.sigquals
-      | uu____22857 -> false
+               | uu____22936 -> false) se.FStar_Syntax_Syntax.sigquals
+      | uu____22938 -> false
   
 let (is_type_constructor : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
     fun lid  ->
       let mapper x =
         match FStar_Pervasives_Native.fst x with
-        | FStar_Util.Inl uu____22933 -> FStar_Pervasives_Native.Some false
-        | FStar_Util.Inr (se,uu____22951) ->
+        | FStar_Util.Inl uu____23014 -> FStar_Pervasives_Native.Some false
+        | FStar_Util.Inr (se,uu____23032) ->
             (match se.FStar_Syntax_Syntax.sigel with
-             | FStar_Syntax_Syntax.Sig_declare_typ uu____22969 ->
+             | FStar_Syntax_Syntax.Sig_declare_typ uu____23050 ->
                  FStar_Pervasives_Native.Some
                    (FStar_List.contains FStar_Syntax_Syntax.New
                       se.FStar_Syntax_Syntax.sigquals)
-             | FStar_Syntax_Syntax.Sig_inductive_typ uu____22977 ->
+             | FStar_Syntax_Syntax.Sig_inductive_typ uu____23058 ->
                  FStar_Pervasives_Native.Some true
-             | uu____22996 -> FStar_Pervasives_Native.Some false)
+             | uu____23077 -> FStar_Pervasives_Native.Some false)
          in
-      let uu____22999 =
-        let uu____23003 = lookup_qname env1 lid  in
-        FStar_Util.bind_opt uu____23003 mapper  in
-      match uu____22999 with
+      let uu____23080 =
+        let uu____23084 = lookup_qname env1 lid  in
+        FStar_Util.bind_opt uu____23084 mapper  in
+      match uu____23080 with
       | FStar_Pervasives_Native.Some b -> b
       | FStar_Pervasives_Native.None  -> false
   
@@ -3900,21 +3936,21 @@ let (num_inductive_ty_params :
   env -> FStar_Ident.lident -> Prims.int FStar_Pervasives_Native.option) =
   fun env1  ->
     fun lid  ->
-      let uu____23063 = lookup_qname env1 lid  in
-      match uu____23063 with
+      let uu____23144 = lookup_qname env1 lid  in
+      match uu____23144 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____23067,uu____23068,tps,uu____23070,uu____23071,uu____23072);
-              FStar_Syntax_Syntax.sigrng = uu____23073;
-              FStar_Syntax_Syntax.sigquals = uu____23074;
-              FStar_Syntax_Syntax.sigmeta = uu____23075;
-              FStar_Syntax_Syntax.sigattrs = uu____23076;
-              FStar_Syntax_Syntax.sigopts = uu____23077;_},uu____23078),uu____23079)
+                (uu____23148,uu____23149,tps,uu____23151,uu____23152,uu____23153);
+              FStar_Syntax_Syntax.sigrng = uu____23154;
+              FStar_Syntax_Syntax.sigquals = uu____23155;
+              FStar_Syntax_Syntax.sigmeta = uu____23156;
+              FStar_Syntax_Syntax.sigattrs = uu____23157;
+              FStar_Syntax_Syntax.sigopts = uu____23158;_},uu____23159),uu____23160)
           -> FStar_Pervasives_Native.Some (FStar_List.length tps)
-      | uu____23147 -> FStar_Pervasives_Native.None
+      | uu____23228 -> FStar_Pervasives_Native.None
   
 let (effect_decl_opt :
   env ->
@@ -3926,38 +3962,38 @@ let (effect_decl_opt :
     fun l  ->
       FStar_All.pipe_right (env1.effects).decls
         (FStar_Util.find_opt
-           (fun uu____23193  ->
-              match uu____23193 with
-              | (d,uu____23202) ->
+           (fun uu____23274  ->
+              match uu____23274 with
+              | (d,uu____23283) ->
                   FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname l))
   
 let (get_effect_decl :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.eff_decl) =
   fun env1  ->
     fun l  ->
-      let uu____23218 = effect_decl_opt env1 l  in
-      match uu____23218 with
+      let uu____23299 = effect_decl_opt env1 l  in
+      match uu____23299 with
       | FStar_Pervasives_Native.None  ->
-          let uu____23233 = name_not_found l  in
-          let uu____23239 = FStar_Ident.range_of_lid l  in
-          FStar_Errors.raise_error uu____23233 uu____23239
+          let uu____23314 = name_not_found l  in
+          let uu____23320 = FStar_Ident.range_of_lid l  in
+          FStar_Errors.raise_error uu____23314 uu____23320
       | FStar_Pervasives_Native.Some md -> FStar_Pervasives_Native.fst md
   
 let (is_layered_effect : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
     fun l  ->
-      let uu____23267 = FStar_All.pipe_right l (get_effect_decl env1)  in
-      FStar_All.pipe_right uu____23267 FStar_Syntax_Util.is_layered
+      let uu____23348 = FStar_All.pipe_right l (get_effect_decl env1)  in
+      FStar_All.pipe_right uu____23348 FStar_Syntax_Util.is_layered
   
 let (identity_mlift : mlift) =
   {
     mlift_wp =
-      (fun uu____23274  ->
+      (fun uu____23355  ->
          fun c  -> (c, FStar_TypeChecker_Common.trivial_guard));
     mlift_term =
       (FStar_Pervasives_Native.Some
-         (fun uu____23288  ->
-            fun uu____23289  -> fun e  -> FStar_Util.return_all e))
+         (fun uu____23369  ->
+            fun uu____23370  -> fun e  -> FStar_Util.return_all e))
   } 
 let (join_opt :
   env ->
@@ -3968,12 +4004,12 @@ let (join_opt :
   fun env1  ->
     fun l1  ->
       fun l2  ->
-        let uu____23323 = FStar_Ident.lid_equals l1 l2  in
-        if uu____23323
+        let uu____23404 = FStar_Ident.lid_equals l1 l2  in
+        if uu____23404
         then
           FStar_Pervasives_Native.Some (l1, identity_mlift, identity_mlift)
         else
-          (let uu____23342 =
+          (let uu____23423 =
              ((FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GTot_lid)
                 &&
                 (FStar_Ident.lid_equals l2 FStar_Parser_Const.effect_Tot_lid))
@@ -3983,25 +4019,25 @@ let (join_opt :
                   (FStar_Ident.lid_equals l1
                      FStar_Parser_Const.effect_Tot_lid))
               in
-           if uu____23342
+           if uu____23423
            then
              FStar_Pervasives_Native.Some
                (FStar_Parser_Const.effect_GTot_lid, identity_mlift,
                  identity_mlift)
            else
-             (let uu____23361 =
+             (let uu____23442 =
                 FStar_All.pipe_right (env1.effects).joins
                   (FStar_Util.find_opt
-                     (fun uu____23414  ->
-                        match uu____23414 with
-                        | (m1,m2,uu____23428,uu____23429,uu____23430) ->
+                     (fun uu____23495  ->
+                        match uu____23495 with
+                        | (m1,m2,uu____23509,uu____23510,uu____23511) ->
                             (FStar_Ident.lid_equals l1 m1) &&
                               (FStar_Ident.lid_equals l2 m2)))
                  in
-              match uu____23361 with
+              match uu____23442 with
               | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some
-                  (uu____23455,uu____23456,m3,j1,j2) ->
+                  (uu____23536,uu____23537,m3,j1,j2) ->
                   FStar_Pervasives_Native.Some (m3, j1, j2)))
   
 let (join :
@@ -4012,18 +4048,18 @@ let (join :
   fun env1  ->
     fun l1  ->
       fun l2  ->
-        let uu____23504 = join_opt env1 l1 l2  in
-        match uu____23504 with
+        let uu____23585 = join_opt env1 l1 l2  in
+        match uu____23585 with
         | FStar_Pervasives_Native.None  ->
-            let uu____23525 =
-              let uu____23531 =
-                let uu____23533 = FStar_Syntax_Print.lid_to_string l1  in
-                let uu____23535 = FStar_Syntax_Print.lid_to_string l2  in
+            let uu____23606 =
+              let uu____23612 =
+                let uu____23614 = FStar_Syntax_Print.lid_to_string l1  in
+                let uu____23616 = FStar_Syntax_Print.lid_to_string l2  in
                 FStar_Util.format2 "Effects %s and %s cannot be composed"
-                  uu____23533 uu____23535
+                  uu____23614 uu____23616
                  in
-              (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____23531)  in
-            FStar_Errors.raise_error uu____23525 env1.range
+              (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____23612)  in
+            FStar_Errors.raise_error uu____23606 env1.range
         | FStar_Pervasives_Native.Some t -> t
   
 let (monad_leq :
@@ -4034,12 +4070,12 @@ let (monad_leq :
   fun env1  ->
     fun l1  ->
       fun l2  ->
-        let uu____23578 =
+        let uu____23659 =
           (FStar_Ident.lid_equals l1 l2) ||
             ((FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_Tot_lid) &&
                (FStar_Ident.lid_equals l2 FStar_Parser_Const.effect_GTot_lid))
            in
-        if uu____23578
+        if uu____23659
         then
           FStar_Pervasives_Native.Some
             { msource = l1; mtarget = l2; mlift = identity_mlift }
@@ -4051,44 +4087,44 @@ let (monad_leq :
                     (FStar_Ident.lid_equals l2 e.mtarget)))
   
 let wp_sig_aux :
-  'uuuuuu23598 .
-    (FStar_Syntax_Syntax.eff_decl * 'uuuuuu23598) Prims.list ->
+  'uuuuuu23679 .
+    (FStar_Syntax_Syntax.eff_decl * 'uuuuuu23679) Prims.list ->
       FStar_Ident.lident ->
         (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
           FStar_Syntax_Syntax.syntax)
   =
   fun decls  ->
     fun m  ->
-      let uu____23627 =
+      let uu____23708 =
         FStar_All.pipe_right decls
           (FStar_Util.find_opt
-             (fun uu____23653  ->
-                match uu____23653 with
-                | (d,uu____23660) ->
+             (fun uu____23734  ->
+                match uu____23734 with
+                | (d,uu____23741) ->
                     FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname m))
          in
-      match uu____23627 with
+      match uu____23708 with
       | FStar_Pervasives_Native.None  ->
-          let uu____23671 =
+          let uu____23752 =
+            let uu____23754 = FStar_Ident.string_of_lid m  in
             FStar_Util.format1
-              "Impossible: declaration for monad %s not found"
-              m.FStar_Ident.str
+              "Impossible: declaration for monad %s not found" uu____23754
              in
-          failwith uu____23671
+          failwith uu____23752
       | FStar_Pervasives_Native.Some (md,_q) ->
-          let uu____23686 = inst_tscheme md.FStar_Syntax_Syntax.signature  in
-          (match uu____23686 with
-           | (uu____23697,s) ->
+          let uu____23769 = inst_tscheme md.FStar_Syntax_Syntax.signature  in
+          (match uu____23769 with
+           | (uu____23780,s) ->
                let s1 = FStar_Syntax_Subst.compress s  in
                (match ((md.FStar_Syntax_Syntax.binders),
                         (s1.FStar_Syntax_Syntax.n))
                 with
                 | ([],FStar_Syntax_Syntax.Tm_arrow
-                   ((a,uu____23715)::(wp,uu____23717)::[],c)) when
+                   ((a,uu____23798)::(wp,uu____23800)::[],c)) when
                     FStar_Syntax_Syntax.is_teff
                       (FStar_Syntax_Util.comp_result c)
                     -> (a, (wp.FStar_Syntax_Syntax.sort))
-                | uu____23773 -> failwith "Impossible"))
+                | uu____23856 -> failwith "Impossible"))
   
 let (wp_signature :
   env ->
@@ -4106,7 +4142,7 @@ let (comp_to_comp_typ :
         | FStar_Syntax_Syntax.GTotal (t,FStar_Pervasives_Native.None ) ->
             let u = env1.universe_of env1 t  in
             FStar_Syntax_Syntax.mk_GTotal' t (FStar_Pervasives_Native.Some u)
-        | uu____23838 -> c  in
+        | uu____23921 -> c  in
       FStar_Syntax_Util.comp_to_comp_typ c1
   
 let rec (unfold_effect_abbrev :
@@ -4114,85 +4150,85 @@ let rec (unfold_effect_abbrev :
   fun env1  ->
     fun comp  ->
       let c = comp_to_comp_typ env1 comp  in
-      let uu____23851 =
+      let uu____23934 =
         lookup_effect_abbrev env1 c.FStar_Syntax_Syntax.comp_univs
           c.FStar_Syntax_Syntax.effect_name
          in
-      match uu____23851 with
+      match uu____23934 with
       | FStar_Pervasives_Native.None  -> c
       | FStar_Pervasives_Native.Some (binders,cdef) ->
-          let uu____23868 = FStar_Syntax_Subst.open_comp binders cdef  in
-          (match uu____23868 with
+          let uu____23951 = FStar_Syntax_Subst.open_comp binders cdef  in
+          (match uu____23951 with
            | (binders1,cdef1) ->
                (if
                   (FStar_List.length binders1) <>
                     ((FStar_List.length c.FStar_Syntax_Syntax.effect_args) +
                        Prims.int_one)
                 then
-                  (let uu____23893 =
-                     let uu____23899 =
-                       let uu____23901 =
+                  (let uu____23976 =
+                     let uu____23982 =
+                       let uu____23984 =
                          FStar_Util.string_of_int
                            (FStar_List.length binders1)
                           in
-                       let uu____23909 =
+                       let uu____23992 =
                          FStar_Util.string_of_int
                            ((FStar_List.length
                                c.FStar_Syntax_Syntax.effect_args)
                               + Prims.int_one)
                           in
-                       let uu____23920 =
-                         let uu____23922 = FStar_Syntax_Syntax.mk_Comp c  in
-                         FStar_Syntax_Print.comp_to_string uu____23922  in
+                       let uu____24003 =
+                         let uu____24005 = FStar_Syntax_Syntax.mk_Comp c  in
+                         FStar_Syntax_Print.comp_to_string uu____24005  in
                        FStar_Util.format3
                          "Effect constructor is not fully applied; expected %s args, got %s args, i.e., %s"
-                         uu____23901 uu____23909 uu____23920
+                         uu____23984 uu____23992 uu____24003
                         in
                      (FStar_Errors.Fatal_ConstructorArgLengthMismatch,
-                       uu____23899)
+                       uu____23982)
                       in
-                   FStar_Errors.raise_error uu____23893
+                   FStar_Errors.raise_error uu____23976
                      comp.FStar_Syntax_Syntax.pos)
                 else ();
                 (let inst =
-                   let uu____23930 =
-                     let uu____23941 =
+                   let uu____24013 =
+                     let uu____24024 =
                        FStar_Syntax_Syntax.as_arg
                          c.FStar_Syntax_Syntax.result_typ
                         in
-                     uu____23941 :: (c.FStar_Syntax_Syntax.effect_args)  in
+                     uu____24024 :: (c.FStar_Syntax_Syntax.effect_args)  in
                    FStar_List.map2
-                     (fun uu____23978  ->
-                        fun uu____23979  ->
-                          match (uu____23978, uu____23979) with
-                          | ((x,uu____24009),(t,uu____24011)) ->
+                     (fun uu____24061  ->
+                        fun uu____24062  ->
+                          match (uu____24061, uu____24062) with
+                          | ((x,uu____24092),(t,uu____24094)) ->
                               FStar_Syntax_Syntax.NT (x, t)) binders1
-                     uu____23930
+                     uu____24013
                     in
                  let c1 = FStar_Syntax_Subst.subst_comp inst cdef1  in
                  let c2 =
-                   let uu____24042 =
-                     let uu___1614_24043 = comp_to_comp_typ env1 c1  in
+                   let uu____24125 =
+                     let uu___1614_24126 = comp_to_comp_typ env1 c1  in
                      {
                        FStar_Syntax_Syntax.comp_univs =
-                         (uu___1614_24043.FStar_Syntax_Syntax.comp_univs);
+                         (uu___1614_24126.FStar_Syntax_Syntax.comp_univs);
                        FStar_Syntax_Syntax.effect_name =
-                         (uu___1614_24043.FStar_Syntax_Syntax.effect_name);
+                         (uu___1614_24126.FStar_Syntax_Syntax.effect_name);
                        FStar_Syntax_Syntax.result_typ =
-                         (uu___1614_24043.FStar_Syntax_Syntax.result_typ);
+                         (uu___1614_24126.FStar_Syntax_Syntax.result_typ);
                        FStar_Syntax_Syntax.effect_args =
-                         (uu___1614_24043.FStar_Syntax_Syntax.effect_args);
+                         (uu___1614_24126.FStar_Syntax_Syntax.effect_args);
                        FStar_Syntax_Syntax.flags =
                          (c.FStar_Syntax_Syntax.flags)
                      }  in
-                   FStar_All.pipe_right uu____24042
+                   FStar_All.pipe_right uu____24125
                      FStar_Syntax_Syntax.mk_Comp
                     in
                  unfold_effect_abbrev env1 c2)))
   
 let effect_repr_aux :
-  'uuuuuu24055 .
-    'uuuuuu24055 ->
+  'uuuuuu24138 .
+    'uuuuuu24138 ->
       env ->
         FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
           FStar_Syntax_Syntax.universe ->
@@ -4205,21 +4241,21 @@ let effect_repr_aux :
         fun u_res  ->
           let check_partial_application eff_name args =
             let r = get_range env1  in
-            let uu____24096 =
-              let uu____24103 = num_effect_indices env1 eff_name r  in
-              ((FStar_List.length args), uu____24103)  in
-            match uu____24096 with
+            let uu____24179 =
+              let uu____24186 = num_effect_indices env1 eff_name r  in
+              ((FStar_List.length args), uu____24186)  in
+            match uu____24179 with
             | (given,expected) ->
                 if given = expected
                 then ()
                 else
                   (let message =
-                     let uu____24127 = FStar_Ident.string_of_lid eff_name  in
-                     let uu____24129 = FStar_Util.string_of_int given  in
-                     let uu____24131 = FStar_Util.string_of_int expected  in
+                     let uu____24210 = FStar_Ident.string_of_lid eff_name  in
+                     let uu____24212 = FStar_Util.string_of_int given  in
+                     let uu____24214 = FStar_Util.string_of_int expected  in
                      FStar_Util.format3
                        "Not enough arguments for effect %s, This usually happens when you use a partially applied DM4F effect, like [TAC int] instead of [Tac int] (given:%s, expected:%s)."
-                       uu____24127 uu____24129 uu____24131
+                       uu____24210 uu____24212 uu____24214
                       in
                    FStar_Errors.raise_error
                      (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
@@ -4227,13 +4263,13 @@ let effect_repr_aux :
              in
           let effect_name =
             norm_eff_name env1 (FStar_Syntax_Util.comp_effect_name c)  in
-          let uu____24136 = effect_decl_opt env1 effect_name  in
-          match uu____24136 with
+          let uu____24219 = effect_decl_opt env1 effect_name  in
+          match uu____24219 with
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-          | FStar_Pervasives_Native.Some (ed,uu____24158) ->
-              let uu____24169 =
+          | FStar_Pervasives_Native.Some (ed,uu____24241) ->
+              let uu____24252 =
                 FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr  in
-              (match uu____24169 with
+              (match uu____24252 with
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some ts ->
@@ -4242,25 +4278,25 @@ let effect_repr_aux :
                    let repr = inst_effect_fun_with [u_res] env1 ed ts  in
                    (check_partial_application effect_name
                       c1.FStar_Syntax_Syntax.effect_args;
-                    (let uu____24187 =
-                       let uu____24190 = get_range env1  in
-                       let uu____24191 =
-                         let uu____24198 =
-                           let uu____24199 =
-                             let uu____24216 =
-                               let uu____24227 =
+                    (let uu____24270 =
+                       let uu____24273 = get_range env1  in
+                       let uu____24274 =
+                         let uu____24281 =
+                           let uu____24282 =
+                             let uu____24299 =
+                               let uu____24310 =
                                  FStar_All.pipe_right res_typ
                                    FStar_Syntax_Syntax.as_arg
                                   in
-                               uu____24227 ::
+                               uu____24310 ::
                                  (c1.FStar_Syntax_Syntax.effect_args)
                                 in
-                             (repr, uu____24216)  in
-                           FStar_Syntax_Syntax.Tm_app uu____24199  in
-                         FStar_Syntax_Syntax.mk uu____24198  in
-                       uu____24191 FStar_Pervasives_Native.None uu____24190
+                             (repr, uu____24299)  in
+                           FStar_Syntax_Syntax.Tm_app uu____24282  in
+                         FStar_Syntax_Syntax.mk uu____24281  in
+                       uu____24274 FStar_Pervasives_Native.None uu____24273
                         in
-                     FStar_Pervasives_Native.Some uu____24187)))
+                     FStar_Pervasives_Native.Some uu____24270)))
   
 let (effect_repr :
   env ->
@@ -4282,10 +4318,10 @@ let (is_user_reflectable_effect : env -> FStar_Ident.lident -> Prims.bool) =
       let quals = lookup_effect_quals env1 effect_lid1  in
       FStar_All.pipe_right quals
         (FStar_List.existsb
-           (fun uu___11_24327  ->
-              match uu___11_24327 with
-              | FStar_Syntax_Syntax.Reflectable uu____24329 -> true
-              | uu____24331 -> false))
+           (fun uu___11_24410  ->
+              match uu___11_24410 with
+              | FStar_Syntax_Syntax.Reflectable uu____24412 -> true
+              | uu____24414 -> false))
   
 let (is_total_effect : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
@@ -4312,18 +4348,18 @@ let (is_reifiable_comp : env -> FStar_Syntax_Syntax.comp -> Prims.bool) =
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Comp ct ->
           is_reifiable_effect env1 ct.FStar_Syntax_Syntax.effect_name
-      | uu____24391 -> false
+      | uu____24474 -> false
   
 let (is_reifiable_function : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env1  ->
     fun t  ->
-      let uu____24406 =
-        let uu____24407 = FStar_Syntax_Subst.compress t  in
-        uu____24407.FStar_Syntax_Syntax.n  in
-      match uu____24406 with
-      | FStar_Syntax_Syntax.Tm_arrow (uu____24411,c) ->
+      let uu____24489 =
+        let uu____24490 = FStar_Syntax_Subst.compress t  in
+        uu____24490.FStar_Syntax_Syntax.n  in
+      match uu____24489 with
+      | FStar_Syntax_Syntax.Tm_arrow (uu____24494,c) ->
           is_reifiable_comp env1 c
-      | uu____24433 -> false
+      | uu____24516 -> false
   
 let (reify_comp :
   env ->
@@ -4334,22 +4370,22 @@ let (reify_comp :
     fun c  ->
       fun u_c  ->
         let l = FStar_Syntax_Util.comp_effect_name c  in
-        (let uu____24453 =
-           let uu____24455 = is_reifiable_effect env1 l  in
-           Prims.op_Negation uu____24455  in
-         if uu____24453
+        (let uu____24536 =
+           let uu____24538 = is_reifiable_effect env1 l  in
+           Prims.op_Negation uu____24538  in
+         if uu____24536
          then
-           let uu____24458 =
-             let uu____24464 =
-               let uu____24466 = FStar_Ident.string_of_lid l  in
-               FStar_Util.format1 "Effect %s cannot be reified" uu____24466
+           let uu____24541 =
+             let uu____24547 =
+               let uu____24549 = FStar_Ident.string_of_lid l  in
+               FStar_Util.format1 "Effect %s cannot be reified" uu____24549
                 in
-             (FStar_Errors.Fatal_EffectCannotBeReified, uu____24464)  in
-           let uu____24470 = get_range env1  in
-           FStar_Errors.raise_error uu____24458 uu____24470
+             (FStar_Errors.Fatal_EffectCannotBeReified, uu____24547)  in
+           let uu____24553 = get_range env1  in
+           FStar_Errors.raise_error uu____24541 uu____24553
          else ());
-        (let uu____24473 = effect_repr_aux true env1 c u_c  in
-         match uu____24473 with
+        (let uu____24556 = effect_repr_aux true env1 c u_c  in
+         match uu____24556 with
          | FStar_Pervasives_Native.None  ->
              failwith "internal error: reifiable effect has no repr?"
          | FStar_Pervasives_Native.Some tm -> tm)
@@ -4359,56 +4395,56 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
     fun s  ->
       let sb = ((FStar_Syntax_Util.lids_of_sigelt s), s)  in
       let env2 =
-        let uu___1691_24509 = env1  in
+        let uu___1691_24592 = env1  in
         {
-          solver = (uu___1691_24509.solver);
-          range = (uu___1691_24509.range);
-          curmodule = (uu___1691_24509.curmodule);
-          gamma = (uu___1691_24509.gamma);
+          solver = (uu___1691_24592.solver);
+          range = (uu___1691_24592.range);
+          curmodule = (uu___1691_24592.curmodule);
+          gamma = (uu___1691_24592.gamma);
           gamma_sig = (sb :: (env1.gamma_sig));
-          gamma_cache = (uu___1691_24509.gamma_cache);
-          modules = (uu___1691_24509.modules);
-          expected_typ = (uu___1691_24509.expected_typ);
-          sigtab = (uu___1691_24509.sigtab);
-          attrtab = (uu___1691_24509.attrtab);
-          instantiate_imp = (uu___1691_24509.instantiate_imp);
-          effects = (uu___1691_24509.effects);
-          generalize = (uu___1691_24509.generalize);
-          letrecs = (uu___1691_24509.letrecs);
-          top_level = (uu___1691_24509.top_level);
-          check_uvars = (uu___1691_24509.check_uvars);
-          use_eq = (uu___1691_24509.use_eq);
-          use_eq_strict = (uu___1691_24509.use_eq_strict);
-          is_iface = (uu___1691_24509.is_iface);
-          admit = (uu___1691_24509.admit);
-          lax = (uu___1691_24509.lax);
-          lax_universes = (uu___1691_24509.lax_universes);
-          phase1 = (uu___1691_24509.phase1);
-          failhard = (uu___1691_24509.failhard);
-          nosynth = (uu___1691_24509.nosynth);
-          uvar_subtyping = (uu___1691_24509.uvar_subtyping);
-          tc_term = (uu___1691_24509.tc_term);
-          type_of = (uu___1691_24509.type_of);
-          universe_of = (uu___1691_24509.universe_of);
-          check_type_of = (uu___1691_24509.check_type_of);
-          use_bv_sorts = (uu___1691_24509.use_bv_sorts);
-          qtbl_name_and_index = (uu___1691_24509.qtbl_name_and_index);
-          normalized_eff_names = (uu___1691_24509.normalized_eff_names);
-          fv_delta_depths = (uu___1691_24509.fv_delta_depths);
-          proof_ns = (uu___1691_24509.proof_ns);
-          synth_hook = (uu___1691_24509.synth_hook);
+          gamma_cache = (uu___1691_24592.gamma_cache);
+          modules = (uu___1691_24592.modules);
+          expected_typ = (uu___1691_24592.expected_typ);
+          sigtab = (uu___1691_24592.sigtab);
+          attrtab = (uu___1691_24592.attrtab);
+          instantiate_imp = (uu___1691_24592.instantiate_imp);
+          effects = (uu___1691_24592.effects);
+          generalize = (uu___1691_24592.generalize);
+          letrecs = (uu___1691_24592.letrecs);
+          top_level = (uu___1691_24592.top_level);
+          check_uvars = (uu___1691_24592.check_uvars);
+          use_eq = (uu___1691_24592.use_eq);
+          use_eq_strict = (uu___1691_24592.use_eq_strict);
+          is_iface = (uu___1691_24592.is_iface);
+          admit = (uu___1691_24592.admit);
+          lax = (uu___1691_24592.lax);
+          lax_universes = (uu___1691_24592.lax_universes);
+          phase1 = (uu___1691_24592.phase1);
+          failhard = (uu___1691_24592.failhard);
+          nosynth = (uu___1691_24592.nosynth);
+          uvar_subtyping = (uu___1691_24592.uvar_subtyping);
+          tc_term = (uu___1691_24592.tc_term);
+          type_of = (uu___1691_24592.type_of);
+          universe_of = (uu___1691_24592.universe_of);
+          check_type_of = (uu___1691_24592.check_type_of);
+          use_bv_sorts = (uu___1691_24592.use_bv_sorts);
+          qtbl_name_and_index = (uu___1691_24592.qtbl_name_and_index);
+          normalized_eff_names = (uu___1691_24592.normalized_eff_names);
+          fv_delta_depths = (uu___1691_24592.fv_delta_depths);
+          proof_ns = (uu___1691_24592.proof_ns);
+          synth_hook = (uu___1691_24592.synth_hook);
           try_solve_implicits_hook =
-            (uu___1691_24509.try_solve_implicits_hook);
-          splice = (uu___1691_24509.splice);
-          mpreprocess = (uu___1691_24509.mpreprocess);
-          postprocess = (uu___1691_24509.postprocess);
-          is_native_tactic = (uu___1691_24509.is_native_tactic);
-          identifier_info = (uu___1691_24509.identifier_info);
-          tc_hooks = (uu___1691_24509.tc_hooks);
-          dsenv = (uu___1691_24509.dsenv);
-          nbe = (uu___1691_24509.nbe);
-          strict_args_tab = (uu___1691_24509.strict_args_tab);
-          erasable_types_tab = (uu___1691_24509.erasable_types_tab)
+            (uu___1691_24592.try_solve_implicits_hook);
+          splice = (uu___1691_24592.splice);
+          mpreprocess = (uu___1691_24592.mpreprocess);
+          postprocess = (uu___1691_24592.postprocess);
+          is_native_tactic = (uu___1691_24592.is_native_tactic);
+          identifier_info = (uu___1691_24592.identifier_info);
+          tc_hooks = (uu___1691_24592.tc_hooks);
+          dsenv = (uu___1691_24592.dsenv);
+          nbe = (uu___1691_24592.nbe);
+          strict_args_tab = (uu___1691_24592.strict_args_tab);
+          erasable_types_tab = (uu___1691_24592.erasable_types_tab)
         }  in
       add_sigelt env2 s;
       (env2.tc_hooks).tc_push_in_gamma_hook env2 (FStar_Util.Inr sb);
@@ -4420,67 +4456,67 @@ let (push_new_effect :
       -> env)
   =
   fun env1  ->
-    fun uu____24528  ->
-      match uu____24528 with
+    fun uu____24611  ->
+      match uu____24611 with
       | (ed,quals) ->
           let effects1 =
-            let uu___1700_24542 = env1.effects  in
+            let uu___1700_24625 = env1.effects  in
             {
               decls = ((ed, quals) :: ((env1.effects).decls));
-              order = (uu___1700_24542.order);
-              joins = (uu___1700_24542.joins);
-              polymonadic_binds = (uu___1700_24542.polymonadic_binds)
+              order = (uu___1700_24625.order);
+              joins = (uu___1700_24625.joins);
+              polymonadic_binds = (uu___1700_24625.polymonadic_binds)
             }  in
-          let uu___1703_24551 = env1  in
+          let uu___1703_24634 = env1  in
           {
-            solver = (uu___1703_24551.solver);
-            range = (uu___1703_24551.range);
-            curmodule = (uu___1703_24551.curmodule);
-            gamma = (uu___1703_24551.gamma);
-            gamma_sig = (uu___1703_24551.gamma_sig);
-            gamma_cache = (uu___1703_24551.gamma_cache);
-            modules = (uu___1703_24551.modules);
-            expected_typ = (uu___1703_24551.expected_typ);
-            sigtab = (uu___1703_24551.sigtab);
-            attrtab = (uu___1703_24551.attrtab);
-            instantiate_imp = (uu___1703_24551.instantiate_imp);
+            solver = (uu___1703_24634.solver);
+            range = (uu___1703_24634.range);
+            curmodule = (uu___1703_24634.curmodule);
+            gamma = (uu___1703_24634.gamma);
+            gamma_sig = (uu___1703_24634.gamma_sig);
+            gamma_cache = (uu___1703_24634.gamma_cache);
+            modules = (uu___1703_24634.modules);
+            expected_typ = (uu___1703_24634.expected_typ);
+            sigtab = (uu___1703_24634.sigtab);
+            attrtab = (uu___1703_24634.attrtab);
+            instantiate_imp = (uu___1703_24634.instantiate_imp);
             effects = effects1;
-            generalize = (uu___1703_24551.generalize);
-            letrecs = (uu___1703_24551.letrecs);
-            top_level = (uu___1703_24551.top_level);
-            check_uvars = (uu___1703_24551.check_uvars);
-            use_eq = (uu___1703_24551.use_eq);
-            use_eq_strict = (uu___1703_24551.use_eq_strict);
-            is_iface = (uu___1703_24551.is_iface);
-            admit = (uu___1703_24551.admit);
-            lax = (uu___1703_24551.lax);
-            lax_universes = (uu___1703_24551.lax_universes);
-            phase1 = (uu___1703_24551.phase1);
-            failhard = (uu___1703_24551.failhard);
-            nosynth = (uu___1703_24551.nosynth);
-            uvar_subtyping = (uu___1703_24551.uvar_subtyping);
-            tc_term = (uu___1703_24551.tc_term);
-            type_of = (uu___1703_24551.type_of);
-            universe_of = (uu___1703_24551.universe_of);
-            check_type_of = (uu___1703_24551.check_type_of);
-            use_bv_sorts = (uu___1703_24551.use_bv_sorts);
-            qtbl_name_and_index = (uu___1703_24551.qtbl_name_and_index);
-            normalized_eff_names = (uu___1703_24551.normalized_eff_names);
-            fv_delta_depths = (uu___1703_24551.fv_delta_depths);
-            proof_ns = (uu___1703_24551.proof_ns);
-            synth_hook = (uu___1703_24551.synth_hook);
+            generalize = (uu___1703_24634.generalize);
+            letrecs = (uu___1703_24634.letrecs);
+            top_level = (uu___1703_24634.top_level);
+            check_uvars = (uu___1703_24634.check_uvars);
+            use_eq = (uu___1703_24634.use_eq);
+            use_eq_strict = (uu___1703_24634.use_eq_strict);
+            is_iface = (uu___1703_24634.is_iface);
+            admit = (uu___1703_24634.admit);
+            lax = (uu___1703_24634.lax);
+            lax_universes = (uu___1703_24634.lax_universes);
+            phase1 = (uu___1703_24634.phase1);
+            failhard = (uu___1703_24634.failhard);
+            nosynth = (uu___1703_24634.nosynth);
+            uvar_subtyping = (uu___1703_24634.uvar_subtyping);
+            tc_term = (uu___1703_24634.tc_term);
+            type_of = (uu___1703_24634.type_of);
+            universe_of = (uu___1703_24634.universe_of);
+            check_type_of = (uu___1703_24634.check_type_of);
+            use_bv_sorts = (uu___1703_24634.use_bv_sorts);
+            qtbl_name_and_index = (uu___1703_24634.qtbl_name_and_index);
+            normalized_eff_names = (uu___1703_24634.normalized_eff_names);
+            fv_delta_depths = (uu___1703_24634.fv_delta_depths);
+            proof_ns = (uu___1703_24634.proof_ns);
+            synth_hook = (uu___1703_24634.synth_hook);
             try_solve_implicits_hook =
-              (uu___1703_24551.try_solve_implicits_hook);
-            splice = (uu___1703_24551.splice);
-            mpreprocess = (uu___1703_24551.mpreprocess);
-            postprocess = (uu___1703_24551.postprocess);
-            is_native_tactic = (uu___1703_24551.is_native_tactic);
-            identifier_info = (uu___1703_24551.identifier_info);
-            tc_hooks = (uu___1703_24551.tc_hooks);
-            dsenv = (uu___1703_24551.dsenv);
-            nbe = (uu___1703_24551.nbe);
-            strict_args_tab = (uu___1703_24551.strict_args_tab);
-            erasable_types_tab = (uu___1703_24551.erasable_types_tab)
+              (uu___1703_24634.try_solve_implicits_hook);
+            splice = (uu___1703_24634.splice);
+            mpreprocess = (uu___1703_24634.mpreprocess);
+            postprocess = (uu___1703_24634.postprocess);
+            is_native_tactic = (uu___1703_24634.is_native_tactic);
+            identifier_info = (uu___1703_24634.identifier_info);
+            tc_hooks = (uu___1703_24634.tc_hooks);
+            dsenv = (uu___1703_24634.dsenv);
+            nbe = (uu___1703_24634.nbe);
+            strict_args_tab = (uu___1703_24634.strict_args_tab);
+            erasable_types_tab = (uu___1703_24634.erasable_types_tab)
           }
   
 let (exists_polymonadic_bind :
@@ -4493,19 +4529,19 @@ let (exists_polymonadic_bind :
   fun env1  ->
     fun m  ->
       fun n  ->
-        let uu____24580 =
+        let uu____24663 =
           FStar_All.pipe_right (env1.effects).polymonadic_binds
             (FStar_Util.find_opt
-               (fun uu____24648  ->
-                  match uu____24648 with
-                  | (m1,n1,uu____24666,uu____24667) ->
+               (fun uu____24731  ->
+                  match uu____24731 with
+                  | (m1,n1,uu____24749,uu____24750) ->
                       (FStar_Ident.lid_equals m m1) &&
                         (FStar_Ident.lid_equals n n1)))
            in
-        match uu____24580 with
-        | FStar_Pervasives_Native.Some (uu____24692,uu____24693,p,t) ->
+        match uu____24663 with
+        | FStar_Pervasives_Native.Some (uu____24775,uu____24776,p,t) ->
             FStar_Pervasives_Native.Some (p, t)
-        | uu____24738 -> FStar_Pervasives_Native.None
+        | uu____24821 -> FStar_Pervasives_Native.None
   
 let (update_effect_lattice :
   env -> FStar_Ident.lident -> FStar_Ident.lident -> mlift -> env) =
@@ -4516,23 +4552,23 @@ let (update_effect_lattice :
           let compose_edges e1 e2 =
             let composed_lift =
               let mlift_wp env2 c =
-                let uu____24813 =
+                let uu____24896 =
                   FStar_All.pipe_right c ((e1.mlift).mlift_wp env2)  in
-                FStar_All.pipe_right uu____24813
-                  (fun uu____24834  ->
-                     match uu____24834 with
+                FStar_All.pipe_right uu____24896
+                  (fun uu____24917  ->
+                     match uu____24917 with
                      | (c1,g1) ->
-                         let uu____24845 =
+                         let uu____24928 =
                            FStar_All.pipe_right c1 ((e2.mlift).mlift_wp env2)
                             in
-                         FStar_All.pipe_right uu____24845
-                           (fun uu____24866  ->
-                              match uu____24866 with
+                         FStar_All.pipe_right uu____24928
+                           (fun uu____24949  ->
+                              match uu____24949 with
                               | (c2,g2) ->
-                                  let uu____24877 =
+                                  let uu____24960 =
                                     FStar_TypeChecker_Common.conj_guard g1 g2
                                      in
-                                  (c2, uu____24877)))
+                                  (c2, uu____24960)))
                  in
               let mlift_term =
                 match (((e1.mlift).mlift_term), ((e2.mlift).mlift_term)) with
@@ -4542,9 +4578,9 @@ let (update_effect_lattice :
                       ((fun u  ->
                           fun t  ->
                             fun e  ->
-                              let uu____24999 = l1 u t e  in
-                              l2 u t uu____24999))
-                | uu____25000 -> FStar_Pervasives_Native.None  in
+                              let uu____25082 = l1 u t e  in
+                              l2 u t uu____25082))
+                | uu____25083 -> FStar_Pervasives_Native.None  in
               { mlift_wp; mlift_term }  in
             {
               msource = (e1.msource);
@@ -4558,19 +4594,19 @@ let (update_effect_lattice :
           let ms =
             FStar_All.pipe_right (env1.effects).decls
               (FStar_List.map
-                 (fun uu____25068  ->
-                    match uu____25068 with
-                    | (e,uu____25076) -> e.FStar_Syntax_Syntax.mname))
+                 (fun uu____25151  ->
+                    match uu____25151 with
+                    | (e,uu____25159) -> e.FStar_Syntax_Syntax.mname))
              in
-          let find_edge order1 uu____25099 =
-            match uu____25099 with
+          let find_edge order1 uu____25182 =
+            match uu____25182 with
             | (i,j) ->
-                let uu____25110 = FStar_Ident.lid_equals i j  in
-                if uu____25110
+                let uu____25193 = FStar_Ident.lid_equals i j  in
+                if uu____25193
                 then
                   FStar_All.pipe_right (id_edge i)
-                    (fun uu____25117  ->
-                       FStar_Pervasives_Native.Some uu____25117)
+                    (fun uu____25200  ->
+                       FStar_Pervasives_Native.Some uu____25200)
                 else
                   FStar_All.pipe_right order1
                     (FStar_Util.find_opt
@@ -4580,38 +4616,38 @@ let (update_effect_lattice :
              in
           let order1 =
             let fold_fun order1 k =
-              let uu____25146 =
+              let uu____25229 =
                 FStar_All.pipe_right ms
                   (FStar_List.collect
                      (fun i  ->
-                        let uu____25156 = FStar_Ident.lid_equals i k  in
-                        if uu____25156
+                        let uu____25239 = FStar_Ident.lid_equals i k  in
+                        if uu____25239
                         then []
                         else
                           FStar_All.pipe_right ms
                             (FStar_List.collect
                                (fun j  ->
-                                  let uu____25170 =
+                                  let uu____25253 =
                                     FStar_Ident.lid_equals j k  in
-                                  if uu____25170
+                                  if uu____25253
                                   then []
                                   else
-                                    (let uu____25177 =
-                                       let uu____25186 =
+                                    (let uu____25260 =
+                                       let uu____25269 =
                                          find_edge order1 (i, k)  in
-                                       let uu____25189 =
+                                       let uu____25272 =
                                          find_edge order1 (k, j)  in
-                                       (uu____25186, uu____25189)  in
-                                     match uu____25177 with
+                                       (uu____25269, uu____25272)  in
+                                     match uu____25260 with
                                      | (FStar_Pervasives_Native.Some
                                         e1,FStar_Pervasives_Native.Some e2)
                                          ->
-                                         let uu____25204 =
+                                         let uu____25287 =
                                            compose_edges e1 e2  in
-                                         [uu____25204]
-                                     | uu____25205 -> [])))))
+                                         [uu____25287]
+                                     | uu____25288 -> [])))))
                  in
-              FStar_List.append order1 uu____25146  in
+              FStar_List.append order1 uu____25229  in
             FStar_All.pipe_right ms (FStar_List.fold_left fold_fun order)  in
           let order2 =
             FStar_Util.remove_dups
@@ -4623,28 +4659,30 @@ let (update_effect_lattice :
           FStar_All.pipe_right order2
             (FStar_List.iter
                (fun edge2  ->
-                  let uu____25235 =
+                  let uu____25318 =
                     (FStar_Ident.lid_equals edge2.msource
                        FStar_Parser_Const.effect_DIV_lid)
                       &&
-                      (let uu____25238 =
+                      (let uu____25321 =
                          lookup_effect_quals env1 edge2.mtarget  in
-                       FStar_All.pipe_right uu____25238
+                       FStar_All.pipe_right uu____25321
                          (FStar_List.contains FStar_Syntax_Syntax.TotalEffect))
                      in
-                  if uu____25235
+                  if uu____25318
                   then
-                    let uu____25245 =
-                      let uu____25251 =
+                    let uu____25328 =
+                      let uu____25334 =
+                        let uu____25336 =
+                          FStar_Ident.string_of_lid edge2.mtarget  in
                         FStar_Util.format1
                           "Divergent computations cannot be included in an effect %s marked 'total'"
-                          (edge2.mtarget).FStar_Ident.str
+                          uu____25336
                          in
                       (FStar_Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                        uu____25251)
+                        uu____25334)
                        in
-                    let uu____25255 = get_range env1  in
-                    FStar_Errors.raise_error uu____25245 uu____25255
+                    let uu____25340 = get_range env1  in
+                    FStar_Errors.raise_error uu____25328 uu____25340
                   else ()));
           (let joins =
              FStar_All.pipe_right ms
@@ -4654,9 +4692,9 @@ let (update_effect_lattice :
                        (FStar_List.collect
                           (fun j  ->
                              let join_opt1 =
-                               let uu____25333 = FStar_Ident.lid_equals i j
+                               let uu____25418 = FStar_Ident.lid_equals i j
                                   in
-                               if uu____25333
+                               if uu____25418
                                then
                                  FStar_Pervasives_Native.Some
                                    (i, (id_edge i), (id_edge i))
@@ -4665,13 +4703,13 @@ let (update_effect_lattice :
                                    (FStar_List.fold_left
                                       (fun bopt  ->
                                          fun k  ->
-                                           let uu____25385 =
-                                             let uu____25394 =
+                                           let uu____25470 =
+                                             let uu____25479 =
                                                find_edge order2 (i, k)  in
-                                             let uu____25397 =
+                                             let uu____25482 =
                                                find_edge order2 (j, k)  in
-                                             (uu____25394, uu____25397)  in
-                                           match uu____25385 with
+                                             (uu____25479, uu____25482)  in
+                                           match uu____25470 with
                                            | (FStar_Pervasives_Native.Some
                                               ik,FStar_Pervasives_Native.Some
                                               jk) ->
@@ -4681,35 +4719,35 @@ let (update_effect_lattice :
                                                     FStar_Pervasives_Native.Some
                                                       (k, ik, jk)
                                                 | FStar_Pervasives_Native.Some
-                                                    (ub,uu____25439,uu____25440)
+                                                    (ub,uu____25524,uu____25525)
                                                     ->
-                                                    let uu____25447 =
-                                                      let uu____25454 =
-                                                        let uu____25456 =
+                                                    let uu____25532 =
+                                                      let uu____25539 =
+                                                        let uu____25541 =
                                                           find_edge order2
                                                             (k, ub)
                                                            in
                                                         FStar_Util.is_some
-                                                          uu____25456
+                                                          uu____25541
                                                          in
-                                                      let uu____25459 =
-                                                        let uu____25461 =
+                                                      let uu____25544 =
+                                                        let uu____25546 =
                                                           find_edge order2
                                                             (ub, k)
                                                            in
                                                         FStar_Util.is_some
-                                                          uu____25461
+                                                          uu____25546
                                                          in
-                                                      (uu____25454,
-                                                        uu____25459)
+                                                      (uu____25539,
+                                                        uu____25544)
                                                        in
-                                                    (match uu____25447 with
+                                                    (match uu____25532 with
                                                      | (true ,true ) ->
-                                                         let uu____25478 =
+                                                         let uu____25563 =
                                                            FStar_Ident.lid_equals
                                                              k ub
                                                             in
-                                                         if uu____25478
+                                                         if uu____25563
                                                          then
                                                            (FStar_Errors.log_issue
                                                               FStar_Range.dummyRange
@@ -4725,100 +4763,100 @@ let (update_effect_lattice :
                                                          FStar_Pervasives_Native.Some
                                                            (k, ik, jk)
                                                      | (false ,true ) -> bopt))
-                                           | uu____25521 -> bopt)
+                                           | uu____25606 -> bopt)
                                       FStar_Pervasives_Native.None)
                                 in
                              match join_opt1 with
                              | FStar_Pervasives_Native.None  -> []
                              | FStar_Pervasives_Native.Some (k,e1,e2) ->
-                                 let uu____25573 =
-                                   let uu____25575 =
+                                 let uu____25658 =
+                                   let uu____25660 =
                                      exists_polymonadic_bind env1 i j  in
-                                   FStar_All.pipe_right uu____25575
+                                   FStar_All.pipe_right uu____25660
                                      FStar_Util.is_some
                                     in
-                                 if uu____25573
+                                 if uu____25658
                                  then
-                                   let uu____25624 =
-                                     let uu____25630 =
-                                       let uu____25632 =
+                                   let uu____25709 =
+                                     let uu____25715 =
+                                       let uu____25717 =
                                          FStar_Ident.string_of_lid src  in
-                                       let uu____25634 =
+                                       let uu____25719 =
                                          FStar_Ident.string_of_lid tgt  in
-                                       let uu____25636 =
+                                       let uu____25721 =
                                          FStar_Ident.string_of_lid i  in
-                                       let uu____25638 =
+                                       let uu____25723 =
                                          FStar_Ident.string_of_lid j  in
                                        FStar_Util.format4
                                          "Updating effect lattice with a lift between %s and %s induces a path from %s and %s in the effect lattice, and this conflicts with a polymonadic bind between them"
-                                         uu____25632 uu____25634 uu____25636
-                                         uu____25638
+                                         uu____25717 uu____25719 uu____25721
+                                         uu____25723
                                         in
                                      (FStar_Errors.Fatal_PolymonadicBind_conflict,
-                                       uu____25630)
+                                       uu____25715)
                                       in
-                                   FStar_Errors.raise_error uu____25624
+                                   FStar_Errors.raise_error uu____25709
                                      env1.range
                                  else [(i, j, k, (e1.mlift), (e2.mlift))]))))
               in
            let effects1 =
-             let uu___1824_25677 = env1.effects  in
+             let uu___1824_25762 = env1.effects  in
              {
-               decls = (uu___1824_25677.decls);
+               decls = (uu___1824_25762.decls);
                order = order2;
                joins;
-               polymonadic_binds = (uu___1824_25677.polymonadic_binds)
+               polymonadic_binds = (uu___1824_25762.polymonadic_binds)
              }  in
-           let uu___1827_25678 = env1  in
+           let uu___1827_25763 = env1  in
            {
-             solver = (uu___1827_25678.solver);
-             range = (uu___1827_25678.range);
-             curmodule = (uu___1827_25678.curmodule);
-             gamma = (uu___1827_25678.gamma);
-             gamma_sig = (uu___1827_25678.gamma_sig);
-             gamma_cache = (uu___1827_25678.gamma_cache);
-             modules = (uu___1827_25678.modules);
-             expected_typ = (uu___1827_25678.expected_typ);
-             sigtab = (uu___1827_25678.sigtab);
-             attrtab = (uu___1827_25678.attrtab);
-             instantiate_imp = (uu___1827_25678.instantiate_imp);
+             solver = (uu___1827_25763.solver);
+             range = (uu___1827_25763.range);
+             curmodule = (uu___1827_25763.curmodule);
+             gamma = (uu___1827_25763.gamma);
+             gamma_sig = (uu___1827_25763.gamma_sig);
+             gamma_cache = (uu___1827_25763.gamma_cache);
+             modules = (uu___1827_25763.modules);
+             expected_typ = (uu___1827_25763.expected_typ);
+             sigtab = (uu___1827_25763.sigtab);
+             attrtab = (uu___1827_25763.attrtab);
+             instantiate_imp = (uu___1827_25763.instantiate_imp);
              effects = effects1;
-             generalize = (uu___1827_25678.generalize);
-             letrecs = (uu___1827_25678.letrecs);
-             top_level = (uu___1827_25678.top_level);
-             check_uvars = (uu___1827_25678.check_uvars);
-             use_eq = (uu___1827_25678.use_eq);
-             use_eq_strict = (uu___1827_25678.use_eq_strict);
-             is_iface = (uu___1827_25678.is_iface);
-             admit = (uu___1827_25678.admit);
-             lax = (uu___1827_25678.lax);
-             lax_universes = (uu___1827_25678.lax_universes);
-             phase1 = (uu___1827_25678.phase1);
-             failhard = (uu___1827_25678.failhard);
-             nosynth = (uu___1827_25678.nosynth);
-             uvar_subtyping = (uu___1827_25678.uvar_subtyping);
-             tc_term = (uu___1827_25678.tc_term);
-             type_of = (uu___1827_25678.type_of);
-             universe_of = (uu___1827_25678.universe_of);
-             check_type_of = (uu___1827_25678.check_type_of);
-             use_bv_sorts = (uu___1827_25678.use_bv_sorts);
-             qtbl_name_and_index = (uu___1827_25678.qtbl_name_and_index);
-             normalized_eff_names = (uu___1827_25678.normalized_eff_names);
-             fv_delta_depths = (uu___1827_25678.fv_delta_depths);
-             proof_ns = (uu___1827_25678.proof_ns);
-             synth_hook = (uu___1827_25678.synth_hook);
+             generalize = (uu___1827_25763.generalize);
+             letrecs = (uu___1827_25763.letrecs);
+             top_level = (uu___1827_25763.top_level);
+             check_uvars = (uu___1827_25763.check_uvars);
+             use_eq = (uu___1827_25763.use_eq);
+             use_eq_strict = (uu___1827_25763.use_eq_strict);
+             is_iface = (uu___1827_25763.is_iface);
+             admit = (uu___1827_25763.admit);
+             lax = (uu___1827_25763.lax);
+             lax_universes = (uu___1827_25763.lax_universes);
+             phase1 = (uu___1827_25763.phase1);
+             failhard = (uu___1827_25763.failhard);
+             nosynth = (uu___1827_25763.nosynth);
+             uvar_subtyping = (uu___1827_25763.uvar_subtyping);
+             tc_term = (uu___1827_25763.tc_term);
+             type_of = (uu___1827_25763.type_of);
+             universe_of = (uu___1827_25763.universe_of);
+             check_type_of = (uu___1827_25763.check_type_of);
+             use_bv_sorts = (uu___1827_25763.use_bv_sorts);
+             qtbl_name_and_index = (uu___1827_25763.qtbl_name_and_index);
+             normalized_eff_names = (uu___1827_25763.normalized_eff_names);
+             fv_delta_depths = (uu___1827_25763.fv_delta_depths);
+             proof_ns = (uu___1827_25763.proof_ns);
+             synth_hook = (uu___1827_25763.synth_hook);
              try_solve_implicits_hook =
-               (uu___1827_25678.try_solve_implicits_hook);
-             splice = (uu___1827_25678.splice);
-             mpreprocess = (uu___1827_25678.mpreprocess);
-             postprocess = (uu___1827_25678.postprocess);
-             is_native_tactic = (uu___1827_25678.is_native_tactic);
-             identifier_info = (uu___1827_25678.identifier_info);
-             tc_hooks = (uu___1827_25678.tc_hooks);
-             dsenv = (uu___1827_25678.dsenv);
-             nbe = (uu___1827_25678.nbe);
-             strict_args_tab = (uu___1827_25678.strict_args_tab);
-             erasable_types_tab = (uu___1827_25678.erasable_types_tab)
+               (uu___1827_25763.try_solve_implicits_hook);
+             splice = (uu___1827_25763.splice);
+             mpreprocess = (uu___1827_25763.mpreprocess);
+             postprocess = (uu___1827_25763.postprocess);
+             is_native_tactic = (uu___1827_25763.is_native_tactic);
+             identifier_info = (uu___1827_25763.identifier_info);
+             tc_hooks = (uu___1827_25763.tc_hooks);
+             dsenv = (uu___1827_25763.dsenv);
+             nbe = (uu___1827_25763.nbe);
+             strict_args_tab = (uu___1827_25763.strict_args_tab);
+             erasable_types_tab = (uu___1827_25763.erasable_types_tab)
            })
   
 let (add_polymonadic_bind :
@@ -4832,152 +4870,152 @@ let (add_polymonadic_bind :
         fun p  ->
           fun ty  ->
             let err_msg poly =
-              let uu____25726 = FStar_Ident.string_of_lid m  in
-              let uu____25728 = FStar_Ident.string_of_lid n  in
-              let uu____25730 = FStar_Ident.string_of_lid p  in
+              let uu____25811 = FStar_Ident.string_of_lid m  in
+              let uu____25813 = FStar_Ident.string_of_lid n  in
+              let uu____25815 = FStar_Ident.string_of_lid p  in
               FStar_Util.format4
                 "Polymonadic bind ((%s, %s) |> %s) conflicts with an already existing %s"
-                uu____25726 uu____25728 uu____25730
+                uu____25811 uu____25813 uu____25815
                 (if poly
                  then "polymonadic bind"
                  else "path in the effect lattice")
                in
-            let uu____25739 =
-              let uu____25741 = exists_polymonadic_bind env1 m n  in
-              FStar_All.pipe_right uu____25741 FStar_Util.is_some  in
-            if uu____25739
+            let uu____25824 =
+              let uu____25826 = exists_polymonadic_bind env1 m n  in
+              FStar_All.pipe_right uu____25826 FStar_Util.is_some  in
+            if uu____25824
             then
-              let uu____25778 =
-                let uu____25784 = err_msg true  in
-                (FStar_Errors.Fatal_PolymonadicBind_conflict, uu____25784)
+              let uu____25863 =
+                let uu____25869 = err_msg true  in
+                (FStar_Errors.Fatal_PolymonadicBind_conflict, uu____25869)
                  in
-              FStar_Errors.raise_error uu____25778 env1.range
+              FStar_Errors.raise_error uu____25863 env1.range
             else
-              (let uu____25790 =
-                 let uu____25792 = join_opt env1 m n  in
-                 FStar_All.pipe_right uu____25792 FStar_Util.is_some  in
-               if uu____25790
+              (let uu____25875 =
+                 let uu____25877 = join_opt env1 m n  in
+                 FStar_All.pipe_right uu____25877 FStar_Util.is_some  in
+               if uu____25875
                then
-                 let uu____25817 =
-                   let uu____25823 = err_msg false  in
-                   (FStar_Errors.Fatal_PolymonadicBind_conflict, uu____25823)
+                 let uu____25902 =
+                   let uu____25908 = err_msg false  in
+                   (FStar_Errors.Fatal_PolymonadicBind_conflict, uu____25908)
                     in
-                 FStar_Errors.raise_error uu____25817 env1.range
+                 FStar_Errors.raise_error uu____25902 env1.range
                else
-                 (let uu___1842_25829 = env1  in
+                 (let uu___1842_25914 = env1  in
                   {
-                    solver = (uu___1842_25829.solver);
-                    range = (uu___1842_25829.range);
-                    curmodule = (uu___1842_25829.curmodule);
-                    gamma = (uu___1842_25829.gamma);
-                    gamma_sig = (uu___1842_25829.gamma_sig);
-                    gamma_cache = (uu___1842_25829.gamma_cache);
-                    modules = (uu___1842_25829.modules);
-                    expected_typ = (uu___1842_25829.expected_typ);
-                    sigtab = (uu___1842_25829.sigtab);
-                    attrtab = (uu___1842_25829.attrtab);
-                    instantiate_imp = (uu___1842_25829.instantiate_imp);
+                    solver = (uu___1842_25914.solver);
+                    range = (uu___1842_25914.range);
+                    curmodule = (uu___1842_25914.curmodule);
+                    gamma = (uu___1842_25914.gamma);
+                    gamma_sig = (uu___1842_25914.gamma_sig);
+                    gamma_cache = (uu___1842_25914.gamma_cache);
+                    modules = (uu___1842_25914.modules);
+                    expected_typ = (uu___1842_25914.expected_typ);
+                    sigtab = (uu___1842_25914.sigtab);
+                    attrtab = (uu___1842_25914.attrtab);
+                    instantiate_imp = (uu___1842_25914.instantiate_imp);
                     effects =
-                      (let uu___1844_25831 = env1.effects  in
+                      (let uu___1844_25916 = env1.effects  in
                        {
-                         decls = (uu___1844_25831.decls);
-                         order = (uu___1844_25831.order);
-                         joins = (uu___1844_25831.joins);
+                         decls = (uu___1844_25916.decls);
+                         order = (uu___1844_25916.order);
+                         joins = (uu___1844_25916.joins);
                          polymonadic_binds = ((m, n, p, ty) ::
                            ((env1.effects).polymonadic_binds))
                        });
-                    generalize = (uu___1842_25829.generalize);
-                    letrecs = (uu___1842_25829.letrecs);
-                    top_level = (uu___1842_25829.top_level);
-                    check_uvars = (uu___1842_25829.check_uvars);
-                    use_eq = (uu___1842_25829.use_eq);
-                    use_eq_strict = (uu___1842_25829.use_eq_strict);
-                    is_iface = (uu___1842_25829.is_iface);
-                    admit = (uu___1842_25829.admit);
-                    lax = (uu___1842_25829.lax);
-                    lax_universes = (uu___1842_25829.lax_universes);
-                    phase1 = (uu___1842_25829.phase1);
-                    failhard = (uu___1842_25829.failhard);
-                    nosynth = (uu___1842_25829.nosynth);
-                    uvar_subtyping = (uu___1842_25829.uvar_subtyping);
-                    tc_term = (uu___1842_25829.tc_term);
-                    type_of = (uu___1842_25829.type_of);
-                    universe_of = (uu___1842_25829.universe_of);
-                    check_type_of = (uu___1842_25829.check_type_of);
-                    use_bv_sorts = (uu___1842_25829.use_bv_sorts);
+                    generalize = (uu___1842_25914.generalize);
+                    letrecs = (uu___1842_25914.letrecs);
+                    top_level = (uu___1842_25914.top_level);
+                    check_uvars = (uu___1842_25914.check_uvars);
+                    use_eq = (uu___1842_25914.use_eq);
+                    use_eq_strict = (uu___1842_25914.use_eq_strict);
+                    is_iface = (uu___1842_25914.is_iface);
+                    admit = (uu___1842_25914.admit);
+                    lax = (uu___1842_25914.lax);
+                    lax_universes = (uu___1842_25914.lax_universes);
+                    phase1 = (uu___1842_25914.phase1);
+                    failhard = (uu___1842_25914.failhard);
+                    nosynth = (uu___1842_25914.nosynth);
+                    uvar_subtyping = (uu___1842_25914.uvar_subtyping);
+                    tc_term = (uu___1842_25914.tc_term);
+                    type_of = (uu___1842_25914.type_of);
+                    universe_of = (uu___1842_25914.universe_of);
+                    check_type_of = (uu___1842_25914.check_type_of);
+                    use_bv_sorts = (uu___1842_25914.use_bv_sorts);
                     qtbl_name_and_index =
-                      (uu___1842_25829.qtbl_name_and_index);
+                      (uu___1842_25914.qtbl_name_and_index);
                     normalized_eff_names =
-                      (uu___1842_25829.normalized_eff_names);
-                    fv_delta_depths = (uu___1842_25829.fv_delta_depths);
-                    proof_ns = (uu___1842_25829.proof_ns);
-                    synth_hook = (uu___1842_25829.synth_hook);
+                      (uu___1842_25914.normalized_eff_names);
+                    fv_delta_depths = (uu___1842_25914.fv_delta_depths);
+                    proof_ns = (uu___1842_25914.proof_ns);
+                    synth_hook = (uu___1842_25914.synth_hook);
                     try_solve_implicits_hook =
-                      (uu___1842_25829.try_solve_implicits_hook);
-                    splice = (uu___1842_25829.splice);
-                    mpreprocess = (uu___1842_25829.mpreprocess);
-                    postprocess = (uu___1842_25829.postprocess);
-                    is_native_tactic = (uu___1842_25829.is_native_tactic);
-                    identifier_info = (uu___1842_25829.identifier_info);
-                    tc_hooks = (uu___1842_25829.tc_hooks);
-                    dsenv = (uu___1842_25829.dsenv);
-                    nbe = (uu___1842_25829.nbe);
-                    strict_args_tab = (uu___1842_25829.strict_args_tab);
-                    erasable_types_tab = (uu___1842_25829.erasable_types_tab)
+                      (uu___1842_25914.try_solve_implicits_hook);
+                    splice = (uu___1842_25914.splice);
+                    mpreprocess = (uu___1842_25914.mpreprocess);
+                    postprocess = (uu___1842_25914.postprocess);
+                    is_native_tactic = (uu___1842_25914.is_native_tactic);
+                    identifier_info = (uu___1842_25914.identifier_info);
+                    tc_hooks = (uu___1842_25914.tc_hooks);
+                    dsenv = (uu___1842_25914.dsenv);
+                    nbe = (uu___1842_25914.nbe);
+                    strict_args_tab = (uu___1842_25914.strict_args_tab);
+                    erasable_types_tab = (uu___1842_25914.erasable_types_tab)
                   }))
   
 let (push_local_binding : env -> FStar_Syntax_Syntax.binding -> env) =
   fun env1  ->
     fun b  ->
-      let uu___1848_25903 = env1  in
+      let uu___1848_25988 = env1  in
       {
-        solver = (uu___1848_25903.solver);
-        range = (uu___1848_25903.range);
-        curmodule = (uu___1848_25903.curmodule);
+        solver = (uu___1848_25988.solver);
+        range = (uu___1848_25988.range);
+        curmodule = (uu___1848_25988.curmodule);
         gamma = (b :: (env1.gamma));
-        gamma_sig = (uu___1848_25903.gamma_sig);
-        gamma_cache = (uu___1848_25903.gamma_cache);
-        modules = (uu___1848_25903.modules);
-        expected_typ = (uu___1848_25903.expected_typ);
-        sigtab = (uu___1848_25903.sigtab);
-        attrtab = (uu___1848_25903.attrtab);
-        instantiate_imp = (uu___1848_25903.instantiate_imp);
-        effects = (uu___1848_25903.effects);
-        generalize = (uu___1848_25903.generalize);
-        letrecs = (uu___1848_25903.letrecs);
-        top_level = (uu___1848_25903.top_level);
-        check_uvars = (uu___1848_25903.check_uvars);
-        use_eq = (uu___1848_25903.use_eq);
-        use_eq_strict = (uu___1848_25903.use_eq_strict);
-        is_iface = (uu___1848_25903.is_iface);
-        admit = (uu___1848_25903.admit);
-        lax = (uu___1848_25903.lax);
-        lax_universes = (uu___1848_25903.lax_universes);
-        phase1 = (uu___1848_25903.phase1);
-        failhard = (uu___1848_25903.failhard);
-        nosynth = (uu___1848_25903.nosynth);
-        uvar_subtyping = (uu___1848_25903.uvar_subtyping);
-        tc_term = (uu___1848_25903.tc_term);
-        type_of = (uu___1848_25903.type_of);
-        universe_of = (uu___1848_25903.universe_of);
-        check_type_of = (uu___1848_25903.check_type_of);
-        use_bv_sorts = (uu___1848_25903.use_bv_sorts);
-        qtbl_name_and_index = (uu___1848_25903.qtbl_name_and_index);
-        normalized_eff_names = (uu___1848_25903.normalized_eff_names);
-        fv_delta_depths = (uu___1848_25903.fv_delta_depths);
-        proof_ns = (uu___1848_25903.proof_ns);
-        synth_hook = (uu___1848_25903.synth_hook);
-        try_solve_implicits_hook = (uu___1848_25903.try_solve_implicits_hook);
-        splice = (uu___1848_25903.splice);
-        mpreprocess = (uu___1848_25903.mpreprocess);
-        postprocess = (uu___1848_25903.postprocess);
-        is_native_tactic = (uu___1848_25903.is_native_tactic);
-        identifier_info = (uu___1848_25903.identifier_info);
-        tc_hooks = (uu___1848_25903.tc_hooks);
-        dsenv = (uu___1848_25903.dsenv);
-        nbe = (uu___1848_25903.nbe);
-        strict_args_tab = (uu___1848_25903.strict_args_tab);
-        erasable_types_tab = (uu___1848_25903.erasable_types_tab)
+        gamma_sig = (uu___1848_25988.gamma_sig);
+        gamma_cache = (uu___1848_25988.gamma_cache);
+        modules = (uu___1848_25988.modules);
+        expected_typ = (uu___1848_25988.expected_typ);
+        sigtab = (uu___1848_25988.sigtab);
+        attrtab = (uu___1848_25988.attrtab);
+        instantiate_imp = (uu___1848_25988.instantiate_imp);
+        effects = (uu___1848_25988.effects);
+        generalize = (uu___1848_25988.generalize);
+        letrecs = (uu___1848_25988.letrecs);
+        top_level = (uu___1848_25988.top_level);
+        check_uvars = (uu___1848_25988.check_uvars);
+        use_eq = (uu___1848_25988.use_eq);
+        use_eq_strict = (uu___1848_25988.use_eq_strict);
+        is_iface = (uu___1848_25988.is_iface);
+        admit = (uu___1848_25988.admit);
+        lax = (uu___1848_25988.lax);
+        lax_universes = (uu___1848_25988.lax_universes);
+        phase1 = (uu___1848_25988.phase1);
+        failhard = (uu___1848_25988.failhard);
+        nosynth = (uu___1848_25988.nosynth);
+        uvar_subtyping = (uu___1848_25988.uvar_subtyping);
+        tc_term = (uu___1848_25988.tc_term);
+        type_of = (uu___1848_25988.type_of);
+        universe_of = (uu___1848_25988.universe_of);
+        check_type_of = (uu___1848_25988.check_type_of);
+        use_bv_sorts = (uu___1848_25988.use_bv_sorts);
+        qtbl_name_and_index = (uu___1848_25988.qtbl_name_and_index);
+        normalized_eff_names = (uu___1848_25988.normalized_eff_names);
+        fv_delta_depths = (uu___1848_25988.fv_delta_depths);
+        proof_ns = (uu___1848_25988.proof_ns);
+        synth_hook = (uu___1848_25988.synth_hook);
+        try_solve_implicits_hook = (uu___1848_25988.try_solve_implicits_hook);
+        splice = (uu___1848_25988.splice);
+        mpreprocess = (uu___1848_25988.mpreprocess);
+        postprocess = (uu___1848_25988.postprocess);
+        is_native_tactic = (uu___1848_25988.is_native_tactic);
+        identifier_info = (uu___1848_25988.identifier_info);
+        tc_hooks = (uu___1848_25988.tc_hooks);
+        dsenv = (uu___1848_25988.dsenv);
+        nbe = (uu___1848_25988.nbe);
+        strict_args_tab = (uu___1848_25988.strict_args_tab);
+        erasable_types_tab = (uu___1848_25988.erasable_types_tab)
       }
   
 let (push_bv : env -> FStar_Syntax_Syntax.bv -> env) =
@@ -4996,66 +5034,66 @@ let (pop_bv :
     | (FStar_Syntax_Syntax.Binding_var x)::rest ->
         FStar_Pervasives_Native.Some
           (x,
-            (let uu___1861_25961 = env1  in
+            (let uu___1861_26046 = env1  in
              {
-               solver = (uu___1861_25961.solver);
-               range = (uu___1861_25961.range);
-               curmodule = (uu___1861_25961.curmodule);
+               solver = (uu___1861_26046.solver);
+               range = (uu___1861_26046.range);
+               curmodule = (uu___1861_26046.curmodule);
                gamma = rest;
-               gamma_sig = (uu___1861_25961.gamma_sig);
-               gamma_cache = (uu___1861_25961.gamma_cache);
-               modules = (uu___1861_25961.modules);
-               expected_typ = (uu___1861_25961.expected_typ);
-               sigtab = (uu___1861_25961.sigtab);
-               attrtab = (uu___1861_25961.attrtab);
-               instantiate_imp = (uu___1861_25961.instantiate_imp);
-               effects = (uu___1861_25961.effects);
-               generalize = (uu___1861_25961.generalize);
-               letrecs = (uu___1861_25961.letrecs);
-               top_level = (uu___1861_25961.top_level);
-               check_uvars = (uu___1861_25961.check_uvars);
-               use_eq = (uu___1861_25961.use_eq);
-               use_eq_strict = (uu___1861_25961.use_eq_strict);
-               is_iface = (uu___1861_25961.is_iface);
-               admit = (uu___1861_25961.admit);
-               lax = (uu___1861_25961.lax);
-               lax_universes = (uu___1861_25961.lax_universes);
-               phase1 = (uu___1861_25961.phase1);
-               failhard = (uu___1861_25961.failhard);
-               nosynth = (uu___1861_25961.nosynth);
-               uvar_subtyping = (uu___1861_25961.uvar_subtyping);
-               tc_term = (uu___1861_25961.tc_term);
-               type_of = (uu___1861_25961.type_of);
-               universe_of = (uu___1861_25961.universe_of);
-               check_type_of = (uu___1861_25961.check_type_of);
-               use_bv_sorts = (uu___1861_25961.use_bv_sorts);
-               qtbl_name_and_index = (uu___1861_25961.qtbl_name_and_index);
-               normalized_eff_names = (uu___1861_25961.normalized_eff_names);
-               fv_delta_depths = (uu___1861_25961.fv_delta_depths);
-               proof_ns = (uu___1861_25961.proof_ns);
-               synth_hook = (uu___1861_25961.synth_hook);
+               gamma_sig = (uu___1861_26046.gamma_sig);
+               gamma_cache = (uu___1861_26046.gamma_cache);
+               modules = (uu___1861_26046.modules);
+               expected_typ = (uu___1861_26046.expected_typ);
+               sigtab = (uu___1861_26046.sigtab);
+               attrtab = (uu___1861_26046.attrtab);
+               instantiate_imp = (uu___1861_26046.instantiate_imp);
+               effects = (uu___1861_26046.effects);
+               generalize = (uu___1861_26046.generalize);
+               letrecs = (uu___1861_26046.letrecs);
+               top_level = (uu___1861_26046.top_level);
+               check_uvars = (uu___1861_26046.check_uvars);
+               use_eq = (uu___1861_26046.use_eq);
+               use_eq_strict = (uu___1861_26046.use_eq_strict);
+               is_iface = (uu___1861_26046.is_iface);
+               admit = (uu___1861_26046.admit);
+               lax = (uu___1861_26046.lax);
+               lax_universes = (uu___1861_26046.lax_universes);
+               phase1 = (uu___1861_26046.phase1);
+               failhard = (uu___1861_26046.failhard);
+               nosynth = (uu___1861_26046.nosynth);
+               uvar_subtyping = (uu___1861_26046.uvar_subtyping);
+               tc_term = (uu___1861_26046.tc_term);
+               type_of = (uu___1861_26046.type_of);
+               universe_of = (uu___1861_26046.universe_of);
+               check_type_of = (uu___1861_26046.check_type_of);
+               use_bv_sorts = (uu___1861_26046.use_bv_sorts);
+               qtbl_name_and_index = (uu___1861_26046.qtbl_name_and_index);
+               normalized_eff_names = (uu___1861_26046.normalized_eff_names);
+               fv_delta_depths = (uu___1861_26046.fv_delta_depths);
+               proof_ns = (uu___1861_26046.proof_ns);
+               synth_hook = (uu___1861_26046.synth_hook);
                try_solve_implicits_hook =
-                 (uu___1861_25961.try_solve_implicits_hook);
-               splice = (uu___1861_25961.splice);
-               mpreprocess = (uu___1861_25961.mpreprocess);
-               postprocess = (uu___1861_25961.postprocess);
-               is_native_tactic = (uu___1861_25961.is_native_tactic);
-               identifier_info = (uu___1861_25961.identifier_info);
-               tc_hooks = (uu___1861_25961.tc_hooks);
-               dsenv = (uu___1861_25961.dsenv);
-               nbe = (uu___1861_25961.nbe);
-               strict_args_tab = (uu___1861_25961.strict_args_tab);
-               erasable_types_tab = (uu___1861_25961.erasable_types_tab)
+                 (uu___1861_26046.try_solve_implicits_hook);
+               splice = (uu___1861_26046.splice);
+               mpreprocess = (uu___1861_26046.mpreprocess);
+               postprocess = (uu___1861_26046.postprocess);
+               is_native_tactic = (uu___1861_26046.is_native_tactic);
+               identifier_info = (uu___1861_26046.identifier_info);
+               tc_hooks = (uu___1861_26046.tc_hooks);
+               dsenv = (uu___1861_26046.dsenv);
+               nbe = (uu___1861_26046.nbe);
+               strict_args_tab = (uu___1861_26046.strict_args_tab);
+               erasable_types_tab = (uu___1861_26046.erasable_types_tab)
              }))
-    | uu____25962 -> FStar_Pervasives_Native.None
+    | uu____26047 -> FStar_Pervasives_Native.None
   
 let (push_binders : env -> FStar_Syntax_Syntax.binders -> env) =
   fun env1  ->
     fun bs  ->
       FStar_List.fold_left
         (fun env2  ->
-           fun uu____25991  ->
-             match uu____25991 with | (x,uu____25999) -> push_bv env2 x) env1
+           fun uu____26076  ->
+             match uu____26076 with | (x,uu____26084) -> push_bv env2 x) env1
         bs
   
 let (binding_of_lb :
@@ -5068,12 +5106,12 @@ let (binding_of_lb :
       match x with
       | FStar_Util.Inl x1 ->
           let x2 =
-            let uu___1875_26034 = x1  in
+            let uu___1875_26119 = x1  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___1875_26034.FStar_Syntax_Syntax.ppname);
+                (uu___1875_26119.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___1875_26034.FStar_Syntax_Syntax.index);
+                (uu___1875_26119.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = (FStar_Pervasives_Native.snd t)
             }  in
           FStar_Syntax_Syntax.Binding_var x2
@@ -5105,66 +5143,66 @@ let (open_universes_in :
   fun env1  ->
     fun uvs  ->
       fun terms  ->
-        let uu____26107 = FStar_Syntax_Subst.univ_var_opening uvs  in
-        match uu____26107 with
+        let uu____26192 = FStar_Syntax_Subst.univ_var_opening uvs  in
+        match uu____26192 with
         | (univ_subst,univ_vars) ->
             let env' = push_univ_vars env1 univ_vars  in
-            let uu____26135 =
+            let uu____26220 =
               FStar_List.map (FStar_Syntax_Subst.subst univ_subst) terms  in
-            (env', univ_vars, uu____26135)
+            (env', univ_vars, uu____26220)
   
 let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
   fun env1  ->
     fun t  ->
-      let uu___1896_26151 = env1  in
+      let uu___1896_26236 = env1  in
       {
-        solver = (uu___1896_26151.solver);
-        range = (uu___1896_26151.range);
-        curmodule = (uu___1896_26151.curmodule);
-        gamma = (uu___1896_26151.gamma);
-        gamma_sig = (uu___1896_26151.gamma_sig);
-        gamma_cache = (uu___1896_26151.gamma_cache);
-        modules = (uu___1896_26151.modules);
+        solver = (uu___1896_26236.solver);
+        range = (uu___1896_26236.range);
+        curmodule = (uu___1896_26236.curmodule);
+        gamma = (uu___1896_26236.gamma);
+        gamma_sig = (uu___1896_26236.gamma_sig);
+        gamma_cache = (uu___1896_26236.gamma_cache);
+        modules = (uu___1896_26236.modules);
         expected_typ = (FStar_Pervasives_Native.Some t);
-        sigtab = (uu___1896_26151.sigtab);
-        attrtab = (uu___1896_26151.attrtab);
-        instantiate_imp = (uu___1896_26151.instantiate_imp);
-        effects = (uu___1896_26151.effects);
-        generalize = (uu___1896_26151.generalize);
-        letrecs = (uu___1896_26151.letrecs);
-        top_level = (uu___1896_26151.top_level);
-        check_uvars = (uu___1896_26151.check_uvars);
+        sigtab = (uu___1896_26236.sigtab);
+        attrtab = (uu___1896_26236.attrtab);
+        instantiate_imp = (uu___1896_26236.instantiate_imp);
+        effects = (uu___1896_26236.effects);
+        generalize = (uu___1896_26236.generalize);
+        letrecs = (uu___1896_26236.letrecs);
+        top_level = (uu___1896_26236.top_level);
+        check_uvars = (uu___1896_26236.check_uvars);
         use_eq = false;
-        use_eq_strict = (uu___1896_26151.use_eq_strict);
-        is_iface = (uu___1896_26151.is_iface);
-        admit = (uu___1896_26151.admit);
-        lax = (uu___1896_26151.lax);
-        lax_universes = (uu___1896_26151.lax_universes);
-        phase1 = (uu___1896_26151.phase1);
-        failhard = (uu___1896_26151.failhard);
-        nosynth = (uu___1896_26151.nosynth);
-        uvar_subtyping = (uu___1896_26151.uvar_subtyping);
-        tc_term = (uu___1896_26151.tc_term);
-        type_of = (uu___1896_26151.type_of);
-        universe_of = (uu___1896_26151.universe_of);
-        check_type_of = (uu___1896_26151.check_type_of);
-        use_bv_sorts = (uu___1896_26151.use_bv_sorts);
-        qtbl_name_and_index = (uu___1896_26151.qtbl_name_and_index);
-        normalized_eff_names = (uu___1896_26151.normalized_eff_names);
-        fv_delta_depths = (uu___1896_26151.fv_delta_depths);
-        proof_ns = (uu___1896_26151.proof_ns);
-        synth_hook = (uu___1896_26151.synth_hook);
-        try_solve_implicits_hook = (uu___1896_26151.try_solve_implicits_hook);
-        splice = (uu___1896_26151.splice);
-        mpreprocess = (uu___1896_26151.mpreprocess);
-        postprocess = (uu___1896_26151.postprocess);
-        is_native_tactic = (uu___1896_26151.is_native_tactic);
-        identifier_info = (uu___1896_26151.identifier_info);
-        tc_hooks = (uu___1896_26151.tc_hooks);
-        dsenv = (uu___1896_26151.dsenv);
-        nbe = (uu___1896_26151.nbe);
-        strict_args_tab = (uu___1896_26151.strict_args_tab);
-        erasable_types_tab = (uu___1896_26151.erasable_types_tab)
+        use_eq_strict = (uu___1896_26236.use_eq_strict);
+        is_iface = (uu___1896_26236.is_iface);
+        admit = (uu___1896_26236.admit);
+        lax = (uu___1896_26236.lax);
+        lax_universes = (uu___1896_26236.lax_universes);
+        phase1 = (uu___1896_26236.phase1);
+        failhard = (uu___1896_26236.failhard);
+        nosynth = (uu___1896_26236.nosynth);
+        uvar_subtyping = (uu___1896_26236.uvar_subtyping);
+        tc_term = (uu___1896_26236.tc_term);
+        type_of = (uu___1896_26236.type_of);
+        universe_of = (uu___1896_26236.universe_of);
+        check_type_of = (uu___1896_26236.check_type_of);
+        use_bv_sorts = (uu___1896_26236.use_bv_sorts);
+        qtbl_name_and_index = (uu___1896_26236.qtbl_name_and_index);
+        normalized_eff_names = (uu___1896_26236.normalized_eff_names);
+        fv_delta_depths = (uu___1896_26236.fv_delta_depths);
+        proof_ns = (uu___1896_26236.proof_ns);
+        synth_hook = (uu___1896_26236.synth_hook);
+        try_solve_implicits_hook = (uu___1896_26236.try_solve_implicits_hook);
+        splice = (uu___1896_26236.splice);
+        mpreprocess = (uu___1896_26236.mpreprocess);
+        postprocess = (uu___1896_26236.postprocess);
+        is_native_tactic = (uu___1896_26236.is_native_tactic);
+        identifier_info = (uu___1896_26236.identifier_info);
+        tc_hooks = (uu___1896_26236.tc_hooks);
+        dsenv = (uu___1896_26236.dsenv);
+        nbe = (uu___1896_26236.nbe);
+        strict_args_tab = (uu___1896_26236.strict_args_tab);
+        erasable_types_tab = (uu___1896_26236.erasable_types_tab)
       }
   
 let (expected_typ :
@@ -5177,129 +5215,129 @@ let (expected_typ :
 let (clear_expected_typ :
   env -> (env * FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)) =
   fun env_  ->
-    let uu____26182 = expected_typ env_  in
-    ((let uu___1903_26188 = env_  in
+    let uu____26267 = expected_typ env_  in
+    ((let uu___1903_26273 = env_  in
       {
-        solver = (uu___1903_26188.solver);
-        range = (uu___1903_26188.range);
-        curmodule = (uu___1903_26188.curmodule);
-        gamma = (uu___1903_26188.gamma);
-        gamma_sig = (uu___1903_26188.gamma_sig);
-        gamma_cache = (uu___1903_26188.gamma_cache);
-        modules = (uu___1903_26188.modules);
+        solver = (uu___1903_26273.solver);
+        range = (uu___1903_26273.range);
+        curmodule = (uu___1903_26273.curmodule);
+        gamma = (uu___1903_26273.gamma);
+        gamma_sig = (uu___1903_26273.gamma_sig);
+        gamma_cache = (uu___1903_26273.gamma_cache);
+        modules = (uu___1903_26273.modules);
         expected_typ = FStar_Pervasives_Native.None;
-        sigtab = (uu___1903_26188.sigtab);
-        attrtab = (uu___1903_26188.attrtab);
-        instantiate_imp = (uu___1903_26188.instantiate_imp);
-        effects = (uu___1903_26188.effects);
-        generalize = (uu___1903_26188.generalize);
-        letrecs = (uu___1903_26188.letrecs);
-        top_level = (uu___1903_26188.top_level);
-        check_uvars = (uu___1903_26188.check_uvars);
+        sigtab = (uu___1903_26273.sigtab);
+        attrtab = (uu___1903_26273.attrtab);
+        instantiate_imp = (uu___1903_26273.instantiate_imp);
+        effects = (uu___1903_26273.effects);
+        generalize = (uu___1903_26273.generalize);
+        letrecs = (uu___1903_26273.letrecs);
+        top_level = (uu___1903_26273.top_level);
+        check_uvars = (uu___1903_26273.check_uvars);
         use_eq = false;
-        use_eq_strict = (uu___1903_26188.use_eq_strict);
-        is_iface = (uu___1903_26188.is_iface);
-        admit = (uu___1903_26188.admit);
-        lax = (uu___1903_26188.lax);
-        lax_universes = (uu___1903_26188.lax_universes);
-        phase1 = (uu___1903_26188.phase1);
-        failhard = (uu___1903_26188.failhard);
-        nosynth = (uu___1903_26188.nosynth);
-        uvar_subtyping = (uu___1903_26188.uvar_subtyping);
-        tc_term = (uu___1903_26188.tc_term);
-        type_of = (uu___1903_26188.type_of);
-        universe_of = (uu___1903_26188.universe_of);
-        check_type_of = (uu___1903_26188.check_type_of);
-        use_bv_sorts = (uu___1903_26188.use_bv_sorts);
-        qtbl_name_and_index = (uu___1903_26188.qtbl_name_and_index);
-        normalized_eff_names = (uu___1903_26188.normalized_eff_names);
-        fv_delta_depths = (uu___1903_26188.fv_delta_depths);
-        proof_ns = (uu___1903_26188.proof_ns);
-        synth_hook = (uu___1903_26188.synth_hook);
-        try_solve_implicits_hook = (uu___1903_26188.try_solve_implicits_hook);
-        splice = (uu___1903_26188.splice);
-        mpreprocess = (uu___1903_26188.mpreprocess);
-        postprocess = (uu___1903_26188.postprocess);
-        is_native_tactic = (uu___1903_26188.is_native_tactic);
-        identifier_info = (uu___1903_26188.identifier_info);
-        tc_hooks = (uu___1903_26188.tc_hooks);
-        dsenv = (uu___1903_26188.dsenv);
-        nbe = (uu___1903_26188.nbe);
-        strict_args_tab = (uu___1903_26188.strict_args_tab);
-        erasable_types_tab = (uu___1903_26188.erasable_types_tab)
-      }), uu____26182)
+        use_eq_strict = (uu___1903_26273.use_eq_strict);
+        is_iface = (uu___1903_26273.is_iface);
+        admit = (uu___1903_26273.admit);
+        lax = (uu___1903_26273.lax);
+        lax_universes = (uu___1903_26273.lax_universes);
+        phase1 = (uu___1903_26273.phase1);
+        failhard = (uu___1903_26273.failhard);
+        nosynth = (uu___1903_26273.nosynth);
+        uvar_subtyping = (uu___1903_26273.uvar_subtyping);
+        tc_term = (uu___1903_26273.tc_term);
+        type_of = (uu___1903_26273.type_of);
+        universe_of = (uu___1903_26273.universe_of);
+        check_type_of = (uu___1903_26273.check_type_of);
+        use_bv_sorts = (uu___1903_26273.use_bv_sorts);
+        qtbl_name_and_index = (uu___1903_26273.qtbl_name_and_index);
+        normalized_eff_names = (uu___1903_26273.normalized_eff_names);
+        fv_delta_depths = (uu___1903_26273.fv_delta_depths);
+        proof_ns = (uu___1903_26273.proof_ns);
+        synth_hook = (uu___1903_26273.synth_hook);
+        try_solve_implicits_hook = (uu___1903_26273.try_solve_implicits_hook);
+        splice = (uu___1903_26273.splice);
+        mpreprocess = (uu___1903_26273.mpreprocess);
+        postprocess = (uu___1903_26273.postprocess);
+        is_native_tactic = (uu___1903_26273.is_native_tactic);
+        identifier_info = (uu___1903_26273.identifier_info);
+        tc_hooks = (uu___1903_26273.tc_hooks);
+        dsenv = (uu___1903_26273.dsenv);
+        nbe = (uu___1903_26273.nbe);
+        strict_args_tab = (uu___1903_26273.strict_args_tab);
+        erasable_types_tab = (uu___1903_26273.erasable_types_tab)
+      }), uu____26267)
   
 let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
   let empty_lid =
-    let uu____26200 =
-      let uu____26203 = FStar_Ident.id_of_text ""  in [uu____26203]  in
-    FStar_Ident.lid_of_ids uu____26200  in
+    let uu____26285 =
+      let uu____26286 = FStar_Ident.id_of_text ""  in [uu____26286]  in
+    FStar_Ident.lid_of_ids uu____26285  in
   fun env1  ->
     fun m  ->
       let sigs =
-        let uu____26210 =
+        let uu____26293 =
           FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name
             FStar_Parser_Const.prims_lid
            in
-        if uu____26210
+        if uu____26293
         then
-          let uu____26215 =
+          let uu____26298 =
             FStar_All.pipe_right env1.gamma_sig
               (FStar_List.map FStar_Pervasives_Native.snd)
              in
-          FStar_All.pipe_right uu____26215 FStar_List.rev
+          FStar_All.pipe_right uu____26298 FStar_List.rev
         else m.FStar_Syntax_Syntax.exports  in
       add_sigelts env1 sigs;
-      (let uu___1911_26243 = env1  in
+      (let uu___1911_26326 = env1  in
        {
-         solver = (uu___1911_26243.solver);
-         range = (uu___1911_26243.range);
+         solver = (uu___1911_26326.solver);
+         range = (uu___1911_26326.range);
          curmodule = empty_lid;
          gamma = [];
          gamma_sig = [];
-         gamma_cache = (uu___1911_26243.gamma_cache);
+         gamma_cache = (uu___1911_26326.gamma_cache);
          modules = (m :: (env1.modules));
-         expected_typ = (uu___1911_26243.expected_typ);
-         sigtab = (uu___1911_26243.sigtab);
-         attrtab = (uu___1911_26243.attrtab);
-         instantiate_imp = (uu___1911_26243.instantiate_imp);
-         effects = (uu___1911_26243.effects);
-         generalize = (uu___1911_26243.generalize);
-         letrecs = (uu___1911_26243.letrecs);
-         top_level = (uu___1911_26243.top_level);
-         check_uvars = (uu___1911_26243.check_uvars);
-         use_eq = (uu___1911_26243.use_eq);
-         use_eq_strict = (uu___1911_26243.use_eq_strict);
-         is_iface = (uu___1911_26243.is_iface);
-         admit = (uu___1911_26243.admit);
-         lax = (uu___1911_26243.lax);
-         lax_universes = (uu___1911_26243.lax_universes);
-         phase1 = (uu___1911_26243.phase1);
-         failhard = (uu___1911_26243.failhard);
-         nosynth = (uu___1911_26243.nosynth);
-         uvar_subtyping = (uu___1911_26243.uvar_subtyping);
-         tc_term = (uu___1911_26243.tc_term);
-         type_of = (uu___1911_26243.type_of);
-         universe_of = (uu___1911_26243.universe_of);
-         check_type_of = (uu___1911_26243.check_type_of);
-         use_bv_sorts = (uu___1911_26243.use_bv_sorts);
-         qtbl_name_and_index = (uu___1911_26243.qtbl_name_and_index);
-         normalized_eff_names = (uu___1911_26243.normalized_eff_names);
-         fv_delta_depths = (uu___1911_26243.fv_delta_depths);
-         proof_ns = (uu___1911_26243.proof_ns);
-         synth_hook = (uu___1911_26243.synth_hook);
+         expected_typ = (uu___1911_26326.expected_typ);
+         sigtab = (uu___1911_26326.sigtab);
+         attrtab = (uu___1911_26326.attrtab);
+         instantiate_imp = (uu___1911_26326.instantiate_imp);
+         effects = (uu___1911_26326.effects);
+         generalize = (uu___1911_26326.generalize);
+         letrecs = (uu___1911_26326.letrecs);
+         top_level = (uu___1911_26326.top_level);
+         check_uvars = (uu___1911_26326.check_uvars);
+         use_eq = (uu___1911_26326.use_eq);
+         use_eq_strict = (uu___1911_26326.use_eq_strict);
+         is_iface = (uu___1911_26326.is_iface);
+         admit = (uu___1911_26326.admit);
+         lax = (uu___1911_26326.lax);
+         lax_universes = (uu___1911_26326.lax_universes);
+         phase1 = (uu___1911_26326.phase1);
+         failhard = (uu___1911_26326.failhard);
+         nosynth = (uu___1911_26326.nosynth);
+         uvar_subtyping = (uu___1911_26326.uvar_subtyping);
+         tc_term = (uu___1911_26326.tc_term);
+         type_of = (uu___1911_26326.type_of);
+         universe_of = (uu___1911_26326.universe_of);
+         check_type_of = (uu___1911_26326.check_type_of);
+         use_bv_sorts = (uu___1911_26326.use_bv_sorts);
+         qtbl_name_and_index = (uu___1911_26326.qtbl_name_and_index);
+         normalized_eff_names = (uu___1911_26326.normalized_eff_names);
+         fv_delta_depths = (uu___1911_26326.fv_delta_depths);
+         proof_ns = (uu___1911_26326.proof_ns);
+         synth_hook = (uu___1911_26326.synth_hook);
          try_solve_implicits_hook =
-           (uu___1911_26243.try_solve_implicits_hook);
-         splice = (uu___1911_26243.splice);
-         mpreprocess = (uu___1911_26243.mpreprocess);
-         postprocess = (uu___1911_26243.postprocess);
-         is_native_tactic = (uu___1911_26243.is_native_tactic);
-         identifier_info = (uu___1911_26243.identifier_info);
-         tc_hooks = (uu___1911_26243.tc_hooks);
-         dsenv = (uu___1911_26243.dsenv);
-         nbe = (uu___1911_26243.nbe);
-         strict_args_tab = (uu___1911_26243.strict_args_tab);
-         erasable_types_tab = (uu___1911_26243.erasable_types_tab)
+           (uu___1911_26326.try_solve_implicits_hook);
+         splice = (uu___1911_26326.splice);
+         mpreprocess = (uu___1911_26326.mpreprocess);
+         postprocess = (uu___1911_26326.postprocess);
+         is_native_tactic = (uu___1911_26326.is_native_tactic);
+         identifier_info = (uu___1911_26326.identifier_info);
+         tc_hooks = (uu___1911_26326.tc_hooks);
+         dsenv = (uu___1911_26326.dsenv);
+         nbe = (uu___1911_26326.nbe);
+         strict_args_tab = (uu___1911_26326.strict_args_tab);
+         erasable_types_tab = (uu___1911_26326.erasable_types_tab)
        })
   
 let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
@@ -5309,22 +5347,22 @@ let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____26295)::tl -> aux out tl
-      | (FStar_Syntax_Syntax.Binding_lid (uu____26299,(uu____26300,t)))::tl
+      | (FStar_Syntax_Syntax.Binding_univ uu____26378)::tl -> aux out tl
+      | (FStar_Syntax_Syntax.Binding_lid (uu____26382,(uu____26383,t)))::tl
           ->
-          let uu____26321 =
-            let uu____26324 = FStar_Syntax_Free.uvars t  in
-            ext out uu____26324  in
-          aux uu____26321 tl
+          let uu____26404 =
+            let uu____26407 = FStar_Syntax_Free.uvars t  in
+            ext out uu____26407  in
+          aux uu____26404 tl
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____26327;
-            FStar_Syntax_Syntax.index = uu____26328;
+          { FStar_Syntax_Syntax.ppname = uu____26410;
+            FStar_Syntax_Syntax.index = uu____26411;
             FStar_Syntax_Syntax.sort = t;_})::tl
           ->
-          let uu____26336 =
-            let uu____26339 = FStar_Syntax_Free.uvars t  in
-            ext out uu____26339  in
-          aux uu____26336 tl
+          let uu____26419 =
+            let uu____26422 = FStar_Syntax_Free.uvars t  in
+            ext out uu____26422  in
+          aux uu____26419 tl
        in
     aux no_uvs env1.gamma
   
@@ -5335,22 +5373,22 @@ let (univ_vars : env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____26397)::tl -> aux out tl
-      | (FStar_Syntax_Syntax.Binding_lid (uu____26401,(uu____26402,t)))::tl
+      | (FStar_Syntax_Syntax.Binding_univ uu____26480)::tl -> aux out tl
+      | (FStar_Syntax_Syntax.Binding_lid (uu____26484,(uu____26485,t)))::tl
           ->
-          let uu____26423 =
-            let uu____26426 = FStar_Syntax_Free.univs t  in
-            ext out uu____26426  in
-          aux uu____26423 tl
+          let uu____26506 =
+            let uu____26509 = FStar_Syntax_Free.univs t  in
+            ext out uu____26509  in
+          aux uu____26506 tl
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____26429;
-            FStar_Syntax_Syntax.index = uu____26430;
+          { FStar_Syntax_Syntax.ppname = uu____26512;
+            FStar_Syntax_Syntax.index = uu____26513;
             FStar_Syntax_Syntax.sort = t;_})::tl
           ->
-          let uu____26438 =
-            let uu____26441 = FStar_Syntax_Free.univs t  in
-            ext out uu____26441  in
-          aux uu____26438 tl
+          let uu____26521 =
+            let uu____26524 = FStar_Syntax_Free.univs t  in
+            ext out uu____26524  in
+          aux uu____26521 tl
        in
     aux no_univs env1.gamma
   
@@ -5362,23 +5400,23 @@ let (univnames : env -> FStar_Syntax_Syntax.univ_name FStar_Util.set) =
       match g with
       | [] -> out
       | (FStar_Syntax_Syntax.Binding_univ uname)::tl ->
-          let uu____26503 = FStar_Util.set_add uname out  in
-          aux uu____26503 tl
-      | (FStar_Syntax_Syntax.Binding_lid (uu____26506,(uu____26507,t)))::tl
+          let uu____26586 = FStar_Util.set_add uname out  in
+          aux uu____26586 tl
+      | (FStar_Syntax_Syntax.Binding_lid (uu____26589,(uu____26590,t)))::tl
           ->
-          let uu____26528 =
-            let uu____26531 = FStar_Syntax_Free.univnames t  in
-            ext out uu____26531  in
-          aux uu____26528 tl
+          let uu____26611 =
+            let uu____26614 = FStar_Syntax_Free.univnames t  in
+            ext out uu____26614  in
+          aux uu____26611 tl
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____26534;
-            FStar_Syntax_Syntax.index = uu____26535;
+          { FStar_Syntax_Syntax.ppname = uu____26617;
+            FStar_Syntax_Syntax.index = uu____26618;
             FStar_Syntax_Syntax.sort = t;_})::tl
           ->
-          let uu____26543 =
-            let uu____26546 = FStar_Syntax_Free.univnames t  in
-            ext out uu____26546  in
-          aux uu____26543 tl
+          let uu____26626 =
+            let uu____26629 = FStar_Syntax_Free.univnames t  in
+            ext out uu____26629  in
+          aux uu____26626 tl
        in
     aux no_univ_names env1.gamma
   
@@ -5388,21 +5426,21 @@ let (bound_vars_of_bindings :
   fun bs  ->
     FStar_All.pipe_right bs
       (FStar_List.collect
-         (fun uu___12_26567  ->
-            match uu___12_26567 with
+         (fun uu___12_26650  ->
+            match uu___12_26650 with
             | FStar_Syntax_Syntax.Binding_var x -> [x]
-            | FStar_Syntax_Syntax.Binding_lid uu____26571 -> []
-            | FStar_Syntax_Syntax.Binding_univ uu____26584 -> []))
+            | FStar_Syntax_Syntax.Binding_lid uu____26654 -> []
+            | FStar_Syntax_Syntax.Binding_univ uu____26667 -> []))
   
 let (binders_of_bindings :
   FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.binders) =
   fun bs  ->
-    let uu____26595 =
-      let uu____26604 = bound_vars_of_bindings bs  in
-      FStar_All.pipe_right uu____26604
+    let uu____26678 =
+      let uu____26687 = bound_vars_of_bindings bs  in
+      FStar_All.pipe_right uu____26687
         (FStar_List.map FStar_Syntax_Syntax.mk_binder)
        in
-    FStar_All.pipe_right uu____26595 FStar_List.rev
+    FStar_All.pipe_right uu____26678 FStar_List.rev
   
 let (bound_vars : env -> FStar_Syntax_Syntax.bv Prims.list) =
   fun env1  -> bound_vars_of_bindings env1.gamma 
@@ -5410,38 +5448,39 @@ let (all_binders : env -> FStar_Syntax_Syntax.binders) =
   fun env1  -> binders_of_bindings env1.gamma 
 let (print_gamma : FStar_Syntax_Syntax.gamma -> Prims.string) =
   fun gamma  ->
-    let uu____26652 =
+    let uu____26735 =
       FStar_All.pipe_right gamma
         (FStar_List.map
-           (fun uu___13_26665  ->
-              match uu___13_26665 with
+           (fun uu___13_26748  ->
+              match uu___13_26748 with
               | FStar_Syntax_Syntax.Binding_var x ->
-                  let uu____26668 = FStar_Syntax_Print.bv_to_string x  in
-                  Prims.op_Hat "Binding_var " uu____26668
+                  let uu____26751 = FStar_Syntax_Print.bv_to_string x  in
+                  Prims.op_Hat "Binding_var " uu____26751
               | FStar_Syntax_Syntax.Binding_univ u ->
-                  Prims.op_Hat "Binding_univ " u.FStar_Ident.idText
-              | FStar_Syntax_Syntax.Binding_lid (l,uu____26674) ->
-                  let uu____26691 = FStar_Ident.string_of_lid l  in
-                  Prims.op_Hat "Binding_lid " uu____26691))
+                  let uu____26755 = FStar_Ident.text_of_id u  in
+                  Prims.op_Hat "Binding_univ " uu____26755
+              | FStar_Syntax_Syntax.Binding_lid (l,uu____26759) ->
+                  let uu____26776 = FStar_Ident.string_of_lid l  in
+                  Prims.op_Hat "Binding_lid " uu____26776))
        in
-    FStar_All.pipe_right uu____26652 (FStar_String.concat "::\n")
+    FStar_All.pipe_right uu____26735 (FStar_String.concat "::\n")
   
 let (string_of_delta_level : delta_level -> Prims.string) =
-  fun uu___14_26705  ->
-    match uu___14_26705 with
+  fun uu___14_26790  ->
+    match uu___14_26790 with
     | NoDelta  -> "NoDelta"
     | InliningDelta  -> "Inlining"
     | Eager_unfolding_only  -> "Eager_unfolding_only"
     | Unfold d ->
-        let uu____26711 = FStar_Syntax_Print.delta_depth_to_string d  in
-        Prims.op_Hat "Unfold " uu____26711
+        let uu____26796 = FStar_Syntax_Print.delta_depth_to_string d  in
+        Prims.op_Hat "Unfold " uu____26796
   
 let (lidents : env -> FStar_Ident.lident Prims.list) =
   fun env1  ->
     let keys = FStar_List.collect FStar_Pervasives_Native.fst env1.gamma_sig
        in
     FStar_Util.smap_fold (sigtab env1)
-      (fun uu____26734  ->
+      (fun uu____26819  ->
          fun v  ->
            fun keys1  ->
              FStar_List.append (FStar_Syntax_Util.lids_of_sigelt v) keys1)
@@ -5452,81 +5491,81 @@ let (should_enc_path : env -> Prims.string Prims.list -> Prims.bool) =
     fun path  ->
       let rec str_i_prefix xs ys =
         match (xs, ys) with
-        | ([],uu____26789) -> true
+        | ([],uu____26874) -> true
         | (x::xs1,y::ys1) ->
             ((FStar_String.lowercase x) = (FStar_String.lowercase y)) &&
               (str_i_prefix xs1 ys1)
-        | (uu____26822,uu____26823) -> false  in
-      let uu____26837 =
+        | (uu____26907,uu____26908) -> false  in
+      let uu____26922 =
         FStar_List.tryFind
-          (fun uu____26859  ->
-             match uu____26859 with | (p,uu____26870) -> str_i_prefix p path)
+          (fun uu____26944  ->
+             match uu____26944 with | (p,uu____26955) -> str_i_prefix p path)
           env1.proof_ns
          in
-      match uu____26837 with
+      match uu____26922 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some (uu____26889,b) -> b
+      | FStar_Pervasives_Native.Some (uu____26974,b) -> b
   
 let (should_enc_lid : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
     fun lid  ->
-      let uu____26919 = FStar_Ident.path_of_lid lid  in
-      should_enc_path env1 uu____26919
+      let uu____27004 = FStar_Ident.path_of_lid lid  in
+      should_enc_path env1 uu____27004
   
 let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
   fun b  ->
     fun e  ->
       fun path  ->
-        let uu___2054_26941 = e  in
+        let uu___2054_27026 = e  in
         {
-          solver = (uu___2054_26941.solver);
-          range = (uu___2054_26941.range);
-          curmodule = (uu___2054_26941.curmodule);
-          gamma = (uu___2054_26941.gamma);
-          gamma_sig = (uu___2054_26941.gamma_sig);
-          gamma_cache = (uu___2054_26941.gamma_cache);
-          modules = (uu___2054_26941.modules);
-          expected_typ = (uu___2054_26941.expected_typ);
-          sigtab = (uu___2054_26941.sigtab);
-          attrtab = (uu___2054_26941.attrtab);
-          instantiate_imp = (uu___2054_26941.instantiate_imp);
-          effects = (uu___2054_26941.effects);
-          generalize = (uu___2054_26941.generalize);
-          letrecs = (uu___2054_26941.letrecs);
-          top_level = (uu___2054_26941.top_level);
-          check_uvars = (uu___2054_26941.check_uvars);
-          use_eq = (uu___2054_26941.use_eq);
-          use_eq_strict = (uu___2054_26941.use_eq_strict);
-          is_iface = (uu___2054_26941.is_iface);
-          admit = (uu___2054_26941.admit);
-          lax = (uu___2054_26941.lax);
-          lax_universes = (uu___2054_26941.lax_universes);
-          phase1 = (uu___2054_26941.phase1);
-          failhard = (uu___2054_26941.failhard);
-          nosynth = (uu___2054_26941.nosynth);
-          uvar_subtyping = (uu___2054_26941.uvar_subtyping);
-          tc_term = (uu___2054_26941.tc_term);
-          type_of = (uu___2054_26941.type_of);
-          universe_of = (uu___2054_26941.universe_of);
-          check_type_of = (uu___2054_26941.check_type_of);
-          use_bv_sorts = (uu___2054_26941.use_bv_sorts);
-          qtbl_name_and_index = (uu___2054_26941.qtbl_name_and_index);
-          normalized_eff_names = (uu___2054_26941.normalized_eff_names);
-          fv_delta_depths = (uu___2054_26941.fv_delta_depths);
+          solver = (uu___2054_27026.solver);
+          range = (uu___2054_27026.range);
+          curmodule = (uu___2054_27026.curmodule);
+          gamma = (uu___2054_27026.gamma);
+          gamma_sig = (uu___2054_27026.gamma_sig);
+          gamma_cache = (uu___2054_27026.gamma_cache);
+          modules = (uu___2054_27026.modules);
+          expected_typ = (uu___2054_27026.expected_typ);
+          sigtab = (uu___2054_27026.sigtab);
+          attrtab = (uu___2054_27026.attrtab);
+          instantiate_imp = (uu___2054_27026.instantiate_imp);
+          effects = (uu___2054_27026.effects);
+          generalize = (uu___2054_27026.generalize);
+          letrecs = (uu___2054_27026.letrecs);
+          top_level = (uu___2054_27026.top_level);
+          check_uvars = (uu___2054_27026.check_uvars);
+          use_eq = (uu___2054_27026.use_eq);
+          use_eq_strict = (uu___2054_27026.use_eq_strict);
+          is_iface = (uu___2054_27026.is_iface);
+          admit = (uu___2054_27026.admit);
+          lax = (uu___2054_27026.lax);
+          lax_universes = (uu___2054_27026.lax_universes);
+          phase1 = (uu___2054_27026.phase1);
+          failhard = (uu___2054_27026.failhard);
+          nosynth = (uu___2054_27026.nosynth);
+          uvar_subtyping = (uu___2054_27026.uvar_subtyping);
+          tc_term = (uu___2054_27026.tc_term);
+          type_of = (uu___2054_27026.type_of);
+          universe_of = (uu___2054_27026.universe_of);
+          check_type_of = (uu___2054_27026.check_type_of);
+          use_bv_sorts = (uu___2054_27026.use_bv_sorts);
+          qtbl_name_and_index = (uu___2054_27026.qtbl_name_and_index);
+          normalized_eff_names = (uu___2054_27026.normalized_eff_names);
+          fv_delta_depths = (uu___2054_27026.fv_delta_depths);
           proof_ns = ((path, b) :: (e.proof_ns));
-          synth_hook = (uu___2054_26941.synth_hook);
+          synth_hook = (uu___2054_27026.synth_hook);
           try_solve_implicits_hook =
-            (uu___2054_26941.try_solve_implicits_hook);
-          splice = (uu___2054_26941.splice);
-          mpreprocess = (uu___2054_26941.mpreprocess);
-          postprocess = (uu___2054_26941.postprocess);
-          is_native_tactic = (uu___2054_26941.is_native_tactic);
-          identifier_info = (uu___2054_26941.identifier_info);
-          tc_hooks = (uu___2054_26941.tc_hooks);
-          dsenv = (uu___2054_26941.dsenv);
-          nbe = (uu___2054_26941.nbe);
-          strict_args_tab = (uu___2054_26941.strict_args_tab);
-          erasable_types_tab = (uu___2054_26941.erasable_types_tab)
+            (uu___2054_27026.try_solve_implicits_hook);
+          splice = (uu___2054_27026.splice);
+          mpreprocess = (uu___2054_27026.mpreprocess);
+          postprocess = (uu___2054_27026.postprocess);
+          is_native_tactic = (uu___2054_27026.is_native_tactic);
+          identifier_info = (uu___2054_27026.identifier_info);
+          tc_hooks = (uu___2054_27026.tc_hooks);
+          dsenv = (uu___2054_27026.dsenv);
+          nbe = (uu___2054_27026.nbe);
+          strict_args_tab = (uu___2054_27026.strict_args_tab);
+          erasable_types_tab = (uu___2054_27026.erasable_types_tab)
         }
   
 let (add_proof_ns : env -> name_prefix -> env) =
@@ -5537,92 +5576,92 @@ let (get_proof_ns : env -> proof_namespace) = fun e  -> e.proof_ns
 let (set_proof_ns : proof_namespace -> env -> env) =
   fun ns  ->
     fun e  ->
-      let uu___2063_26989 = e  in
+      let uu___2063_27074 = e  in
       {
-        solver = (uu___2063_26989.solver);
-        range = (uu___2063_26989.range);
-        curmodule = (uu___2063_26989.curmodule);
-        gamma = (uu___2063_26989.gamma);
-        gamma_sig = (uu___2063_26989.gamma_sig);
-        gamma_cache = (uu___2063_26989.gamma_cache);
-        modules = (uu___2063_26989.modules);
-        expected_typ = (uu___2063_26989.expected_typ);
-        sigtab = (uu___2063_26989.sigtab);
-        attrtab = (uu___2063_26989.attrtab);
-        instantiate_imp = (uu___2063_26989.instantiate_imp);
-        effects = (uu___2063_26989.effects);
-        generalize = (uu___2063_26989.generalize);
-        letrecs = (uu___2063_26989.letrecs);
-        top_level = (uu___2063_26989.top_level);
-        check_uvars = (uu___2063_26989.check_uvars);
-        use_eq = (uu___2063_26989.use_eq);
-        use_eq_strict = (uu___2063_26989.use_eq_strict);
-        is_iface = (uu___2063_26989.is_iface);
-        admit = (uu___2063_26989.admit);
-        lax = (uu___2063_26989.lax);
-        lax_universes = (uu___2063_26989.lax_universes);
-        phase1 = (uu___2063_26989.phase1);
-        failhard = (uu___2063_26989.failhard);
-        nosynth = (uu___2063_26989.nosynth);
-        uvar_subtyping = (uu___2063_26989.uvar_subtyping);
-        tc_term = (uu___2063_26989.tc_term);
-        type_of = (uu___2063_26989.type_of);
-        universe_of = (uu___2063_26989.universe_of);
-        check_type_of = (uu___2063_26989.check_type_of);
-        use_bv_sorts = (uu___2063_26989.use_bv_sorts);
-        qtbl_name_and_index = (uu___2063_26989.qtbl_name_and_index);
-        normalized_eff_names = (uu___2063_26989.normalized_eff_names);
-        fv_delta_depths = (uu___2063_26989.fv_delta_depths);
+        solver = (uu___2063_27074.solver);
+        range = (uu___2063_27074.range);
+        curmodule = (uu___2063_27074.curmodule);
+        gamma = (uu___2063_27074.gamma);
+        gamma_sig = (uu___2063_27074.gamma_sig);
+        gamma_cache = (uu___2063_27074.gamma_cache);
+        modules = (uu___2063_27074.modules);
+        expected_typ = (uu___2063_27074.expected_typ);
+        sigtab = (uu___2063_27074.sigtab);
+        attrtab = (uu___2063_27074.attrtab);
+        instantiate_imp = (uu___2063_27074.instantiate_imp);
+        effects = (uu___2063_27074.effects);
+        generalize = (uu___2063_27074.generalize);
+        letrecs = (uu___2063_27074.letrecs);
+        top_level = (uu___2063_27074.top_level);
+        check_uvars = (uu___2063_27074.check_uvars);
+        use_eq = (uu___2063_27074.use_eq);
+        use_eq_strict = (uu___2063_27074.use_eq_strict);
+        is_iface = (uu___2063_27074.is_iface);
+        admit = (uu___2063_27074.admit);
+        lax = (uu___2063_27074.lax);
+        lax_universes = (uu___2063_27074.lax_universes);
+        phase1 = (uu___2063_27074.phase1);
+        failhard = (uu___2063_27074.failhard);
+        nosynth = (uu___2063_27074.nosynth);
+        uvar_subtyping = (uu___2063_27074.uvar_subtyping);
+        tc_term = (uu___2063_27074.tc_term);
+        type_of = (uu___2063_27074.type_of);
+        universe_of = (uu___2063_27074.universe_of);
+        check_type_of = (uu___2063_27074.check_type_of);
+        use_bv_sorts = (uu___2063_27074.use_bv_sorts);
+        qtbl_name_and_index = (uu___2063_27074.qtbl_name_and_index);
+        normalized_eff_names = (uu___2063_27074.normalized_eff_names);
+        fv_delta_depths = (uu___2063_27074.fv_delta_depths);
         proof_ns = ns;
-        synth_hook = (uu___2063_26989.synth_hook);
-        try_solve_implicits_hook = (uu___2063_26989.try_solve_implicits_hook);
-        splice = (uu___2063_26989.splice);
-        mpreprocess = (uu___2063_26989.mpreprocess);
-        postprocess = (uu___2063_26989.postprocess);
-        is_native_tactic = (uu___2063_26989.is_native_tactic);
-        identifier_info = (uu___2063_26989.identifier_info);
-        tc_hooks = (uu___2063_26989.tc_hooks);
-        dsenv = (uu___2063_26989.dsenv);
-        nbe = (uu___2063_26989.nbe);
-        strict_args_tab = (uu___2063_26989.strict_args_tab);
-        erasable_types_tab = (uu___2063_26989.erasable_types_tab)
+        synth_hook = (uu___2063_27074.synth_hook);
+        try_solve_implicits_hook = (uu___2063_27074.try_solve_implicits_hook);
+        splice = (uu___2063_27074.splice);
+        mpreprocess = (uu___2063_27074.mpreprocess);
+        postprocess = (uu___2063_27074.postprocess);
+        is_native_tactic = (uu___2063_27074.is_native_tactic);
+        identifier_info = (uu___2063_27074.identifier_info);
+        tc_hooks = (uu___2063_27074.tc_hooks);
+        dsenv = (uu___2063_27074.dsenv);
+        nbe = (uu___2063_27074.nbe);
+        strict_args_tab = (uu___2063_27074.strict_args_tab);
+        erasable_types_tab = (uu___2063_27074.erasable_types_tab)
       }
   
 let (unbound_vars :
   env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set) =
   fun e  ->
     fun t  ->
-      let uu____27005 = FStar_Syntax_Free.names t  in
-      let uu____27008 = bound_vars e  in
+      let uu____27090 = FStar_Syntax_Free.names t  in
+      let uu____27093 = bound_vars e  in
       FStar_List.fold_left (fun s  -> fun bv  -> FStar_Util.set_remove bv s)
-        uu____27005 uu____27008
+        uu____27090 uu____27093
   
 let (closed : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e  ->
     fun t  ->
-      let uu____27031 = unbound_vars e t  in
-      FStar_Util.set_is_empty uu____27031
+      let uu____27116 = unbound_vars e t  in
+      FStar_Util.set_is_empty uu____27116
   
 let (closed' : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____27041 = FStar_Syntax_Free.names t  in
-    FStar_Util.set_is_empty uu____27041
+    let uu____27126 = FStar_Syntax_Free.names t  in
+    FStar_Util.set_is_empty uu____27126
   
 let (string_of_proof_ns : env -> Prims.string) =
   fun env1  ->
-    let aux uu____27062 =
-      match uu____27062 with
+    let aux uu____27147 =
+      match uu____27147 with
       | (p,b) ->
           if (p = []) && b
           then "*"
           else
-            (let uu____27082 = FStar_Ident.text_of_path p  in
-             Prims.op_Hat (if b then "+" else "-") uu____27082)
+            (let uu____27167 = FStar_Ident.text_of_path p  in
+             Prims.op_Hat (if b then "+" else "-") uu____27167)
        in
-    let uu____27090 =
-      let uu____27094 = FStar_List.map aux env1.proof_ns  in
-      FStar_All.pipe_right uu____27094 FStar_List.rev  in
-    FStar_All.pipe_right uu____27090 (FStar_String.concat " ")
+    let uu____27175 =
+      let uu____27179 = FStar_List.map aux env1.proof_ns  in
+      FStar_All.pipe_right uu____27179 FStar_List.rev  in
+    FStar_All.pipe_right uu____27175 (FStar_String.concat " ")
   
 let (guard_of_guard_formula :
   FStar_TypeChecker_Common.guard_formula -> guard_t) =
@@ -5649,23 +5688,23 @@ let (is_trivial : guard_t -> Prims.bool) =
                 ((imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check
                    = FStar_Syntax_Syntax.Allow_unresolved)
                   ||
-                  (let uu____27162 =
+                  (let uu____27247 =
                      FStar_Syntax_Unionfind.find
                        (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head
                       in
-                   match uu____27162 with
-                   | FStar_Pervasives_Native.Some uu____27166 -> true
+                   match uu____27247 with
+                   | FStar_Pervasives_Native.Some uu____27251 -> true
                    | FStar_Pervasives_Native.None  -> false)))
-    | uu____27169 -> false
+    | uu____27254 -> false
   
 let (is_trivial_guard_formula : guard_t -> Prims.bool) =
   fun g  ->
     match g with
     | { FStar_TypeChecker_Common.guard_f = FStar_TypeChecker_Common.Trivial ;
-        FStar_TypeChecker_Common.deferred = uu____27179;
-        FStar_TypeChecker_Common.univ_ineqs = uu____27180;
-        FStar_TypeChecker_Common.implicits = uu____27181;_} -> true
-    | uu____27191 -> false
+        FStar_TypeChecker_Common.deferred = uu____27264;
+        FStar_TypeChecker_Common.univ_ineqs = uu____27265;
+        FStar_TypeChecker_Common.implicits = uu____27266;_} -> true
+    | uu____27276 -> false
   
 let (trivial_guard : guard_t) = FStar_TypeChecker_Common.trivial_guard 
 let (abstract_guard_n :
@@ -5680,16 +5719,16 @@ let (abstract_guard_n :
               (FStar_Pervasives_Native.Some
                  (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype0))
              in
-          let uu___2107_27213 = g  in
+          let uu___2107_27298 = g  in
           {
             FStar_TypeChecker_Common.guard_f =
               (FStar_TypeChecker_Common.NonTrivial f');
             FStar_TypeChecker_Common.deferred =
-              (uu___2107_27213.FStar_TypeChecker_Common.deferred);
+              (uu___2107_27298.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2107_27213.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___2107_27298.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2107_27213.FStar_TypeChecker_Common.implicits)
+              (uu___2107_27298.FStar_TypeChecker_Common.implicits)
           }
   
 let (abstract_guard : FStar_Syntax_Syntax.binder -> guard_t -> guard_t) =
@@ -5704,31 +5743,31 @@ let (def_check_vars_in_set :
     fun msg  ->
       fun vset  ->
         fun t  ->
-          let uu____27252 = FStar_Options.defensive ()  in
-          if uu____27252
+          let uu____27337 = FStar_Options.defensive ()  in
+          if uu____27337
           then
             let s = FStar_Syntax_Free.names t  in
-            let uu____27258 =
-              let uu____27260 =
-                let uu____27262 = FStar_Util.set_difference s vset  in
-                FStar_All.pipe_left FStar_Util.set_is_empty uu____27262  in
-              Prims.op_Negation uu____27260  in
-            (if uu____27258
+            let uu____27343 =
+              let uu____27345 =
+                let uu____27347 = FStar_Util.set_difference s vset  in
+                FStar_All.pipe_left FStar_Util.set_is_empty uu____27347  in
+              Prims.op_Negation uu____27345  in
+            (if uu____27343
              then
-               let uu____27269 =
-                 let uu____27275 =
-                   let uu____27277 = FStar_Syntax_Print.term_to_string t  in
-                   let uu____27279 =
-                     let uu____27281 = FStar_Util.set_elements s  in
-                     FStar_All.pipe_right uu____27281
+               let uu____27354 =
+                 let uu____27360 =
+                   let uu____27362 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____27364 =
+                     let uu____27366 = FStar_Util.set_elements s  in
+                     FStar_All.pipe_right uu____27366
                        (FStar_Syntax_Print.bvs_to_string ",\n\t")
                       in
                    FStar_Util.format3
                      "Internal: term is not closed (%s).\nt = (%s)\nFVs = (%s)\n"
-                     msg uu____27277 uu____27279
+                     msg uu____27362 uu____27364
                     in
-                 (FStar_Errors.Warning_Defensive, uu____27275)  in
-               FStar_Errors.log_issue rng uu____27269
+                 (FStar_Errors.Warning_Defensive, uu____27360)  in
+               FStar_Errors.log_issue rng uu____27354
              else ())
           else ()
   
@@ -5741,15 +5780,15 @@ let (def_check_closed_in :
     fun msg  ->
       fun l  ->
         fun t  ->
-          let uu____27321 =
-            let uu____27323 = FStar_Options.defensive ()  in
-            Prims.op_Negation uu____27323  in
-          if uu____27321
+          let uu____27406 =
+            let uu____27408 = FStar_Options.defensive ()  in
+            Prims.op_Negation uu____27408  in
+          if uu____27406
           then ()
           else
-            (let uu____27328 =
+            (let uu____27413 =
                FStar_Util.as_set l FStar_Syntax_Syntax.order_bv  in
-             def_check_vars_in_set rng msg uu____27328 t)
+             def_check_vars_in_set rng msg uu____27413 t)
   
 let (def_check_closed_in_env :
   FStar_Range.range ->
@@ -5759,14 +5798,14 @@ let (def_check_closed_in_env :
     fun msg  ->
       fun e  ->
         fun t  ->
-          let uu____27354 =
-            let uu____27356 = FStar_Options.defensive ()  in
-            Prims.op_Negation uu____27356  in
-          if uu____27354
+          let uu____27439 =
+            let uu____27441 = FStar_Options.defensive ()  in
+            Prims.op_Negation uu____27441  in
+          if uu____27439
           then ()
           else
-            (let uu____27361 = bound_vars e  in
-             def_check_closed_in rng msg uu____27361 t)
+            (let uu____27446 = bound_vars e  in
+             def_check_closed_in rng msg uu____27446 t)
   
 let (def_check_guard_wf :
   FStar_Range.range -> Prims.string -> env -> guard_t -> unit) =
@@ -5785,33 +5824,33 @@ let (apply_guard : guard_t -> FStar_Syntax_Syntax.term -> guard_t) =
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2144_27400 = g  in
-          let uu____27401 =
-            let uu____27402 =
-              let uu____27403 =
-                let uu____27410 =
-                  let uu____27411 =
-                    let uu____27428 =
-                      let uu____27439 = FStar_Syntax_Syntax.as_arg e  in
-                      [uu____27439]  in
-                    (f, uu____27428)  in
-                  FStar_Syntax_Syntax.Tm_app uu____27411  in
-                FStar_Syntax_Syntax.mk uu____27410  in
-              uu____27403 FStar_Pervasives_Native.None
+          let uu___2144_27485 = g  in
+          let uu____27486 =
+            let uu____27487 =
+              let uu____27488 =
+                let uu____27495 =
+                  let uu____27496 =
+                    let uu____27513 =
+                      let uu____27524 = FStar_Syntax_Syntax.as_arg e  in
+                      [uu____27524]  in
+                    (f, uu____27513)  in
+                  FStar_Syntax_Syntax.Tm_app uu____27496  in
+                FStar_Syntax_Syntax.mk uu____27495  in
+              uu____27488 FStar_Pervasives_Native.None
                 f.FStar_Syntax_Syntax.pos
                in
             FStar_All.pipe_left
-              (fun uu____27476  ->
-                 FStar_TypeChecker_Common.NonTrivial uu____27476) uu____27402
+              (fun uu____27561  ->
+                 FStar_TypeChecker_Common.NonTrivial uu____27561) uu____27487
              in
           {
-            FStar_TypeChecker_Common.guard_f = uu____27401;
+            FStar_TypeChecker_Common.guard_f = uu____27486;
             FStar_TypeChecker_Common.deferred =
-              (uu___2144_27400.FStar_TypeChecker_Common.deferred);
+              (uu___2144_27485.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2144_27400.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___2144_27485.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2144_27400.FStar_TypeChecker_Common.implicits)
+              (uu___2144_27485.FStar_TypeChecker_Common.implicits)
           }
   
 let (map_guard :
@@ -5823,18 +5862,18 @@ let (map_guard :
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2151_27494 = g  in
-          let uu____27495 =
-            let uu____27496 = map f  in
-            FStar_TypeChecker_Common.NonTrivial uu____27496  in
+          let uu___2151_27579 = g  in
+          let uu____27580 =
+            let uu____27581 = map f  in
+            FStar_TypeChecker_Common.NonTrivial uu____27581  in
           {
-            FStar_TypeChecker_Common.guard_f = uu____27495;
+            FStar_TypeChecker_Common.guard_f = uu____27580;
             FStar_TypeChecker_Common.deferred =
-              (uu___2151_27494.FStar_TypeChecker_Common.deferred);
+              (uu___2151_27579.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2151_27494.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___2151_27579.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2151_27494.FStar_TypeChecker_Common.implicits)
+              (uu___2151_27579.FStar_TypeChecker_Common.implicits)
           }
   
 let (always_map_guard :
@@ -5845,39 +5884,39 @@ let (always_map_guard :
     fun map  ->
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial  ->
-          let uu___2156_27513 = g  in
-          let uu____27514 =
-            let uu____27515 = map FStar_Syntax_Util.t_true  in
-            FStar_TypeChecker_Common.NonTrivial uu____27515  in
+          let uu___2156_27598 = g  in
+          let uu____27599 =
+            let uu____27600 = map FStar_Syntax_Util.t_true  in
+            FStar_TypeChecker_Common.NonTrivial uu____27600  in
           {
-            FStar_TypeChecker_Common.guard_f = uu____27514;
+            FStar_TypeChecker_Common.guard_f = uu____27599;
             FStar_TypeChecker_Common.deferred =
-              (uu___2156_27513.FStar_TypeChecker_Common.deferred);
+              (uu___2156_27598.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2156_27513.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___2156_27598.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2156_27513.FStar_TypeChecker_Common.implicits)
+              (uu___2156_27598.FStar_TypeChecker_Common.implicits)
           }
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2160_27517 = g  in
-          let uu____27518 =
-            let uu____27519 = map f  in
-            FStar_TypeChecker_Common.NonTrivial uu____27519  in
+          let uu___2160_27602 = g  in
+          let uu____27603 =
+            let uu____27604 = map f  in
+            FStar_TypeChecker_Common.NonTrivial uu____27604  in
           {
-            FStar_TypeChecker_Common.guard_f = uu____27518;
+            FStar_TypeChecker_Common.guard_f = uu____27603;
             FStar_TypeChecker_Common.deferred =
-              (uu___2160_27517.FStar_TypeChecker_Common.deferred);
+              (uu___2160_27602.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2160_27517.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___2160_27602.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2160_27517.FStar_TypeChecker_Common.implicits)
+              (uu___2160_27602.FStar_TypeChecker_Common.implicits)
           }
   
 let (trivial : FStar_TypeChecker_Common.guard_formula -> unit) =
   fun t  ->
     match t with
     | FStar_TypeChecker_Common.Trivial  -> ()
-    | FStar_TypeChecker_Common.NonTrivial uu____27526 ->
+    | FStar_TypeChecker_Common.NonTrivial uu____27611 ->
         failwith "impossible"
   
 let (check_trivial :
@@ -5904,24 +5943,24 @@ let (close_guard_univs :
                 (fun u  ->
                    fun b  ->
                      fun f1  ->
-                       let uu____27603 = FStar_Syntax_Syntax.is_null_binder b
+                       let uu____27688 = FStar_Syntax_Syntax.is_null_binder b
                           in
-                       if uu____27603
+                       if uu____27688
                        then f1
                        else
                          FStar_Syntax_Util.mk_forall u
                            (FStar_Pervasives_Native.fst b) f1) us bs f
                in
-            let uu___2183_27610 = g  in
+            let uu___2183_27695 = g  in
             {
               FStar_TypeChecker_Common.guard_f =
                 (FStar_TypeChecker_Common.NonTrivial f1);
               FStar_TypeChecker_Common.deferred =
-                (uu___2183_27610.FStar_TypeChecker_Common.deferred);
+                (uu___2183_27695.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___2183_27610.FStar_TypeChecker_Common.univ_ineqs);
+                (uu___2183_27695.FStar_TypeChecker_Common.univ_ineqs);
               FStar_TypeChecker_Common.implicits =
-                (uu___2183_27610.FStar_TypeChecker_Common.implicits)
+                (uu___2183_27695.FStar_TypeChecker_Common.implicits)
             }
   
 let (close_forall :
@@ -5935,8 +5974,8 @@ let (close_forall :
         FStar_List.fold_right
           (fun b  ->
              fun f1  ->
-               let uu____27644 = FStar_Syntax_Syntax.is_null_binder b  in
-               if uu____27644
+               let uu____27729 = FStar_Syntax_Syntax.is_null_binder b  in
+               if uu____27729
                then f1
                else
                  (let u =
@@ -5954,18 +5993,18 @@ let (close_guard : env -> FStar_Syntax_Syntax.binders -> guard_t -> guard_t)
         match g.FStar_TypeChecker_Common.guard_f with
         | FStar_TypeChecker_Common.Trivial  -> g
         | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___2198_27671 = g  in
-            let uu____27672 =
-              let uu____27673 = close_forall env1 binders f  in
-              FStar_TypeChecker_Common.NonTrivial uu____27673  in
+            let uu___2198_27756 = g  in
+            let uu____27757 =
+              let uu____27758 = close_forall env1 binders f  in
+              FStar_TypeChecker_Common.NonTrivial uu____27758  in
             {
-              FStar_TypeChecker_Common.guard_f = uu____27672;
+              FStar_TypeChecker_Common.guard_f = uu____27757;
               FStar_TypeChecker_Common.deferred =
-                (uu___2198_27671.FStar_TypeChecker_Common.deferred);
+                (uu___2198_27756.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___2198_27671.FStar_TypeChecker_Common.univ_ineqs);
+                (uu___2198_27756.FStar_TypeChecker_Common.univ_ineqs);
               FStar_TypeChecker_Common.implicits =
-                (uu___2198_27671.FStar_TypeChecker_Common.implicits)
+                (uu___2198_27756.FStar_TypeChecker_Common.implicits)
             }
   
 let (new_implicit_var_aux :
@@ -5985,12 +6024,12 @@ let (new_implicit_var_aux :
         fun k  ->
           fun should_check  ->
             fun meta  ->
-              let uu____27731 =
+              let uu____27816 =
                 FStar_Syntax_Util.destruct k FStar_Parser_Const.range_of_lid
                  in
-              match uu____27731 with
+              match uu____27816 with
               | FStar_Pervasives_Native.Some
-                  (uu____27756::(tm,uu____27758)::[]) ->
+                  (uu____27841::(tm,uu____27843)::[]) ->
                   let t =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_constant
@@ -5999,13 +6038,13 @@ let (new_implicit_var_aux :
                       FStar_Pervasives_Native.None tm.FStar_Syntax_Syntax.pos
                      in
                   (t, [], trivial_guard)
-              | uu____27822 ->
+              | uu____27907 ->
                   let binders = all_binders env1  in
                   let gamma = env1.gamma  in
                   let ctx_uvar =
-                    let uu____27840 = FStar_Syntax_Unionfind.fresh ()  in
+                    let uu____27925 = FStar_Syntax_Unionfind.fresh ()  in
                     {
-                      FStar_Syntax_Syntax.ctx_uvar_head = uu____27840;
+                      FStar_Syntax_Syntax.ctx_uvar_head = uu____27925;
                       FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
                       FStar_Syntax_Syntax.ctx_uvar_binders = binders;
                       FStar_Syntax_Syntax.ctx_uvar_typ = k;
@@ -6030,26 +6069,26 @@ let (new_implicit_var_aux :
                         FStar_TypeChecker_Common.imp_tm = t;
                         FStar_TypeChecker_Common.imp_range = r
                       }  in
-                    (let uu____27872 =
+                    (let uu____27957 =
                        debug env1 (FStar_Options.Other "ImplicitTrace")  in
-                     if uu____27872
+                     if uu____27957
                      then
-                       let uu____27876 =
+                       let uu____27961 =
                          FStar_Syntax_Print.uvar_to_string
                            ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head
                           in
                        FStar_Util.print1
-                         "Just created uvar for implicit {%s}\n" uu____27876
+                         "Just created uvar for implicit {%s}\n" uu____27961
                      else ());
                     (let g =
-                       let uu___2222_27882 = trivial_guard  in
+                       let uu___2222_27967 = trivial_guard  in
                        {
                          FStar_TypeChecker_Common.guard_f =
-                           (uu___2222_27882.FStar_TypeChecker_Common.guard_f);
+                           (uu___2222_27967.FStar_TypeChecker_Common.guard_f);
                          FStar_TypeChecker_Common.deferred =
-                           (uu___2222_27882.FStar_TypeChecker_Common.deferred);
+                           (uu___2222_27967.FStar_TypeChecker_Common.deferred);
                          FStar_TypeChecker_Common.univ_ineqs =
-                           (uu___2222_27882.FStar_TypeChecker_Common.univ_ineqs);
+                           (uu___2222_27967.FStar_TypeChecker_Common.univ_ineqs);
                          FStar_TypeChecker_Common.implicits = [imp]
                        }  in
                      (t, [(ctx_uvar, r)], g))))
@@ -6067,44 +6106,44 @@ let (uvars_for_binders :
       fun substs  ->
         fun reason  ->
           fun r  ->
-            let uu____27936 =
+            let uu____28021 =
               FStar_All.pipe_right bs
                 (FStar_List.fold_left
-                   (fun uu____27993  ->
+                   (fun uu____28078  ->
                       fun b  ->
-                        match uu____27993 with
+                        match uu____28078 with
                         | (substs1,uvars,g) ->
                             let sort =
                               FStar_Syntax_Subst.subst substs1
                                 (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                in
-                            let uu____28035 =
-                              let uu____28048 = reason b  in
-                              new_implicit_var_aux uu____28048 r env1 sort
+                            let uu____28120 =
+                              let uu____28133 = reason b  in
+                              new_implicit_var_aux uu____28133 r env1 sort
                                 FStar_Syntax_Syntax.Allow_untyped
                                 FStar_Pervasives_Native.None
                                in
-                            (match uu____28035 with
-                             | (t,uu____28065,g_t) ->
-                                 let uu____28079 =
-                                   let uu____28082 =
-                                     let uu____28085 =
-                                       let uu____28086 =
-                                         let uu____28093 =
+                            (match uu____28120 with
+                             | (t,uu____28150,g_t) ->
+                                 let uu____28164 =
+                                   let uu____28167 =
+                                     let uu____28170 =
+                                       let uu____28171 =
+                                         let uu____28178 =
                                            FStar_All.pipe_right b
                                              FStar_Pervasives_Native.fst
                                             in
-                                         (uu____28093, t)  in
-                                       FStar_Syntax_Syntax.NT uu____28086  in
-                                     [uu____28085]  in
-                                   FStar_List.append substs1 uu____28082  in
-                                 let uu____28104 = conj_guard g g_t  in
-                                 (uu____28079, (FStar_List.append uvars [t]),
-                                   uu____28104))) (substs, [], trivial_guard))
+                                         (uu____28178, t)  in
+                                       FStar_Syntax_Syntax.NT uu____28171  in
+                                     [uu____28170]  in
+                                   FStar_List.append substs1 uu____28167  in
+                                 let uu____28189 = conj_guard g g_t  in
+                                 (uu____28164, (FStar_List.append uvars [t]),
+                                   uu____28189))) (substs, [], trivial_guard))
                in
-            FStar_All.pipe_right uu____27936
-              (fun uu____28133  ->
-                 match uu____28133 with | (uu____28150,uvars,g) -> (uvars, g))
+            FStar_All.pipe_right uu____28021
+              (fun uu____28218  ->
+                 match uu____28218 with | (uu____28235,uvars,g) -> (uvars, g))
   
 let (pure_precondition_for_trivial_post :
   env ->
@@ -6120,50 +6159,50 @@ let (pure_precondition_for_trivial_post :
           fun r  ->
             let trivial_post =
               let post_ts =
-                let uu____28191 =
+                let uu____28276 =
                   lookup_definition [NoDelta] env1
                     FStar_Parser_Const.trivial_pure_post_lid
                    in
-                FStar_All.pipe_right uu____28191 FStar_Util.must  in
-              let uu____28208 = inst_tscheme_with post_ts [u]  in
-              match uu____28208 with
-              | (uu____28213,post) ->
-                  let uu____28215 =
-                    let uu____28220 =
-                      let uu____28221 =
+                FStar_All.pipe_right uu____28276 FStar_Util.must  in
+              let uu____28293 = inst_tscheme_with post_ts [u]  in
+              match uu____28293 with
+              | (uu____28298,post) ->
+                  let uu____28300 =
+                    let uu____28305 =
+                      let uu____28306 =
                         FStar_All.pipe_right t FStar_Syntax_Syntax.as_arg  in
-                      [uu____28221]  in
-                    FStar_Syntax_Syntax.mk_Tm_app post uu____28220  in
-                  uu____28215 FStar_Pervasives_Native.None r
+                      [uu____28306]  in
+                    FStar_Syntax_Syntax.mk_Tm_app post uu____28305  in
+                  uu____28300 FStar_Pervasives_Native.None r
                in
-            let uu____28254 =
-              let uu____28259 =
-                let uu____28260 =
+            let uu____28339 =
+              let uu____28344 =
+                let uu____28345 =
                   FStar_All.pipe_right trivial_post
                     FStar_Syntax_Syntax.as_arg
                    in
-                [uu____28260]  in
-              FStar_Syntax_Syntax.mk_Tm_app wp uu____28259  in
-            uu____28254 FStar_Pervasives_Native.None r
+                [uu____28345]  in
+              FStar_Syntax_Syntax.mk_Tm_app wp uu____28344  in
+            uu____28339 FStar_Pervasives_Native.None r
   
 let (dummy_solver : solver_t) =
   {
-    init = (fun uu____28296  -> ());
-    push = (fun uu____28298  -> ());
-    pop = (fun uu____28301  -> ());
+    init = (fun uu____28381  -> ());
+    push = (fun uu____28383  -> ());
+    pop = (fun uu____28386  -> ());
     snapshot =
-      (fun uu____28304  ->
+      (fun uu____28389  ->
          ((Prims.int_zero, Prims.int_zero, Prims.int_zero), ()));
-    rollback = (fun uu____28323  -> fun uu____28324  -> ());
-    encode_sig = (fun uu____28339  -> fun uu____28340  -> ());
+    rollback = (fun uu____28408  -> fun uu____28409  -> ());
+    encode_sig = (fun uu____28424  -> fun uu____28425  -> ());
     preprocess =
       (fun e  ->
          fun g  ->
-           let uu____28346 =
-             let uu____28353 = FStar_Options.peek ()  in (e, g, uu____28353)
+           let uu____28431 =
+             let uu____28438 = FStar_Options.peek ()  in (e, g, uu____28438)
               in
-           [uu____28346]);
-    solve = (fun uu____28369  -> fun uu____28370  -> fun uu____28371  -> ());
-    finish = (fun uu____28378  -> ());
-    refresh = (fun uu____28380  -> ())
+           [uu____28431]);
+    solve = (fun uu____28454  -> fun uu____28455  -> fun uu____28456  -> ());
+    finish = (fun uu____28463  -> ());
+    refresh = (fun uu____28465  -> ())
   } 

--- a/src/ocaml-output/FStar_TypeChecker_Err.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Err.ml
@@ -249,11 +249,12 @@ let (unexpected_signature_for_monad :
     fun m  ->
       fun k  ->
         let uu____1048 =
-          let uu____1050 = FStar_TypeChecker_Normalize.term_to_string env k
+          let uu____1050 = FStar_Ident.string_of_lid m  in
+          let uu____1052 = FStar_TypeChecker_Normalize.term_to_string env k
              in
           FStar_Util.format2
             "Unexpected signature for monad \"%s\". Expected a signature of the form (a:Type => WP a => Effect); got %s"
-            m.FStar_Ident.str uu____1050
+            uu____1050 uu____1052
            in
         (FStar_Errors.Fatal_UnexpectedSignatureForMonad, uu____1048)
   
@@ -267,15 +268,15 @@ let (expected_a_term_of_type_t_got_a_function :
     fun msg  ->
       fun t  ->
         fun e  ->
-          let uu____1082 =
-            let uu____1084 = FStar_TypeChecker_Normalize.term_to_string env t
+          let uu____1084 =
+            let uu____1086 = FStar_TypeChecker_Normalize.term_to_string env t
                in
-            let uu____1086 = FStar_Syntax_Print.term_to_string e  in
+            let uu____1088 = FStar_Syntax_Print.term_to_string e  in
             FStar_Util.format3
               "Expected a term of type \"%s\"; got a function \"%s\" (%s)"
-              uu____1084 uu____1086 msg
+              uu____1086 uu____1088 msg
              in
-          (FStar_Errors.Fatal_ExpectTermGotFunction, uu____1082)
+          (FStar_Errors.Fatal_ExpectTermGotFunction, uu____1084)
   
 let (unexpected_implicit_argument : (FStar_Errors.raw_error * Prims.string))
   =
@@ -292,16 +293,16 @@ let (expected_expression_of_type :
     fun t1  ->
       fun e  ->
         fun t2  ->
-          let uu____1124 = err_msg_type_strings env t1 t2  in
-          match uu____1124 with
+          let uu____1126 = err_msg_type_strings env t1 t2  in
+          match uu____1126 with
           | (s1,s2) ->
-              let uu____1142 =
-                let uu____1144 = FStar_Syntax_Print.term_to_string e  in
+              let uu____1144 =
+                let uu____1146 = FStar_Syntax_Print.term_to_string e  in
                 FStar_Util.format3
                   "Expected expression of type \"%s\"; got expression \"%s\" of type \"%s\""
-                  s1 uu____1144 s2
+                  s1 uu____1146 s2
                  in
-              (FStar_Errors.Fatal_UnexpectedExpressionType, uu____1142)
+              (FStar_Errors.Fatal_UnexpectedExpressionType, uu____1144)
   
 let (expected_pattern_of_type :
   FStar_TypeChecker_Env.env ->
@@ -313,16 +314,16 @@ let (expected_pattern_of_type :
     fun t1  ->
       fun e  ->
         fun t2  ->
-          let uu____1174 = err_msg_type_strings env t1 t2  in
-          match uu____1174 with
+          let uu____1176 = err_msg_type_strings env t1 t2  in
+          match uu____1176 with
           | (s1,s2) ->
-              let uu____1192 =
-                let uu____1194 = FStar_Syntax_Print.term_to_string e  in
+              let uu____1194 =
+                let uu____1196 = FStar_Syntax_Print.term_to_string e  in
                 FStar_Util.format3
                   "Expected pattern of type \"%s\"; got pattern \"%s\" of type \"%s\""
-                  s1 uu____1194 s2
+                  s1 uu____1196 s2
                  in
-              (FStar_Errors.Fatal_UnexpectedPattern, uu____1192)
+              (FStar_Errors.Fatal_UnexpectedPattern, uu____1194)
   
 let (basic_type_error :
   FStar_TypeChecker_Env.env ->
@@ -334,8 +335,8 @@ let (basic_type_error :
     fun eopt  ->
       fun t1  ->
         fun t2  ->
-          let uu____1228 = err_msg_type_strings env t1 t2  in
-          match uu____1228 with
+          let uu____1230 = err_msg_type_strings env t1 t2  in
+          match uu____1230 with
           | (s1,s2) ->
               let msg =
                 match eopt with
@@ -343,11 +344,11 @@ let (basic_type_error :
                     FStar_Util.format2
                       "Expected type \"%s\"; got type \"%s\"" s1 s2
                 | FStar_Pervasives_Native.Some e ->
-                    let uu____1251 =
+                    let uu____1253 =
                       FStar_TypeChecker_Normalize.term_to_string env e  in
                     FStar_Util.format3
                       "Expected type \"%s\"; but \"%s\" has type \"%s\"" s1
-                      uu____1251 s2
+                      uu____1253 s2
                  in
               (FStar_Errors.Error_TypeError, msg)
   
@@ -356,33 +357,33 @@ let (occurs_check : (FStar_Errors.raw_error * Prims.string)) =
     "Possibly infinite typ (occurs check failed)")
   
 let constructor_fails_the_positivity_check :
-  'uuuuuu1272 .
-    'uuuuuu1272 ->
+  'uuuuuu1274 .
+    'uuuuuu1274 ->
       FStar_Syntax_Syntax.term ->
         FStar_Ident.lid -> (FStar_Errors.raw_error * Prims.string)
   =
   fun env  ->
     fun d  ->
       fun l  ->
-        let uu____1293 =
-          let uu____1295 = FStar_Syntax_Print.term_to_string d  in
-          let uu____1297 = FStar_Syntax_Print.lid_to_string l  in
+        let uu____1295 =
+          let uu____1297 = FStar_Syntax_Print.term_to_string d  in
+          let uu____1299 = FStar_Syntax_Print.lid_to_string l  in
           FStar_Util.format2
             "Constructor \"%s\" fails the strict positivity check; the constructed type \"%s\" occurs to the left of a pure function type"
-            uu____1295 uu____1297
+            uu____1297 uu____1299
            in
-        (FStar_Errors.Fatal_ConstructorFailedCheck, uu____1293)
+        (FStar_Errors.Fatal_ConstructorFailedCheck, uu____1295)
   
 let (inline_type_annotation_and_val_decl :
   FStar_Ident.lid -> (FStar_Errors.raw_error * Prims.string)) =
   fun l  ->
-    let uu____1312 =
-      let uu____1314 = FStar_Syntax_Print.lid_to_string l  in
+    let uu____1314 =
+      let uu____1316 = FStar_Syntax_Print.lid_to_string l  in
       FStar_Util.format1
         "\"%s\" has a val declaration as well as an inlined type annotation; remove one"
-        uu____1314
+        uu____1316
        in
-    (FStar_Errors.Fatal_DuplicateTypeAnnotationAndValDecl, uu____1312)
+    (FStar_Errors.Fatal_DuplicateTypeAnnotationAndValDecl, uu____1314)
   
 let (inferred_type_causes_variable_to_escape :
   FStar_TypeChecker_Env.env ->
@@ -392,15 +393,15 @@ let (inferred_type_causes_variable_to_escape :
   fun env  ->
     fun t  ->
       fun x  ->
-        let uu____1339 =
-          let uu____1341 = FStar_TypeChecker_Normalize.term_to_string env t
+        let uu____1341 =
+          let uu____1343 = FStar_TypeChecker_Normalize.term_to_string env t
              in
-          let uu____1343 = FStar_Syntax_Print.bv_to_string x  in
+          let uu____1345 = FStar_Syntax_Print.bv_to_string x  in
           FStar_Util.format2
             "Inferred type \"%s\" causes variable \"%s\" to escape its scope"
-            uu____1341 uu____1343
+            uu____1343 uu____1345
            in
-        (FStar_Errors.Fatal_InferredTypeCauseVarEscape, uu____1339)
+        (FStar_Errors.Fatal_InferredTypeCauseVarEscape, uu____1341)
   
 let (expected_function_typ :
   FStar_TypeChecker_Env.env ->
@@ -408,12 +409,12 @@ let (expected_function_typ :
   =
   fun env  ->
     fun t  ->
-      let uu____1363 =
-        let uu____1365 = FStar_TypeChecker_Normalize.term_to_string env t  in
+      let uu____1365 =
+        let uu____1367 = FStar_TypeChecker_Normalize.term_to_string env t  in
         FStar_Util.format1
-          "Expected a function; got an expression of type \"%s\"" uu____1365
+          "Expected a function; got an expression of type \"%s\"" uu____1367
          in
-      (FStar_Errors.Fatal_FunctionTypeExpected, uu____1363)
+      (FStar_Errors.Fatal_FunctionTypeExpected, uu____1365)
   
 let (expected_poly_typ :
   FStar_TypeChecker_Env.env ->
@@ -425,17 +426,17 @@ let (expected_poly_typ :
     fun f  ->
       fun t  ->
         fun targ  ->
-          let uu____1395 =
-            let uu____1397 = FStar_Syntax_Print.term_to_string f  in
-            let uu____1399 = FStar_TypeChecker_Normalize.term_to_string env t
+          let uu____1397 =
+            let uu____1399 = FStar_Syntax_Print.term_to_string f  in
+            let uu____1401 = FStar_TypeChecker_Normalize.term_to_string env t
                in
-            let uu____1401 =
+            let uu____1403 =
               FStar_TypeChecker_Normalize.term_to_string env targ  in
             FStar_Util.format3
               "Expected a polymorphic function; got an expression \"%s\" of type \"%s\" applied to a type \"%s\""
-              uu____1397 uu____1399 uu____1401
+              uu____1399 uu____1401 uu____1403
              in
-          (FStar_Errors.Fatal_PolyTypeExpected, uu____1395)
+          (FStar_Errors.Fatal_PolyTypeExpected, uu____1397)
   
 let (disjunctive_pattern_vars :
   FStar_Syntax_Syntax.bv Prims.list ->
@@ -445,19 +446,19 @@ let (disjunctive_pattern_vars :
   fun v1  ->
     fun v2  ->
       let vars v =
-        let uu____1440 =
+        let uu____1442 =
           FStar_All.pipe_right v
             (FStar_List.map FStar_Syntax_Print.bv_to_string)
            in
-        FStar_All.pipe_right uu____1440 (FStar_String.concat ", ")  in
-      let uu____1455 =
-        let uu____1457 = vars v1  in
-        let uu____1459 = vars v2  in
+        FStar_All.pipe_right uu____1442 (FStar_String.concat ", ")  in
+      let uu____1457 =
+        let uu____1459 = vars v1  in
+        let uu____1461 = vars v2  in
         FStar_Util.format2
           "Every alternative of an 'or' pattern must bind the same variables; here one branch binds (\"%s\") and another (\"%s\")"
-          uu____1457 uu____1459
+          uu____1459 uu____1461
          in
-      (FStar_Errors.Fatal_DisjuctivePatternVarsMismatch, uu____1455)
+      (FStar_Errors.Fatal_DisjuctivePatternVarsMismatch, uu____1457)
   
 let (name_and_result :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -465,18 +466,18 @@ let (name_and_result :
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (t,uu____1488) -> ("Tot", t)
-    | FStar_Syntax_Syntax.GTotal (t,uu____1502) -> ("GTot", t)
+    | FStar_Syntax_Syntax.Total (t,uu____1490) -> ("Tot", t)
+    | FStar_Syntax_Syntax.GTotal (t,uu____1504) -> ("GTot", t)
     | FStar_Syntax_Syntax.Comp ct ->
-        let uu____1516 =
+        let uu____1518 =
           FStar_Syntax_Print.lid_to_string ct.FStar_Syntax_Syntax.effect_name
            in
-        (uu____1516, (ct.FStar_Syntax_Syntax.result_typ))
+        (uu____1518, (ct.FStar_Syntax_Syntax.result_typ))
   
 let computed_computation_type_does_not_match_annotation :
-  'uuuuuu1532 .
+  'uuuuuu1534 .
     FStar_TypeChecker_Env.env ->
-      'uuuuuu1532 ->
+      'uuuuuu1534 ->
         FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
           FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
             (FStar_Errors.raw_error * Prims.string)
@@ -485,27 +486,27 @@ let computed_computation_type_does_not_match_annotation :
     fun e  ->
       fun c  ->
         fun c'  ->
-          let uu____1566 = name_and_result c  in
-          match uu____1566 with
+          let uu____1568 = name_and_result c  in
+          match uu____1568 with
           | (f1,r1) ->
-              let uu____1587 = name_and_result c'  in
-              (match uu____1587 with
+              let uu____1589 = name_and_result c'  in
+              (match uu____1589 with
                | (f2,r2) ->
-                   let uu____1608 = err_msg_type_strings env r1 r2  in
-                   (match uu____1608 with
+                   let uu____1610 = err_msg_type_strings env r1 r2  in
+                   (match uu____1610 with
                     | (s1,s2) ->
-                        let uu____1626 =
+                        let uu____1628 =
                           FStar_Util.format4
                             "Computed type \"%s\" and effect \"%s\" is not compatible with the annotated type \"%s\" effect \"%s\""
                             s1 f1 s2 f2
                            in
                         (FStar_Errors.Fatal_ComputedTypeNotMatchAnnotation,
-                          uu____1626)))
+                          uu____1628)))
   
 let computed_computation_type_does_not_match_annotation_eq :
-  'uuuuuu1641 .
+  'uuuuuu1643 .
     FStar_TypeChecker_Env.env ->
-      'uuuuuu1641 ->
+      'uuuuuu1643 ->
         FStar_Syntax_Syntax.comp ->
           FStar_Syntax_Syntax.comp -> (FStar_Errors.raw_error * Prims.string)
   =
@@ -513,15 +514,15 @@ let computed_computation_type_does_not_match_annotation_eq :
     fun e  ->
       fun c  ->
         fun c'  ->
-          let uu____1667 = err_msg_comp_strings env c c'  in
-          match uu____1667 with
+          let uu____1669 = err_msg_comp_strings env c c'  in
+          match uu____1669 with
           | (s1,s2) ->
-              let uu____1685 =
+              let uu____1687 =
                 FStar_Util.format2
                   "Computed type \"%s\" does not match annotated type \"%s\", and no subtyping was allowed"
                   s1 s2
                  in
-              (FStar_Errors.Fatal_ComputedTypeNotMatchAnnotation, uu____1685)
+              (FStar_Errors.Fatal_ComputedTypeNotMatchAnnotation, uu____1687)
   
 let (unexpected_non_trivial_precondition_on_term :
   FStar_TypeChecker_Env.env ->
@@ -529,12 +530,12 @@ let (unexpected_non_trivial_precondition_on_term :
   =
   fun env  ->
     fun f  ->
-      let uu____1705 =
-        let uu____1707 = FStar_TypeChecker_Normalize.term_to_string env f  in
+      let uu____1707 =
+        let uu____1709 = FStar_TypeChecker_Normalize.term_to_string env f  in
         FStar_Util.format1
-          "Term has an unexpected non-trivial pre-condition: %s" uu____1707
+          "Term has an unexpected non-trivial pre-condition: %s" uu____1709
          in
-      (FStar_Errors.Fatal_UnExpectedPreCondition, uu____1705)
+      (FStar_Errors.Fatal_UnExpectedPreCondition, uu____1707)
   
 let (expected_pure_expression :
   FStar_Syntax_Syntax.term ->
@@ -543,16 +544,16 @@ let (expected_pure_expression :
   =
   fun e  ->
     fun c  ->
-      let uu____1731 =
-        let uu____1733 = FStar_Syntax_Print.term_to_string e  in
-        let uu____1735 =
-          let uu____1737 = name_and_result c  in
-          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____1737  in
+      let uu____1733 =
+        let uu____1735 = FStar_Syntax_Print.term_to_string e  in
+        let uu____1737 =
+          let uu____1739 = name_and_result c  in
+          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____1739  in
         FStar_Util.format2
           "Expected a pure expression; got an expression \"%s\" with effect \"%s\""
-          uu____1733 uu____1735
+          uu____1735 uu____1737
          in
-      (FStar_Errors.Fatal_ExpectedPureExpression, uu____1731)
+      (FStar_Errors.Fatal_ExpectedPureExpression, uu____1733)
   
 let (expected_ghost_expression :
   FStar_Syntax_Syntax.term ->
@@ -561,16 +562,16 @@ let (expected_ghost_expression :
   =
   fun e  ->
     fun c  ->
-      let uu____1778 =
-        let uu____1780 = FStar_Syntax_Print.term_to_string e  in
-        let uu____1782 =
-          let uu____1784 = name_and_result c  in
-          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____1784  in
+      let uu____1780 =
+        let uu____1782 = FStar_Syntax_Print.term_to_string e  in
+        let uu____1784 =
+          let uu____1786 = name_and_result c  in
+          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____1786  in
         FStar_Util.format2
           "Expected a ghost expression; got an expression \"%s\" with effect \"%s\""
-          uu____1780 uu____1782
+          uu____1782 uu____1784
          in
-      (FStar_Errors.Fatal_ExpectedGhostExpression, uu____1778)
+      (FStar_Errors.Fatal_ExpectedGhostExpression, uu____1780)
   
 let (expected_effect_1_got_effect_2 :
   FStar_Ident.lident ->
@@ -578,14 +579,14 @@ let (expected_effect_1_got_effect_2 :
   =
   fun c1  ->
     fun c2  ->
-      let uu____1821 =
-        let uu____1823 = FStar_Syntax_Print.lid_to_string c1  in
-        let uu____1825 = FStar_Syntax_Print.lid_to_string c2  in
+      let uu____1823 =
+        let uu____1825 = FStar_Syntax_Print.lid_to_string c1  in
+        let uu____1827 = FStar_Syntax_Print.lid_to_string c2  in
         FStar_Util.format2
           "Expected a computation with effect %s; but it has effect %s"
-          uu____1823 uu____1825
+          uu____1825 uu____1827
          in
-      (FStar_Errors.Fatal_UnexpectedEffect, uu____1821)
+      (FStar_Errors.Fatal_UnexpectedEffect, uu____1823)
   
 let (failed_to_prove_specification_of :
   FStar_Syntax_Syntax.lbname ->
@@ -593,15 +594,15 @@ let (failed_to_prove_specification_of :
   =
   fun l  ->
     fun lbls  ->
-      let uu____1851 =
-        let uu____1853 = FStar_Syntax_Print.lbname_to_string l  in
-        let uu____1855 = FStar_All.pipe_right lbls (FStar_String.concat ", ")
+      let uu____1853 =
+        let uu____1855 = FStar_Syntax_Print.lbname_to_string l  in
+        let uu____1857 = FStar_All.pipe_right lbls (FStar_String.concat ", ")
            in
         FStar_Util.format2
           "Failed to prove specification of %s; assertions at [%s] may fail"
-          uu____1853 uu____1855
+          uu____1855 uu____1857
          in
-      (FStar_Errors.Error_TypeCheckerFailToProve, uu____1851)
+      (FStar_Errors.Error_TypeCheckerFailToProve, uu____1853)
   
 let (failed_to_prove_specification :
   Prims.string Prims.list -> (FStar_Errors.raw_error * Prims.string)) =
@@ -610,11 +611,11 @@ let (failed_to_prove_specification :
       match lbls with
       | [] ->
           "An unknown assertion in the term at this location was not provable"
-      | uu____1886 ->
-          let uu____1890 =
+      | uu____1888 ->
+          let uu____1892 =
             FStar_All.pipe_right lbls (FStar_String.concat "\n\t")  in
           FStar_Util.format1 "The following problems were found:\n\t%s"
-            uu____1890
+            uu____1892
        in
     (FStar_Errors.Error_TypeCheckerFailToProve, msg)
   
@@ -629,13 +630,13 @@ let (cardinality_constraint_violated :
   =
   fun l  ->
     fun a  ->
-      let uu____1927 =
-        let uu____1929 = FStar_Syntax_Print.lid_to_string l  in
-        let uu____1931 =
+      let uu____1929 =
+        let uu____1931 = FStar_Syntax_Print.lid_to_string l  in
+        let uu____1933 =
           FStar_Syntax_Print.bv_to_string a.FStar_Syntax_Syntax.v  in
         FStar_Util.format2
           "Constructor %s violates the cardinality of Type at parameter '%s'; type arguments are not allowed"
-          uu____1929 uu____1931
+          uu____1931 uu____1933
          in
-      (FStar_Errors.Fatal_CardinalityConstraintViolated, uu____1927)
+      (FStar_Errors.Fatal_CardinalityConstraintViolated, uu____1929)
   

--- a/src/ocaml-output/FStar_TypeChecker_NBE.ml
+++ b/src/ocaml-output/FStar_TypeChecker_NBE.ml
@@ -268,7 +268,8 @@ let (cache_add :
     fun fv  ->
       fun v  ->
         let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-        FStar_Util.smap_add cfg.fv_cache lid.FStar_Ident.str v
+        let uu____619 = FStar_Ident.string_of_lid lid  in
+        FStar_Util.smap_add cfg.fv_cache uu____619 v
   
 let (try_in_cache :
   config ->
@@ -278,14 +279,15 @@ let (try_in_cache :
   fun cfg  ->
     fun fv  ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-      FStar_Util.smap_try_find cfg.fv_cache lid.FStar_Ident.str
+      let uu____637 = FStar_Ident.string_of_lid lid  in
+      FStar_Util.smap_try_find cfg.fv_cache uu____637
   
 let (debug : config -> (unit -> unit) -> unit) =
   fun cfg  -> fun f  -> FStar_TypeChecker_Cfg.log_nbe cfg.core_cfg f 
 let (unlazy : FStar_TypeChecker_NBETerm.t -> FStar_TypeChecker_NBETerm.t) =
   fun t  ->
     match t with
-    | FStar_TypeChecker_NBETerm.Lazy (uu____657,t1) -> FStar_Thunk.force t1
+    | FStar_TypeChecker_NBETerm.Lazy (uu____661,t1) -> FStar_Thunk.force t1
     | t1 -> t1
   
 let (pickBranch :
@@ -302,12 +304,12 @@ let (pickBranch :
         let rec pickBranch_aux scrut1 branches1 branches0 =
           let rec matches_pat scrutinee0 p =
             debug cfg
-              (fun uu____788  ->
-                 let uu____789 =
+              (fun uu____792  ->
+                 let uu____793 =
                    FStar_TypeChecker_NBETerm.t_to_string scrutinee0  in
-                 let uu____791 = FStar_Syntax_Print.pat_to_string p  in
-                 FStar_Util.print2 "matches_pat (%s, %s)\n" uu____789
-                   uu____791);
+                 let uu____795 = FStar_Syntax_Print.pat_to_string p  in
+                 FStar_Util.print2 "matches_pat (%s, %s)\n" uu____793
+                   uu____795);
             (let scrutinee = unlazy scrutinee0  in
              let r =
                match p.FStar_Syntax_Syntax.v with
@@ -315,19 +317,19 @@ let (pickBranch :
                    FStar_Util.Inl [scrutinee0]
                | FStar_Syntax_Syntax.Pat_wild bv ->
                    FStar_Util.Inl [scrutinee0]
-               | FStar_Syntax_Syntax.Pat_dot_term uu____818 ->
+               | FStar_Syntax_Syntax.Pat_dot_term uu____822 ->
                    FStar_Util.Inl []
                | FStar_Syntax_Syntax.Pat_constant s ->
                    let matches_const c s1 =
                      debug cfg
-                       (fun uu____845  ->
-                          let uu____846 =
+                       (fun uu____849  ->
+                          let uu____850 =
                             FStar_TypeChecker_NBETerm.t_to_string c  in
-                          let uu____848 =
+                          let uu____852 =
                             FStar_Syntax_Print.const_to_string s1  in
                           FStar_Util.print2
-                            "Testing term %s against pattern %s\n" uu____846
-                            uu____848);
+                            "Testing term %s against pattern %s\n" uu____850
+                            uu____852);
                      (match c with
                       | FStar_TypeChecker_NBETerm.Constant
                           (FStar_TypeChecker_NBETerm.Unit ) ->
@@ -336,87 +338,87 @@ let (pickBranch :
                           (FStar_TypeChecker_NBETerm.Bool b) ->
                           (match s1 with
                            | FStar_Const.Const_bool p1 -> b = p1
-                           | uu____858 -> false)
+                           | uu____862 -> false)
                       | FStar_TypeChecker_NBETerm.Constant
                           (FStar_TypeChecker_NBETerm.Int i) ->
                           (match s1 with
                            | FStar_Const.Const_int
                                (p1,FStar_Pervasives_Native.None ) ->
-                               let uu____875 =
+                               let uu____879 =
                                  FStar_BigInt.big_int_of_string p1  in
-                               i = uu____875
-                           | uu____876 -> false)
+                               i = uu____879
+                           | uu____880 -> false)
                       | FStar_TypeChecker_NBETerm.Constant
-                          (FStar_TypeChecker_NBETerm.String (st,uu____879))
+                          (FStar_TypeChecker_NBETerm.String (st,uu____883))
                           ->
                           (match s1 with
-                           | FStar_Const.Const_string (p1,uu____884) ->
+                           | FStar_Const.Const_string (p1,uu____888) ->
                                st = p1
-                           | uu____888 -> false)
+                           | uu____892 -> false)
                       | FStar_TypeChecker_NBETerm.Constant
                           (FStar_TypeChecker_NBETerm.Char c1) ->
                           (match s1 with
                            | FStar_Const.Const_char p1 -> c1 = p1
-                           | uu____896 -> false)
-                      | uu____898 -> false)
+                           | uu____900 -> false)
+                      | uu____902 -> false)
                       in
-                   let uu____900 = matches_const scrutinee s  in
-                   if uu____900
+                   let uu____904 = matches_const scrutinee s  in
+                   if uu____904
                    then FStar_Util.Inl []
                    else FStar_Util.Inr false
                | FStar_Syntax_Syntax.Pat_cons (fv,arg_pats) ->
                    let rec matches_args out a p1 =
                      match (a, p1) with
                      | ([],[]) -> FStar_Util.Inl out
-                     | ((t,uu____1038)::rest_a,(p2,uu____1041)::rest_p) ->
-                         let uu____1080 = matches_pat t p2  in
-                         (match uu____1080 with
+                     | ((t,uu____1042)::rest_a,(p2,uu____1045)::rest_p) ->
+                         let uu____1084 = matches_pat t p2  in
+                         (match uu____1084 with
                           | FStar_Util.Inl s ->
                               matches_args (FStar_List.append out s) rest_a
                                 rest_p
                           | m -> m)
-                     | uu____1109 -> FStar_Util.Inr false  in
+                     | uu____1113 -> FStar_Util.Inr false  in
                    (match scrutinee with
                     | FStar_TypeChecker_NBETerm.Construct (fv',_us,args_rev)
                         ->
-                        let uu____1157 = FStar_Syntax_Syntax.fv_eq fv fv'  in
-                        if uu____1157
+                        let uu____1161 = FStar_Syntax_Syntax.fv_eq fv fv'  in
+                        if uu____1161
                         then
                           matches_args [] (FStar_List.rev args_rev) arg_pats
                         else FStar_Util.Inr false
-                    | uu____1177 -> FStar_Util.Inr true)
+                    | uu____1181 -> FStar_Util.Inr true)
                 in
-             let res_to_string uu___0_1195 =
-               match uu___0_1195 with
+             let res_to_string uu___0_1199 =
+               match uu___0_1199 with
                | FStar_Util.Inr b ->
-                   let uu____1209 = FStar_Util.string_of_bool b  in
-                   Prims.op_Hat "Inr " uu____1209
+                   let uu____1213 = FStar_Util.string_of_bool b  in
+                   Prims.op_Hat "Inr " uu____1213
                | FStar_Util.Inl bs ->
-                   let uu____1218 =
+                   let uu____1222 =
                      FStar_Util.string_of_int (FStar_List.length bs)  in
-                   Prims.op_Hat "Inl " uu____1218
+                   Prims.op_Hat "Inl " uu____1222
                 in
              debug cfg
-               (fun uu____1226  ->
-                  let uu____1227 =
+               (fun uu____1230  ->
+                  let uu____1231 =
                     FStar_TypeChecker_NBETerm.t_to_string scrutinee  in
-                  let uu____1229 = FStar_Syntax_Print.pat_to_string p  in
-                  let uu____1231 = res_to_string r  in
-                  FStar_Util.print3 "matches_pat (%s, %s) = %s\n" uu____1227
-                    uu____1229 uu____1231);
+                  let uu____1233 = FStar_Syntax_Print.pat_to_string p  in
+                  let uu____1235 = res_to_string r  in
+                  FStar_Util.print3 "matches_pat (%s, %s) = %s\n" uu____1231
+                    uu____1233 uu____1235);
              r)
              in
           match branches1 with
           | [] -> FStar_Pervasives_Native.None
           | (p,_wopt,e)::branches2 ->
-              let uu____1270 = matches_pat scrut1 p  in
-              (match uu____1270 with
+              let uu____1274 = matches_pat scrut1 p  in
+              (match uu____1274 with
                | FStar_Util.Inl matches ->
                    (debug cfg
-                      (fun uu____1295  ->
-                         let uu____1296 = FStar_Syntax_Print.pat_to_string p
+                      (fun uu____1299  ->
+                         let uu____1300 = FStar_Syntax_Print.pat_to_string p
                             in
-                         FStar_Util.print1 "Pattern %s matches\n" uu____1296);
+                         FStar_Util.print1 "Pattern %s matches\n" uu____1300);
                     FStar_Pervasives_Native.Some (e, matches))
                | FStar_Util.Inr (false ) ->
                    pickBranch_aux scrut1 branches2 branches0
@@ -434,15 +436,15 @@ let (should_reduce_recursive_definition :
     fun formals_in_decreases  ->
       let rec aux ts ar_list acc =
         match (ts, ar_list) with
-        | (uu____1445,[]) -> (true, acc, ts)
-        | ([],uu____1476::uu____1477) -> (false, acc, [])
+        | (uu____1449,[]) -> (true, acc, ts)
+        | ([],uu____1480::uu____1481) -> (false, acc, [])
         | (t::ts1,in_decreases_clause::bs) ->
-            let uu____1546 =
+            let uu____1550 =
               in_decreases_clause &&
                 (FStar_TypeChecker_NBETerm.isAccu
                    (FStar_Pervasives_Native.fst t))
                in
-            if uu____1546
+            if uu____1550
             then (false, (FStar_List.rev_append ts1 acc), [])
             else aux ts1 bs (t :: acc)
          in
@@ -457,40 +459,40 @@ let (find_sigelt_in_gamma :
   fun cfg  ->
     fun env  ->
       fun lid  ->
-        let mapper uu____1645 =
-          match uu____1645 with
+        let mapper uu____1649 =
+          match uu____1649 with
           | (lr,rng) ->
               (match lr with
                | FStar_Util.Inr (elt,FStar_Pervasives_Native.None ) ->
                    FStar_Pervasives_Native.Some elt
                | FStar_Util.Inr (elt,FStar_Pervasives_Native.Some us) ->
                    (debug cfg
-                      (fun uu____1728  ->
-                         let uu____1729 =
+                      (fun uu____1732  ->
+                         let uu____1733 =
                            FStar_Syntax_Print.univs_to_string us  in
                          FStar_Util.print1
-                           "Universes in local declaration: %s\n" uu____1729);
+                           "Universes in local declaration: %s\n" uu____1733);
                     FStar_Pervasives_Native.Some elt)
-               | uu____1732 -> FStar_Pervasives_Native.None)
+               | uu____1736 -> FStar_Pervasives_Native.None)
            in
-        let uu____1747 = FStar_TypeChecker_Env.lookup_qname env lid  in
-        FStar_Util.bind_opt uu____1747 mapper
+        let uu____1751 = FStar_TypeChecker_Env.lookup_qname env lid  in
+        FStar_Util.bind_opt uu____1751 mapper
   
 let (is_univ : FStar_TypeChecker_NBETerm.t -> Prims.bool) =
   fun tm  ->
     match tm with
-    | FStar_TypeChecker_NBETerm.Univ uu____1794 -> true
-    | uu____1796 -> false
+    | FStar_TypeChecker_NBETerm.Univ uu____1798 -> true
+    | uu____1800 -> false
   
 let (un_univ : FStar_TypeChecker_NBETerm.t -> FStar_Syntax_Syntax.universe) =
   fun tm  ->
     match tm with
     | FStar_TypeChecker_NBETerm.Univ u -> u
     | t ->
-        let uu____1806 =
-          let uu____1808 = FStar_TypeChecker_NBETerm.t_to_string t  in
-          Prims.op_Hat "Not a universe: " uu____1808  in
-        failwith uu____1806
+        let uu____1810 =
+          let uu____1812 = FStar_TypeChecker_NBETerm.t_to_string t  in
+          Prims.op_Hat "Not a universe: " uu____1812  in
+        failwith uu____1810
   
 let (is_constr_fv : FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun fvar  ->
@@ -504,14 +506,14 @@ let (is_constr : FStar_TypeChecker_Env.qninfo -> Prims.bool) =
         (FStar_Util.Inr
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (uu____1830,uu____1831,uu____1832,uu____1833,uu____1834,uu____1835);
-            FStar_Syntax_Syntax.sigrng = uu____1836;
-            FStar_Syntax_Syntax.sigquals = uu____1837;
-            FStar_Syntax_Syntax.sigmeta = uu____1838;
-            FStar_Syntax_Syntax.sigattrs = uu____1839;
-            FStar_Syntax_Syntax.sigopts = uu____1840;_},uu____1841),uu____1842)
+              (uu____1834,uu____1835,uu____1836,uu____1837,uu____1838,uu____1839);
+            FStar_Syntax_Syntax.sigrng = uu____1840;
+            FStar_Syntax_Syntax.sigquals = uu____1841;
+            FStar_Syntax_Syntax.sigmeta = uu____1842;
+            FStar_Syntax_Syntax.sigattrs = uu____1843;
+            FStar_Syntax_Syntax.sigopts = uu____1844;_},uu____1845),uu____1846)
         -> true
-    | uu____1902 -> false
+    | uu____1906 -> false
   
 let (translate_univ :
   config ->
@@ -533,14 +535,14 @@ let (translate_univ :
                 then FStar_Syntax_Syntax.U_zero
                 else failwith "Universe index out of bounds"
           | FStar_Syntax_Syntax.U_succ u3 ->
-              let uu____1942 = aux u3  in
-              FStar_Syntax_Syntax.U_succ uu____1942
+              let uu____1946 = aux u3  in
+              FStar_Syntax_Syntax.U_succ uu____1946
           | FStar_Syntax_Syntax.U_max us ->
-              let uu____1946 = FStar_List.map aux us  in
-              FStar_Syntax_Syntax.U_max uu____1946
+              let uu____1950 = FStar_List.map aux us  in
+              FStar_Syntax_Syntax.U_max uu____1950
           | FStar_Syntax_Syntax.U_unknown  -> u2
-          | FStar_Syntax_Syntax.U_name uu____1949 -> u2
-          | FStar_Syntax_Syntax.U_unif uu____1950 -> u2
+          | FStar_Syntax_Syntax.U_name uu____1953 -> u2
+          | FStar_Syntax_Syntax.U_unif uu____1954 -> u2
           | FStar_Syntax_Syntax.U_zero  -> u2  in
         aux u
   
@@ -554,10 +556,10 @@ let (find_let :
       FStar_Util.find_map lbs
         (fun lb  ->
            match lb.FStar_Syntax_Syntax.lbname with
-           | FStar_Util.Inl uu____1981 -> failwith "find_let : impossible"
+           | FStar_Util.Inl uu____1985 -> failwith "find_let : impossible"
            | FStar_Util.Inr name ->
-               let uu____1986 = FStar_Syntax_Syntax.fv_eq name fvar  in
-               if uu____1986
+               let uu____1990 = FStar_Syntax_Syntax.fv_eq name fvar  in
+               if uu____1990
                then FStar_Pervasives_Native.Some lb
                else FStar_Pervasives_Native.None)
   
@@ -571,112 +573,112 @@ let rec (translate :
       fun e  ->
         let debug1 = debug cfg  in
         debug1
-          (fun uu____2257  ->
-             let uu____2258 =
-               let uu____2260 = FStar_Syntax_Subst.compress e  in
-               FStar_Syntax_Print.tag_of_term uu____2260  in
-             let uu____2261 =
-               let uu____2263 = FStar_Syntax_Subst.compress e  in
-               FStar_Syntax_Print.term_to_string uu____2263  in
-             FStar_Util.print2 "Term: %s - %s\n" uu____2258 uu____2261);
-        (let uu____2265 =
-           let uu____2266 = FStar_Syntax_Subst.compress e  in
-           uu____2266.FStar_Syntax_Syntax.n  in
-         match uu____2265 with
-         | FStar_Syntax_Syntax.Tm_delayed (uu____2269,uu____2270) ->
+          (fun uu____2261  ->
+             let uu____2262 =
+               let uu____2264 = FStar_Syntax_Subst.compress e  in
+               FStar_Syntax_Print.tag_of_term uu____2264  in
+             let uu____2265 =
+               let uu____2267 = FStar_Syntax_Subst.compress e  in
+               FStar_Syntax_Print.term_to_string uu____2267  in
+             FStar_Util.print2 "Term: %s - %s\n" uu____2262 uu____2265);
+        (let uu____2269 =
+           let uu____2270 = FStar_Syntax_Subst.compress e  in
+           uu____2270.FStar_Syntax_Syntax.n  in
+         match uu____2269 with
+         | FStar_Syntax_Syntax.Tm_delayed (uu____2273,uu____2274) ->
              failwith "Tm_delayed: Impossible"
          | FStar_Syntax_Syntax.Tm_unknown  ->
              FStar_TypeChecker_NBETerm.Unknown
          | FStar_Syntax_Syntax.Tm_constant c ->
-             let uu____2293 = translate_constant c  in
-             FStar_TypeChecker_NBETerm.Constant uu____2293
+             let uu____2297 = translate_constant c  in
+             FStar_TypeChecker_NBETerm.Constant uu____2297
          | FStar_Syntax_Syntax.Tm_bvar db ->
              if db.FStar_Syntax_Syntax.index < (FStar_List.length bs)
              then
                let t = FStar_List.nth bs db.FStar_Syntax_Syntax.index  in
                (debug1
-                  (fun uu____2304  ->
-                     let uu____2305 = FStar_TypeChecker_NBETerm.t_to_string t
+                  (fun uu____2308  ->
+                     let uu____2309 = FStar_TypeChecker_NBETerm.t_to_string t
                         in
-                     let uu____2307 =
-                       let uu____2309 =
+                     let uu____2311 =
+                       let uu____2313 =
                          FStar_List.map FStar_TypeChecker_NBETerm.t_to_string
                            bs
                           in
-                       FStar_All.pipe_right uu____2309
+                       FStar_All.pipe_right uu____2313
                          (FStar_String.concat "; ")
                         in
                      FStar_Util.print2
-                       "Resolved bvar to %s\n\tcontext is [%s]\n" uu____2305
-                       uu____2307);
+                       "Resolved bvar to %s\n\tcontext is [%s]\n" uu____2309
+                       uu____2311);
                 t)
              else failwith "de Bruijn index out of bounds"
          | FStar_Syntax_Syntax.Tm_uinst (t,us) ->
              (debug1
-                (fun uu____2336  ->
-                   let uu____2337 = FStar_Syntax_Print.term_to_string t  in
-                   let uu____2339 =
-                     let uu____2341 =
+                (fun uu____2340  ->
+                   let uu____2341 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____2343 =
+                     let uu____2345 =
                        FStar_List.map FStar_Syntax_Print.univ_to_string us
                         in
-                     FStar_All.pipe_right uu____2341
+                     FStar_All.pipe_right uu____2345
                        (FStar_String.concat ", ")
                       in
                    FStar_Util.print2 "Uinst term : %s\nUnivs : %s\n"
-                     uu____2337 uu____2339);
-              (let uu____2352 = translate cfg bs t  in
-               let uu____2353 =
+                     uu____2341 uu____2343);
+              (let uu____2356 = translate cfg bs t  in
+               let uu____2357 =
                  FStar_List.map
                    (fun x  ->
-                      let uu____2357 =
-                        let uu____2358 = translate_univ cfg bs x  in
-                        FStar_TypeChecker_NBETerm.Univ uu____2358  in
-                      FStar_TypeChecker_NBETerm.as_arg uu____2357) us
+                      let uu____2361 =
+                        let uu____2362 = translate_univ cfg bs x  in
+                        FStar_TypeChecker_NBETerm.Univ uu____2362  in
+                      FStar_TypeChecker_NBETerm.as_arg uu____2361) us
                   in
-               iapp cfg uu____2352 uu____2353))
+               iapp cfg uu____2356 uu____2357))
          | FStar_Syntax_Syntax.Tm_type u ->
-             let uu____2360 = translate_univ cfg bs u  in
-             FStar_TypeChecker_NBETerm.Type_t uu____2360
+             let uu____2364 = translate_univ cfg bs u  in
+             FStar_TypeChecker_NBETerm.Type_t uu____2364
          | FStar_Syntax_Syntax.Tm_arrow (xs,c) ->
-             let norm uu____2390 =
-               let uu____2391 =
+             let norm uu____2394 =
+               let uu____2395 =
                  FStar_List.fold_left
-                   (fun uu____2435  ->
-                      fun uu____2436  ->
-                        match (uu____2435, uu____2436) with
+                   (fun uu____2439  ->
+                      fun uu____2440  ->
+                        match (uu____2439, uu____2440) with
                         | ((ctx,binders_rev),(x,q)) ->
                             let t =
-                              let uu____2540 =
+                              let uu____2544 =
                                 translate cfg ctx x.FStar_Syntax_Syntax.sort
                                  in
-                              readback cfg uu____2540  in
+                              readback cfg uu____2544  in
                             let x1 =
-                              let uu___380_2542 =
+                              let uu___380_2546 =
                                 FStar_Syntax_Syntax.freshen_bv x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___380_2542.FStar_Syntax_Syntax.ppname);
+                                  (uu___380_2546.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___380_2542.FStar_Syntax_Syntax.index);
+                                  (uu___380_2546.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t
                               }  in
                             let ctx1 =
-                              let uu____2546 =
+                              let uu____2550 =
                                 FStar_TypeChecker_NBETerm.mkAccuVar x1  in
-                              uu____2546 :: ctx  in
+                              uu____2550 :: ctx  in
                             (ctx1, ((x1, q) :: binders_rev))) (bs, []) xs
                   in
-               match uu____2391 with
+               match uu____2395 with
                | (ctx,binders_rev) ->
                    let c1 =
-                     let uu____2606 = translate_comp cfg ctx c  in
-                     readback_comp cfg uu____2606  in
+                     let uu____2610 = translate_comp cfg ctx c  in
+                     readback_comp cfg uu____2610  in
                    FStar_Syntax_Util.arrow (FStar_List.rev binders_rev) c1
                 in
-             let uu____2613 =
-               let uu____2630 = FStar_Thunk.mk norm  in
-               FStar_Util.Inl uu____2630  in
-             FStar_TypeChecker_NBETerm.Arrow uu____2613
+             let uu____2617 =
+               let uu____2634 = FStar_Thunk.mk norm  in
+               FStar_Util.Inl uu____2634  in
+             FStar_TypeChecker_NBETerm.Arrow uu____2617
          | FStar_Syntax_Syntax.Tm_refine (bv,tm) ->
              if
                ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
@@ -684,139 +686,139 @@ let rec (translate :
              else
                FStar_TypeChecker_NBETerm.Refinement
                  (((fun y  -> translate cfg (y :: bs) tm)),
-                   ((fun uu____2668  ->
-                       let uu____2669 =
+                   ((fun uu____2672  ->
+                       let uu____2673 =
                          translate cfg bs bv.FStar_Syntax_Syntax.sort  in
-                       FStar_TypeChecker_NBETerm.as_arg uu____2669)))
-         | FStar_Syntax_Syntax.Tm_ascribed (t,uu____2671,uu____2672) ->
+                       FStar_TypeChecker_NBETerm.as_arg uu____2673)))
+         | FStar_Syntax_Syntax.Tm_ascribed (t,uu____2675,uu____2676) ->
              translate cfg bs t
          | FStar_Syntax_Syntax.Tm_uvar (u,(subst,set_use_range)) ->
-             let norm_uvar uu____2739 =
-               let norm_subst_elt uu___1_2745 =
-                 match uu___1_2745 with
+             let norm_uvar uu____2743 =
+               let norm_subst_elt uu___1_2749 =
+                 match uu___1_2749 with
                  | FStar_Syntax_Syntax.NT (x,t) ->
-                     let uu____2752 =
-                       let uu____2759 =
-                         let uu____2762 = translate cfg bs t  in
-                         readback cfg uu____2762  in
-                       (x, uu____2759)  in
-                     FStar_Syntax_Syntax.NT uu____2752
+                     let uu____2756 =
+                       let uu____2763 =
+                         let uu____2766 = translate cfg bs t  in
+                         readback cfg uu____2766  in
+                       (x, uu____2763)  in
+                     FStar_Syntax_Syntax.NT uu____2756
                  | FStar_Syntax_Syntax.NM (x,i) ->
                      let x_i =
                        FStar_Syntax_Syntax.bv_to_tm
-                         (let uu___417_2772 = x  in
+                         (let uu___417_2776 = x  in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___417_2772.FStar_Syntax_Syntax.ppname);
+                              (uu___417_2776.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index = i;
                             FStar_Syntax_Syntax.sort =
-                              (uu___417_2772.FStar_Syntax_Syntax.sort)
+                              (uu___417_2776.FStar_Syntax_Syntax.sort)
                           })
                         in
                      let t =
-                       let uu____2774 = translate cfg bs x_i  in
-                       readback cfg uu____2774  in
+                       let uu____2778 = translate cfg bs x_i  in
+                       readback cfg uu____2778  in
                      (match t.FStar_Syntax_Syntax.n with
                       | FStar_Syntax_Syntax.Tm_bvar x_j ->
                           FStar_Syntax_Syntax.NM
                             (x, (x_j.FStar_Syntax_Syntax.index))
-                      | uu____2777 -> FStar_Syntax_Syntax.NT (x, t))
-                 | uu____2780 ->
+                      | uu____2781 -> FStar_Syntax_Syntax.NT (x, t))
+                 | uu____2784 ->
                      failwith "Impossible: subst invariant of uvar nodes"
                   in
                let subst1 =
                  FStar_List.map (FStar_List.map norm_subst_elt) subst  in
-               let uu___427_2791 = e  in
+               let uu___427_2795 = e  in
                {
                  FStar_Syntax_Syntax.n =
                    (FStar_Syntax_Syntax.Tm_uvar (u, (subst1, set_use_range)));
                  FStar_Syntax_Syntax.pos =
-                   (uu___427_2791.FStar_Syntax_Syntax.pos);
+                   (uu___427_2795.FStar_Syntax_Syntax.pos);
                  FStar_Syntax_Syntax.vars =
-                   (uu___427_2791.FStar_Syntax_Syntax.vars)
+                   (uu___427_2795.FStar_Syntax_Syntax.vars)
                }  in
-             let uu____2804 =
-               let uu____2815 =
-                 let uu____2816 = FStar_Thunk.mk norm_uvar  in
-                 FStar_TypeChecker_NBETerm.UVar uu____2816  in
-               (uu____2815, [])  in
-             FStar_TypeChecker_NBETerm.Accu uu____2804
+             let uu____2808 =
+               let uu____2819 =
+                 let uu____2820 = FStar_Thunk.mk norm_uvar  in
+                 FStar_TypeChecker_NBETerm.UVar uu____2820  in
+               (uu____2819, [])  in
+             FStar_TypeChecker_NBETerm.Accu uu____2808
          | FStar_Syntax_Syntax.Tm_name x ->
              FStar_TypeChecker_NBETerm.mkAccuVar x
-         | FStar_Syntax_Syntax.Tm_abs ([],uu____2830,uu____2831) ->
+         | FStar_Syntax_Syntax.Tm_abs ([],uu____2834,uu____2835) ->
              failwith "Impossible: abstraction with no binders"
          | FStar_Syntax_Syntax.Tm_abs (xs,body,resc) ->
              FStar_TypeChecker_NBETerm.Lam
                (((fun ys  -> translate cfg (FStar_List.append ys bs) body)),
                  (FStar_Util.Inl (bs, xs, resc)), (FStar_List.length xs))
          | FStar_Syntax_Syntax.Tm_fvar fvar ->
-             let uu____2939 = try_in_cache cfg fvar  in
-             (match uu____2939 with
+             let uu____2943 = try_in_cache cfg fvar  in
+             (match uu____2943 with
               | FStar_Pervasives_Native.Some t -> t
-              | uu____2943 -> translate_fv cfg bs fvar)
+              | uu____2947 -> translate_fv cfg bs fvar)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reify );
-                FStar_Syntax_Syntax.pos = uu____2946;
-                FStar_Syntax_Syntax.vars = uu____2947;_},arg::more::args)
+                FStar_Syntax_Syntax.pos = uu____2950;
+                FStar_Syntax_Syntax.vars = uu____2951;_},arg::more::args)
              ->
-             let uu____3007 = FStar_Syntax_Util.head_and_args e  in
-             (match uu____3007 with
-              | (head,uu____3025) ->
+             let uu____3011 = FStar_Syntax_Util.head_and_args e  in
+             (match uu____3011 with
+              | (head,uu____3029) ->
                   let head1 =
                     FStar_Syntax_Syntax.mk_Tm_app head [arg]
                       FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
                      in
-                  let uu____3069 =
+                  let uu____3073 =
                     FStar_Syntax_Syntax.mk_Tm_app head1 (more :: args)
                       FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
                      in
-                  translate cfg bs uu____3069)
+                  translate cfg bs uu____3073)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____3078);
-                FStar_Syntax_Syntax.pos = uu____3079;
-                FStar_Syntax_Syntax.vars = uu____3080;_},arg::more::args)
+                  (FStar_Const.Const_reflect uu____3082);
+                FStar_Syntax_Syntax.pos = uu____3083;
+                FStar_Syntax_Syntax.vars = uu____3084;_},arg::more::args)
              ->
-             let uu____3140 = FStar_Syntax_Util.head_and_args e  in
-             (match uu____3140 with
-              | (head,uu____3158) ->
+             let uu____3144 = FStar_Syntax_Util.head_and_args e  in
+             (match uu____3144 with
+              | (head,uu____3162) ->
                   let head1 =
                     FStar_Syntax_Syntax.mk_Tm_app head [arg]
                       FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
                      in
-                  let uu____3202 =
+                  let uu____3206 =
                     FStar_Syntax_Syntax.mk_Tm_app head1 (more :: args)
                       FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
                      in
-                  translate cfg bs uu____3202)
+                  translate cfg bs uu____3206)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____3211);
-                FStar_Syntax_Syntax.pos = uu____3212;
-                FStar_Syntax_Syntax.vars = uu____3213;_},arg::[])
+                  (FStar_Const.Const_reflect uu____3215);
+                FStar_Syntax_Syntax.pos = uu____3216;
+                FStar_Syntax_Syntax.vars = uu____3217;_},arg::[])
              when (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying ->
              let cfg1 = reifying_false cfg  in
              translate cfg1 bs (FStar_Pervasives_Native.fst arg)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____3258);
-                FStar_Syntax_Syntax.pos = uu____3259;
-                FStar_Syntax_Syntax.vars = uu____3260;_},arg::[])
+                  (FStar_Const.Const_reflect uu____3262);
+                FStar_Syntax_Syntax.pos = uu____3263;
+                FStar_Syntax_Syntax.vars = uu____3264;_},arg::[])
              ->
-             let uu____3300 =
+             let uu____3304 =
                translate cfg bs (FStar_Pervasives_Native.fst arg)  in
-             FStar_TypeChecker_NBETerm.Reflect uu____3300
+             FStar_TypeChecker_NBETerm.Reflect uu____3304
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reify );
-                FStar_Syntax_Syntax.pos = uu____3305;
-                FStar_Syntax_Syntax.vars = uu____3306;_},arg::[])
+                FStar_Syntax_Syntax.pos = uu____3309;
+                FStar_Syntax_Syntax.vars = uu____3310;_},arg::[])
              when
              ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
              ->
@@ -824,175 +826,175 @@ let rec (translate :
              translate cfg1 bs (FStar_Pervasives_Native.fst arg)
          | FStar_Syntax_Syntax.Tm_app (head,args) ->
              (debug1
-                (fun uu____3385  ->
-                   let uu____3386 = FStar_Syntax_Print.term_to_string head
+                (fun uu____3389  ->
+                   let uu____3390 = FStar_Syntax_Print.term_to_string head
                       in
-                   let uu____3388 = FStar_Syntax_Print.args_to_string args
+                   let uu____3392 = FStar_Syntax_Print.args_to_string args
                       in
-                   FStar_Util.print2 "Application: %s @ %s\n" uu____3386
-                     uu____3388);
-              (let uu____3391 = translate cfg bs head  in
-               let uu____3392 =
+                   FStar_Util.print2 "Application: %s @ %s\n" uu____3390
+                     uu____3392);
+              (let uu____3395 = translate cfg bs head  in
+               let uu____3396 =
                  FStar_List.map
                    (fun x  ->
-                      let uu____3414 =
+                      let uu____3418 =
                         translate cfg bs (FStar_Pervasives_Native.fst x)  in
-                      (uu____3414, (FStar_Pervasives_Native.snd x))) args
+                      (uu____3418, (FStar_Pervasives_Native.snd x))) args
                   in
-               iapp cfg uu____3391 uu____3392))
+               iapp cfg uu____3395 uu____3396))
          | FStar_Syntax_Syntax.Tm_match (scrut,branches) ->
-             let make_branches uu____3466 =
+             let make_branches uu____3470 =
                let cfg1 = zeta_false cfg  in
                let rec process_pattern bs1 p =
-                 let uu____3497 =
+                 let uu____3501 =
                    match p.FStar_Syntax_Syntax.v with
                    | FStar_Syntax_Syntax.Pat_constant c ->
                        (bs1, (FStar_Syntax_Syntax.Pat_constant c))
                    | FStar_Syntax_Syntax.Pat_cons (fvar,args) ->
-                       let uu____3533 =
+                       let uu____3537 =
                          FStar_List.fold_left
-                           (fun uu____3574  ->
-                              fun uu____3575  ->
-                                match (uu____3574, uu____3575) with
+                           (fun uu____3578  ->
+                              fun uu____3579  ->
+                                match (uu____3578, uu____3579) with
                                 | ((bs2,args1),(arg,b)) ->
-                                    let uu____3667 = process_pattern bs2 arg
+                                    let uu____3671 = process_pattern bs2 arg
                                        in
-                                    (match uu____3667 with
+                                    (match uu____3671 with
                                      | (bs',arg') ->
                                          (bs', ((arg', b) :: args1))))
                            (bs1, []) args
                           in
-                       (match uu____3533 with
+                       (match uu____3537 with
                         | (bs',args') ->
                             (bs',
                               (FStar_Syntax_Syntax.Pat_cons
                                  (fvar, (FStar_List.rev args')))))
                    | FStar_Syntax_Syntax.Pat_var bvar ->
                        let x =
-                         let uu____3766 =
-                           let uu____3767 =
+                         let uu____3770 =
+                           let uu____3771 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort
                               in
-                           readback cfg1 uu____3767  in
+                           readback cfg1 uu____3771  in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____3766
+                           FStar_Pervasives_Native.None uu____3770
                           in
-                       let uu____3768 =
-                         let uu____3771 =
+                       let uu____3772 =
+                         let uu____3775 =
                            FStar_TypeChecker_NBETerm.mkAccuVar x  in
-                         uu____3771 :: bs1  in
-                       (uu____3768, (FStar_Syntax_Syntax.Pat_var x))
+                         uu____3775 :: bs1  in
+                       (uu____3772, (FStar_Syntax_Syntax.Pat_var x))
                    | FStar_Syntax_Syntax.Pat_wild bvar ->
                        let x =
-                         let uu____3776 =
-                           let uu____3777 =
+                         let uu____3780 =
+                           let uu____3781 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort
                               in
-                           readback cfg1 uu____3777  in
+                           readback cfg1 uu____3781  in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____3776
+                           FStar_Pervasives_Native.None uu____3780
                           in
-                       let uu____3778 =
-                         let uu____3781 =
+                       let uu____3782 =
+                         let uu____3785 =
                            FStar_TypeChecker_NBETerm.mkAccuVar x  in
-                         uu____3781 :: bs1  in
-                       (uu____3778, (FStar_Syntax_Syntax.Pat_wild x))
+                         uu____3785 :: bs1  in
+                       (uu____3782, (FStar_Syntax_Syntax.Pat_wild x))
                    | FStar_Syntax_Syntax.Pat_dot_term (bvar,tm) ->
                        let x =
-                         let uu____3791 =
-                           let uu____3792 =
+                         let uu____3795 =
+                           let uu____3796 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort
                               in
-                           readback cfg1 uu____3792  in
+                           readback cfg1 uu____3796  in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____3791
+                           FStar_Pervasives_Native.None uu____3795
                           in
-                       let uu____3793 =
-                         let uu____3794 =
-                           let uu____3801 =
-                             let uu____3804 = translate cfg1 bs1 tm  in
-                             readback cfg1 uu____3804  in
-                           (x, uu____3801)  in
-                         FStar_Syntax_Syntax.Pat_dot_term uu____3794  in
-                       (bs1, uu____3793)
+                       let uu____3797 =
+                         let uu____3798 =
+                           let uu____3805 =
+                             let uu____3808 = translate cfg1 bs1 tm  in
+                             readback cfg1 uu____3808  in
+                           (x, uu____3805)  in
+                         FStar_Syntax_Syntax.Pat_dot_term uu____3798  in
+                       (bs1, uu____3797)
                     in
-                 match uu____3497 with
+                 match uu____3501 with
                  | (bs2,p_new) ->
                      (bs2,
-                       (let uu___554_3824 = p  in
+                       (let uu___554_3828 = p  in
                         {
                           FStar_Syntax_Syntax.v = p_new;
                           FStar_Syntax_Syntax.p =
-                            (uu___554_3824.FStar_Syntax_Syntax.p)
+                            (uu___554_3828.FStar_Syntax_Syntax.p)
                         }))
                   in
                FStar_List.map
-                 (fun uu____3843  ->
-                    match uu____3843 with
+                 (fun uu____3847  ->
+                    match uu____3847 with
                     | (pat,when_clause,e1) ->
-                        let uu____3865 = process_pattern bs pat  in
-                        (match uu____3865 with
+                        let uu____3869 = process_pattern bs pat  in
+                        (match uu____3869 with
                          | (bs',pat') ->
-                             let uu____3878 =
-                               let uu____3879 =
-                                 let uu____3882 = translate cfg1 bs' e1  in
-                                 readback cfg1 uu____3882  in
-                               (pat', when_clause, uu____3879)  in
-                             FStar_Syntax_Util.branch uu____3878)) branches
+                             let uu____3882 =
+                               let uu____3883 =
+                                 let uu____3886 = translate cfg1 bs' e1  in
+                                 readback cfg1 uu____3886  in
+                               (pat', when_clause, uu____3883)  in
+                             FStar_Syntax_Util.branch uu____3882)) branches
                 in
              let scrut1 = translate cfg bs scrut  in
              (debug1
-                (fun uu____3899  ->
-                   let uu____3900 =
+                (fun uu____3903  ->
+                   let uu____3904 =
                      FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos
                       in
-                   let uu____3902 = FStar_Syntax_Print.term_to_string e  in
-                   FStar_Util.print2 "%s: Translating match %s\n" uu____3900
-                     uu____3902);
+                   let uu____3906 = FStar_Syntax_Print.term_to_string e  in
+                   FStar_Util.print2 "%s: Translating match %s\n" uu____3904
+                     uu____3906);
               (let scrut2 = unlazy scrut1  in
                match scrut2 with
                | FStar_TypeChecker_NBETerm.Construct (c,us,args) ->
                    (debug1
-                      (fun uu____3930  ->
-                         let uu____3931 =
-                           let uu____3933 =
+                      (fun uu____3934  ->
+                         let uu____3935 =
+                           let uu____3937 =
                              FStar_All.pipe_right args
                                (FStar_List.map
-                                  (fun uu____3959  ->
-                                     match uu____3959 with
+                                  (fun uu____3963  ->
+                                     match uu____3963 with
                                      | (x,q) ->
-                                         let uu____3973 =
+                                         let uu____3977 =
                                            FStar_TypeChecker_NBETerm.t_to_string
                                              x
                                             in
                                          Prims.op_Hat
                                            (if FStar_Util.is_some q
                                             then "#"
-                                            else "") uu____3973))
+                                            else "") uu____3977))
                               in
-                           FStar_All.pipe_right uu____3933
+                           FStar_All.pipe_right uu____3937
                              (FStar_String.concat "; ")
                             in
-                         FStar_Util.print1 "Match args: %s\n" uu____3931);
-                    (let uu____3987 = pickBranch cfg scrut2 branches  in
-                     match uu____3987 with
+                         FStar_Util.print1 "Match args: %s\n" uu____3935);
+                    (let uu____3991 = pickBranch cfg scrut2 branches  in
+                     match uu____3991 with
                      | FStar_Pervasives_Native.Some (branch,args1) ->
-                         let uu____4008 =
+                         let uu____4012 =
                            FStar_List.fold_left
                              (fun bs1  -> fun x  -> x :: bs1) bs args1
                             in
-                         translate cfg uu____4008 branch
+                         translate cfg uu____4012 branch
                      | FStar_Pervasives_Native.None  ->
                          FStar_TypeChecker_NBETerm.mkAccuMatch scrut2
                            make_branches))
                | FStar_TypeChecker_NBETerm.Constant c ->
                    (debug1
-                      (fun uu____4031  ->
-                         let uu____4032 =
+                      (fun uu____4035  ->
+                         let uu____4036 =
                            FStar_TypeChecker_NBETerm.t_to_string scrut2  in
-                         FStar_Util.print1 "Match constant : %s\n" uu____4032);
-                    (let uu____4035 = pickBranch cfg scrut2 branches  in
-                     match uu____4035 with
+                         FStar_Util.print1 "Match constant : %s\n" uu____4036);
+                    (let uu____4039 = pickBranch cfg scrut2 branches  in
+                     match uu____4039 with
                      | FStar_Pervasives_Native.Some (branch,[]) ->
                          translate cfg bs branch
                      | FStar_Pervasives_Native.Some (branch,arg::[]) ->
@@ -1000,10 +1002,10 @@ let rec (translate :
                      | FStar_Pervasives_Native.None  ->
                          FStar_TypeChecker_NBETerm.mkAccuMatch scrut2
                            make_branches
-                     | FStar_Pervasives_Native.Some (uu____4069,hd::tl) ->
+                     | FStar_Pervasives_Native.Some (uu____4073,hd::tl) ->
                          failwith
                            "Impossible: Matching on constants cannot bind more than one variable"))
-               | uu____4083 ->
+               | uu____4087 ->
                    FStar_TypeChecker_NBETerm.mkAccuMatch scrut2 make_branches))
          | FStar_Syntax_Syntax.Tm_meta
              (e1,FStar_Syntax_Syntax.Meta_monadic (m,t)) when
@@ -1014,12 +1016,12 @@ let rec (translate :
              (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying ->
              translate_monadic_lift (m, m', t) cfg bs e1
          | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
-             let uu____4128 =
+             let uu____4132 =
                FStar_TypeChecker_Cfg.should_reduce_local_let cfg.core_cfg lb
                 in
-             if uu____4128
+             if uu____4132
              then
-               let uu____4131 =
+               let uu____4135 =
                  (((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                     &&
                     (FStar_Syntax_Util.is_unit lb.FStar_Syntax_Syntax.lbtyp))
@@ -1027,7 +1029,7 @@ let rec (translate :
                    (FStar_Syntax_Util.is_pure_or_ghost_effect
                       lb.FStar_Syntax_Syntax.lbeff)
                   in
-               (if uu____4131
+               (if uu____4135
                 then
                   let bs1 =
                     (FStar_TypeChecker_NBETerm.Constant
@@ -1036,12 +1038,12 @@ let rec (translate :
                   translate cfg bs1 body
                 else
                   (let bs1 =
-                     let uu____4142 = translate_letbinding cfg bs lb  in
-                     uu____4142 :: bs  in
+                     let uu____4146 = translate_letbinding cfg bs lb  in
+                     uu____4146 :: bs  in
                    translate cfg bs1 body))
              else
-               (let def uu____4150 =
-                  let uu____4151 =
+               (let def uu____4154 =
+                  let uu____4155 =
                     (((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                        &&
                        (FStar_Syntax_Util.is_unit
@@ -1050,32 +1052,32 @@ let rec (translate :
                       (FStar_Syntax_Util.is_pure_or_ghost_effect
                          lb.FStar_Syntax_Syntax.lbeff)
                      in
-                  if uu____4151
+                  if uu____4155
                   then
                     FStar_TypeChecker_NBETerm.Constant
                       FStar_TypeChecker_NBETerm.Unit
                   else translate cfg bs lb.FStar_Syntax_Syntax.lbdef  in
-                let typ uu____4161 =
+                let typ uu____4165 =
                   translate cfg bs lb.FStar_Syntax_Syntax.lbtyp  in
                 let name =
-                  let uu____4163 =
+                  let uu____4167 =
                     FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                  FStar_Syntax_Syntax.freshen_bv uu____4163  in
+                  FStar_Syntax_Syntax.freshen_bv uu____4167  in
                 let bs1 =
                   (FStar_TypeChecker_NBETerm.Accu
                      ((FStar_TypeChecker_NBETerm.Var name), []))
                   :: bs  in
-                let body1 uu____4182 = translate cfg bs1 body  in
-                let uu____4183 =
-                  let uu____4194 =
-                    let uu____4195 =
-                      let uu____4212 = FStar_Thunk.mk typ  in
-                      let uu____4215 = FStar_Thunk.mk def  in
-                      let uu____4218 = FStar_Thunk.mk body1  in
-                      (name, uu____4212, uu____4215, uu____4218, lb)  in
-                    FStar_TypeChecker_NBETerm.UnreducedLet uu____4195  in
-                  (uu____4194, [])  in
-                FStar_TypeChecker_NBETerm.Accu uu____4183)
+                let body1 uu____4186 = translate cfg bs1 body  in
+                let uu____4187 =
+                  let uu____4198 =
+                    let uu____4199 =
+                      let uu____4216 = FStar_Thunk.mk typ  in
+                      let uu____4219 = FStar_Thunk.mk def  in
+                      let uu____4222 = FStar_Thunk.mk body1  in
+                      (name, uu____4216, uu____4219, uu____4222, lb)  in
+                    FStar_TypeChecker_NBETerm.UnreducedLet uu____4199  in
+                  (uu____4198, [])  in
+                FStar_TypeChecker_NBETerm.Accu uu____4187)
          | FStar_Syntax_Syntax.Tm_let ((_rec,lbs),body) ->
              if
                (Prims.op_Negation
@@ -1086,9 +1088,9 @@ let rec (translate :
                let vars =
                  FStar_List.map
                    (fun lb  ->
-                      let uu____4264 =
+                      let uu____4268 =
                         FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                      FStar_Syntax_Syntax.freshen_bv uu____4264) lbs
+                      FStar_Syntax_Syntax.freshen_bv uu____4268) lbs
                   in
                let typs =
                  FStar_List.map
@@ -1096,36 +1098,36 @@ let rec (translate :
                    lbs
                   in
                let rec_bs =
-                 let uu____4273 =
+                 let uu____4277 =
                    FStar_List.map
                      (fun v  ->
                         FStar_TypeChecker_NBETerm.Accu
                           ((FStar_TypeChecker_NBETerm.Var v), [])) vars
                     in
-                 FStar_List.append uu____4273 bs  in
+                 FStar_List.append uu____4277 bs  in
                let defs =
                  FStar_List.map
                    (fun lb  ->
                       translate cfg rec_bs lb.FStar_Syntax_Syntax.lbdef) lbs
                   in
                let body1 = translate cfg rec_bs body  in
-               let uu____4294 =
-                 let uu____4305 =
-                   let uu____4306 =
-                     let uu____4323 = FStar_List.zip3 vars typs defs  in
-                     (uu____4323, body1, lbs)  in
-                   FStar_TypeChecker_NBETerm.UnreducedLetRec uu____4306  in
-                 (uu____4305, [])  in
-               FStar_TypeChecker_NBETerm.Accu uu____4294
+               let uu____4298 =
+                 let uu____4309 =
+                   let uu____4310 =
+                     let uu____4327 = FStar_List.zip3 vars typs defs  in
+                     (uu____4327, body1, lbs)  in
+                   FStar_TypeChecker_NBETerm.UnreducedLetRec uu____4310  in
+                 (uu____4309, [])  in
+               FStar_TypeChecker_NBETerm.Accu uu____4298
              else
-               (let uu____4354 = make_rec_env lbs bs  in
-                translate cfg uu____4354 body)
-         | FStar_Syntax_Syntax.Tm_meta (e1,uu____4358) -> translate cfg bs e1
+               (let uu____4358 = make_rec_env lbs bs  in
+                translate cfg uu____4358 body)
+         | FStar_Syntax_Syntax.Tm_meta (e1,uu____4362) -> translate cfg bs e1
          | FStar_Syntax_Syntax.Tm_quoted (qt,qi) ->
              let close t =
                let bvs =
                  FStar_List.map
-                   (fun uu____4379  ->
+                   (fun uu____4383  ->
                       FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
                         FStar_Syntax_Syntax.tun) bs
                   in
@@ -1134,18 +1136,18 @@ let rec (translate :
                    (fun i  -> fun bv  -> FStar_Syntax_Syntax.DB (i, bv)) bvs
                   in
                let s2 =
-                 let uu____4392 = FStar_List.zip bvs bs  in
+                 let uu____4396 = FStar_List.zip bvs bs  in
                  FStar_List.map
-                   (fun uu____4407  ->
-                      match uu____4407 with
+                   (fun uu____4411  ->
+                      match uu____4411 with
                       | (bv,t1) ->
-                          let uu____4414 =
-                            let uu____4421 = readback cfg t1  in
-                            (bv, uu____4421)  in
-                          FStar_Syntax_Syntax.NT uu____4414) uu____4392
+                          let uu____4418 =
+                            let uu____4425 = readback cfg t1  in
+                            (bv, uu____4425)  in
+                          FStar_Syntax_Syntax.NT uu____4418) uu____4396
                   in
-               let uu____4426 = FStar_Syntax_Subst.subst s1 t  in
-               FStar_Syntax_Subst.subst s2 uu____4426  in
+               let uu____4430 = FStar_Syntax_Subst.subst s1 t  in
+               FStar_Syntax_Subst.subst s2 uu____4430  in
              (match qi.FStar_Syntax_Syntax.qkind with
               | FStar_Syntax_Syntax.Quote_dynamic  ->
                   let qt1 = close qt  in
@@ -1154,18 +1156,18 @@ let rec (translate :
                   let qi1 = FStar_Syntax_Syntax.on_antiquoted close qi  in
                   FStar_TypeChecker_NBETerm.Quote (qt, qi1))
          | FStar_Syntax_Syntax.Tm_lazy li ->
-             let f uu____4435 =
+             let f uu____4439 =
                let t = FStar_Syntax_Util.unfold_lazy li  in
                debug1
-                 (fun uu____4442  ->
-                    let uu____4443 = FStar_Syntax_Print.term_to_string t  in
+                 (fun uu____4446  ->
+                    let uu____4447 = FStar_Syntax_Print.term_to_string t  in
                     FStar_Util.print1 ">> Unfolding Tm_lazy to %s\n"
-                      uu____4443);
+                      uu____4447);
                translate cfg bs t  in
-             let uu____4446 =
-               let uu____4461 = FStar_Thunk.mk f  in
-               ((FStar_Util.Inl li), uu____4461)  in
-             FStar_TypeChecker_NBETerm.Lazy uu____4446)
+             let uu____4450 =
+               let uu____4465 = FStar_Thunk.mk f  in
+               ((FStar_Util.Inl li), uu____4465)  in
+             FStar_TypeChecker_NBETerm.Lazy uu____4450)
 
 and (translate_comp :
   config ->
@@ -1177,20 +1179,20 @@ and (translate_comp :
       fun c  ->
         match c.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Total (typ,u) ->
-            let uu____4493 =
-              let uu____4500 = translate cfg bs typ  in
-              let uu____4501 = fmap_opt (translate_univ cfg bs) u  in
-              (uu____4500, uu____4501)  in
-            FStar_TypeChecker_NBETerm.Tot uu____4493
+            let uu____4497 =
+              let uu____4504 = translate cfg bs typ  in
+              let uu____4505 = fmap_opt (translate_univ cfg bs) u  in
+              (uu____4504, uu____4505)  in
+            FStar_TypeChecker_NBETerm.Tot uu____4497
         | FStar_Syntax_Syntax.GTotal (typ,u) ->
-            let uu____4516 =
-              let uu____4523 = translate cfg bs typ  in
-              let uu____4524 = fmap_opt (translate_univ cfg bs) u  in
-              (uu____4523, uu____4524)  in
-            FStar_TypeChecker_NBETerm.GTot uu____4516
+            let uu____4520 =
+              let uu____4527 = translate cfg bs typ  in
+              let uu____4528 = fmap_opt (translate_univ cfg bs) u  in
+              (uu____4527, uu____4528)  in
+            FStar_TypeChecker_NBETerm.GTot uu____4520
         | FStar_Syntax_Syntax.Comp ctyp ->
-            let uu____4530 = translate_comp_typ cfg bs ctyp  in
-            FStar_TypeChecker_NBETerm.Comp uu____4530
+            let uu____4534 = translate_comp_typ cfg bs ctyp  in
+            FStar_TypeChecker_NBETerm.Comp uu____4534
 
 and (iapp :
   config ->
@@ -1210,13 +1212,13 @@ and (iapp :
               let binders1 =
                 match binders with
                 | FStar_Util.Inr raw_args ->
-                    let uu____4666 = FStar_List.splitAt m raw_args  in
-                    (match uu____4666 with
-                     | (uu____4707,raw_args1) -> FStar_Util.Inr raw_args1)
+                    let uu____4670 = FStar_List.splitAt m raw_args  in
+                    (match uu____4670 with
+                     | (uu____4711,raw_args1) -> FStar_Util.Inr raw_args1)
                 | FStar_Util.Inl (ctx,xs,rc) ->
-                    let uu____4776 = FStar_List.splitAt m xs  in
-                    (match uu____4776 with
-                     | (uu____4823,xs1) ->
+                    let uu____4780 = FStar_List.splitAt m xs  in
+                    (match uu____4780 with
+                     | (uu____4827,xs1) ->
                          let ctx1 = FStar_List.append arg_values_rev ctx  in
                          FStar_Util.Inl (ctx1, xs1, rc))
                  in
@@ -1230,36 +1232,36 @@ and (iapp :
                    map_rev FStar_Pervasives_Native.fst args  in
                  f1 arg_values_rev)
               else
-                (let uu____4923 = FStar_List.splitAt n args  in
-                 match uu____4923 with
+                (let uu____4927 = FStar_List.splitAt n args  in
+                 match uu____4927 with
                  | (args1,args') ->
-                     let uu____4970 =
-                       let uu____4971 =
+                     let uu____4974 =
+                       let uu____4975 =
                          map_rev FStar_Pervasives_Native.fst args1  in
-                       f1 uu____4971  in
-                     iapp cfg uu____4970 args')
+                       f1 uu____4975  in
+                     iapp cfg uu____4974 args')
         | FStar_TypeChecker_NBETerm.Accu (a,ts) ->
             FStar_TypeChecker_NBETerm.Accu
               (a, (FStar_List.rev_append args ts))
         | FStar_TypeChecker_NBETerm.Construct (i,us,ts) ->
             let rec aux args1 us1 ts1 =
               match args1 with
-              | (FStar_TypeChecker_NBETerm.Univ u,uu____5090)::args2 ->
+              | (FStar_TypeChecker_NBETerm.Univ u,uu____5094)::args2 ->
                   aux args2 (u :: us1) ts1
               | a::args2 -> aux args2 us1 (a :: ts1)
               | [] -> (us1, ts1)  in
-            let uu____5134 = aux args us ts  in
-            (match uu____5134 with
+            let uu____5138 = aux args us ts  in
+            (match uu____5138 with
              | (us',ts') -> FStar_TypeChecker_NBETerm.Construct (i, us', ts'))
         | FStar_TypeChecker_NBETerm.FV (i,us,ts) ->
             let rec aux args1 us1 ts1 =
               match args1 with
-              | (FStar_TypeChecker_NBETerm.Univ u,uu____5261)::args2 ->
+              | (FStar_TypeChecker_NBETerm.Univ u,uu____5265)::args2 ->
                   aux args2 (u :: us1) ts1
               | a::args2 -> aux args2 us1 (a :: ts1)
               | [] -> (us1, ts1)  in
-            let uu____5305 = aux args us ts  in
-            (match uu____5305 with
+            let uu____5309 = aux args us ts  in
+            (match uu____5309 with
              | (us',ts') -> FStar_TypeChecker_NBETerm.FV (i, us', ts'))
         | FStar_TypeChecker_NBETerm.TopLevelLet (lb,arity,args_rev) ->
             let args_rev1 = FStar_List.rev_append args args_rev  in
@@ -1267,85 +1269,85 @@ and (iapp :
             let n_univs = FStar_List.length lb.FStar_Syntax_Syntax.lbunivs
                in
             (debug cfg
-               (fun uu____5383  ->
-                  let uu____5384 =
+               (fun uu____5387  ->
+                  let uu____5388 =
                     FStar_Syntax_Print.lbname_to_string
                       lb.FStar_Syntax_Syntax.lbname
                      in
-                  let uu____5386 = FStar_Util.string_of_int arity  in
-                  let uu____5388 = FStar_Util.string_of_int n_args_rev  in
+                  let uu____5390 = FStar_Util.string_of_int arity  in
+                  let uu____5392 = FStar_Util.string_of_int n_args_rev  in
                   FStar_Util.print3
                     "Reached iapp for %s with arity %s and n_args = %s\n"
-                    uu____5384 uu____5386 uu____5388);
+                    uu____5388 uu____5390 uu____5392);
              if n_args_rev >= arity
              then
-               (let uu____5392 =
-                  let uu____5405 =
-                    let uu____5406 =
+               (let uu____5396 =
+                  let uu____5409 =
+                    let uu____5410 =
                       FStar_Syntax_Util.unascribe
                         lb.FStar_Syntax_Syntax.lbdef
                        in
-                    uu____5406.FStar_Syntax_Syntax.n  in
-                  match uu____5405 with
-                  | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____5423) ->
+                    uu____5410.FStar_Syntax_Syntax.n  in
+                  match uu____5409 with
+                  | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____5427) ->
                       (bs, body)
-                  | uu____5456 -> ([], (lb.FStar_Syntax_Syntax.lbdef))  in
-                match uu____5392 with
+                  | uu____5460 -> ([], (lb.FStar_Syntax_Syntax.lbdef))  in
+                match uu____5396 with
                 | (bs,body) ->
                     if (n_univs + (FStar_List.length bs)) = arity
                     then
-                      let uu____5497 =
+                      let uu____5501 =
                         FStar_Util.first_N (n_args_rev - arity) args_rev1  in
-                      (match uu____5497 with
+                      (match uu____5501 with
                        | (extra,args_rev2) ->
                            (debug cfg
-                              (fun uu____5549  ->
-                                 let uu____5550 =
+                              (fun uu____5553  ->
+                                 let uu____5554 =
                                    FStar_Syntax_Print.lbname_to_string
                                      lb.FStar_Syntax_Syntax.lbname
                                     in
-                                 let uu____5552 =
+                                 let uu____5556 =
                                    FStar_Syntax_Print.term_to_string body  in
-                                 let uu____5554 =
-                                   let uu____5556 =
+                                 let uu____5558 =
+                                   let uu____5560 =
                                      FStar_List.map
-                                       (fun uu____5568  ->
-                                          match uu____5568 with
-                                          | (x,uu____5575) ->
+                                       (fun uu____5572  ->
+                                          match uu____5572 with
+                                          | (x,uu____5579) ->
                                               FStar_TypeChecker_NBETerm.t_to_string
                                                 x) args_rev2
                                       in
-                                   FStar_All.pipe_right uu____5556
+                                   FStar_All.pipe_right uu____5560
                                      (FStar_String.concat ", ")
                                     in
                                  FStar_Util.print3
                                    "Reducing body of %s = %s,\n\twith args = %s\n"
-                                   uu____5550 uu____5552 uu____5554);
+                                   uu____5554 uu____5556 uu____5558);
                             (let t =
-                               let uu____5583 =
+                               let uu____5587 =
                                  FStar_List.map FStar_Pervasives_Native.fst
                                    args_rev2
                                   in
-                               translate cfg uu____5583 body  in
+                               translate cfg uu____5587 body  in
                              match extra with
                              | [] -> t
-                             | uu____5594 ->
+                             | uu____5598 ->
                                  iapp cfg t (FStar_List.rev extra))))
                     else
-                      (let uu____5607 =
+                      (let uu____5611 =
                          FStar_Util.first_N (n_args_rev - n_univs) args_rev1
                           in
-                       match uu____5607 with
+                       match uu____5611 with
                        | (extra,univs) ->
-                           let uu____5654 =
-                             let uu____5655 =
+                           let uu____5658 =
+                             let uu____5659 =
                                FStar_List.map FStar_Pervasives_Native.fst
                                  univs
                                 in
-                             translate cfg uu____5655
+                             translate cfg uu____5659
                                lb.FStar_Syntax_Syntax.lbdef
                               in
-                           iapp cfg uu____5654 (FStar_List.rev extra)))
+                           iapp cfg uu____5658 (FStar_List.rev extra)))
              else
                FStar_TypeChecker_NBETerm.TopLevelLet (lb, arity, args_rev1))
         | FStar_TypeChecker_NBETerm.TopLevelRec
@@ -1353,52 +1355,52 @@ and (iapp :
             let args1 = FStar_List.append args' args  in
             if (FStar_List.length args1) >= arity
             then
-              let uu____5715 =
+              let uu____5719 =
                 should_reduce_recursive_definition args1 decreases_list  in
-              (match uu____5715 with
-               | (should_reduce,uu____5724,uu____5725) ->
+              (match uu____5719 with
+               | (should_reduce,uu____5728,uu____5729) ->
                    if Prims.op_Negation should_reduce
                    then
                      let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname
                         in
                      (debug cfg
-                        (fun uu____5733  ->
-                           let uu____5734 =
+                        (fun uu____5737  ->
+                           let uu____5738 =
                              FStar_Syntax_Print.fv_to_string fv  in
                            FStar_Util.print1
                              "Decided to not unfold recursive definition %s\n"
-                             uu____5734);
+                             uu____5738);
                       iapp cfg (FStar_TypeChecker_NBETerm.FV (fv, [], []))
                         args1)
                    else
                      (debug cfg
-                        (fun uu____5754  ->
-                           let uu____5755 =
-                             let uu____5757 =
+                        (fun uu____5758  ->
+                           let uu____5759 =
+                             let uu____5761 =
                                FStar_Util.right lb.FStar_Syntax_Syntax.lbname
                                 in
-                             FStar_Syntax_Print.fv_to_string uu____5757  in
+                             FStar_Syntax_Print.fv_to_string uu____5761  in
                            FStar_Util.print1
                              "Yes, Decided to unfold recursive definition %s\n"
-                             uu____5755);
-                      (let uu____5759 =
+                             uu____5759);
+                      (let uu____5763 =
                          FStar_Util.first_N
                            (FStar_List.length lb.FStar_Syntax_Syntax.lbunivs)
                            args1
                           in
-                       match uu____5759 with
+                       match uu____5763 with
                        | (univs,rest) ->
-                           let uu____5806 =
-                             let uu____5807 =
-                               let uu____5810 =
+                           let uu____5810 =
+                             let uu____5811 =
+                               let uu____5814 =
                                  FStar_List.map FStar_Pervasives_Native.fst
                                    univs
                                   in
-                               FStar_List.rev uu____5810  in
-                             translate cfg uu____5807
+                               FStar_List.rev uu____5814  in
+                             translate cfg uu____5811
                                lb.FStar_Syntax_Syntax.lbdef
                               in
-                           iapp cfg uu____5806 rest)))
+                           iapp cfg uu____5810 rest)))
             else
               FStar_TypeChecker_NBETerm.TopLevelRec
                 (lb, arity, decreases_list, args1)
@@ -1421,11 +1423,11 @@ and (iapp :
                      (remaining_arity - n_args), decreases_list)
                else
                  (let args1 = FStar_List.append acc_args args  in
-                  let uu____5928 =
+                  let uu____5932 =
                     should_reduce_recursive_definition args1 decreases_list
                      in
-                  match uu____5928 with
-                  | (should_reduce,uu____5937,uu____5938) ->
+                  match uu____5932 with
+                  | (should_reduce,uu____5941,uu____5942) ->
                       if Prims.op_Negation should_reduce
                       then
                         FStar_TypeChecker_NBETerm.LocalLetRec
@@ -1434,37 +1436,37 @@ and (iapp :
                       else
                         (let env = make_rec_env mutual_lbs local_env  in
                          debug cfg
-                           (fun uu____5967  ->
-                              (let uu____5969 =
-                                 let uu____5971 =
+                           (fun uu____5971  ->
+                              (let uu____5973 =
+                                 let uu____5975 =
                                    FStar_List.map
                                      FStar_TypeChecker_NBETerm.t_to_string
                                      env
                                     in
-                                 FStar_String.concat ",\n\t " uu____5971  in
+                                 FStar_String.concat ",\n\t " uu____5975  in
                                FStar_Util.print1
-                                 "LocalLetRec Env = {\n\t%s\n}\n" uu____5969);
-                              (let uu____5978 =
-                                 let uu____5980 =
+                                 "LocalLetRec Env = {\n\t%s\n}\n" uu____5973);
+                              (let uu____5982 =
+                                 let uu____5984 =
                                    FStar_List.map
-                                     (fun uu____5992  ->
-                                        match uu____5992 with
-                                        | (t,uu____5999) ->
+                                     (fun uu____5996  ->
+                                        match uu____5996 with
+                                        | (t,uu____6003) ->
                                             FStar_TypeChecker_NBETerm.t_to_string
                                               t) args1
                                     in
-                                 FStar_String.concat ",\n\t " uu____5980  in
+                                 FStar_String.concat ",\n\t " uu____5984  in
                                FStar_Util.print1
-                                 "LocalLetRec Args = {\n\t%s\n}\n" uu____5978));
-                         (let uu____6002 =
+                                 "LocalLetRec Args = {\n\t%s\n}\n" uu____5982));
+                         (let uu____6006 =
                             translate cfg env lb.FStar_Syntax_Syntax.lbdef
                              in
-                          iapp cfg uu____6002 args1))))
-        | uu____6003 ->
-            let uu____6004 =
-              let uu____6006 = FStar_TypeChecker_NBETerm.t_to_string f  in
-              Prims.op_Hat "NBE ill-typed application: " uu____6006  in
-            failwith uu____6004
+                          iapp cfg uu____6006 args1))))
+        | uu____6007 ->
+            let uu____6008 =
+              let uu____6010 = FStar_TypeChecker_NBETerm.t_to_string f  in
+              Prims.op_Hat "NBE ill-typed application: " uu____6010  in
+            failwith uu____6008
 
 and (translate_fv :
   config ->
@@ -1476,31 +1478,31 @@ and (translate_fv :
       fun fvar  ->
         let debug1 = debug cfg  in
         let qninfo =
-          let uu____6023 = FStar_TypeChecker_Cfg.cfg_env cfg.core_cfg  in
-          let uu____6024 = FStar_Syntax_Syntax.lid_of_fv fvar  in
-          FStar_TypeChecker_Env.lookup_qname uu____6023 uu____6024  in
-        let uu____6025 = (is_constr qninfo) || (is_constr_fv fvar)  in
-        if uu____6025
+          let uu____6027 = FStar_TypeChecker_Cfg.cfg_env cfg.core_cfg  in
+          let uu____6028 = FStar_Syntax_Syntax.lid_of_fv fvar  in
+          FStar_TypeChecker_Env.lookup_qname uu____6027 uu____6028  in
+        let uu____6029 = (is_constr qninfo) || (is_constr_fv fvar)  in
+        if uu____6029
         then FStar_TypeChecker_NBETerm.mkConstruct fvar [] []
         else
-          (let uu____6034 =
+          (let uu____6038 =
              FStar_TypeChecker_Normalize.should_unfold cfg.core_cfg
-               (fun uu____6036  ->
+               (fun uu____6040  ->
                   (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying) fvar qninfo
               in
-           match uu____6034 with
+           match uu____6038 with
            | FStar_TypeChecker_Normalize.Should_unfold_fully  ->
                failwith "Not yet handled"
            | FStar_TypeChecker_Normalize.Should_unfold_no  ->
                (debug1
-                  (fun uu____6043  ->
-                     let uu____6044 = FStar_Syntax_Print.fv_to_string fvar
+                  (fun uu____6047  ->
+                     let uu____6048 = FStar_Syntax_Print.fv_to_string fvar
                         in
                      FStar_Util.print1 "(1) Decided to not unfold %s\n"
-                       uu____6044);
-                (let uu____6047 =
+                       uu____6048);
+                (let uu____6051 =
                    FStar_TypeChecker_Cfg.find_prim_step cfg.core_cfg fvar  in
-                 match uu____6047 with
+                 match uu____6051 with
                  | FStar_Pervasives_Native.Some prim_step when
                      prim_step.FStar_TypeChecker_Cfg.strong_reduction_ok ->
                      let arity =
@@ -1508,25 +1510,25 @@ and (translate_fv :
                          prim_step.FStar_TypeChecker_Cfg.univ_arity
                         in
                      (debug1
-                        (fun uu____6058  ->
-                           let uu____6059 =
+                        (fun uu____6062  ->
+                           let uu____6063 =
                              FStar_Syntax_Print.fv_to_string fvar  in
-                           FStar_Util.print1 "Found a primop %s\n" uu____6059);
-                      (let uu____6062 =
-                         let uu____6095 =
-                           let f uu____6128 =
-                             let uu____6130 =
+                           FStar_Util.print1 "Found a primop %s\n" uu____6063);
+                      (let uu____6066 =
+                         let uu____6099 =
+                           let f uu____6132 =
+                             let uu____6134 =
                                FStar_Syntax_Syntax.new_bv
                                  FStar_Pervasives_Native.None
                                  FStar_Syntax_Syntax.t_unit
                                 in
-                             (uu____6130, FStar_Pervasives_Native.None)  in
-                           let uu____6133 =
-                             let uu____6144 = FStar_Common.tabulate arity f
+                             (uu____6134, FStar_Pervasives_Native.None)  in
+                           let uu____6137 =
+                             let uu____6148 = FStar_Common.tabulate arity f
                                 in
-                             ([], uu____6144, FStar_Pervasives_Native.None)
+                             ([], uu____6148, FStar_Pervasives_Native.None)
                               in
-                           FStar_Util.Inl uu____6133  in
+                           FStar_Util.Inl uu____6137  in
                          ((fun args_rev  ->
                              let args' =
                                map_rev FStar_TypeChecker_NBETerm.as_arg
@@ -1538,68 +1540,68 @@ and (translate_fv :
                                  FStar_TypeChecker_NBETerm.translate =
                                    (translate cfg bs)
                                }  in
-                             let uu____6218 =
+                             let uu____6222 =
                                prim_step.FStar_TypeChecker_Cfg.interpretation_nbe
                                  callbacks args'
                                 in
-                             match uu____6218 with
+                             match uu____6222 with
                              | FStar_Pervasives_Native.Some x ->
                                  (debug1
-                                    (fun uu____6229  ->
-                                       let uu____6230 =
+                                    (fun uu____6233  ->
+                                       let uu____6234 =
                                          FStar_Syntax_Print.fv_to_string fvar
                                           in
-                                       let uu____6232 =
+                                       let uu____6236 =
                                          FStar_TypeChecker_NBETerm.t_to_string
                                            x
                                           in
                                        FStar_Util.print2
                                          "Primitive operator %s returned %s\n"
-                                         uu____6230 uu____6232);
+                                         uu____6234 uu____6236);
                                   x)
                              | FStar_Pervasives_Native.None  ->
                                  (debug1
-                                    (fun uu____6240  ->
-                                       let uu____6241 =
+                                    (fun uu____6244  ->
+                                       let uu____6245 =
                                          FStar_Syntax_Print.fv_to_string fvar
                                           in
                                        FStar_Util.print1
                                          "Primitive operator %s failed\n"
-                                         uu____6241);
-                                  (let uu____6244 =
+                                         uu____6245);
+                                  (let uu____6248 =
                                      FStar_TypeChecker_NBETerm.mkFV fvar []
                                        []
                                       in
-                                   iapp cfg uu____6244 args'))), uu____6095,
+                                   iapp cfg uu____6248 args'))), uu____6099,
                            arity)
                           in
-                       FStar_TypeChecker_NBETerm.Lam uu____6062))
-                 | FStar_Pervasives_Native.Some uu____6249 ->
+                       FStar_TypeChecker_NBETerm.Lam uu____6066))
+                 | FStar_Pervasives_Native.Some uu____6253 ->
                      (debug1
-                        (fun uu____6255  ->
-                           let uu____6256 =
+                        (fun uu____6259  ->
+                           let uu____6260 =
                              FStar_Syntax_Print.fv_to_string fvar  in
                            FStar_Util.print1 "(2) Decided to not unfold %s\n"
-                             uu____6256);
+                             uu____6260);
                       FStar_TypeChecker_NBETerm.mkFV fvar [] [])
-                 | uu____6263 ->
+                 | uu____6267 ->
                      (debug1
-                        (fun uu____6271  ->
-                           let uu____6272 =
+                        (fun uu____6275  ->
+                           let uu____6276 =
                              FStar_Syntax_Print.fv_to_string fvar  in
                            FStar_Util.print1 "(3) Decided to not unfold %s\n"
-                             uu____6272);
+                             uu____6276);
                       FStar_TypeChecker_NBETerm.mkFV fvar [] [])))
            | FStar_TypeChecker_Normalize.Should_unfold_reify  ->
                let t =
                  let is_qninfo_visible =
-                   let uu____6282 =
+                   let uu____6286 =
                      FStar_TypeChecker_Env.lookup_definition_qninfo
                        (cfg.core_cfg).FStar_TypeChecker_Cfg.delta_level
                        (fvar.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                        qninfo
                       in
-                   FStar_Option.isSome uu____6282  in
+                   FStar_Option.isSome uu____6286  in
                  if is_qninfo_visible
                  then
                    match qninfo with
@@ -1608,18 +1610,18 @@ and (translate_fv :
                         ({
                            FStar_Syntax_Syntax.sigel =
                              FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),names);
-                           FStar_Syntax_Syntax.sigrng = uu____6297;
-                           FStar_Syntax_Syntax.sigquals = uu____6298;
-                           FStar_Syntax_Syntax.sigmeta = uu____6299;
-                           FStar_Syntax_Syntax.sigattrs = uu____6300;
-                           FStar_Syntax_Syntax.sigopts = uu____6301;_},_us_opt),_rng)
+                           FStar_Syntax_Syntax.sigrng = uu____6301;
+                           FStar_Syntax_Syntax.sigquals = uu____6302;
+                           FStar_Syntax_Syntax.sigmeta = uu____6303;
+                           FStar_Syntax_Syntax.sigattrs = uu____6304;
+                           FStar_Syntax_Syntax.sigopts = uu____6305;_},_us_opt),_rng)
                        ->
                        (debug1
-                          (fun uu____6371  ->
-                             let uu____6372 =
+                          (fun uu____6375  ->
+                             let uu____6376 =
                                FStar_Syntax_Print.fv_to_string fvar  in
                              FStar_Util.print1 "(1) Decided to unfold %s\n"
-                               uu____6372);
+                               uu____6376);
                         (let lbm = find_let lbs fvar  in
                          match lbm with
                          | FStar_Pervasives_Native.Some lb ->
@@ -1627,43 +1629,43 @@ and (translate_fv :
                                is_rec &&
                                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
                              then
-                               let uu____6380 = let_rec_arity lb  in
-                               (match uu____6380 with
+                               let uu____6384 = let_rec_arity lb  in
+                               (match uu____6384 with
                                 | (ar,lst) ->
                                     FStar_TypeChecker_NBETerm.TopLevelRec
                                       (lb, ar, lst, []))
                              else translate_letbinding cfg bs lb
                          | FStar_Pervasives_Native.None  ->
                              failwith "Could not find let binding"))
-                   | uu____6416 ->
+                   | uu____6420 ->
                        (debug1
-                          (fun uu____6422  ->
-                             let uu____6423 =
+                          (fun uu____6426  ->
+                             let uu____6427 =
                                FStar_Syntax_Print.fv_to_string fvar  in
                              FStar_Util.print1
-                               "(1) qninfo is None for (%s)\n" uu____6423);
+                               "(1) qninfo is None for (%s)\n" uu____6427);
                         FStar_TypeChecker_NBETerm.mkFV fvar [] [])
                  else
                    (debug1
-                      (fun uu____6437  ->
-                         let uu____6438 =
+                      (fun uu____6441  ->
+                         let uu____6442 =
                            FStar_Syntax_Print.fv_to_string fvar  in
                          FStar_Util.print1
                            "(1) qninfo is not visible at this level (%s)\n"
-                           uu____6438);
+                           uu____6442);
                     FStar_TypeChecker_NBETerm.mkFV fvar [] [])
                   in
                (cache_add cfg fvar t; t)
            | FStar_TypeChecker_Normalize.Should_unfold_yes  ->
                let t =
                  let is_qninfo_visible =
-                   let uu____6449 =
+                   let uu____6453 =
                      FStar_TypeChecker_Env.lookup_definition_qninfo
                        (cfg.core_cfg).FStar_TypeChecker_Cfg.delta_level
                        (fvar.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                        qninfo
                       in
-                   FStar_Option.isSome uu____6449  in
+                   FStar_Option.isSome uu____6453  in
                  if is_qninfo_visible
                  then
                    match qninfo with
@@ -1672,18 +1674,18 @@ and (translate_fv :
                         ({
                            FStar_Syntax_Syntax.sigel =
                              FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),names);
-                           FStar_Syntax_Syntax.sigrng = uu____6464;
-                           FStar_Syntax_Syntax.sigquals = uu____6465;
-                           FStar_Syntax_Syntax.sigmeta = uu____6466;
-                           FStar_Syntax_Syntax.sigattrs = uu____6467;
-                           FStar_Syntax_Syntax.sigopts = uu____6468;_},_us_opt),_rng)
+                           FStar_Syntax_Syntax.sigrng = uu____6468;
+                           FStar_Syntax_Syntax.sigquals = uu____6469;
+                           FStar_Syntax_Syntax.sigmeta = uu____6470;
+                           FStar_Syntax_Syntax.sigattrs = uu____6471;
+                           FStar_Syntax_Syntax.sigopts = uu____6472;_},_us_opt),_rng)
                        ->
                        (debug1
-                          (fun uu____6538  ->
-                             let uu____6539 =
+                          (fun uu____6542  ->
+                             let uu____6543 =
                                FStar_Syntax_Print.fv_to_string fvar  in
                              FStar_Util.print1 "(1) Decided to unfold %s\n"
-                               uu____6539);
+                               uu____6543);
                         (let lbm = find_let lbs fvar  in
                          match lbm with
                          | FStar_Pervasives_Native.Some lb ->
@@ -1691,30 +1693,30 @@ and (translate_fv :
                                is_rec &&
                                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
                              then
-                               let uu____6547 = let_rec_arity lb  in
-                               (match uu____6547 with
+                               let uu____6551 = let_rec_arity lb  in
+                               (match uu____6551 with
                                 | (ar,lst) ->
                                     FStar_TypeChecker_NBETerm.TopLevelRec
                                       (lb, ar, lst, []))
                              else translate_letbinding cfg bs lb
                          | FStar_Pervasives_Native.None  ->
                              failwith "Could not find let binding"))
-                   | uu____6583 ->
+                   | uu____6587 ->
                        (debug1
-                          (fun uu____6589  ->
-                             let uu____6590 =
+                          (fun uu____6593  ->
+                             let uu____6594 =
                                FStar_Syntax_Print.fv_to_string fvar  in
                              FStar_Util.print1
-                               "(1) qninfo is None for (%s)\n" uu____6590);
+                               "(1) qninfo is None for (%s)\n" uu____6594);
                         FStar_TypeChecker_NBETerm.mkFV fvar [] [])
                  else
                    (debug1
-                      (fun uu____6604  ->
-                         let uu____6605 =
+                      (fun uu____6608  ->
+                         let uu____6609 =
                            FStar_Syntax_Print.fv_to_string fvar  in
                          FStar_Util.print1
                            "(1) qninfo is not visible at this level (%s)\n"
-                           uu____6605);
+                           uu____6609);
                     FStar_TypeChecker_NBETerm.mkFV fvar [] [])
                   in
                (cache_add cfg fvar t; t))
@@ -1729,29 +1731,29 @@ and (translate_letbinding :
       fun lb  ->
         let debug1 = debug cfg  in
         let us = lb.FStar_Syntax_Syntax.lbunivs  in
-        let uu____6629 =
+        let uu____6633 =
           FStar_Syntax_Util.arrow_formals lb.FStar_Syntax_Syntax.lbtyp  in
-        match uu____6629 with
-        | (formals,uu____6637) ->
+        match uu____6633 with
+        | (formals,uu____6641) ->
             let arity = (FStar_List.length us) + (FStar_List.length formals)
                in
             if arity = Prims.int_zero
             then translate cfg bs lb.FStar_Syntax_Syntax.lbdef
             else
-              (let uu____6655 =
+              (let uu____6659 =
                  FStar_Util.is_right lb.FStar_Syntax_Syntax.lbname  in
-               if uu____6655
+               if uu____6659
                then
                  (debug1
-                    (fun uu____6665  ->
-                       let uu____6666 =
+                    (fun uu____6669  ->
+                       let uu____6670 =
                          FStar_Syntax_Print.lbname_to_string
                            lb.FStar_Syntax_Syntax.lbname
                           in
-                       let uu____6668 = FStar_Util.string_of_int arity  in
+                       let uu____6672 = FStar_Util.string_of_int arity  in
                        FStar_Util.print2
                          "Making TopLevelLet for %s with arity %s\n"
-                         uu____6666 uu____6668);
+                         uu____6670 uu____6672);
                   FStar_TypeChecker_NBETerm.TopLevelLet (lb, arity, []))
                else translate cfg bs lb.FStar_Syntax_Syntax.lbdef)
 
@@ -1765,8 +1767,8 @@ and (mkRec :
     fun b  ->
       fun bs  ->
         fun env  ->
-          let uu____6693 = let_rec_arity b  in
-          match uu____6693 with
+          let uu____6697 = let_rec_arity b  in
+          match uu____6697 with
           | (ar,ar_lst) ->
               FStar_TypeChecker_NBETerm.LocalLetRec
                 (i, b, bs, env, [], ar, ar_lst)
@@ -1791,13 +1793,13 @@ and (translate_constant :
     | FStar_Const.Const_unit  -> FStar_TypeChecker_NBETerm.Unit
     | FStar_Const.Const_bool b -> FStar_TypeChecker_NBETerm.Bool b
     | FStar_Const.Const_int (s,FStar_Pervasives_Native.None ) ->
-        let uu____6763 = FStar_BigInt.big_int_of_string s  in
-        FStar_TypeChecker_NBETerm.Int uu____6763
+        let uu____6767 = FStar_BigInt.big_int_of_string s  in
+        FStar_TypeChecker_NBETerm.Int uu____6767
     | FStar_Const.Const_string (s,r) ->
         FStar_TypeChecker_NBETerm.String (s, r)
     | FStar_Const.Const_char c1 -> FStar_TypeChecker_NBETerm.Char c1
     | FStar_Const.Const_range r -> FStar_TypeChecker_NBETerm.Range r
-    | uu____6772 -> FStar_TypeChecker_NBETerm.SConst c
+    | uu____6776 -> FStar_TypeChecker_NBETerm.SConst c
 
 and (readback_comp :
   config -> FStar_TypeChecker_NBETerm.comp -> FStar_Syntax_Syntax.comp) =
@@ -1806,16 +1808,16 @@ and (readback_comp :
       let c' =
         match c with
         | FStar_TypeChecker_NBETerm.Tot (typ,u) ->
-            let uu____6782 =
-              let uu____6791 = readback cfg typ  in (uu____6791, u)  in
-            FStar_Syntax_Syntax.Total uu____6782
+            let uu____6786 =
+              let uu____6795 = readback cfg typ  in (uu____6795, u)  in
+            FStar_Syntax_Syntax.Total uu____6786
         | FStar_TypeChecker_NBETerm.GTot (typ,u) ->
-            let uu____6804 =
-              let uu____6813 = readback cfg typ  in (uu____6813, u)  in
-            FStar_Syntax_Syntax.GTotal uu____6804
+            let uu____6808 =
+              let uu____6817 = readback cfg typ  in (uu____6817, u)  in
+            FStar_Syntax_Syntax.GTotal uu____6808
         | FStar_TypeChecker_NBETerm.Comp ctyp ->
-            let uu____6821 = readback_comp_typ cfg ctyp  in
-            FStar_Syntax_Syntax.Comp uu____6821
+            let uu____6825 = readback_comp_typ cfg ctyp  in
+            FStar_Syntax_Syntax.Comp uu____6825
          in
       FStar_Syntax_Syntax.mk c' FStar_Pervasives_Native.None
         FStar_Range.dummyRange
@@ -1828,30 +1830,30 @@ and (translate_comp_typ :
   fun cfg  ->
     fun bs  ->
       fun c  ->
-        let uu____6827 = c  in
-        match uu____6827 with
+        let uu____6831 = c  in
+        match uu____6831 with
         | { FStar_Syntax_Syntax.comp_univs = comp_univs;
             FStar_Syntax_Syntax.effect_name = effect_name;
             FStar_Syntax_Syntax.result_typ = result_typ;
             FStar_Syntax_Syntax.effect_args = effect_args;
             FStar_Syntax_Syntax.flags = flags;_} ->
-            let uu____6847 =
+            let uu____6851 =
               FStar_List.map (translate_univ cfg bs) comp_univs  in
-            let uu____6848 = translate cfg bs result_typ  in
-            let uu____6849 =
+            let uu____6852 = translate cfg bs result_typ  in
+            let uu____6853 =
               FStar_List.map
                 (fun x  ->
-                   let uu____6877 =
+                   let uu____6881 =
                      translate cfg bs (FStar_Pervasives_Native.fst x)  in
-                   (uu____6877, (FStar_Pervasives_Native.snd x))) effect_args
+                   (uu____6881, (FStar_Pervasives_Native.snd x))) effect_args
                in
-            let uu____6884 = FStar_List.map (translate_flag cfg bs) flags  in
+            let uu____6888 = FStar_List.map (translate_flag cfg bs) flags  in
             {
-              FStar_TypeChecker_NBETerm.comp_univs = uu____6847;
+              FStar_TypeChecker_NBETerm.comp_univs = uu____6851;
               FStar_TypeChecker_NBETerm.effect_name = effect_name;
-              FStar_TypeChecker_NBETerm.result_typ = uu____6848;
-              FStar_TypeChecker_NBETerm.effect_args = uu____6849;
-              FStar_TypeChecker_NBETerm.flags = uu____6884
+              FStar_TypeChecker_NBETerm.result_typ = uu____6852;
+              FStar_TypeChecker_NBETerm.effect_args = uu____6853;
+              FStar_TypeChecker_NBETerm.flags = uu____6888
             }
 
 and (readback_comp_typ :
@@ -1860,17 +1862,17 @@ and (readback_comp_typ :
   =
   fun cfg  ->
     fun c  ->
-      let uu____6889 = readback cfg c.FStar_TypeChecker_NBETerm.result_typ
+      let uu____6893 = readback cfg c.FStar_TypeChecker_NBETerm.result_typ
          in
-      let uu____6892 =
+      let uu____6896 =
         FStar_List.map
           (fun x  ->
-             let uu____6918 = readback cfg (FStar_Pervasives_Native.fst x)
+             let uu____6922 = readback cfg (FStar_Pervasives_Native.fst x)
                 in
-             (uu____6918, (FStar_Pervasives_Native.snd x)))
+             (uu____6922, (FStar_Pervasives_Native.snd x)))
           c.FStar_TypeChecker_NBETerm.effect_args
          in
-      let uu____6919 =
+      let uu____6923 =
         FStar_List.map (readback_flag cfg) c.FStar_TypeChecker_NBETerm.flags
          in
       {
@@ -1878,9 +1880,9 @@ and (readback_comp_typ :
           (c.FStar_TypeChecker_NBETerm.comp_univs);
         FStar_Syntax_Syntax.effect_name =
           (c.FStar_TypeChecker_NBETerm.effect_name);
-        FStar_Syntax_Syntax.result_typ = uu____6889;
-        FStar_Syntax_Syntax.effect_args = uu____6892;
-        FStar_Syntax_Syntax.flags = uu____6919
+        FStar_Syntax_Syntax.result_typ = uu____6893;
+        FStar_Syntax_Syntax.effect_args = uu____6896;
+        FStar_Syntax_Syntax.flags = uu____6923
       }
 
 and (translate_residual_comp :
@@ -1892,22 +1894,22 @@ and (translate_residual_comp :
   fun cfg  ->
     fun bs  ->
       fun c  ->
-        let uu____6927 = c  in
-        match uu____6927 with
+        let uu____6931 = c  in
+        match uu____6931 with
         | { FStar_Syntax_Syntax.residual_effect = residual_effect;
             FStar_Syntax_Syntax.residual_typ = residual_typ;
             FStar_Syntax_Syntax.residual_flags = residual_flags;_} ->
-            let uu____6937 =
+            let uu____6941 =
               if
                 ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
               then FStar_Pervasives_Native.None
               else FStar_Util.map_opt residual_typ (translate cfg bs)  in
-            let uu____6947 =
+            let uu____6951 =
               FStar_List.map (translate_flag cfg bs) residual_flags  in
             {
               FStar_TypeChecker_NBETerm.residual_effect = residual_effect;
-              FStar_TypeChecker_NBETerm.residual_typ = uu____6937;
-              FStar_TypeChecker_NBETerm.residual_flags = uu____6947
+              FStar_TypeChecker_NBETerm.residual_typ = uu____6941;
+              FStar_TypeChecker_NBETerm.residual_flags = uu____6951
             }
 
 and (readback_residual_comp :
@@ -1917,26 +1919,26 @@ and (readback_residual_comp :
   =
   fun cfg  ->
     fun c  ->
-      let uu____6952 =
+      let uu____6956 =
         FStar_Util.map_opt c.FStar_TypeChecker_NBETerm.residual_typ
           (fun x  ->
              debug cfg
-               (fun uu____6963  ->
-                  let uu____6964 = FStar_TypeChecker_NBETerm.t_to_string x
+               (fun uu____6967  ->
+                  let uu____6968 = FStar_TypeChecker_NBETerm.t_to_string x
                      in
                   FStar_Util.print1 "Reading back residualtype %s\n"
-                    uu____6964);
+                    uu____6968);
              readback cfg x)
          in
-      let uu____6967 =
+      let uu____6971 =
         FStar_List.map (readback_flag cfg)
           c.FStar_TypeChecker_NBETerm.residual_flags
          in
       {
         FStar_Syntax_Syntax.residual_effect =
           (c.FStar_TypeChecker_NBETerm.residual_effect);
-        FStar_Syntax_Syntax.residual_typ = uu____6952;
-        FStar_Syntax_Syntax.residual_flags = uu____6967
+        FStar_Syntax_Syntax.residual_typ = uu____6956;
+        FStar_Syntax_Syntax.residual_flags = uu____6971
       }
 
 and (translate_flag :
@@ -1962,8 +1964,8 @@ and (translate_flag :
         | FStar_Syntax_Syntax.LEMMA  -> FStar_TypeChecker_NBETerm.LEMMA
         | FStar_Syntax_Syntax.CPS  -> FStar_TypeChecker_NBETerm.CPS
         | FStar_Syntax_Syntax.DECREASES tm ->
-            let uu____6978 = translate cfg bs tm  in
-            FStar_TypeChecker_NBETerm.DECREASES uu____6978
+            let uu____6982 = translate cfg bs tm  in
+            FStar_TypeChecker_NBETerm.DECREASES uu____6982
 
 and (readback_flag :
   config -> FStar_TypeChecker_NBETerm.cflag -> FStar_Syntax_Syntax.cflag) =
@@ -1984,8 +1986,8 @@ and (readback_flag :
       | FStar_TypeChecker_NBETerm.LEMMA  -> FStar_Syntax_Syntax.LEMMA
       | FStar_TypeChecker_NBETerm.CPS  -> FStar_Syntax_Syntax.CPS
       | FStar_TypeChecker_NBETerm.DECREASES t ->
-          let uu____6982 = readback cfg t  in
-          FStar_Syntax_Syntax.DECREASES uu____6982
+          let uu____6986 = readback cfg t  in
+          FStar_Syntax_Syntax.DECREASES uu____6986
 
 and (translate_monadic :
   (FStar_Syntax_Syntax.monad_name * FStar_Syntax_Syntax.term'
@@ -1995,31 +1997,31 @@ and (translate_monadic :
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           FStar_TypeChecker_NBETerm.t)
   =
-  fun uu____6985  ->
+  fun uu____6989  ->
     fun cfg  ->
       fun bs  ->
         fun e  ->
-          match uu____6985 with
+          match uu____6989 with
           | (m,ty) ->
               let e1 = FStar_Syntax_Util.unascribe e  in
               (match e1.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
-                   let uu____7023 =
-                     let uu____7032 =
+                   let uu____7027 =
+                     let uu____7036 =
                        FStar_TypeChecker_Env.norm_eff_name
                          (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv m
                         in
                      FStar_TypeChecker_Env.effect_decl_opt
-                       (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu____7032
+                       (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu____7036
                       in
-                   (match uu____7023 with
+                   (match uu____7027 with
                     | FStar_Pervasives_Native.None  ->
-                        let uu____7039 =
-                          let uu____7041 = FStar_Ident.string_of_lid m  in
+                        let uu____7043 =
+                          let uu____7045 = FStar_Ident.string_of_lid m  in
                           FStar_Util.format1
-                            "Effect declaration not found: %s" uu____7041
+                            "Effect declaration not found: %s" uu____7045
                            in
-                        failwith uu____7039
+                        failwith uu____7043
                     | FStar_Pervasives_Native.Some (ed,q) ->
                         let cfg' = reifying_false cfg  in
                         let body_lam =
@@ -2030,80 +2032,80 @@ and (translate_monadic :
                                 (FStar_Pervasives_Native.Some ty);
                               FStar_Syntax_Syntax.residual_flags = []
                             }  in
-                          let uu____7063 =
-                            let uu____7070 =
-                              let uu____7071 =
-                                let uu____7090 =
-                                  let uu____7099 =
-                                    let uu____7106 =
+                          let uu____7067 =
+                            let uu____7074 =
+                              let uu____7075 =
+                                let uu____7094 =
+                                  let uu____7103 =
+                                    let uu____7110 =
                                       FStar_Util.left
                                         lb.FStar_Syntax_Syntax.lbname
                                        in
-                                    (uu____7106,
+                                    (uu____7110,
                                       FStar_Pervasives_Native.None)
                                      in
-                                  [uu____7099]  in
-                                (uu____7090, body,
+                                  [uu____7103]  in
+                                (uu____7094, body,
                                   (FStar_Pervasives_Native.Some body_rc))
                                  in
-                              FStar_Syntax_Syntax.Tm_abs uu____7071  in
-                            FStar_Syntax_Syntax.mk uu____7070  in
-                          uu____7063 FStar_Pervasives_Native.None
+                              FStar_Syntax_Syntax.Tm_abs uu____7075  in
+                            FStar_Syntax_Syntax.mk uu____7074  in
+                          uu____7067 FStar_Pervasives_Native.None
                             body.FStar_Syntax_Syntax.pos
                            in
                         let maybe_range_arg =
-                          let uu____7140 =
+                          let uu____7144 =
                             FStar_Util.for_some
                               (FStar_Syntax_Util.attr_eq
                                  FStar_Syntax_Util.dm4f_bind_range_attr)
                               ed.FStar_Syntax_Syntax.eff_attrs
                              in
-                          if uu____7140
+                          if uu____7144
                           then
-                            let uu____7149 =
-                              let uu____7154 =
-                                let uu____7155 =
+                            let uu____7153 =
+                              let uu____7158 =
+                                let uu____7159 =
                                   FStar_TypeChecker_Cfg.embed_simple
                                     FStar_Syntax_Embeddings.e_range
                                     lb.FStar_Syntax_Syntax.lbpos
                                     lb.FStar_Syntax_Syntax.lbpos
                                    in
-                                translate cfg [] uu____7155  in
-                              (uu____7154, FStar_Pervasives_Native.None)  in
-                            let uu____7156 =
-                              let uu____7163 =
-                                let uu____7168 =
-                                  let uu____7169 =
+                                translate cfg [] uu____7159  in
+                              (uu____7158, FStar_Pervasives_Native.None)  in
+                            let uu____7160 =
+                              let uu____7167 =
+                                let uu____7172 =
+                                  let uu____7173 =
                                     FStar_TypeChecker_Cfg.embed_simple
                                       FStar_Syntax_Embeddings.e_range
                                       body.FStar_Syntax_Syntax.pos
                                       body.FStar_Syntax_Syntax.pos
                                      in
-                                  translate cfg [] uu____7169  in
-                                (uu____7168, FStar_Pervasives_Native.None)
+                                  translate cfg [] uu____7173  in
+                                (uu____7172, FStar_Pervasives_Native.None)
                                  in
-                              [uu____7163]  in
-                            uu____7149 :: uu____7156
+                              [uu____7167]  in
+                            uu____7153 :: uu____7160
                           else []  in
                         let t =
-                          let uu____7189 =
-                            let uu____7190 =
-                              let uu____7191 =
-                                let uu____7192 =
-                                  let uu____7193 =
-                                    let uu____7200 =
+                          let uu____7193 =
+                            let uu____7194 =
+                              let uu____7195 =
+                                let uu____7196 =
+                                  let uu____7197 =
+                                    let uu____7204 =
                                       FStar_All.pipe_right ed
                                         FStar_Syntax_Util.get_bind_repr
                                        in
-                                    FStar_All.pipe_right uu____7200
+                                    FStar_All.pipe_right uu____7204
                                       FStar_Util.must
                                      in
-                                  FStar_All.pipe_right uu____7193
+                                  FStar_All.pipe_right uu____7197
                                     FStar_Pervasives_Native.snd
                                    in
-                                FStar_Syntax_Util.un_uinst uu____7192  in
-                              translate cfg' [] uu____7191  in
-                            iapp cfg uu____7190
+                                FStar_Syntax_Util.un_uinst uu____7196  in
+                              translate cfg' [] uu____7195  in
+                            iapp cfg uu____7194
                               [((FStar_TypeChecker_NBETerm.Univ
                                    FStar_Syntax_Syntax.U_unknown),
                                  FStar_Pervasives_Native.None);
@@ -2111,84 +2113,84 @@ and (translate_monadic :
                                   FStar_Syntax_Syntax.U_unknown),
                                 FStar_Pervasives_Native.None)]
                              in
-                          let uu____7233 =
-                            let uu____7234 =
-                              let uu____7241 =
-                                let uu____7246 =
+                          let uu____7237 =
+                            let uu____7238 =
+                              let uu____7245 =
+                                let uu____7250 =
                                   translate cfg' bs
                                     lb.FStar_Syntax_Syntax.lbtyp
                                    in
-                                (uu____7246, FStar_Pervasives_Native.None)
+                                (uu____7250, FStar_Pervasives_Native.None)
                                  in
-                              let uu____7247 =
-                                let uu____7254 =
-                                  let uu____7259 = translate cfg' bs ty  in
-                                  (uu____7259, FStar_Pervasives_Native.None)
+                              let uu____7251 =
+                                let uu____7258 =
+                                  let uu____7263 = translate cfg' bs ty  in
+                                  (uu____7263, FStar_Pervasives_Native.None)
                                    in
-                                [uu____7254]  in
-                              uu____7241 :: uu____7247  in
-                            let uu____7272 =
-                              let uu____7279 =
-                                let uu____7286 =
-                                  let uu____7293 =
-                                    let uu____7298 =
+                                [uu____7258]  in
+                              uu____7245 :: uu____7251  in
+                            let uu____7276 =
+                              let uu____7283 =
+                                let uu____7290 =
+                                  let uu____7297 =
+                                    let uu____7302 =
                                       translate cfg bs
                                         lb.FStar_Syntax_Syntax.lbdef
                                        in
-                                    (uu____7298,
+                                    (uu____7302,
                                       FStar_Pervasives_Native.None)
                                      in
-                                  let uu____7299 =
-                                    let uu____7306 =
-                                      let uu____7313 =
-                                        let uu____7318 =
+                                  let uu____7303 =
+                                    let uu____7310 =
+                                      let uu____7317 =
+                                        let uu____7322 =
                                           translate cfg bs body_lam  in
-                                        (uu____7318,
+                                        (uu____7322,
                                           FStar_Pervasives_Native.None)
                                          in
-                                      [uu____7313]  in
+                                      [uu____7317]  in
                                     (FStar_TypeChecker_NBETerm.Unknown,
                                       FStar_Pervasives_Native.None) ::
-                                      uu____7306
+                                      uu____7310
                                      in
-                                  uu____7293 :: uu____7299  in
+                                  uu____7297 :: uu____7303  in
                                 (FStar_TypeChecker_NBETerm.Unknown,
-                                  FStar_Pervasives_Native.None) :: uu____7286
+                                  FStar_Pervasives_Native.None) :: uu____7290
                                  in
-                              FStar_List.append maybe_range_arg uu____7279
+                              FStar_List.append maybe_range_arg uu____7283
                                in
-                            FStar_List.append uu____7234 uu____7272  in
-                          iapp cfg uu____7189 uu____7233  in
+                            FStar_List.append uu____7238 uu____7276  in
+                          iapp cfg uu____7193 uu____7237  in
                         (debug cfg
-                           (fun uu____7350  ->
-                              let uu____7351 =
+                           (fun uu____7354  ->
+                              let uu____7355 =
                                 FStar_TypeChecker_NBETerm.t_to_string t  in
                               FStar_Util.print1 "translate_monadic: %s\n"
-                                uu____7351);
+                                uu____7355);
                          t))
                | FStar_Syntax_Syntax.Tm_app
                    ({
                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                        (FStar_Const.Const_reflect uu____7354);
-                      FStar_Syntax_Syntax.pos = uu____7355;
-                      FStar_Syntax_Syntax.vars = uu____7356;_},(e2,uu____7358)::[])
+                        (FStar_Const.Const_reflect uu____7358);
+                      FStar_Syntax_Syntax.pos = uu____7359;
+                      FStar_Syntax_Syntax.vars = uu____7360;_},(e2,uu____7362)::[])
                    ->
-                   let uu____7397 = reifying_false cfg  in
-                   translate uu____7397 bs e2
+                   let uu____7401 = reifying_false cfg  in
+                   translate uu____7401 bs e2
                | FStar_Syntax_Syntax.Tm_app (head,args) ->
                    (debug cfg
-                      (fun uu____7428  ->
-                         let uu____7429 =
+                      (fun uu____7432  ->
+                         let uu____7433 =
                            FStar_Syntax_Print.term_to_string head  in
-                         let uu____7431 =
+                         let uu____7435 =
                            FStar_Syntax_Print.args_to_string args  in
                          FStar_Util.print2
-                           "translate_monadic app (%s) @ (%s)\n" uu____7429
-                           uu____7431);
-                    (let fallback1 uu____7439 = translate cfg bs e1  in
-                     let fallback2 uu____7445 =
-                       let uu____7446 = reifying_false cfg  in
-                       let uu____7447 =
+                           "translate_monadic app (%s) @ (%s)\n" uu____7433
+                           uu____7435);
+                    (let fallback1 uu____7443 = translate cfg bs e1  in
+                     let fallback2 uu____7449 =
+                       let uu____7450 = reifying_false cfg  in
+                       let uu____7451 =
                          FStar_Syntax_Syntax.mk
                            (FStar_Syntax_Syntax.Tm_meta
                               (e1,
@@ -2196,60 +2198,60 @@ and (translate_monadic :
                            FStar_Pervasives_Native.None
                            e1.FStar_Syntax_Syntax.pos
                           in
-                       translate uu____7446 bs uu____7447  in
-                     let uu____7452 =
-                       let uu____7453 = FStar_Syntax_Util.un_uinst head  in
-                       uu____7453.FStar_Syntax_Syntax.n  in
-                     match uu____7452 with
+                       translate uu____7450 bs uu____7451  in
+                     let uu____7456 =
+                       let uu____7457 = FStar_Syntax_Util.un_uinst head  in
+                       uu____7457.FStar_Syntax_Syntax.n  in
+                     match uu____7456 with
                      | FStar_Syntax_Syntax.Tm_fvar fv ->
                          let lid = FStar_Syntax_Syntax.lid_of_fv fv  in
                          let qninfo =
                            FStar_TypeChecker_Env.lookup_qname
                              (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv lid
                             in
-                         let uu____7459 =
-                           let uu____7461 =
+                         let uu____7463 =
+                           let uu____7465 =
                              FStar_TypeChecker_Env.is_action
                                (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv lid
                               in
-                           Prims.op_Negation uu____7461  in
-                         if uu____7459
+                           Prims.op_Negation uu____7465  in
+                         if uu____7463
                          then fallback1 ()
                          else
-                           (let uu____7466 =
-                              let uu____7468 =
+                           (let uu____7470 =
+                              let uu____7472 =
                                 FStar_TypeChecker_Env.lookup_definition_qninfo
                                   (cfg.core_cfg).FStar_TypeChecker_Cfg.delta_level
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                   qninfo
                                  in
-                              FStar_Option.isNone uu____7468  in
-                            if uu____7466
+                              FStar_Option.isNone uu____7472  in
+                            if uu____7470
                             then fallback2 ()
                             else
                               (let e2 =
-                                 let uu____7485 =
-                                   let uu____7490 =
+                                 let uu____7489 =
+                                   let uu____7494 =
                                      FStar_Syntax_Util.mk_reify head  in
-                                   FStar_Syntax_Syntax.mk_Tm_app uu____7490
+                                   FStar_Syntax_Syntax.mk_Tm_app uu____7494
                                      args
                                     in
-                                 uu____7485 FStar_Pervasives_Native.None
+                                 uu____7489 FStar_Pervasives_Native.None
                                    e1.FStar_Syntax_Syntax.pos
                                   in
-                               let uu____7491 = reifying_false cfg  in
-                               translate uu____7491 bs e2))
-                     | uu____7492 -> fallback1 ()))
+                               let uu____7495 = reifying_false cfg  in
+                               translate uu____7495 bs e2))
+                     | uu____7496 -> fallback1 ()))
                | FStar_Syntax_Syntax.Tm_match (sc,branches) ->
                    let branches1 =
                      FStar_All.pipe_right branches
                        (FStar_List.map
-                          (fun uu____7613  ->
-                             match uu____7613 with
+                          (fun uu____7617  ->
+                             match uu____7617 with
                              | (pat,wopt,tm) ->
-                                 let uu____7661 =
+                                 let uu____7665 =
                                    FStar_Syntax_Util.mk_reify tm  in
-                                 (pat, wopt, uu____7661)))
+                                 (pat, wopt, uu____7665)))
                       in
                    let tm =
                      FStar_Syntax_Syntax.mk
@@ -2257,21 +2259,21 @@ and (translate_monadic :
                        FStar_Pervasives_Native.None
                        e1.FStar_Syntax_Syntax.pos
                       in
-                   let uu____7693 = reifying_false cfg  in
-                   translate uu____7693 bs tm
+                   let uu____7697 = reifying_false cfg  in
+                   translate uu____7697 bs tm
                | FStar_Syntax_Syntax.Tm_meta
-                   (t,FStar_Syntax_Syntax.Meta_monadic uu____7695) ->
+                   (t,FStar_Syntax_Syntax.Meta_monadic uu____7699) ->
                    translate_monadic (m, ty) cfg bs e1
                | FStar_Syntax_Syntax.Tm_meta
                    (t,FStar_Syntax_Syntax.Meta_monadic_lift (msrc,mtgt,ty'))
                    -> translate_monadic_lift (msrc, mtgt, ty') cfg bs e1
-               | uu____7722 ->
-                   let uu____7723 =
-                     let uu____7725 = FStar_Syntax_Print.tag_of_term e1  in
+               | uu____7726 ->
+                   let uu____7727 =
+                     let uu____7729 = FStar_Syntax_Print.tag_of_term e1  in
                      FStar_Util.format1
-                       "Unexpected case in translate_monadic: %s" uu____7725
+                       "Unexpected case in translate_monadic: %s" uu____7729
                       in
-                   failwith uu____7723)
+                   failwith uu____7727)
 
 and (translate_monadic_lift :
   (FStar_Syntax_Syntax.monad_name * FStar_Syntax_Syntax.monad_name *
@@ -2281,115 +2283,115 @@ and (translate_monadic_lift :
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           FStar_TypeChecker_NBETerm.t)
   =
-  fun uu____7728  ->
+  fun uu____7732  ->
     fun cfg  ->
       fun bs  ->
         fun e  ->
-          match uu____7728 with
+          match uu____7732 with
           | (msrc,mtgt,ty) ->
               let e1 = FStar_Syntax_Util.unascribe e  in
-              let uu____7752 =
+              let uu____7756 =
                 (FStar_Syntax_Util.is_pure_effect msrc) ||
                   (FStar_Syntax_Util.is_div_effect msrc)
                  in
-              if uu____7752
+              if uu____7756
               then
                 let ed =
-                  let uu____7756 =
+                  let uu____7760 =
                     FStar_TypeChecker_Env.norm_eff_name
                       (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv mtgt
                      in
                   FStar_TypeChecker_Env.get_effect_decl
-                    (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu____7756
+                    (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu____7760
                    in
                 let ret =
-                  let uu____7758 =
-                    let uu____7759 =
-                      let uu____7762 =
-                        let uu____7763 =
-                          let uu____7770 =
+                  let uu____7762 =
+                    let uu____7763 =
+                      let uu____7766 =
+                        let uu____7767 =
+                          let uu____7774 =
                             FStar_All.pipe_right ed
                               FStar_Syntax_Util.get_return_repr
                              in
-                          FStar_All.pipe_right uu____7770 FStar_Util.must  in
-                        FStar_All.pipe_right uu____7763
+                          FStar_All.pipe_right uu____7774 FStar_Util.must  in
+                        FStar_All.pipe_right uu____7767
                           FStar_Pervasives_Native.snd
                          in
-                      FStar_Syntax_Subst.compress uu____7762  in
-                    uu____7759.FStar_Syntax_Syntax.n  in
-                  match uu____7758 with
-                  | FStar_Syntax_Syntax.Tm_uinst (ret,uu____7816::[]) ->
+                      FStar_Syntax_Subst.compress uu____7766  in
+                    uu____7763.FStar_Syntax_Syntax.n  in
+                  match uu____7762 with
+                  | FStar_Syntax_Syntax.Tm_uinst (ret,uu____7820::[]) ->
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_uinst
                            (ret, [FStar_Syntax_Syntax.U_unknown]))
                         FStar_Pervasives_Native.None
                         e1.FStar_Syntax_Syntax.pos
-                  | uu____7823 ->
+                  | uu____7827 ->
                       failwith "NYI: Reification of indexed effect (NBE)"
                    in
                 let cfg' = reifying_false cfg  in
                 let t =
-                  let uu____7827 =
-                    let uu____7828 = translate cfg' [] ret  in
-                    iapp cfg' uu____7828
+                  let uu____7831 =
+                    let uu____7832 = translate cfg' [] ret  in
+                    iapp cfg' uu____7832
                       [((FStar_TypeChecker_NBETerm.Univ
                            FStar_Syntax_Syntax.U_unknown),
                          FStar_Pervasives_Native.None)]
                      in
-                  let uu____7837 =
-                    let uu____7838 =
-                      let uu____7843 = translate cfg' bs ty  in
-                      (uu____7843, FStar_Pervasives_Native.None)  in
-                    let uu____7844 =
-                      let uu____7851 =
-                        let uu____7856 = translate cfg' bs e1  in
-                        (uu____7856, FStar_Pervasives_Native.None)  in
-                      [uu____7851]  in
-                    uu____7838 :: uu____7844  in
-                  iapp cfg' uu____7827 uu____7837  in
+                  let uu____7841 =
+                    let uu____7842 =
+                      let uu____7847 = translate cfg' bs ty  in
+                      (uu____7847, FStar_Pervasives_Native.None)  in
+                    let uu____7848 =
+                      let uu____7855 =
+                        let uu____7860 = translate cfg' bs e1  in
+                        (uu____7860, FStar_Pervasives_Native.None)  in
+                      [uu____7855]  in
+                    uu____7842 :: uu____7848  in
+                  iapp cfg' uu____7831 uu____7841  in
                 (debug cfg
-                   (fun uu____7872  ->
-                      let uu____7873 =
+                   (fun uu____7876  ->
+                      let uu____7877 =
                         FStar_TypeChecker_NBETerm.t_to_string t  in
                       FStar_Util.print1 "translate_monadic_lift(1): %s\n"
-                        uu____7873);
+                        uu____7877);
                  t)
               else
-                (let uu____7878 =
+                (let uu____7882 =
                    FStar_TypeChecker_Env.monad_leq
                      (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv msrc mtgt
                     in
-                 match uu____7878 with
+                 match uu____7882 with
                  | FStar_Pervasives_Native.None  ->
-                     let uu____7881 =
-                       let uu____7883 = FStar_Ident.text_of_lid msrc  in
-                       let uu____7885 = FStar_Ident.text_of_lid mtgt  in
+                     let uu____7885 =
+                       let uu____7887 = FStar_Ident.string_of_lid msrc  in
+                       let uu____7889 = FStar_Ident.string_of_lid mtgt  in
                        FStar_Util.format2
                          "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
-                         uu____7883 uu____7885
+                         uu____7887 uu____7889
                         in
-                     failwith uu____7881
+                     failwith uu____7885
                  | FStar_Pervasives_Native.Some
-                     { FStar_TypeChecker_Env.msource = uu____7888;
-                       FStar_TypeChecker_Env.mtarget = uu____7889;
+                     { FStar_TypeChecker_Env.msource = uu____7892;
+                       FStar_TypeChecker_Env.mtarget = uu____7893;
                        FStar_TypeChecker_Env.mlift =
-                         { FStar_TypeChecker_Env.mlift_wp = uu____7890;
+                         { FStar_TypeChecker_Env.mlift_wp = uu____7894;
                            FStar_TypeChecker_Env.mlift_term =
                              FStar_Pervasives_Native.None ;_};_}
                      ->
-                     let uu____7910 =
-                       let uu____7912 = FStar_Ident.text_of_lid msrc  in
-                       let uu____7914 = FStar_Ident.text_of_lid mtgt  in
+                     let uu____7914 =
+                       let uu____7916 = FStar_Ident.string_of_lid msrc  in
+                       let uu____7918 = FStar_Ident.string_of_lid mtgt  in
                        FStar_Util.format2
                          "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
-                         uu____7912 uu____7914
+                         uu____7916 uu____7918
                         in
-                     failwith uu____7910
+                     failwith uu____7914
                  | FStar_Pervasives_Native.Some
-                     { FStar_TypeChecker_Env.msource = uu____7917;
-                       FStar_TypeChecker_Env.mtarget = uu____7918;
+                     { FStar_TypeChecker_Env.msource = uu____7921;
+                       FStar_TypeChecker_Env.mtarget = uu____7922;
                        FStar_TypeChecker_Env.mlift =
-                         { FStar_TypeChecker_Env.mlift_wp = uu____7919;
+                         { FStar_TypeChecker_Env.mlift_wp = uu____7923;
                            FStar_TypeChecker_Env.mlift_term =
                              FStar_Pervasives_Native.Some lift;_};_}
                      ->
@@ -2399,29 +2401,29 @@ and (translate_monadic_lift :
                            FStar_Pervasives_Native.None
                            FStar_Syntax_Syntax.tun
                           in
-                       let uu____7953 =
-                         let uu____7956 = FStar_Syntax_Syntax.bv_to_name x
+                       let uu____7957 =
+                         let uu____7960 = FStar_Syntax_Syntax.bv_to_name x
                             in
-                         lift FStar_Syntax_Syntax.U_unknown ty uu____7956  in
+                         lift FStar_Syntax_Syntax.U_unknown ty uu____7960  in
                        FStar_Syntax_Util.abs
-                         [(x, FStar_Pervasives_Native.None)] uu____7953
+                         [(x, FStar_Pervasives_Native.None)] uu____7957
                          FStar_Pervasives_Native.None
                         in
                      let cfg' = reifying_false cfg  in
                      let t =
-                       let uu____7973 = translate cfg' [] lift_lam  in
-                       let uu____7974 =
-                         let uu____7975 =
-                           let uu____7980 = translate cfg bs e1  in
-                           (uu____7980, FStar_Pervasives_Native.None)  in
-                         [uu____7975]  in
-                       iapp cfg uu____7973 uu____7974  in
+                       let uu____7977 = translate cfg' [] lift_lam  in
+                       let uu____7978 =
+                         let uu____7979 =
+                           let uu____7984 = translate cfg bs e1  in
+                           (uu____7984, FStar_Pervasives_Native.None)  in
+                         [uu____7979]  in
+                       iapp cfg uu____7977 uu____7978  in
                      (debug cfg
-                        (fun uu____7992  ->
-                           let uu____7993 =
+                        (fun uu____7996  ->
+                           let uu____7997 =
                              FStar_TypeChecker_NBETerm.t_to_string t  in
                            FStar_Util.print1
-                             "translate_monadic_lift(2): %s\n" uu____7993);
+                             "translate_monadic_lift(2): %s\n" uu____7997);
                       t))
 
 and (readback :
@@ -2431,15 +2433,15 @@ and (readback :
       let debug1 = debug cfg  in
       let readback_args cfg1 args =
         map_rev
-          (fun uu____8047  ->
-             match uu____8047 with
+          (fun uu____8051  ->
+             match uu____8051 with
              | (x1,q) ->
-                 let uu____8058 = readback cfg1 x1  in (uu____8058, q)) args
+                 let uu____8062 = readback cfg1 x1  in (uu____8062, q)) args
          in
       debug1
-        (fun uu____8064  ->
-           let uu____8065 = FStar_TypeChecker_NBETerm.t_to_string x  in
-           FStar_Util.print1 "Readback: %s\n" uu____8065);
+        (fun uu____8068  ->
+           let uu____8069 = FStar_TypeChecker_NBETerm.t_to_string x  in
+           FStar_Util.print1 "Readback: %s\n" uu____8069);
       (match x with
        | FStar_TypeChecker_NBETerm.Univ u ->
            failwith "Readback of universes should not occur"
@@ -2454,8 +2456,8 @@ and (readback :
            (false )) -> FStar_Syntax_Util.exp_false_bool
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.Int i)
            ->
-           let uu____8073 = FStar_BigInt.string_of_big_int i  in
-           FStar_All.pipe_right uu____8073 FStar_Syntax_Util.exp_int
+           let uu____8077 = FStar_BigInt.string_of_big_int i  in
+           FStar_All.pipe_right uu____8077 FStar_Syntax_Util.exp_int
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.String
            (s,r)) ->
            FStar_Syntax_Syntax.mk
@@ -2476,29 +2478,29 @@ and (readback :
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
              FStar_Pervasives_Native.None FStar_Range.dummyRange
        | FStar_TypeChecker_NBETerm.Lam (f,binders,arity) ->
-           let uu____8141 =
+           let uu____8145 =
              match binders with
              | FStar_Util.Inl (ctx,binders1,rc) ->
-                 let uu____8189 =
+                 let uu____8193 =
                    FStar_List.fold_left
-                     (fun uu____8243  ->
-                        fun uu____8244  ->
-                          match (uu____8243, uu____8244) with
+                     (fun uu____8247  ->
+                        fun uu____8248  ->
+                          match (uu____8247, uu____8248) with
                           | ((ctx1,binders_rev,accus_rev),(x1,q)) ->
                               let tnorm =
-                                let uu____8369 =
+                                let uu____8373 =
                                   translate cfg ctx1
                                     x1.FStar_Syntax_Syntax.sort
                                    in
-                                readback cfg uu____8369  in
+                                readback cfg uu____8373  in
                               let x2 =
-                                let uu___1227_8371 =
+                                let uu___1227_8375 =
                                   FStar_Syntax_Syntax.freshen_bv x1  in
                                 {
                                   FStar_Syntax_Syntax.ppname =
-                                    (uu___1227_8371.FStar_Syntax_Syntax.ppname);
+                                    (uu___1227_8375.FStar_Syntax_Syntax.ppname);
                                   FStar_Syntax_Syntax.index =
-                                    (uu___1227_8371.FStar_Syntax_Syntax.index);
+                                    (uu___1227_8375.FStar_Syntax_Syntax.index);
                                   FStar_Syntax_Syntax.sort = tnorm
                                 }  in
                               let ax = FStar_TypeChecker_NBETerm.mkAccuVar x2
@@ -2507,73 +2509,73 @@ and (readback :
                               (ctx2, ((x2, q) :: binders_rev), (ax ::
                                 accus_rev))) (ctx, [], []) binders1
                     in
-                 (match uu____8189 with
+                 (match uu____8193 with
                   | (ctx1,binders_rev,accus_rev) ->
                       let rc1 =
                         match rc with
                         | FStar_Pervasives_Native.None  ->
                             FStar_Pervasives_Native.None
                         | FStar_Pervasives_Native.Some rc1 ->
-                            let uu____8457 =
-                              let uu____8458 =
+                            let uu____8461 =
+                              let uu____8462 =
                                 translate_residual_comp cfg ctx1 rc1  in
-                              readback_residual_comp cfg uu____8458  in
-                            FStar_Pervasives_Native.Some uu____8457
+                              readback_residual_comp cfg uu____8462  in
+                            FStar_Pervasives_Native.Some uu____8461
                          in
                       ((FStar_List.rev binders_rev), accus_rev, rc1))
              | FStar_Util.Inr args ->
-                 let uu____8492 =
+                 let uu____8496 =
                    FStar_List.fold_right
-                     (fun uu____8533  ->
-                        fun uu____8534  ->
-                          match (uu____8533, uu____8534) with
-                          | ((t,uu____8586),(binders1,accus)) ->
+                     (fun uu____8537  ->
+                        fun uu____8538  ->
+                          match (uu____8537, uu____8538) with
+                          | ((t,uu____8590),(binders1,accus)) ->
                               let x1 =
-                                let uu____8628 = readback cfg t  in
+                                let uu____8632 = readback cfg t  in
                                 FStar_Syntax_Syntax.new_bv
-                                  FStar_Pervasives_Native.None uu____8628
+                                  FStar_Pervasives_Native.None uu____8632
                                  in
-                              let uu____8629 =
-                                let uu____8632 =
+                              let uu____8633 =
+                                let uu____8636 =
                                   FStar_TypeChecker_NBETerm.mkAccuVar x1  in
-                                uu____8632 :: accus  in
+                                uu____8636 :: accus  in
                               (((x1, FStar_Pervasives_Native.None) ::
-                                binders1), uu____8629)) args ([], [])
+                                binders1), uu____8633)) args ([], [])
                     in
-                 (match uu____8492 with
+                 (match uu____8496 with
                   | (binders1,accus) ->
                       (binders1, (FStar_List.rev accus),
                         FStar_Pervasives_Native.None))
               in
-           (match uu____8141 with
+           (match uu____8145 with
             | (binders1,accus_rev,rc) ->
                 let body =
-                  let uu____8715 = f accus_rev  in readback cfg uu____8715
+                  let uu____8719 = f accus_rev  in readback cfg uu____8719
                    in
                 FStar_Syntax_Util.abs binders1 body rc)
        | FStar_TypeChecker_NBETerm.Refinement (f,targ) ->
            if
              ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
            then
-             let uu____8739 =
-               let uu____8740 = targ ()  in
-               FStar_Pervasives_Native.fst uu____8740  in
-             readback cfg uu____8739
+             let uu____8743 =
+               let uu____8744 = targ ()  in
+               FStar_Pervasives_Native.fst uu____8744  in
+             readback cfg uu____8743
            else
              (let x1 =
-                let uu____8748 =
-                  let uu____8749 =
-                    let uu____8750 = targ ()  in
-                    FStar_Pervasives_Native.fst uu____8750  in
-                  readback cfg uu____8749  in
+                let uu____8752 =
+                  let uu____8753 =
+                    let uu____8754 = targ ()  in
+                    FStar_Pervasives_Native.fst uu____8754  in
+                  readback cfg uu____8753  in
                 FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                  uu____8748
+                  uu____8752
                  in
               let body =
-                let uu____8756 =
-                  let uu____8757 = FStar_TypeChecker_NBETerm.mkAccuVar x1  in
-                  f uu____8757  in
-                readback cfg uu____8756  in
+                let uu____8760 =
+                  let uu____8761 = FStar_TypeChecker_NBETerm.mkAccuVar x1  in
+                  f uu____8761  in
+                readback cfg uu____8760  in
               let refinement = FStar_Syntax_Util.refine x1 body  in
               if
                 ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
@@ -2589,8 +2591,8 @@ and (readback :
        | FStar_TypeChecker_NBETerm.Arrow (FStar_Util.Inr (args,c)) ->
            let binders =
              FStar_List.map
-               (fun uu____8827  ->
-                  match uu____8827 with
+               (fun uu____8831  ->
+                  match uu____8831 with
                   | (t,q) ->
                       let t1 = readback cfg t  in
                       let x1 =
@@ -2604,10 +2606,10 @@ and (readback :
        | FStar_TypeChecker_NBETerm.Construct (fv,us,args) ->
            let args1 =
              map_rev
-               (fun uu____8879  ->
-                  match uu____8879 with
+               (fun uu____8883  ->
+                  match uu____8883 with
                   | (x1,q) ->
-                      let uu____8890 = readback cfg x1  in (uu____8890, q))
+                      let uu____8894 = readback cfg x1  in (uu____8894, q))
                args
               in
            let fv1 =
@@ -2615,17 +2617,17 @@ and (readback :
                FStar_Pervasives_Native.None FStar_Range.dummyRange
               in
            let app =
-             let uu____8897 =
+             let uu____8901 =
                FStar_Syntax_Syntax.mk_Tm_uinst fv1 (FStar_List.rev us)  in
-             FStar_Syntax_Util.mk_app uu____8897 args1  in
+             FStar_Syntax_Util.mk_app uu____8901 args1  in
            app
        | FStar_TypeChecker_NBETerm.FV (fv,us,args) ->
            let args1 =
              map_rev
-               (fun uu____8938  ->
-                  match uu____8938 with
+               (fun uu____8942  ->
+                  match uu____8942 with
                   | (x1,q) ->
-                      let uu____8949 = readback cfg x1  in (uu____8949, q))
+                      let uu____8953 = readback cfg x1  in (uu____8953, q))
                args
               in
            let fv1 =
@@ -2633,9 +2635,9 @@ and (readback :
                FStar_Pervasives_Native.None FStar_Range.dummyRange
               in
            let app =
-             let uu____8956 =
+             let uu____8960 =
                FStar_Syntax_Syntax.mk_Tm_uinst fv1 (FStar_List.rev us)  in
-             FStar_Syntax_Util.mk_app uu____8956 args1  in
+             FStar_Syntax_Util.mk_app uu____8960 args1  in
            if
              ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
            then
@@ -2649,8 +2651,8 @@ and (readback :
            (FStar_TypeChecker_NBETerm.Var bv,args) ->
            let args1 = readback_args cfg args  in
            let app =
-             let uu____8997 = FStar_Syntax_Syntax.bv_to_name bv  in
-             FStar_Syntax_Util.mk_app uu____8997 args1  in
+             let uu____9001 = FStar_Syntax_Syntax.bv_to_name bv  in
+             FStar_Syntax_Util.mk_app uu____9001 args1  in
            if
              ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
            then
@@ -2681,44 +2683,44 @@ and (readback :
             (var,typ,defn,body,lb),args)
            ->
            let typ1 =
-             let uu____9097 = FStar_Thunk.force typ  in
-             readback cfg uu____9097  in
+             let uu____9101 = FStar_Thunk.force typ  in
+             readback cfg uu____9101  in
            let defn1 =
-             let uu____9099 = FStar_Thunk.force defn  in
-             readback cfg uu____9099  in
+             let uu____9103 = FStar_Thunk.force defn  in
+             readback cfg uu____9103  in
            let body1 =
-             let uu____9101 =
-               let uu____9102 = FStar_Thunk.force body  in
-               readback cfg uu____9102  in
+             let uu____9105 =
+               let uu____9106 = FStar_Thunk.force body  in
+               readback cfg uu____9106  in
              FStar_Syntax_Subst.close [(var, FStar_Pervasives_Native.None)]
-               uu____9101
+               uu____9105
               in
            let lbname =
-             let uu____9122 =
-               let uu___1346_9123 =
+             let uu____9126 =
+               let uu___1346_9127 =
                  FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
                {
                  FStar_Syntax_Syntax.ppname =
-                   (uu___1346_9123.FStar_Syntax_Syntax.ppname);
+                   (uu___1346_9127.FStar_Syntax_Syntax.ppname);
                  FStar_Syntax_Syntax.index =
-                   (uu___1346_9123.FStar_Syntax_Syntax.index);
+                   (uu___1346_9127.FStar_Syntax_Syntax.index);
                  FStar_Syntax_Syntax.sort = typ1
                }  in
-             FStar_Util.Inl uu____9122  in
+             FStar_Util.Inl uu____9126  in
            let lb1 =
-             let uu___1349_9125 = lb  in
+             let uu___1349_9129 = lb  in
              {
                FStar_Syntax_Syntax.lbname = lbname;
                FStar_Syntax_Syntax.lbunivs =
-                 (uu___1349_9125.FStar_Syntax_Syntax.lbunivs);
+                 (uu___1349_9129.FStar_Syntax_Syntax.lbunivs);
                FStar_Syntax_Syntax.lbtyp = typ1;
                FStar_Syntax_Syntax.lbeff =
-                 (uu___1349_9125.FStar_Syntax_Syntax.lbeff);
+                 (uu___1349_9129.FStar_Syntax_Syntax.lbeff);
                FStar_Syntax_Syntax.lbdef = defn1;
                FStar_Syntax_Syntax.lbattrs =
-                 (uu___1349_9125.FStar_Syntax_Syntax.lbattrs);
+                 (uu___1349_9129.FStar_Syntax_Syntax.lbattrs);
                FStar_Syntax_Syntax.lbpos =
-                 (uu___1349_9125.FStar_Syntax_Syntax.lbpos)
+                 (uu___1349_9129.FStar_Syntax_Syntax.lbpos)
              }  in
            let hd =
              FStar_Syntax_Syntax.mk
@@ -2733,39 +2735,39 @@ and (readback :
            ->
            let lbs1 =
              FStar_List.map2
-               (fun uu____9203  ->
+               (fun uu____9207  ->
                   fun lb  ->
-                    match uu____9203 with
+                    match uu____9207 with
                     | (v,t,d) ->
                         let t1 = readback cfg t  in
                         let def = readback cfg d  in
                         let v1 =
-                          let uu___1369_9217 = v  in
+                          let uu___1369_9221 = v  in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___1369_9217.FStar_Syntax_Syntax.ppname);
+                              (uu___1369_9221.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___1369_9217.FStar_Syntax_Syntax.index);
+                              (uu___1369_9221.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t1
                           }  in
-                        let uu___1372_9218 = lb  in
+                        let uu___1372_9222 = lb  in
                         {
                           FStar_Syntax_Syntax.lbname = (FStar_Util.Inl v1);
                           FStar_Syntax_Syntax.lbunivs =
-                            (uu___1372_9218.FStar_Syntax_Syntax.lbunivs);
+                            (uu___1372_9222.FStar_Syntax_Syntax.lbunivs);
                           FStar_Syntax_Syntax.lbtyp = t1;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___1372_9218.FStar_Syntax_Syntax.lbeff);
+                            (uu___1372_9222.FStar_Syntax_Syntax.lbeff);
                           FStar_Syntax_Syntax.lbdef = def;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___1372_9218.FStar_Syntax_Syntax.lbattrs);
+                            (uu___1372_9222.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___1372_9218.FStar_Syntax_Syntax.lbpos)
+                            (uu___1372_9222.FStar_Syntax_Syntax.lbpos)
                         }) vars_typs_defns lbs
               in
            let body1 = readback cfg body  in
-           let uu____9220 = FStar_Syntax_Subst.close_let_rec lbs1 body1  in
-           (match uu____9220 with
+           let uu____9224 = FStar_Syntax_Subst.close_let_rec lbs1 body1  in
+           (match uu____9224 with
             | (lbs2,body2) ->
                 let hd =
                   FStar_Syntax_Syntax.mk
@@ -2782,19 +2784,19 @@ and (readback :
        | FStar_TypeChecker_NBETerm.TopLevelLet (lb,arity,args_rev) ->
            let n_univs = FStar_List.length lb.FStar_Syntax_Syntax.lbunivs  in
            let n_args = FStar_List.length args_rev  in
-           let uu____9303 = FStar_Util.first_N (n_args - n_univs) args_rev
+           let uu____9307 = FStar_Util.first_N (n_args - n_univs) args_rev
               in
-           (match uu____9303 with
+           (match uu____9307 with
             | (args_rev1,univs) ->
-                let uu____9350 =
-                  let uu____9351 =
-                    let uu____9352 =
+                let uu____9354 =
+                  let uu____9355 =
+                    let uu____9356 =
                       FStar_List.map FStar_Pervasives_Native.fst univs  in
-                    translate cfg uu____9352 lb.FStar_Syntax_Syntax.lbdef  in
-                  iapp cfg uu____9351 (FStar_List.rev args_rev1)  in
-                readback cfg uu____9350)
+                    translate cfg uu____9356 lb.FStar_Syntax_Syntax.lbdef  in
+                  iapp cfg uu____9355 (FStar_List.rev args_rev1)  in
+                readback cfg uu____9354)
        | FStar_TypeChecker_NBETerm.TopLevelRec
-           (lb,uu____9364,uu____9365,args) ->
+           (lb,uu____9368,uu____9369,args) ->
            let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
            let head =
              FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
@@ -2802,70 +2804,70 @@ and (readback :
               in
            let args1 =
              FStar_List.map
-               (fun uu____9410  ->
-                  match uu____9410 with
+               (fun uu____9414  ->
+                  match uu____9414 with
                   | (t,q) ->
-                      let uu____9421 = readback cfg t  in (uu____9421, q))
+                      let uu____9425 = readback cfg t  in (uu____9425, q))
                args
               in
            FStar_Syntax_Util.mk_app head args1
        | FStar_TypeChecker_NBETerm.LocalLetRec
-           (i,uu____9423,lbs,bs,args,_ar,_ar_lst) ->
+           (i,uu____9427,lbs,bs,args,_ar,_ar_lst) ->
            let lbnames =
              FStar_List.map
                (fun lb  ->
-                  let uu____9465 =
-                    let uu____9467 =
-                      let uu____9468 =
+                  let uu____9469 =
+                    let uu____9471 =
+                      let uu____9472 =
                         FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                      uu____9468.FStar_Syntax_Syntax.ppname  in
-                    FStar_Ident.text_of_id uu____9467  in
-                  FStar_Syntax_Syntax.gen_bv uu____9465
+                      uu____9472.FStar_Syntax_Syntax.ppname  in
+                    FStar_Ident.text_of_id uu____9471  in
+                  FStar_Syntax_Syntax.gen_bv uu____9469
                     FStar_Pervasives_Native.None lb.FStar_Syntax_Syntax.lbtyp)
                lbs
               in
            let let_rec_env =
-             let uu____9472 =
+             let uu____9476 =
                FStar_List.map
                  (fun x1  ->
                     FStar_TypeChecker_NBETerm.Accu
                       ((FStar_TypeChecker_NBETerm.Var x1), [])) lbnames
                 in
-             FStar_List.rev_append uu____9472 bs  in
+             FStar_List.rev_append uu____9476 bs  in
            let lbs1 =
              FStar_List.map2
                (fun lb  ->
                   fun lbname  ->
                     let lbdef =
-                      let uu____9498 =
+                      let uu____9502 =
                         translate cfg let_rec_env
                           lb.FStar_Syntax_Syntax.lbdef
                          in
-                      readback cfg uu____9498  in
+                      readback cfg uu____9502  in
                     let lbtyp =
-                      let uu____9500 =
+                      let uu____9504 =
                         translate cfg bs lb.FStar_Syntax_Syntax.lbtyp  in
-                      readback cfg uu____9500  in
-                    let uu___1427_9501 = lb  in
+                      readback cfg uu____9504  in
+                    let uu___1427_9505 = lb  in
                     {
                       FStar_Syntax_Syntax.lbname = (FStar_Util.Inl lbname);
                       FStar_Syntax_Syntax.lbunivs =
-                        (uu___1427_9501.FStar_Syntax_Syntax.lbunivs);
+                        (uu___1427_9505.FStar_Syntax_Syntax.lbunivs);
                       FStar_Syntax_Syntax.lbtyp = lbtyp;
                       FStar_Syntax_Syntax.lbeff =
-                        (uu___1427_9501.FStar_Syntax_Syntax.lbeff);
+                        (uu___1427_9505.FStar_Syntax_Syntax.lbeff);
                       FStar_Syntax_Syntax.lbdef = lbdef;
                       FStar_Syntax_Syntax.lbattrs =
-                        (uu___1427_9501.FStar_Syntax_Syntax.lbattrs);
+                        (uu___1427_9505.FStar_Syntax_Syntax.lbattrs);
                       FStar_Syntax_Syntax.lbpos =
-                        (uu___1427_9501.FStar_Syntax_Syntax.lbpos)
+                        (uu___1427_9505.FStar_Syntax_Syntax.lbpos)
                     }) lbs lbnames
               in
            let body =
-             let uu____9503 = FStar_List.nth lbnames i  in
-             FStar_Syntax_Syntax.bv_to_name uu____9503  in
-           let uu____9504 = FStar_Syntax_Subst.close_let_rec lbs1 body  in
-           (match uu____9504 with
+             let uu____9507 = FStar_List.nth lbnames i  in
+             FStar_Syntax_Syntax.bv_to_name uu____9507  in
+           let uu____9508 = FStar_Syntax_Subst.close_let_rec lbs1 body  in
+           (match uu____9508 with
             | (lbs2,body1) ->
                 let head =
                   FStar_Syntax_Syntax.mk
@@ -2874,22 +2876,22 @@ and (readback :
                    in
                 let args1 =
                   FStar_List.map
-                    (fun uu____9552  ->
-                       match uu____9552 with
+                    (fun uu____9556  ->
+                       match uu____9556 with
                        | (x1,q) ->
-                           let uu____9563 = readback cfg x1  in
-                           (uu____9563, q)) args
+                           let uu____9567 = readback cfg x1  in
+                           (uu____9567, q)) args
                    in
                 FStar_Syntax_Util.mk_app head args1)
        | FStar_TypeChecker_NBETerm.Quote (qt,qi) ->
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_quoted (qt, qi))
              FStar_Pervasives_Native.None FStar_Range.dummyRange
-       | FStar_TypeChecker_NBETerm.Lazy (FStar_Util.Inl li,uu____9569) ->
+       | FStar_TypeChecker_NBETerm.Lazy (FStar_Util.Inl li,uu____9573) ->
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_lazy li)
              FStar_Pervasives_Native.None FStar_Range.dummyRange
-       | FStar_TypeChecker_NBETerm.Lazy (uu____9586,thunk) ->
-           let uu____9608 = FStar_Thunk.force thunk  in
-           readback cfg uu____9608)
+       | FStar_TypeChecker_NBETerm.Lazy (uu____9590,thunk) ->
+           let uu____9612 = FStar_Thunk.force thunk  in
+           readback cfg uu____9612)
 
 type step =
   | Primops 
@@ -2900,37 +2902,37 @@ type step =
   | Reify 
 let (uu___is_Primops : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Primops  -> true | uu____9637 -> false
+    match projectee with | Primops  -> true | uu____9641 -> false
   
 let (uu___is_UnfoldUntil : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldUntil _0 -> true | uu____9649 -> false
+    match projectee with | UnfoldUntil _0 -> true | uu____9653 -> false
   
 let (__proj__UnfoldUntil__item___0 : step -> FStar_Syntax_Syntax.delta_depth)
   = fun projectee  -> match projectee with | UnfoldUntil _0 -> _0 
 let (uu___is_UnfoldOnly : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldOnly _0 -> true | uu____9670 -> false
+    match projectee with | UnfoldOnly _0 -> true | uu____9674 -> false
   
 let (__proj__UnfoldOnly__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee  -> match projectee with | UnfoldOnly _0 -> _0 
 let (uu___is_UnfoldAttr : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldAttr _0 -> true | uu____9697 -> false
+    match projectee with | UnfoldAttr _0 -> true | uu____9701 -> false
   
 let (__proj__UnfoldAttr__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee  -> match projectee with | UnfoldAttr _0 -> _0 
 let (uu___is_UnfoldTac : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldTac  -> true | uu____9721 -> false
+    match projectee with | UnfoldTac  -> true | uu____9725 -> false
   
 let (uu___is_Reify : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Reify  -> true | uu____9732 -> false
+    match projectee with | Reify  -> true | uu____9736 -> false
   
 let (step_as_normalizer_step : step -> FStar_TypeChecker_Env.step) =
-  fun uu___2_9739  ->
-    match uu___2_9739 with
+  fun uu___2_9743  ->
+    match uu___2_9743 with
     | Primops  -> FStar_TypeChecker_Env.Primops
     | UnfoldUntil d -> FStar_TypeChecker_Env.UnfoldUntil d
     | UnfoldOnly lids -> FStar_TypeChecker_Env.UnfoldOnly lids
@@ -2945,7 +2947,7 @@ let (reduce_application :
   =
   fun cfg  ->
     fun t  ->
-      fun args  -> let uu____9763 = new_config cfg  in iapp uu____9763 t args
+      fun args  -> let uu____9767 = new_config cfg  in iapp uu____9767 t args
   
 let (normalize :
   FStar_TypeChecker_Cfg.primitive_step Prims.list ->
@@ -2959,105 +2961,105 @@ let (normalize :
         fun e  ->
           let cfg = FStar_TypeChecker_Cfg.config' psteps steps env  in
           let cfg1 =
-            let uu___1473_9795 = cfg  in
+            let uu___1473_9799 = cfg  in
             {
               FStar_TypeChecker_Cfg.steps =
-                (let uu___1475_9798 = cfg.FStar_TypeChecker_Cfg.steps  in
+                (let uu___1475_9802 = cfg.FStar_TypeChecker_Cfg.steps  in
                  {
                    FStar_TypeChecker_Cfg.beta =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.beta);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.beta);
                    FStar_TypeChecker_Cfg.iota =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.iota);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.iota);
                    FStar_TypeChecker_Cfg.zeta =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.zeta);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.zeta);
                    FStar_TypeChecker_Cfg.zeta_full =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.zeta_full);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.zeta_full);
                    FStar_TypeChecker_Cfg.weak =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.weak);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.weak);
                    FStar_TypeChecker_Cfg.hnf =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.hnf);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.hnf);
                    FStar_TypeChecker_Cfg.primops =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.primops);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.primops);
                    FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                    FStar_TypeChecker_Cfg.unfold_until =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.unfold_until);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.unfold_until);
                    FStar_TypeChecker_Cfg.unfold_only =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.unfold_only);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.unfold_only);
                    FStar_TypeChecker_Cfg.unfold_fully =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.unfold_fully);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.unfold_fully);
                    FStar_TypeChecker_Cfg.unfold_attr =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.unfold_attr);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.unfold_attr);
                    FStar_TypeChecker_Cfg.unfold_tac =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.unfold_tac);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.unfold_tac);
                    FStar_TypeChecker_Cfg.pure_subterms_within_computations =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                    FStar_TypeChecker_Cfg.simplify =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.simplify);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.simplify);
                    FStar_TypeChecker_Cfg.erase_universes =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.erase_universes);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.erase_universes);
                    FStar_TypeChecker_Cfg.allow_unbound_universes =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.allow_unbound_universes);
                    FStar_TypeChecker_Cfg.reify_ = true;
                    FStar_TypeChecker_Cfg.compress_uvars =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.compress_uvars);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.compress_uvars);
                    FStar_TypeChecker_Cfg.no_full_norm =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.no_full_norm);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.no_full_norm);
                    FStar_TypeChecker_Cfg.check_no_uvars =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.check_no_uvars);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.check_no_uvars);
                    FStar_TypeChecker_Cfg.unmeta =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.unmeta);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.unmeta);
                    FStar_TypeChecker_Cfg.unascribe =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.unascribe);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.unascribe);
                    FStar_TypeChecker_Cfg.in_full_norm_request =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.in_full_norm_request);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.in_full_norm_request);
                    FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                    FStar_TypeChecker_Cfg.nbe_step =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.nbe_step);
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.nbe_step);
                    FStar_TypeChecker_Cfg.for_extraction =
-                     (uu___1475_9798.FStar_TypeChecker_Cfg.for_extraction)
+                     (uu___1475_9802.FStar_TypeChecker_Cfg.for_extraction)
                  });
               FStar_TypeChecker_Cfg.tcenv =
-                (uu___1473_9795.FStar_TypeChecker_Cfg.tcenv);
+                (uu___1473_9799.FStar_TypeChecker_Cfg.tcenv);
               FStar_TypeChecker_Cfg.debug =
-                (uu___1473_9795.FStar_TypeChecker_Cfg.debug);
+                (uu___1473_9799.FStar_TypeChecker_Cfg.debug);
               FStar_TypeChecker_Cfg.delta_level =
-                (uu___1473_9795.FStar_TypeChecker_Cfg.delta_level);
+                (uu___1473_9799.FStar_TypeChecker_Cfg.delta_level);
               FStar_TypeChecker_Cfg.primitive_steps =
-                (uu___1473_9795.FStar_TypeChecker_Cfg.primitive_steps);
+                (uu___1473_9799.FStar_TypeChecker_Cfg.primitive_steps);
               FStar_TypeChecker_Cfg.strong =
-                (uu___1473_9795.FStar_TypeChecker_Cfg.strong);
+                (uu___1473_9799.FStar_TypeChecker_Cfg.strong);
               FStar_TypeChecker_Cfg.memoize_lazy =
-                (uu___1473_9795.FStar_TypeChecker_Cfg.memoize_lazy);
+                (uu___1473_9799.FStar_TypeChecker_Cfg.memoize_lazy);
               FStar_TypeChecker_Cfg.normalize_pure_lets =
-                (uu___1473_9795.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                (uu___1473_9799.FStar_TypeChecker_Cfg.normalize_pure_lets);
               FStar_TypeChecker_Cfg.reifying =
-                (uu___1473_9795.FStar_TypeChecker_Cfg.reifying)
+                (uu___1473_9799.FStar_TypeChecker_Cfg.reifying)
             }  in
-          (let uu____9801 =
+          (let uu____9805 =
              (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBETop"))
                ||
                (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBE"))
               in
-           if uu____9801
+           if uu____9805
            then
-             let uu____9806 = FStar_Syntax_Print.term_to_string e  in
-             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____9806
+             let uu____9810 = FStar_Syntax_Print.term_to_string e  in
+             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____9810
            else ());
           (let cfg2 = new_config cfg1  in
            let r =
-             let uu____9813 = translate cfg2 [] e  in
-             readback cfg2 uu____9813  in
-           (let uu____9815 =
+             let uu____9817 = translate cfg2 [] e  in
+             readback cfg2 uu____9817  in
+           (let uu____9819 =
               (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBETop"))
                 ||
                 (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBE"))
                in
-            if uu____9815
+            if uu____9819
             then
-              let uu____9820 = FStar_Syntax_Print.term_to_string r  in
-              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____9820
+              let uu____9824 = FStar_Syntax_Print.term_to_string r  in
+              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____9824
             else ());
            r)
   
@@ -3071,93 +3073,93 @@ let (normalize_for_unit_test :
       fun e  ->
         let cfg = FStar_TypeChecker_Cfg.config steps env  in
         let cfg1 =
-          let uu___1491_9847 = cfg  in
+          let uu___1491_9851 = cfg  in
           {
             FStar_TypeChecker_Cfg.steps =
-              (let uu___1493_9850 = cfg.FStar_TypeChecker_Cfg.steps  in
+              (let uu___1493_9854 = cfg.FStar_TypeChecker_Cfg.steps  in
                {
                  FStar_TypeChecker_Cfg.beta =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.beta);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.beta);
                  FStar_TypeChecker_Cfg.iota =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.iota);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.iota);
                  FStar_TypeChecker_Cfg.zeta =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.zeta);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.zeta);
                  FStar_TypeChecker_Cfg.zeta_full =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.zeta_full);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.zeta_full);
                  FStar_TypeChecker_Cfg.weak =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.weak);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.weak);
                  FStar_TypeChecker_Cfg.hnf =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.hnf);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.hnf);
                  FStar_TypeChecker_Cfg.primops =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.primops);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.primops);
                  FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                  FStar_TypeChecker_Cfg.unfold_until =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.unfold_until);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.unfold_until);
                  FStar_TypeChecker_Cfg.unfold_only =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.unfold_only);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.unfold_only);
                  FStar_TypeChecker_Cfg.unfold_fully =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.unfold_fully);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.unfold_fully);
                  FStar_TypeChecker_Cfg.unfold_attr =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.unfold_attr);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.unfold_attr);
                  FStar_TypeChecker_Cfg.unfold_tac =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.unfold_tac);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.unfold_tac);
                  FStar_TypeChecker_Cfg.pure_subterms_within_computations =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                  FStar_TypeChecker_Cfg.simplify =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.simplify);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.simplify);
                  FStar_TypeChecker_Cfg.erase_universes =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.erase_universes);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.erase_universes);
                  FStar_TypeChecker_Cfg.allow_unbound_universes =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.allow_unbound_universes);
                  FStar_TypeChecker_Cfg.reify_ = true;
                  FStar_TypeChecker_Cfg.compress_uvars =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.compress_uvars);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.compress_uvars);
                  FStar_TypeChecker_Cfg.no_full_norm =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.no_full_norm);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.no_full_norm);
                  FStar_TypeChecker_Cfg.check_no_uvars =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.check_no_uvars);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.check_no_uvars);
                  FStar_TypeChecker_Cfg.unmeta =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.unmeta);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.unmeta);
                  FStar_TypeChecker_Cfg.unascribe =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.unascribe);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.unascribe);
                  FStar_TypeChecker_Cfg.in_full_norm_request =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.in_full_norm_request);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.in_full_norm_request);
                  FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                  FStar_TypeChecker_Cfg.nbe_step =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.nbe_step);
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.nbe_step);
                  FStar_TypeChecker_Cfg.for_extraction =
-                   (uu___1493_9850.FStar_TypeChecker_Cfg.for_extraction)
+                   (uu___1493_9854.FStar_TypeChecker_Cfg.for_extraction)
                });
             FStar_TypeChecker_Cfg.tcenv =
-              (uu___1491_9847.FStar_TypeChecker_Cfg.tcenv);
+              (uu___1491_9851.FStar_TypeChecker_Cfg.tcenv);
             FStar_TypeChecker_Cfg.debug =
-              (uu___1491_9847.FStar_TypeChecker_Cfg.debug);
+              (uu___1491_9851.FStar_TypeChecker_Cfg.debug);
             FStar_TypeChecker_Cfg.delta_level =
-              (uu___1491_9847.FStar_TypeChecker_Cfg.delta_level);
+              (uu___1491_9851.FStar_TypeChecker_Cfg.delta_level);
             FStar_TypeChecker_Cfg.primitive_steps =
-              (uu___1491_9847.FStar_TypeChecker_Cfg.primitive_steps);
+              (uu___1491_9851.FStar_TypeChecker_Cfg.primitive_steps);
             FStar_TypeChecker_Cfg.strong =
-              (uu___1491_9847.FStar_TypeChecker_Cfg.strong);
+              (uu___1491_9851.FStar_TypeChecker_Cfg.strong);
             FStar_TypeChecker_Cfg.memoize_lazy =
-              (uu___1491_9847.FStar_TypeChecker_Cfg.memoize_lazy);
+              (uu___1491_9851.FStar_TypeChecker_Cfg.memoize_lazy);
             FStar_TypeChecker_Cfg.normalize_pure_lets =
-              (uu___1491_9847.FStar_TypeChecker_Cfg.normalize_pure_lets);
+              (uu___1491_9851.FStar_TypeChecker_Cfg.normalize_pure_lets);
             FStar_TypeChecker_Cfg.reifying =
-              (uu___1491_9847.FStar_TypeChecker_Cfg.reifying)
+              (uu___1491_9851.FStar_TypeChecker_Cfg.reifying)
           }  in
         let cfg2 = new_config cfg1  in
         debug cfg2
-          (fun uu____9856  ->
-             let uu____9857 = FStar_Syntax_Print.term_to_string e  in
-             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____9857);
+          (fun uu____9860  ->
+             let uu____9861 = FStar_Syntax_Print.term_to_string e  in
+             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____9861);
         (let r =
-           let uu____9861 = translate cfg2 [] e  in readback cfg2 uu____9861
+           let uu____9865 = translate cfg2 [] e  in readback cfg2 uu____9865
             in
          debug cfg2
-           (fun uu____9865  ->
-              let uu____9866 = FStar_Syntax_Print.term_to_string r  in
-              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____9866);
+           (fun uu____9869  ->
+              let uu____9870 = FStar_Syntax_Print.term_to_string r  in
+              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____9870);
          r)
   

--- a/src/ocaml-output/FStar_TypeChecker_NBETerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_NBETerm.ml
@@ -534,8 +534,10 @@ and (eq_atom : atom -> atom -> FStar_Syntax_Util.eq_result) =
   fun a1  ->
     fun a2  ->
       match (a1, a2) with
-      | (Var bv1,Var bv2) -> equal_if (FStar_Syntax_Syntax.bv_eq bv1 bv2)
-      | (uu____3198,uu____3199) -> FStar_Syntax_Util.Unknown
+      | (Var bv1,Var bv2) ->
+          let uu____3198 = FStar_Syntax_Syntax.bv_eq bv1 bv2  in
+          equal_if uu____3198
+      | (uu____3200,uu____3201) -> FStar_Syntax_Util.Unknown
 
 and (eq_arg : arg -> arg -> FStar_Syntax_Util.eq_result) =
   fun a1  ->
@@ -548,9 +550,9 @@ and (eq_args : args -> args -> FStar_Syntax_Util.eq_result) =
       match (as1, as2) with
       | ([],[]) -> FStar_Syntax_Util.Equal
       | (x::xs,y::ys) ->
-          let uu____3280 = eq_arg x y  in
-          eq_and uu____3280 (fun uu____3282  -> eq_args xs ys)
-      | (uu____3283,uu____3284) -> FStar_Syntax_Util.Unknown
+          let uu____3282 = eq_arg x y  in
+          eq_and uu____3282 (fun uu____3284  -> eq_args xs ys)
+      | (uu____3285,uu____3286) -> FStar_Syntax_Util.Unknown
 
 let (constant_to_string : constant -> Prims.string) =
   fun c  ->
@@ -559,191 +561,191 @@ let (constant_to_string : constant -> Prims.string) =
     | Bool b -> if b then "Bool true" else "Bool false"
     | Int i -> FStar_BigInt.string_of_big_int i
     | Char c1 -> FStar_Util.format1 "'%s'" (FStar_Util.string_of_char c1)
-    | String (s,uu____3331) -> FStar_Util.format1 "\"%s\"" s
+    | String (s,uu____3333) -> FStar_Util.format1 "\"%s\"" s
     | Range r ->
-        let uu____3336 = FStar_Range.string_of_range r  in
-        FStar_Util.format1 "Range %s" uu____3336
+        let uu____3338 = FStar_Range.string_of_range r  in
+        FStar_Util.format1 "Range %s" uu____3338
     | SConst s -> FStar_Syntax_Print.const_to_string s
   
 let rec (t_to_string : t -> Prims.string) =
   fun x  ->
     match x with
-    | Lam (b,uu____3354,arity) ->
-        let uu____3408 = FStar_Util.string_of_int arity  in
-        FStar_Util.format1 "Lam (_, %s args)" uu____3408
+    | Lam (b,uu____3356,arity) ->
+        let uu____3410 = FStar_Util.string_of_int arity  in
+        FStar_Util.format1 "Lam (_, %s args)" uu____3410
     | Accu (a,l) ->
-        let uu____3425 =
-          let uu____3427 = atom_to_string a  in
-          let uu____3429 =
-            let uu____3431 =
-              let uu____3433 =
-                let uu____3435 =
+        let uu____3427 =
+          let uu____3429 = atom_to_string a  in
+          let uu____3431 =
+            let uu____3433 =
+              let uu____3435 =
+                let uu____3437 =
                   FStar_List.map
                     (fun x1  -> t_to_string (FStar_Pervasives_Native.fst x1))
                     l
                    in
-                FStar_String.concat "; " uu____3435  in
-              FStar_String.op_Hat uu____3433 ")"  in
-            FStar_String.op_Hat ") (" uu____3431  in
-          FStar_String.op_Hat uu____3427 uu____3429  in
-        FStar_String.op_Hat "Accu (" uu____3425
+                FStar_String.concat "; " uu____3437  in
+              FStar_String.op_Hat uu____3435 ")"  in
+            FStar_String.op_Hat ") (" uu____3433  in
+          FStar_String.op_Hat uu____3429 uu____3431  in
+        FStar_String.op_Hat "Accu (" uu____3427
     | Construct (fv,us,l) ->
-        let uu____3473 =
-          let uu____3475 = FStar_Syntax_Print.fv_to_string fv  in
-          let uu____3477 =
-            let uu____3479 =
-              let uu____3481 =
-                let uu____3483 =
+        let uu____3475 =
+          let uu____3477 = FStar_Syntax_Print.fv_to_string fv  in
+          let uu____3479 =
+            let uu____3481 =
+              let uu____3483 =
+                let uu____3485 =
                   FStar_List.map FStar_Syntax_Print.univ_to_string us  in
-                FStar_String.concat "; " uu____3483  in
-              let uu____3489 =
-                let uu____3491 =
-                  let uu____3493 =
-                    let uu____3495 =
+                FStar_String.concat "; " uu____3485  in
+              let uu____3491 =
+                let uu____3493 =
+                  let uu____3495 =
+                    let uu____3497 =
                       FStar_List.map
                         (fun x1  ->
                            t_to_string (FStar_Pervasives_Native.fst x1)) l
                        in
-                    FStar_String.concat "; " uu____3495  in
-                  FStar_String.op_Hat uu____3493 "]"  in
-                FStar_String.op_Hat "] [" uu____3491  in
-              FStar_String.op_Hat uu____3481 uu____3489  in
-            FStar_String.op_Hat ") [" uu____3479  in
-          FStar_String.op_Hat uu____3475 uu____3477  in
-        FStar_String.op_Hat "Construct (" uu____3473
+                    FStar_String.concat "; " uu____3497  in
+                  FStar_String.op_Hat uu____3495 "]"  in
+                FStar_String.op_Hat "] [" uu____3493  in
+              FStar_String.op_Hat uu____3483 uu____3491  in
+            FStar_String.op_Hat ") [" uu____3481  in
+          FStar_String.op_Hat uu____3477 uu____3479  in
+        FStar_String.op_Hat "Construct (" uu____3475
     | FV (fv,us,l) ->
-        let uu____3534 =
-          let uu____3536 = FStar_Syntax_Print.fv_to_string fv  in
-          let uu____3538 =
-            let uu____3540 =
-              let uu____3542 =
-                let uu____3544 =
+        let uu____3536 =
+          let uu____3538 = FStar_Syntax_Print.fv_to_string fv  in
+          let uu____3540 =
+            let uu____3542 =
+              let uu____3544 =
+                let uu____3546 =
                   FStar_List.map FStar_Syntax_Print.univ_to_string us  in
-                FStar_String.concat "; " uu____3544  in
-              let uu____3550 =
-                let uu____3552 =
-                  let uu____3554 =
-                    let uu____3556 =
+                FStar_String.concat "; " uu____3546  in
+              let uu____3552 =
+                let uu____3554 =
+                  let uu____3556 =
+                    let uu____3558 =
                       FStar_List.map
                         (fun x1  ->
                            t_to_string (FStar_Pervasives_Native.fst x1)) l
                        in
-                    FStar_String.concat "; " uu____3556  in
-                  FStar_String.op_Hat uu____3554 "]"  in
-                FStar_String.op_Hat "] [" uu____3552  in
-              FStar_String.op_Hat uu____3542 uu____3550  in
-            FStar_String.op_Hat ") [" uu____3540  in
-          FStar_String.op_Hat uu____3536 uu____3538  in
-        FStar_String.op_Hat "FV (" uu____3534
+                    FStar_String.concat "; " uu____3558  in
+                  FStar_String.op_Hat uu____3556 "]"  in
+                FStar_String.op_Hat "] [" uu____3554  in
+              FStar_String.op_Hat uu____3544 uu____3552  in
+            FStar_String.op_Hat ") [" uu____3542  in
+          FStar_String.op_Hat uu____3538 uu____3540  in
+        FStar_String.op_Hat "FV (" uu____3536
     | Constant c -> constant_to_string c
     | Univ u ->
-        let uu____3578 = FStar_Syntax_Print.univ_to_string u  in
-        FStar_String.op_Hat "Universe " uu____3578
+        let uu____3580 = FStar_Syntax_Print.univ_to_string u  in
+        FStar_String.op_Hat "Universe " uu____3580
     | Type_t u ->
-        let uu____3582 = FStar_Syntax_Print.univ_to_string u  in
-        FStar_String.op_Hat "Type_t " uu____3582
-    | Arrow uu____3585 -> "Arrow"
+        let uu____3584 = FStar_Syntax_Print.univ_to_string u  in
+        FStar_String.op_Hat "Type_t " uu____3584
+    | Arrow uu____3587 -> "Arrow"
     | Refinement (f,t1) ->
         let x1 =
           FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
             FStar_Syntax_Syntax.t_unit
            in
         let t2 =
-          let uu____3627 = t1 ()  in FStar_Pervasives_Native.fst uu____3627
+          let uu____3629 = t1 ()  in FStar_Pervasives_Native.fst uu____3629
            in
-        let uu____3632 =
-          let uu____3634 = FStar_Syntax_Print.bv_to_string x1  in
-          let uu____3636 =
-            let uu____3638 =
-              let uu____3640 = t_to_string t2  in
-              let uu____3642 =
-                let uu____3644 =
-                  let uu____3646 =
-                    let uu____3648 =
-                      let uu____3649 = mkAccuVar x1  in f uu____3649  in
-                    t_to_string uu____3648  in
-                  FStar_String.op_Hat uu____3646 "}"  in
-                FStar_String.op_Hat "{" uu____3644  in
-              FStar_String.op_Hat uu____3640 uu____3642  in
-            FStar_String.op_Hat ":" uu____3638  in
-          FStar_String.op_Hat uu____3634 uu____3636  in
-        FStar_String.op_Hat "Refinement " uu____3632
+        let uu____3634 =
+          let uu____3636 = FStar_Syntax_Print.bv_to_string x1  in
+          let uu____3638 =
+            let uu____3640 =
+              let uu____3642 = t_to_string t2  in
+              let uu____3644 =
+                let uu____3646 =
+                  let uu____3648 =
+                    let uu____3650 =
+                      let uu____3651 = mkAccuVar x1  in f uu____3651  in
+                    t_to_string uu____3650  in
+                  FStar_String.op_Hat uu____3648 "}"  in
+                FStar_String.op_Hat "{" uu____3646  in
+              FStar_String.op_Hat uu____3642 uu____3644  in
+            FStar_String.op_Hat ":" uu____3640  in
+          FStar_String.op_Hat uu____3636 uu____3638  in
+        FStar_String.op_Hat "Refinement " uu____3634
     | Unknown  -> "Unknown"
     | Reflect t1 ->
-        let uu____3656 = t_to_string t1  in
-        FStar_String.op_Hat "Reflect " uu____3656
-    | Quote uu____3659 -> "Quote _"
-    | Lazy (FStar_Util.Inl li,uu____3666) ->
-        let uu____3683 =
-          let uu____3685 = FStar_Syntax_Util.unfold_lazy li  in
-          FStar_Syntax_Print.term_to_string uu____3685  in
-        FStar_Util.format1 "Lazy (Inl {%s})" uu____3683
-    | Lazy (FStar_Util.Inr (uu____3687,et),uu____3689) ->
-        let uu____3706 = FStar_Syntax_Print.emb_typ_to_string et  in
-        FStar_Util.format1 "Lazy (Inr (?, %s))" uu____3706
+        let uu____3658 = t_to_string t1  in
+        FStar_String.op_Hat "Reflect " uu____3658
+    | Quote uu____3661 -> "Quote _"
+    | Lazy (FStar_Util.Inl li,uu____3668) ->
+        let uu____3685 =
+          let uu____3687 = FStar_Syntax_Util.unfold_lazy li  in
+          FStar_Syntax_Print.term_to_string uu____3687  in
+        FStar_Util.format1 "Lazy (Inl {%s})" uu____3685
+    | Lazy (FStar_Util.Inr (uu____3689,et),uu____3691) ->
+        let uu____3708 = FStar_Syntax_Print.emb_typ_to_string et  in
+        FStar_Util.format1 "Lazy (Inr (?, %s))" uu____3708
     | LocalLetRec
-        (uu____3709,l,uu____3711,uu____3712,uu____3713,uu____3714,uu____3715)
+        (uu____3711,l,uu____3713,uu____3714,uu____3715,uu____3716,uu____3717)
         ->
-        let uu____3746 =
-          let uu____3748 = FStar_Syntax_Print.lbs_to_string [] (true, [l])
+        let uu____3748 =
+          let uu____3750 = FStar_Syntax_Print.lbs_to_string [] (true, [l])
              in
-          FStar_String.op_Hat uu____3748 ")"  in
-        FStar_String.op_Hat "LocalLetRec (" uu____3746
-    | TopLevelLet (lb,uu____3757,uu____3758) ->
-        let uu____3773 =
-          let uu____3775 =
-            let uu____3777 = FStar_Util.right lb.FStar_Syntax_Syntax.lbname
+          FStar_String.op_Hat uu____3750 ")"  in
+        FStar_String.op_Hat "LocalLetRec (" uu____3748
+    | TopLevelLet (lb,uu____3759,uu____3760) ->
+        let uu____3775 =
+          let uu____3777 =
+            let uu____3779 = FStar_Util.right lb.FStar_Syntax_Syntax.lbname
                in
-            FStar_Syntax_Print.fv_to_string uu____3777  in
-          FStar_String.op_Hat uu____3775 ")"  in
-        FStar_String.op_Hat "TopLevelLet (" uu____3773
-    | TopLevelRec (lb,uu____3781,uu____3782,uu____3783) ->
-        let uu____3804 =
-          let uu____3806 =
-            let uu____3808 = FStar_Util.right lb.FStar_Syntax_Syntax.lbname
+            FStar_Syntax_Print.fv_to_string uu____3779  in
+          FStar_String.op_Hat uu____3777 ")"  in
+        FStar_String.op_Hat "TopLevelLet (" uu____3775
+    | TopLevelRec (lb,uu____3783,uu____3784,uu____3785) ->
+        let uu____3806 =
+          let uu____3808 =
+            let uu____3810 = FStar_Util.right lb.FStar_Syntax_Syntax.lbname
                in
-            FStar_Syntax_Print.fv_to_string uu____3808  in
-          FStar_String.op_Hat uu____3806 ")"  in
-        FStar_String.op_Hat "TopLevelRec (" uu____3804
+            FStar_Syntax_Print.fv_to_string uu____3810  in
+          FStar_String.op_Hat uu____3808 ")"  in
+        FStar_String.op_Hat "TopLevelRec (" uu____3806
 
 and (atom_to_string : atom -> Prims.string) =
   fun a  ->
     match a with
     | Var v ->
-        let uu____3814 = FStar_Syntax_Print.bv_to_string v  in
-        FStar_String.op_Hat "Var " uu____3814
-    | Match (t1,uu____3818) ->
-        let uu____3829 = t_to_string t1  in
-        FStar_String.op_Hat "Match " uu____3829
+        let uu____3816 = FStar_Syntax_Print.bv_to_string v  in
+        FStar_String.op_Hat "Var " uu____3816
+    | Match (t1,uu____3820) ->
+        let uu____3831 = t_to_string t1  in
+        FStar_String.op_Hat "Match " uu____3831
     | UnreducedLet (var1,typ,def,body,lb) ->
-        let uu____3849 =
-          let uu____3851 = FStar_Syntax_Print.lbs_to_string [] (false, [lb])
+        let uu____3851 =
+          let uu____3853 = FStar_Syntax_Print.lbs_to_string [] (false, [lb])
              in
-          FStar_String.op_Hat uu____3851 " in ...)"  in
-        FStar_String.op_Hat "UnreducedLet(" uu____3849
-    | UnreducedLetRec (uu____3859,body,lbs) ->
-        let uu____3882 =
-          let uu____3884 = FStar_Syntax_Print.lbs_to_string [] (true, lbs)
+          FStar_String.op_Hat uu____3853 " in ...)"  in
+        FStar_String.op_Hat "UnreducedLet(" uu____3851
+    | UnreducedLetRec (uu____3861,body,lbs) ->
+        let uu____3884 =
+          let uu____3886 = FStar_Syntax_Print.lbs_to_string [] (true, lbs)
              in
-          let uu____3890 =
-            let uu____3892 =
-              let uu____3894 = t_to_string body  in
-              FStar_String.op_Hat uu____3894 ")"  in
-            FStar_String.op_Hat " in " uu____3892  in
-          FStar_String.op_Hat uu____3884 uu____3890  in
-        FStar_String.op_Hat "UnreducedLetRec(" uu____3882
-    | UVar uu____3899 -> "UVar"
+          let uu____3892 =
+            let uu____3894 =
+              let uu____3896 = t_to_string body  in
+              FStar_String.op_Hat uu____3896 ")"  in
+            FStar_String.op_Hat " in " uu____3894  in
+          FStar_String.op_Hat uu____3886 uu____3892  in
+        FStar_String.op_Hat "UnreducedLetRec(" uu____3884
+    | UVar uu____3901 -> "UVar"
 
 let (arg_to_string : arg -> Prims.string) =
   fun a  ->
-    let uu____3910 = FStar_All.pipe_right a FStar_Pervasives_Native.fst  in
-    FStar_All.pipe_right uu____3910 t_to_string
+    let uu____3912 = FStar_All.pipe_right a FStar_Pervasives_Native.fst  in
+    FStar_All.pipe_right uu____3912 t_to_string
   
 let (args_to_string : args -> Prims.string) =
   fun args1  ->
-    let uu____3923 =
+    let uu____3925 =
       FStar_All.pipe_right args1 (FStar_List.map arg_to_string)  in
-    FStar_All.pipe_right uu____3923 (FStar_String.concat " ")
+    FStar_All.pipe_right uu____3925 (FStar_String.concat " ")
   
 type nbe_cbs =
   {
@@ -795,11 +797,11 @@ let (lid_as_constr :
   fun l  ->
     fun us  ->
       fun args1  ->
-        let uu____4394 =
+        let uu____4396 =
           FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
             (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
            in
-        mkConstruct uu____4394 us args1
+        mkConstruct uu____4396 us args1
   
 let (lid_as_typ :
   FStar_Ident.lident -> FStar_Syntax_Syntax.universe Prims.list -> args -> t)
@@ -807,11 +809,11 @@ let (lid_as_typ :
   fun l  ->
     fun us  ->
       fun args1  ->
-        let uu____4415 =
+        let uu____4417 =
           FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
             FStar_Pervasives_Native.None
            in
-        mkFV uu____4415 us args1
+        mkFV uu____4417 us args1
   
 let (as_iarg : t -> arg) =
   fun a  -> (a, (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.imp_tag)) 
@@ -825,24 +827,24 @@ let lazy_embed : 'a . FStar_Syntax_Syntax.emb_typ -> 'a -> (unit -> t) -> t =
   fun et  ->
     fun x  ->
       fun f  ->
-        (let uu____4498 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
-         if uu____4498
+        (let uu____4500 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
+         if uu____4500
          then
-           let uu____4522 = FStar_Syntax_Print.emb_typ_to_string et  in
-           FStar_Util.print1 "Embedding\n\temb_typ=%s\n" uu____4522
+           let uu____4524 = FStar_Syntax_Print.emb_typ_to_string et  in
+           FStar_Util.print1 "Embedding\n\temb_typ=%s\n" uu____4524
          else ());
-        (let uu____4527 = FStar_ST.op_Bang FStar_Options.eager_embedding  in
-         if uu____4527
+        (let uu____4529 = FStar_ST.op_Bang FStar_Options.eager_embedding  in
+         if uu____4529
          then f ()
          else
            (let thunk = FStar_Thunk.mk f  in
-            let li = let uu____4561 = FStar_Dyn.mkdyn x  in (uu____4561, et)
+            let li = let uu____4563 = FStar_Dyn.mkdyn x  in (uu____4563, et)
                in
             Lazy ((FStar_Util.Inr li), thunk)))
   
 let lazy_unembed :
-  'uuuuuu4589 'a .
-    'uuuuuu4589 ->
+  'uuuuuu4591 'a .
+    'uuuuuu4591 ->
       FStar_Syntax_Syntax.emb_typ ->
         t ->
           (t -> 'a FStar_Pervasives_Native.option) ->
@@ -854,50 +856,50 @@ let lazy_unembed :
         fun f  ->
           match x with
           | Lazy (FStar_Util.Inl li,thunk) ->
-              let uu____4640 = FStar_Thunk.force thunk  in f uu____4640
+              let uu____4642 = FStar_Thunk.force thunk  in f uu____4642
           | Lazy (FStar_Util.Inr (b,et'),thunk) ->
-              let uu____4660 =
+              let uu____4662 =
                 (et <> et') ||
                   (FStar_ST.op_Bang FStar_Options.eager_embedding)
                  in
-              if uu____4660
+              if uu____4662
               then
                 let res =
-                  let uu____4689 = FStar_Thunk.force thunk  in f uu____4689
+                  let uu____4691 = FStar_Thunk.force thunk  in f uu____4691
                    in
-                ((let uu____4691 =
+                ((let uu____4693 =
                     FStar_ST.op_Bang FStar_Options.debug_embedding  in
-                  if uu____4691
+                  if uu____4693
                   then
-                    let uu____4715 = FStar_Syntax_Print.emb_typ_to_string et
+                    let uu____4717 = FStar_Syntax_Print.emb_typ_to_string et
                        in
-                    let uu____4717 = FStar_Syntax_Print.emb_typ_to_string et'
+                    let uu____4719 = FStar_Syntax_Print.emb_typ_to_string et'
                        in
                     FStar_Util.print2
-                      "Unembed cancellation failed\n\t%s <> %s\n" uu____4715
-                      uu____4717
+                      "Unembed cancellation failed\n\t%s <> %s\n" uu____4717
+                      uu____4719
                   else ());
                  res)
               else
                 (let a1 = FStar_Dyn.undyn b  in
-                 (let uu____4726 =
+                 (let uu____4728 =
                     FStar_ST.op_Bang FStar_Options.debug_embedding  in
-                  if uu____4726
+                  if uu____4728
                   then
-                    let uu____4750 = FStar_Syntax_Print.emb_typ_to_string et
+                    let uu____4752 = FStar_Syntax_Print.emb_typ_to_string et
                        in
-                    FStar_Util.print1 "Unembed cancelled for %s\n" uu____4750
+                    FStar_Util.print1 "Unembed cancelled for %s\n" uu____4752
                   else ());
                  FStar_Pervasives_Native.Some a1)
-          | uu____4755 ->
+          | uu____4757 ->
               let aopt = f x  in
-              ((let uu____4760 =
+              ((let uu____4762 =
                   FStar_ST.op_Bang FStar_Options.debug_embedding  in
-                if uu____4760
+                if uu____4762
                 then
-                  let uu____4784 = FStar_Syntax_Print.emb_typ_to_string et
+                  let uu____4786 = FStar_Syntax_Print.emb_typ_to_string et
                      in
-                  FStar_Util.print1 "Unembedding:\n\temb_typ=%s\n" uu____4784
+                  FStar_Util.print1 "Unembedding:\n\temb_typ=%s\n" uu____4786
                 else ());
                aopt)
   
@@ -910,88 +912,88 @@ let (mk_any_emb : t -> t embedding) =
 let (e_any : t embedding) =
   let em _cb a = a  in
   let un _cb t1 = FStar_Pervasives_Native.Some t1  in
-  let uu____4852 = lid_as_typ FStar_Parser_Const.term_lid [] []  in
-  mk_emb em un uu____4852 FStar_Syntax_Syntax.ET_abstract 
+  let uu____4854 = lid_as_typ FStar_Parser_Const.term_lid [] []  in
+  mk_emb em un uu____4854 FStar_Syntax_Syntax.ET_abstract 
 let (e_unit : unit embedding) =
   let em _cb a = Constant Unit  in
   let un _cb t1 = FStar_Pervasives_Native.Some ()  in
-  let uu____4886 = lid_as_typ FStar_Parser_Const.unit_lid [] []  in
-  let uu____4891 =
+  let uu____4888 = lid_as_typ FStar_Parser_Const.unit_lid [] []  in
+  let uu____4893 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_unit  in
-  mk_emb em un uu____4886 uu____4891 
+  mk_emb em un uu____4888 uu____4893 
 let (e_bool : Prims.bool embedding) =
   let em _cb a = Constant (Bool a)  in
   let un _cb t1 =
     match t1 with
     | Constant (Bool a) -> FStar_Pervasives_Native.Some a
-    | uu____4932 -> FStar_Pervasives_Native.None  in
-  let uu____4934 = lid_as_typ FStar_Parser_Const.bool_lid [] []  in
-  let uu____4939 =
+    | uu____4934 -> FStar_Pervasives_Native.None  in
+  let uu____4936 = lid_as_typ FStar_Parser_Const.bool_lid [] []  in
+  let uu____4941 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_unit  in
-  mk_emb em un uu____4934 uu____4939 
+  mk_emb em un uu____4936 uu____4941 
 let (e_char : FStar_Char.char embedding) =
   let em _cb c = Constant (Char c)  in
   let un _cb c =
     match c with
     | Constant (Char a) -> FStar_Pervasives_Native.Some a
-    | uu____4981 -> FStar_Pervasives_Native.None  in
-  let uu____4983 = lid_as_typ FStar_Parser_Const.char_lid [] []  in
-  let uu____4988 =
+    | uu____4983 -> FStar_Pervasives_Native.None  in
+  let uu____4985 = lid_as_typ FStar_Parser_Const.char_lid [] []  in
+  let uu____4990 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_char  in
-  mk_emb em un uu____4983 uu____4988 
+  mk_emb em un uu____4985 uu____4990 
 let (e_string : Prims.string embedding) =
   let em _cb s = Constant (String (s, FStar_Range.dummyRange))  in
   let un _cb s =
     match s with
-    | Constant (String (s1,uu____5030)) -> FStar_Pervasives_Native.Some s1
-    | uu____5034 -> FStar_Pervasives_Native.None  in
-  let uu____5036 = lid_as_typ FStar_Parser_Const.string_lid [] []  in
-  let uu____5041 =
+    | Constant (String (s1,uu____5032)) -> FStar_Pervasives_Native.Some s1
+    | uu____5036 -> FStar_Pervasives_Native.None  in
+  let uu____5038 = lid_as_typ FStar_Parser_Const.string_lid [] []  in
+  let uu____5043 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_string  in
-  mk_emb em un uu____5036 uu____5041 
+  mk_emb em un uu____5038 uu____5043 
 let (e_int : FStar_BigInt.t embedding) =
   let em _cb c = Constant (Int c)  in
   let un _cb c =
     match c with
     | Constant (Int a) -> FStar_Pervasives_Native.Some a
-    | uu____5076 -> FStar_Pervasives_Native.None  in
-  let uu____5077 = lid_as_typ FStar_Parser_Const.int_lid [] []  in
-  let uu____5082 =
+    | uu____5078 -> FStar_Pervasives_Native.None  in
+  let uu____5079 = lid_as_typ FStar_Parser_Const.int_lid [] []  in
+  let uu____5084 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_int  in
-  mk_emb em un uu____5077 uu____5082 
+  mk_emb em un uu____5079 uu____5084 
 let e_option :
   'a . 'a embedding -> 'a FStar_Pervasives_Native.option embedding =
   fun ea  ->
     let etyp =
-      let uu____5103 =
-        let uu____5111 =
+      let uu____5105 =
+        let uu____5113 =
           FStar_All.pipe_right FStar_Parser_Const.option_lid
             FStar_Ident.string_of_lid
            in
-        (uu____5111, [ea.emb_typ])  in
-      FStar_Syntax_Syntax.ET_app uu____5103  in
+        (uu____5113, [ea.emb_typ])  in
+      FStar_Syntax_Syntax.ET_app uu____5105  in
     let em cb o =
       lazy_embed etyp o
-        (fun uu____5136  ->
+        (fun uu____5138  ->
            match o with
            | FStar_Pervasives_Native.None  ->
-               let uu____5137 =
-                 let uu____5138 =
-                   let uu____5143 = type_of ea  in as_iarg uu____5143  in
-                 [uu____5138]  in
+               let uu____5139 =
+                 let uu____5140 =
+                   let uu____5145 = type_of ea  in as_iarg uu____5145  in
+                 [uu____5140]  in
                lid_as_constr FStar_Parser_Const.none_lid
-                 [FStar_Syntax_Syntax.U_zero] uu____5137
+                 [FStar_Syntax_Syntax.U_zero] uu____5139
            | FStar_Pervasives_Native.Some x ->
-               let uu____5153 =
-                 let uu____5154 =
-                   let uu____5159 = embed ea cb x  in as_arg uu____5159  in
-                 let uu____5160 =
-                   let uu____5167 =
-                     let uu____5172 = type_of ea  in as_iarg uu____5172  in
-                   [uu____5167]  in
-                 uu____5154 :: uu____5160  in
+               let uu____5155 =
+                 let uu____5156 =
+                   let uu____5161 = embed ea cb x  in as_arg uu____5161  in
+                 let uu____5162 =
+                   let uu____5169 =
+                     let uu____5174 = type_of ea  in as_iarg uu____5174  in
+                   [uu____5169]  in
+                 uu____5156 :: uu____5162  in
                lid_as_constr FStar_Parser_Const.some_lid
-                 [FStar_Syntax_Syntax.U_zero] uu____5153)
+                 [FStar_Syntax_Syntax.U_zero] uu____5155)
        in
     let un cb trm =
       lazy_unembed cb etyp trm
@@ -1000,95 +1002,95 @@ let e_option :
            | Construct (fvar,us,args1) when
                FStar_Syntax_Syntax.fv_eq_lid fvar FStar_Parser_Const.none_lid
                -> FStar_Pervasives_Native.Some FStar_Pervasives_Native.None
-           | Construct (fvar,us,(a1,uu____5239)::uu____5240::[]) when
+           | Construct (fvar,us,(a1,uu____5241)::uu____5242::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fvar FStar_Parser_Const.some_lid
                ->
-               let uu____5267 = unembed ea cb a1  in
-               FStar_Util.bind_opt uu____5267
+               let uu____5269 = unembed ea cb a1  in
+               FStar_Util.bind_opt uu____5269
                  (fun a2  ->
                     FStar_Pervasives_Native.Some
                       (FStar_Pervasives_Native.Some a2))
-           | uu____5276 -> FStar_Pervasives_Native.None)
+           | uu____5278 -> FStar_Pervasives_Native.None)
        in
-    let uu____5279 =
-      let uu____5280 =
-        let uu____5281 = let uu____5286 = type_of ea  in as_arg uu____5286
+    let uu____5281 =
+      let uu____5282 =
+        let uu____5283 = let uu____5288 = type_of ea  in as_arg uu____5288
            in
-        [uu____5281]  in
+        [uu____5283]  in
       lid_as_typ FStar_Parser_Const.option_lid [FStar_Syntax_Syntax.U_zero]
-        uu____5280
+        uu____5282
        in
-    mk_emb em un uu____5279 etyp
+    mk_emb em un uu____5281 etyp
   
 let e_tuple2 : 'a 'b . 'a embedding -> 'b embedding -> ('a * 'b) embedding =
   fun ea  ->
     fun eb  ->
       let etyp =
-        let uu____5333 =
-          let uu____5341 =
+        let uu____5335 =
+          let uu____5343 =
             FStar_All.pipe_right FStar_Parser_Const.lid_tuple2
               FStar_Ident.string_of_lid
              in
-          (uu____5341, [ea.emb_typ; eb.emb_typ])  in
-        FStar_Syntax_Syntax.ET_app uu____5333  in
+          (uu____5343, [ea.emb_typ; eb.emb_typ])  in
+        FStar_Syntax_Syntax.ET_app uu____5335  in
       let em cb x =
         lazy_embed etyp x
-          (fun uu____5372  ->
-             let uu____5373 =
-               let uu____5374 =
-                 let uu____5379 = embed eb cb (FStar_Pervasives_Native.snd x)
+          (fun uu____5374  ->
+             let uu____5375 =
+               let uu____5376 =
+                 let uu____5381 = embed eb cb (FStar_Pervasives_Native.snd x)
                     in
-                 as_arg uu____5379  in
-               let uu____5380 =
-                 let uu____5387 =
-                   let uu____5392 =
+                 as_arg uu____5381  in
+               let uu____5382 =
+                 let uu____5389 =
+                   let uu____5394 =
                      embed ea cb (FStar_Pervasives_Native.fst x)  in
-                   as_arg uu____5392  in
-                 let uu____5393 =
-                   let uu____5400 =
-                     let uu____5405 = type_of eb  in as_iarg uu____5405  in
-                   let uu____5406 =
-                     let uu____5413 =
-                       let uu____5418 = type_of ea  in as_iarg uu____5418  in
-                     [uu____5413]  in
-                   uu____5400 :: uu____5406  in
-                 uu____5387 :: uu____5393  in
-               uu____5374 :: uu____5380  in
+                   as_arg uu____5394  in
+                 let uu____5395 =
+                   let uu____5402 =
+                     let uu____5407 = type_of eb  in as_iarg uu____5407  in
+                   let uu____5408 =
+                     let uu____5415 =
+                       let uu____5420 = type_of ea  in as_iarg uu____5420  in
+                     [uu____5415]  in
+                   uu____5402 :: uu____5408  in
+                 uu____5389 :: uu____5395  in
+               uu____5376 :: uu____5382  in
              lid_as_constr FStar_Parser_Const.lid_Mktuple2
                [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
-               uu____5373)
+               uu____5375)
          in
       let un cb trm =
         lazy_unembed cb etyp trm
           (fun trm1  ->
              match trm1 with
              | Construct
-                 (fvar,us,(b1,uu____5486)::(a1,uu____5488)::uu____5489::uu____5490::[])
+                 (fvar,us,(b1,uu____5488)::(a1,uu____5490)::uu____5491::uu____5492::[])
                  when
                  FStar_Syntax_Syntax.fv_eq_lid fvar
                    FStar_Parser_Const.lid_Mktuple2
                  ->
-                 let uu____5529 = unembed ea cb a1  in
-                 FStar_Util.bind_opt uu____5529
+                 let uu____5531 = unembed ea cb a1  in
+                 FStar_Util.bind_opt uu____5531
                    (fun a2  ->
-                      let uu____5539 = unembed eb cb b1  in
-                      FStar_Util.bind_opt uu____5539
+                      let uu____5541 = unembed eb cb b1  in
+                      FStar_Util.bind_opt uu____5541
                         (fun b2  -> FStar_Pervasives_Native.Some (a2, b2)))
-             | uu____5552 -> FStar_Pervasives_Native.None)
+             | uu____5554 -> FStar_Pervasives_Native.None)
          in
-      let uu____5557 =
-        let uu____5558 =
-          let uu____5559 = let uu____5564 = type_of eb  in as_arg uu____5564
+      let uu____5559 =
+        let uu____5560 =
+          let uu____5561 = let uu____5566 = type_of eb  in as_arg uu____5566
              in
-          let uu____5565 =
-            let uu____5572 =
-              let uu____5577 = type_of ea  in as_arg uu____5577  in
-            [uu____5572]  in
-          uu____5559 :: uu____5565  in
+          let uu____5567 =
+            let uu____5574 =
+              let uu____5579 = type_of ea  in as_arg uu____5579  in
+            [uu____5574]  in
+          uu____5561 :: uu____5567  in
         lid_as_typ FStar_Parser_Const.lid_tuple2
-          [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] uu____5558
+          [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] uu____5560
          in
-      mk_emb em un uu____5557 etyp
+      mk_emb em un uu____5559 etyp
   
 let e_either :
   'a 'b . 'a embedding -> 'b embedding -> ('a,'b) FStar_Util.either embedding
@@ -1096,130 +1098,130 @@ let e_either :
   fun ea  ->
     fun eb  ->
       let etyp =
-        let uu____5630 =
-          let uu____5638 =
+        let uu____5632 =
+          let uu____5640 =
             FStar_All.pipe_right FStar_Parser_Const.either_lid
               FStar_Ident.string_of_lid
              in
-          (uu____5638, [ea.emb_typ; eb.emb_typ])  in
-        FStar_Syntax_Syntax.ET_app uu____5630  in
+          (uu____5640, [ea.emb_typ; eb.emb_typ])  in
+        FStar_Syntax_Syntax.ET_app uu____5632  in
       let em cb s =
         lazy_embed etyp s
-          (fun uu____5670  ->
+          (fun uu____5672  ->
              match s with
              | FStar_Util.Inl a1 ->
-                 let uu____5672 =
-                   let uu____5673 =
-                     let uu____5678 = embed ea cb a1  in as_arg uu____5678
+                 let uu____5674 =
+                   let uu____5675 =
+                     let uu____5680 = embed ea cb a1  in as_arg uu____5680
                       in
-                   let uu____5679 =
-                     let uu____5686 =
-                       let uu____5691 = type_of eb  in as_iarg uu____5691  in
-                     let uu____5692 =
-                       let uu____5699 =
-                         let uu____5704 = type_of ea  in as_iarg uu____5704
+                   let uu____5681 =
+                     let uu____5688 =
+                       let uu____5693 = type_of eb  in as_iarg uu____5693  in
+                     let uu____5694 =
+                       let uu____5701 =
+                         let uu____5706 = type_of ea  in as_iarg uu____5706
                           in
-                       [uu____5699]  in
-                     uu____5686 :: uu____5692  in
-                   uu____5673 :: uu____5679  in
+                       [uu____5701]  in
+                     uu____5688 :: uu____5694  in
+                   uu____5675 :: uu____5681  in
                  lid_as_constr FStar_Parser_Const.inl_lid
                    [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
-                   uu____5672
+                   uu____5674
              | FStar_Util.Inr b1 ->
-                 let uu____5722 =
-                   let uu____5723 =
-                     let uu____5728 = embed eb cb b1  in as_arg uu____5728
+                 let uu____5724 =
+                   let uu____5725 =
+                     let uu____5730 = embed eb cb b1  in as_arg uu____5730
                       in
-                   let uu____5729 =
-                     let uu____5736 =
-                       let uu____5741 = type_of eb  in as_iarg uu____5741  in
-                     let uu____5742 =
-                       let uu____5749 =
-                         let uu____5754 = type_of ea  in as_iarg uu____5754
+                   let uu____5731 =
+                     let uu____5738 =
+                       let uu____5743 = type_of eb  in as_iarg uu____5743  in
+                     let uu____5744 =
+                       let uu____5751 =
+                         let uu____5756 = type_of ea  in as_iarg uu____5756
                           in
-                       [uu____5749]  in
-                     uu____5736 :: uu____5742  in
-                   uu____5723 :: uu____5729  in
+                       [uu____5751]  in
+                     uu____5738 :: uu____5744  in
+                   uu____5725 :: uu____5731  in
                  lid_as_constr FStar_Parser_Const.inr_lid
                    [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
-                   uu____5722)
+                   uu____5724)
          in
       let un cb trm =
         lazy_unembed cb etyp trm
           (fun trm1  ->
              match trm1 with
              | Construct
-                 (fvar,us,(a1,uu____5816)::uu____5817::uu____5818::[]) when
+                 (fvar,us,(a1,uu____5818)::uu____5819::uu____5820::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fvar
                    FStar_Parser_Const.inl_lid
                  ->
-                 let uu____5853 = unembed ea cb a1  in
-                 FStar_Util.bind_opt uu____5853
+                 let uu____5855 = unembed ea cb a1  in
+                 FStar_Util.bind_opt uu____5855
                    (fun a2  ->
                       FStar_Pervasives_Native.Some (FStar_Util.Inl a2))
              | Construct
-                 (fvar,us,(b1,uu____5869)::uu____5870::uu____5871::[]) when
+                 (fvar,us,(b1,uu____5871)::uu____5872::uu____5873::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fvar
                    FStar_Parser_Const.inr_lid
                  ->
-                 let uu____5906 = unembed eb cb b1  in
-                 FStar_Util.bind_opt uu____5906
+                 let uu____5908 = unembed eb cb b1  in
+                 FStar_Util.bind_opt uu____5908
                    (fun b2  ->
                       FStar_Pervasives_Native.Some (FStar_Util.Inr b2))
-             | uu____5919 -> FStar_Pervasives_Native.None)
+             | uu____5921 -> FStar_Pervasives_Native.None)
          in
-      let uu____5924 =
-        let uu____5925 =
-          let uu____5926 = let uu____5931 = type_of eb  in as_arg uu____5931
+      let uu____5926 =
+        let uu____5927 =
+          let uu____5928 = let uu____5933 = type_of eb  in as_arg uu____5933
              in
-          let uu____5932 =
-            let uu____5939 =
-              let uu____5944 = type_of ea  in as_arg uu____5944  in
-            [uu____5939]  in
-          uu____5926 :: uu____5932  in
+          let uu____5934 =
+            let uu____5941 =
+              let uu____5946 = type_of ea  in as_arg uu____5946  in
+            [uu____5941]  in
+          uu____5928 :: uu____5934  in
         lid_as_typ FStar_Parser_Const.either_lid
-          [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] uu____5925
+          [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] uu____5927
          in
-      mk_emb em un uu____5924 etyp
+      mk_emb em un uu____5926 etyp
   
 let (e_range : FStar_Range.range embedding) =
   let em cb r = Constant (Range r)  in
   let un cb t1 =
     match t1 with
     | Constant (Range r) -> FStar_Pervasives_Native.Some r
-    | uu____5993 -> FStar_Pervasives_Native.None  in
-  let uu____5994 = lid_as_typ FStar_Parser_Const.range_lid [] []  in
-  let uu____5999 =
+    | uu____5995 -> FStar_Pervasives_Native.None  in
+  let uu____5996 = lid_as_typ FStar_Parser_Const.range_lid [] []  in
+  let uu____6001 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_range  in
-  mk_emb em un uu____5994 uu____5999 
+  mk_emb em un uu____5996 uu____6001 
 let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
   fun ea  ->
     let etyp =
-      let uu____6020 =
-        let uu____6028 =
+      let uu____6022 =
+        let uu____6030 =
           FStar_All.pipe_right FStar_Parser_Const.list_lid
             FStar_Ident.string_of_lid
            in
-        (uu____6028, [ea.emb_typ])  in
-      FStar_Syntax_Syntax.ET_app uu____6020  in
+        (uu____6030, [ea.emb_typ])  in
+      FStar_Syntax_Syntax.ET_app uu____6022  in
     let em cb l =
       lazy_embed etyp l
-        (fun uu____6055  ->
-           let typ = let uu____6057 = type_of ea  in as_iarg uu____6057  in
+        (fun uu____6057  ->
+           let typ = let uu____6059 = type_of ea  in as_iarg uu____6059  in
            let nil =
              lid_as_constr FStar_Parser_Const.nil_lid
                [FStar_Syntax_Syntax.U_zero] [typ]
               in
            let cons hd tl =
-             let uu____6078 =
-               let uu____6079 = as_arg tl  in
-               let uu____6084 =
-                 let uu____6091 =
-                   let uu____6096 = embed ea cb hd  in as_arg uu____6096  in
-                 [uu____6091; typ]  in
-               uu____6079 :: uu____6084  in
+             let uu____6080 =
+               let uu____6081 = as_arg tl  in
+               let uu____6086 =
+                 let uu____6093 =
+                   let uu____6098 = embed ea cb hd  in as_arg uu____6098  in
+                 [uu____6093; typ]  in
+               uu____6081 :: uu____6086  in
              lid_as_constr FStar_Parser_Const.cons_lid
-               [FStar_Syntax_Syntax.U_zero] uu____6078
+               [FStar_Syntax_Syntax.U_zero] uu____6080
               in
            FStar_List.fold_right cons l nil)
        in
@@ -1227,46 +1229,46 @@ let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
       lazy_unembed cb etyp trm
         (fun trm1  ->
            match trm1 with
-           | Construct (fv,uu____6144,uu____6145) when
+           | Construct (fv,uu____6146,uu____6147) when
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid ->
                FStar_Pervasives_Native.Some []
            | Construct
-               (fv,uu____6165,(tl,FStar_Pervasives_Native.None )::(hd,FStar_Pervasives_Native.None
+               (fv,uu____6167,(tl,FStar_Pervasives_Native.None )::(hd,FStar_Pervasives_Native.None
                                                                    )::
-                (uu____6168,FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Syntax.Implicit uu____6169))::[])
+                (uu____6170,FStar_Pervasives_Native.Some
+                 (FStar_Syntax_Syntax.Implicit uu____6171))::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid
                ->
-               let uu____6197 = unembed ea cb hd  in
-               FStar_Util.bind_opt uu____6197
+               let uu____6199 = unembed ea cb hd  in
+               FStar_Util.bind_opt uu____6199
                  (fun hd1  ->
-                    let uu____6205 = un cb tl  in
-                    FStar_Util.bind_opt uu____6205
+                    let uu____6207 = un cb tl  in
+                    FStar_Util.bind_opt uu____6207
                       (fun tl1  -> FStar_Pervasives_Native.Some (hd1 :: tl1)))
            | Construct
-               (fv,uu____6221,(tl,FStar_Pervasives_Native.None )::(hd,FStar_Pervasives_Native.None
+               (fv,uu____6223,(tl,FStar_Pervasives_Native.None )::(hd,FStar_Pervasives_Native.None
                                                                    )::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid
                ->
-               let uu____6246 = unembed ea cb hd  in
-               FStar_Util.bind_opt uu____6246
+               let uu____6248 = unembed ea cb hd  in
+               FStar_Util.bind_opt uu____6248
                  (fun hd1  ->
-                    let uu____6254 = un cb tl  in
-                    FStar_Util.bind_opt uu____6254
+                    let uu____6256 = un cb tl  in
+                    FStar_Util.bind_opt uu____6256
                       (fun tl1  -> FStar_Pervasives_Native.Some (hd1 :: tl1)))
-           | uu____6269 -> FStar_Pervasives_Native.None)
+           | uu____6271 -> FStar_Pervasives_Native.None)
        in
-    let uu____6272 =
-      let uu____6273 =
-        let uu____6274 = let uu____6279 = type_of ea  in as_arg uu____6279
+    let uu____6274 =
+      let uu____6275 =
+        let uu____6276 = let uu____6281 = type_of ea  in as_arg uu____6281
            in
-        [uu____6274]  in
+        [uu____6276]  in
       lid_as_typ FStar_Parser_Const.list_lid [FStar_Syntax_Syntax.U_zero]
-        uu____6273
+        uu____6275
        in
-    mk_emb em un uu____6272 etyp
+    mk_emb em un uu____6274 etyp
   
 let (e_string_list : Prims.string Prims.list embedding) = e_list e_string 
 let e_arrow : 'a 'b . 'a embedding -> 'b embedding -> ('a -> 'b) embedding =
@@ -1275,230 +1277,230 @@ let e_arrow : 'a 'b . 'a embedding -> 'b embedding -> ('a -> 'b) embedding =
       let etyp = FStar_Syntax_Syntax.ET_fun ((ea.emb_typ), (eb.emb_typ))  in
       let em cb f =
         lazy_embed etyp f
-          (fun uu____6353  ->
-             let uu____6354 =
-               let uu____6387 =
-                 let uu____6408 =
-                   let uu____6415 =
-                     let uu____6420 = type_of eb  in as_arg uu____6420  in
-                   [uu____6415]  in
-                 FStar_Util.Inr uu____6408  in
+          (fun uu____6355  ->
+             let uu____6356 =
+               let uu____6389 =
+                 let uu____6410 =
+                   let uu____6417 =
+                     let uu____6422 = type_of eb  in as_arg uu____6422  in
+                   [uu____6417]  in
+                 FStar_Util.Inr uu____6410  in
                ((fun tas  ->
-                   let uu____6478 =
-                     let uu____6481 = FStar_List.hd tas  in
-                     unembed ea cb uu____6481  in
-                   match uu____6478 with
+                   let uu____6480 =
+                     let uu____6483 = FStar_List.hd tas  in
+                     unembed ea cb uu____6483  in
+                   match uu____6480 with
                    | FStar_Pervasives_Native.Some a1 ->
-                       let uu____6483 = f a1  in embed eb cb uu____6483
+                       let uu____6485 = f a1  in embed eb cb uu____6485
                    | FStar_Pervasives_Native.None  ->
                        failwith "cannot unembed function argument"),
-                 uu____6387, Prims.int_one)
+                 uu____6389, Prims.int_one)
                 in
-             Lam uu____6354)
+             Lam uu____6356)
          in
       let un cb lam =
         let k lam1 =
           FStar_Pervasives_Native.Some
             (fun x  ->
-               let uu____6530 =
-                 let uu____6533 =
-                   let uu____6534 =
-                     let uu____6535 =
-                       let uu____6540 = embed ea cb x  in as_arg uu____6540
+               let uu____6532 =
+                 let uu____6535 =
+                   let uu____6536 =
+                     let uu____6537 =
+                       let uu____6542 = embed ea cb x  in as_arg uu____6542
                         in
-                     [uu____6535]  in
-                   cb.iapp lam1 uu____6534  in
-                 unembed eb cb uu____6533  in
-               match uu____6530 with
+                     [uu____6537]  in
+                   cb.iapp lam1 uu____6536  in
+                 unembed eb cb uu____6535  in
+               match uu____6532 with
                | FStar_Pervasives_Native.Some y -> y
                | FStar_Pervasives_Native.None  ->
                    failwith "cannot unembed function result")
            in
         lazy_unembed cb etyp lam k  in
-      let uu____6554 =
-        let uu____6555 = type_of ea  in
-        let uu____6556 = let uu____6557 = type_of eb  in as_iarg uu____6557
+      let uu____6556 =
+        let uu____6557 = type_of ea  in
+        let uu____6558 = let uu____6559 = type_of eb  in as_iarg uu____6559
            in
-        make_arrow1 uu____6555 uu____6556  in
-      mk_emb em un uu____6554 etyp
+        make_arrow1 uu____6557 uu____6558  in
+      mk_emb em un uu____6556 etyp
   
 let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
   let em cb n =
     match n with
     | FStar_Syntax_Embeddings.Simpl  ->
-        let uu____6575 =
+        let uu____6577 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_simpl
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        mkFV uu____6575 [] []
+        mkFV uu____6577 [] []
     | FStar_Syntax_Embeddings.Weak  ->
-        let uu____6580 =
+        let uu____6582 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_weak
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        mkFV uu____6580 [] []
+        mkFV uu____6582 [] []
     | FStar_Syntax_Embeddings.HNF  ->
-        let uu____6585 =
+        let uu____6587 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_hnf
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        mkFV uu____6585 [] []
+        mkFV uu____6587 [] []
     | FStar_Syntax_Embeddings.Primops  ->
-        let uu____6590 =
+        let uu____6592 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_primops
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        mkFV uu____6590 [] []
+        mkFV uu____6592 [] []
     | FStar_Syntax_Embeddings.Delta  ->
-        let uu____6595 =
+        let uu____6597 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_delta
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        mkFV uu____6595 [] []
+        mkFV uu____6597 [] []
     | FStar_Syntax_Embeddings.Zeta  ->
-        let uu____6600 =
+        let uu____6602 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_zeta
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        mkFV uu____6600 [] []
+        mkFV uu____6602 [] []
     | FStar_Syntax_Embeddings.Iota  ->
-        let uu____6605 =
+        let uu____6607 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_iota
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        mkFV uu____6605 [] []
+        mkFV uu____6607 [] []
     | FStar_Syntax_Embeddings.Reify  ->
-        let uu____6610 =
+        let uu____6612 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_reify
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        mkFV uu____6610 [] []
+        mkFV uu____6612 [] []
     | FStar_Syntax_Embeddings.NBE  ->
-        let uu____6615 =
+        let uu____6617 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_nbe
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        mkFV uu____6615 [] []
+        mkFV uu____6617 [] []
     | FStar_Syntax_Embeddings.UnfoldOnly l ->
-        let uu____6624 =
+        let uu____6626 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldonly
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        let uu____6625 =
-          let uu____6626 =
-            let uu____6631 =
-              let uu____6632 = e_list e_string  in embed uu____6632 cb l  in
-            as_arg uu____6631  in
-          [uu____6626]  in
-        mkFV uu____6624 [] uu____6625
+        let uu____6627 =
+          let uu____6628 =
+            let uu____6633 =
+              let uu____6634 = e_list e_string  in embed uu____6634 cb l  in
+            as_arg uu____6633  in
+          [uu____6628]  in
+        mkFV uu____6626 [] uu____6627
     | FStar_Syntax_Embeddings.UnfoldFully l ->
-        let uu____6654 =
+        let uu____6656 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldfully
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        let uu____6655 =
-          let uu____6656 =
-            let uu____6661 =
-              let uu____6662 = e_list e_string  in embed uu____6662 cb l  in
-            as_arg uu____6661  in
-          [uu____6656]  in
-        mkFV uu____6654 [] uu____6655
+        let uu____6657 =
+          let uu____6658 =
+            let uu____6663 =
+              let uu____6664 = e_list e_string  in embed uu____6664 cb l  in
+            as_arg uu____6663  in
+          [uu____6658]  in
+        mkFV uu____6656 [] uu____6657
     | FStar_Syntax_Embeddings.UnfoldAttr l ->
-        let uu____6684 =
+        let uu____6686 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldattr
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        let uu____6685 =
-          let uu____6686 =
-            let uu____6691 =
-              let uu____6692 = e_list e_string  in embed uu____6692 cb l  in
-            as_arg uu____6691  in
-          [uu____6686]  in
-        mkFV uu____6684 [] uu____6685
+        let uu____6687 =
+          let uu____6688 =
+            let uu____6693 =
+              let uu____6694 = e_list e_string  in embed uu____6694 cb l  in
+            as_arg uu____6693  in
+          [uu____6688]  in
+        mkFV uu____6686 [] uu____6687
      in
   let un cb t0 =
     match t0 with
-    | FV (fv,uu____6726,[]) when
+    | FV (fv,uu____6728,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_simpl ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Simpl
-    | FV (fv,uu____6742,[]) when
+    | FV (fv,uu____6744,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_weak ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Weak
-    | FV (fv,uu____6758,[]) when
+    | FV (fv,uu____6760,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_hnf ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.HNF
-    | FV (fv,uu____6774,[]) when
+    | FV (fv,uu____6776,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_primops ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Primops
-    | FV (fv,uu____6790,[]) when
+    | FV (fv,uu____6792,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_delta ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Delta
-    | FV (fv,uu____6806,[]) when
+    | FV (fv,uu____6808,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_zeta ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Zeta
-    | FV (fv,uu____6822,[]) when
+    | FV (fv,uu____6824,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_iota ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Iota
-    | FV (fv,uu____6838,[]) when
+    | FV (fv,uu____6840,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_nbe ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.NBE
-    | FV (fv,uu____6854,[]) when
+    | FV (fv,uu____6856,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_reify ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Reify
-    | FV (fv,uu____6870,(l,uu____6872)::[]) when
+    | FV (fv,uu____6872,(l,uu____6874)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_unfoldonly
         ->
-        let uu____6891 =
-          let uu____6897 = e_list e_string  in unembed uu____6897 cb l  in
-        FStar_Util.bind_opt uu____6891
+        let uu____6893 =
+          let uu____6899 = e_list e_string  in unembed uu____6899 cb l  in
+        FStar_Util.bind_opt uu____6893
           (fun ss  ->
              FStar_All.pipe_left
-               (fun uu____6917  -> FStar_Pervasives_Native.Some uu____6917)
+               (fun uu____6919  -> FStar_Pervasives_Native.Some uu____6919)
                (FStar_Syntax_Embeddings.UnfoldOnly ss))
-    | FV (fv,uu____6919,(l,uu____6921)::[]) when
+    | FV (fv,uu____6921,(l,uu____6923)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_unfoldfully
         ->
-        let uu____6940 =
-          let uu____6946 = e_list e_string  in unembed uu____6946 cb l  in
-        FStar_Util.bind_opt uu____6940
+        let uu____6942 =
+          let uu____6948 = e_list e_string  in unembed uu____6948 cb l  in
+        FStar_Util.bind_opt uu____6942
           (fun ss  ->
              FStar_All.pipe_left
-               (fun uu____6966  -> FStar_Pervasives_Native.Some uu____6966)
+               (fun uu____6968  -> FStar_Pervasives_Native.Some uu____6968)
                (FStar_Syntax_Embeddings.UnfoldFully ss))
-    | FV (fv,uu____6968,(l,uu____6970)::[]) when
+    | FV (fv,uu____6970,(l,uu____6972)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_unfoldattr
         ->
-        let uu____6989 =
-          let uu____6995 = e_list e_string  in unembed uu____6995 cb l  in
-        FStar_Util.bind_opt uu____6989
+        let uu____6991 =
+          let uu____6997 = e_list e_string  in unembed uu____6997 cb l  in
+        FStar_Util.bind_opt uu____6991
           (fun ss  ->
              FStar_All.pipe_left
-               (fun uu____7015  -> FStar_Pervasives_Native.Some uu____7015)
+               (fun uu____7017  -> FStar_Pervasives_Native.Some uu____7017)
                (FStar_Syntax_Embeddings.UnfoldAttr ss))
-    | uu____7016 ->
-        ((let uu____7018 =
-            let uu____7024 =
-              let uu____7026 = t_to_string t0  in
-              FStar_Util.format1 "Not an embedded norm_step: %s" uu____7026
+    | uu____7018 ->
+        ((let uu____7020 =
+            let uu____7026 =
+              let uu____7028 = t_to_string t0  in
+              FStar_Util.format1 "Not an embedded norm_step: %s" uu____7028
                in
-            (FStar_Errors.Warning_NotEmbedded, uu____7024)  in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____7018);
+            (FStar_Errors.Warning_NotEmbedded, uu____7026)  in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu____7020);
          FStar_Pervasives_Native.None)
      in
-  let uu____7030 =
-    let uu____7031 =
+  let uu____7032 =
+    let uu____7033 =
       FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.norm_step_lid
         FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
        in
-    mkFV uu____7031 [] []  in
-  let uu____7036 =
+    mkFV uu____7033 [] []  in
+  let uu____7038 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_norm_step
      in
-  mk_emb em un uu____7030 uu____7036 
+  mk_emb em un uu____7032 uu____7038 
 let (bogus_cbs : nbe_cbs) =
   {
     iapp = (fun h  -> fun _args  -> h);
-    translate = (fun uu____7045  -> failwith "bogus_cbs translate")
+    translate = (fun uu____7047  -> failwith "bogus_cbs translate")
   } 
 let (arg_as_int : arg -> FStar_BigInt.t FStar_Pervasives_Native.option) =
   fun a  ->
@@ -1524,34 +1526,34 @@ let arg_as_list :
   'a . 'a embedding -> arg -> 'a Prims.list FStar_Pervasives_Native.option =
   fun e  ->
     fun a1  ->
-      let uu____7122 =
-        let uu____7131 = e_list e  in unembed uu____7131 bogus_cbs  in
-      FStar_All.pipe_right (FStar_Pervasives_Native.fst a1) uu____7122
+      let uu____7124 =
+        let uu____7133 = e_list e  in unembed uu____7133 bogus_cbs  in
+      FStar_All.pipe_right (FStar_Pervasives_Native.fst a1) uu____7124
   
 let (arg_as_bounded_int :
   arg ->
     (FStar_Syntax_Syntax.fv * FStar_BigInt.t) FStar_Pervasives_Native.option)
   =
-  fun uu____7153  ->
-    match uu____7153 with
-    | (a,uu____7161) ->
+  fun uu____7155  ->
+    match uu____7155 with
+    | (a,uu____7163) ->
         (match a with
-         | FV (fv1,[],(Constant (Int i),uu____7176)::[]) when
-             let uu____7193 =
-               FStar_Ident.text_of_lid
+         | FV (fv1,[],(Constant (Int i),uu____7178)::[]) when
+             let uu____7195 =
+               FStar_Ident.string_of_lid
                  (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                 in
-             FStar_Util.ends_with uu____7193 "int_to_t" ->
+             FStar_Util.ends_with uu____7195 "int_to_t" ->
              FStar_Pervasives_Native.Some (fv1, i)
-         | uu____7200 -> FStar_Pervasives_Native.None)
+         | uu____7202 -> FStar_Pervasives_Native.None)
   
 let (int_as_bounded : FStar_Syntax_Syntax.fv -> FStar_BigInt.t -> t) =
   fun int_to_t  ->
     fun n  ->
       let c = embed e_int bogus_cbs n  in
       let int_to_t1 args1 = FV (int_to_t, [], args1)  in
-      let uu____7243 = let uu____7250 = as_arg c  in [uu____7250]  in
-      int_to_t1 uu____7243
+      let uu____7245 = let uu____7252 = as_arg c  in [uu____7252]  in
+      int_to_t1 uu____7245
   
 let lift_unary :
   'a 'b .
@@ -1563,8 +1565,8 @@ let lift_unary :
     fun aopts  ->
       match aopts with
       | (FStar_Pervasives_Native.Some a1)::[] ->
-          let uu____7304 = f a1  in FStar_Pervasives_Native.Some uu____7304
-      | uu____7305 -> FStar_Pervasives_Native.None
+          let uu____7306 = f a1  in FStar_Pervasives_Native.Some uu____7306
+      | uu____7307 -> FStar_Pervasives_Native.None
   
 let lift_binary :
   'a 'b .
@@ -1577,9 +1579,9 @@ let lift_binary :
       match aopts with
       | (FStar_Pervasives_Native.Some a0)::(FStar_Pervasives_Native.Some
           a1)::[] ->
-          let uu____7359 = f a0 a1  in
-          FStar_Pervasives_Native.Some uu____7359
-      | uu____7360 -> FStar_Pervasives_Native.None
+          let uu____7361 = f a0 a1  in
+          FStar_Pervasives_Native.Some uu____7361
+      | uu____7362 -> FStar_Pervasives_Native.None
   
 let unary_op :
   'a .
@@ -1589,8 +1591,8 @@ let unary_op :
   fun as_a  ->
     fun f  ->
       fun args1  ->
-        let uu____7404 = FStar_List.map as_a args1  in
-        lift_unary f uu____7404
+        let uu____7406 = FStar_List.map as_a args1  in
+        lift_unary f uu____7406
   
 let binary_op :
   'a .
@@ -1600,8 +1602,8 @@ let binary_op :
   fun as_a  ->
     fun f  ->
       fun args1  ->
-        let uu____7459 = FStar_List.map as_a args1  in
-        lift_binary f uu____7459
+        let uu____7461 = FStar_List.map as_a args1  in
+        lift_binary f uu____7461
   
 let (unary_int_op :
   (FStar_BigInt.t -> FStar_BigInt.t) ->
@@ -1609,7 +1611,7 @@ let (unary_int_op :
   =
   fun f  ->
     unary_op arg_as_int
-      (fun x  -> let uu____7489 = f x  in embed e_int bogus_cbs uu____7489)
+      (fun x  -> let uu____7491 = f x  in embed e_int bogus_cbs uu____7491)
   
 let (binary_int_op :
   (FStar_BigInt.t -> FStar_BigInt.t -> FStar_BigInt.t) ->
@@ -1619,13 +1621,13 @@ let (binary_int_op :
     binary_op arg_as_int
       (fun x  ->
          fun y  ->
-           let uu____7516 = f x y  in embed e_int bogus_cbs uu____7516)
+           let uu____7518 = f x y  in embed e_int bogus_cbs uu____7518)
   
 let (unary_bool_op :
   (Prims.bool -> Prims.bool) -> args -> t FStar_Pervasives_Native.option) =
   fun f  ->
     unary_op arg_as_bool
-      (fun x  -> let uu____7542 = f x  in embed e_bool bogus_cbs uu____7542)
+      (fun x  -> let uu____7544 = f x  in embed e_bool bogus_cbs uu____7544)
   
 let (binary_bool_op :
   (Prims.bool -> Prims.bool -> Prims.bool) ->
@@ -1635,7 +1637,7 @@ let (binary_bool_op :
     binary_op arg_as_bool
       (fun x  ->
          fun y  ->
-           let uu____7580 = f x y  in embed e_bool bogus_cbs uu____7580)
+           let uu____7582 = f x y  in embed e_bool bogus_cbs uu____7582)
   
 let (binary_string_op :
   (Prims.string -> Prims.string -> Prims.string) ->
@@ -1645,7 +1647,7 @@ let (binary_string_op :
     binary_op arg_as_string
       (fun x  ->
          fun y  ->
-           let uu____7618 = f x y  in embed e_string bogus_cbs uu____7618)
+           let uu____7620 = f x y  in embed e_string bogus_cbs uu____7620)
   
 let mixed_binary_op :
   'a 'b 'c .
@@ -1661,23 +1663,23 @@ let mixed_binary_op :
           fun args1  ->
             match args1 with
             | a1::b1::[] ->
-                let uu____7723 =
-                  let uu____7732 = as_a a1  in
-                  let uu____7735 = as_b b1  in (uu____7732, uu____7735)  in
-                (match uu____7723 with
+                let uu____7725 =
+                  let uu____7734 = as_a a1  in
+                  let uu____7737 = as_b b1  in (uu____7734, uu____7737)  in
+                (match uu____7725 with
                  | (FStar_Pervasives_Native.Some
                     a2,FStar_Pervasives_Native.Some b2) ->
-                     let uu____7750 =
-                       let uu____7751 = f a2 b2  in embed_c uu____7751  in
-                     FStar_Pervasives_Native.Some uu____7750
-                 | uu____7752 -> FStar_Pervasives_Native.None)
-            | uu____7761 -> FStar_Pervasives_Native.None
+                     let uu____7752 =
+                       let uu____7753 = f a2 b2  in embed_c uu____7753  in
+                     FStar_Pervasives_Native.Some uu____7752
+                 | uu____7754 -> FStar_Pervasives_Native.None)
+            | uu____7763 -> FStar_Pervasives_Native.None
   
 let (list_of_string' : Prims.string -> t) =
   fun s  ->
-    let uu____7770 = e_list e_char  in
-    let uu____7777 = FStar_String.list_of_string s  in
-    embed uu____7770 bogus_cbs uu____7777
+    let uu____7772 = e_list e_char  in
+    let uu____7779 = FStar_String.list_of_string s  in
+    embed uu____7772 bogus_cbs uu____7779
   
 let (string_of_list' : FStar_Char.char Prims.list -> t) =
   fun l  ->
@@ -1688,32 +1690,32 @@ let (string_compare' : Prims.string -> Prims.string -> t) =
   fun s1  ->
     fun s2  ->
       let r = FStar_String.compare s1 s2  in
-      let uu____7816 =
-        let uu____7817 = FStar_Util.string_of_int r  in
-        FStar_BigInt.big_int_of_string uu____7817  in
-      embed e_int bogus_cbs uu____7816
+      let uu____7818 =
+        let uu____7819 = FStar_Util.string_of_int r  in
+        FStar_BigInt.big_int_of_string uu____7819  in
+      embed e_int bogus_cbs uu____7818
   
 let (string_concat' : args -> t FStar_Pervasives_Native.option) =
   fun args1  ->
     match args1 with
     | a1::a2::[] ->
-        let uu____7851 = arg_as_string a1  in
-        (match uu____7851 with
+        let uu____7853 = arg_as_string a1  in
+        (match uu____7853 with
          | FStar_Pervasives_Native.Some s1 ->
-             let uu____7860 = arg_as_list e_string a2  in
-             (match uu____7860 with
+             let uu____7862 = arg_as_list e_string a2  in
+             (match uu____7862 with
               | FStar_Pervasives_Native.Some s2 ->
                   let r = FStar_String.concat s1 s2  in
-                  let uu____7878 = embed e_string bogus_cbs r  in
-                  FStar_Pervasives_Native.Some uu____7878
-              | uu____7880 -> FStar_Pervasives_Native.None)
-         | uu____7886 -> FStar_Pervasives_Native.None)
-    | uu____7890 -> FStar_Pervasives_Native.None
+                  let uu____7880 = embed e_string bogus_cbs r  in
+                  FStar_Pervasives_Native.Some uu____7880
+              | uu____7882 -> FStar_Pervasives_Native.None)
+         | uu____7888 -> FStar_Pervasives_Native.None)
+    | uu____7892 -> FStar_Pervasives_Native.None
   
 let (string_of_int : FStar_BigInt.t -> t) =
   fun i  ->
-    let uu____7897 = FStar_BigInt.string_of_big_int i  in
-    embed e_string bogus_cbs uu____7897
+    let uu____7899 = FStar_BigInt.string_of_big_int i  in
+    embed e_string bogus_cbs uu____7899
   
 let (string_of_bool : Prims.bool -> t) =
   fun b  -> embed e_string bogus_cbs (if b then "true" else "false") 
@@ -1727,186 +1729,186 @@ let (decidable_eq : Prims.bool -> args -> t FStar_Pervasives_Native.option) =
       let tru = embed e_bool bogus_cbs true  in
       let fal = embed e_bool bogus_cbs false  in
       match args1 with
-      | (_typ,uu____7959)::(a1,uu____7961)::(a2,uu____7963)::[] ->
-          let uu____7980 = eq_t a1 a2  in
-          (match uu____7980 with
+      | (_typ,uu____7961)::(a1,uu____7963)::(a2,uu____7965)::[] ->
+          let uu____7982 = eq_t a1 a2  in
+          (match uu____7982 with
            | FStar_Syntax_Util.Equal  ->
                FStar_Pervasives_Native.Some (if neg then fal else tru)
            | FStar_Syntax_Util.NotEqual  ->
                FStar_Pervasives_Native.Some (if neg then tru else fal)
-           | uu____7989 -> FStar_Pervasives_Native.None)
-      | uu____7990 -> failwith "Unexpected number of arguments"
+           | uu____7991 -> FStar_Pervasives_Native.None)
+      | uu____7992 -> failwith "Unexpected number of arguments"
   
 let (interp_prop_eq2 : args -> t FStar_Pervasives_Native.option) =
   fun args1  ->
     match args1 with
-    | (_u,uu____8005)::(_typ,uu____8007)::(a1,uu____8009)::(a2,uu____8011)::[]
+    | (_u,uu____8007)::(_typ,uu____8009)::(a1,uu____8011)::(a2,uu____8013)::[]
         ->
-        let uu____8032 = eq_t a1 a2  in
-        (match uu____8032 with
+        let uu____8034 = eq_t a1 a2  in
+        (match uu____8034 with
          | FStar_Syntax_Util.Equal  ->
-             let uu____8035 = embed e_bool bogus_cbs true  in
-             FStar_Pervasives_Native.Some uu____8035
+             let uu____8037 = embed e_bool bogus_cbs true  in
+             FStar_Pervasives_Native.Some uu____8037
          | FStar_Syntax_Util.NotEqual  ->
-             let uu____8038 = embed e_bool bogus_cbs false  in
-             FStar_Pervasives_Native.Some uu____8038
+             let uu____8040 = embed e_bool bogus_cbs false  in
+             FStar_Pervasives_Native.Some uu____8040
          | FStar_Syntax_Util.Unknown  -> FStar_Pervasives_Native.None)
-    | uu____8041 -> failwith "Unexpected number of arguments"
+    | uu____8043 -> failwith "Unexpected number of arguments"
   
 let (interp_prop_eq3 : args -> t FStar_Pervasives_Native.option) =
   fun args1  ->
     match args1 with
-    | (_u,uu____8056)::(_v,uu____8058)::(t1,uu____8060)::(t2,uu____8062)::
-        (a1,uu____8064)::(a2,uu____8066)::[] ->
-        let uu____8095 =
-          let uu____8096 = eq_t t1 t2  in
-          let uu____8097 = eq_t a1 a2  in
-          FStar_Syntax_Util.eq_inj uu____8096 uu____8097  in
-        (match uu____8095 with
+    | (_u,uu____8058)::(_v,uu____8060)::(t1,uu____8062)::(t2,uu____8064)::
+        (a1,uu____8066)::(a2,uu____8068)::[] ->
+        let uu____8097 =
+          let uu____8098 = eq_t t1 t2  in
+          let uu____8099 = eq_t a1 a2  in
+          FStar_Syntax_Util.eq_inj uu____8098 uu____8099  in
+        (match uu____8097 with
          | FStar_Syntax_Util.Equal  ->
-             let uu____8100 = embed e_bool bogus_cbs true  in
-             FStar_Pervasives_Native.Some uu____8100
+             let uu____8102 = embed e_bool bogus_cbs true  in
+             FStar_Pervasives_Native.Some uu____8102
          | FStar_Syntax_Util.NotEqual  ->
-             let uu____8103 = embed e_bool bogus_cbs false  in
-             FStar_Pervasives_Native.Some uu____8103
+             let uu____8105 = embed e_bool bogus_cbs false  in
+             FStar_Pervasives_Native.Some uu____8105
          | FStar_Syntax_Util.Unknown  -> FStar_Pervasives_Native.None)
-    | uu____8106 -> failwith "Unexpected number of arguments"
+    | uu____8108 -> failwith "Unexpected number of arguments"
   
 let (dummy_interp :
   FStar_Ident.lid -> args -> t FStar_Pervasives_Native.option) =
   fun lid  ->
     fun args1  ->
-      let uu____8125 =
-        let uu____8127 = FStar_Ident.string_of_lid lid  in
-        FStar_String.op_Hat "No interpretation for " uu____8127  in
-      failwith uu____8125
+      let uu____8127 =
+        let uu____8129 = FStar_Ident.string_of_lid lid  in
+        FStar_String.op_Hat "No interpretation for " uu____8129  in
+      failwith uu____8127
   
 let (prims_to_fstar_range_step : args -> t FStar_Pervasives_Native.option) =
   fun args1  ->
     match args1 with
-    | (a1,uu____8143)::[] ->
-        let uu____8152 = unembed e_range bogus_cbs a1  in
-        (match uu____8152 with
+    | (a1,uu____8145)::[] ->
+        let uu____8154 = unembed e_range bogus_cbs a1  in
+        (match uu____8154 with
          | FStar_Pervasives_Native.Some r ->
-             let uu____8158 = embed e_range bogus_cbs r  in
-             FStar_Pervasives_Native.Some uu____8158
+             let uu____8160 = embed e_range bogus_cbs r  in
+             FStar_Pervasives_Native.Some uu____8160
          | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None)
-    | uu____8159 -> failwith "Unexpected number of arguments"
+    | uu____8161 -> failwith "Unexpected number of arguments"
   
 let (string_split' : args -> t FStar_Pervasives_Native.option) =
   fun args1  ->
     match args1 with
     | a1::a2::[] ->
-        let uu____8195 = arg_as_list e_char a1  in
-        (match uu____8195 with
+        let uu____8197 = arg_as_list e_char a1  in
+        (match uu____8197 with
          | FStar_Pervasives_Native.Some s1 ->
-             let uu____8211 = arg_as_string a2  in
-             (match uu____8211 with
+             let uu____8213 = arg_as_string a2  in
+             (match uu____8213 with
               | FStar_Pervasives_Native.Some s2 ->
                   let r = FStar_String.split s1 s2  in
-                  let uu____8224 =
-                    let uu____8225 = e_list e_string  in
-                    embed uu____8225 bogus_cbs r  in
-                  FStar_Pervasives_Native.Some uu____8224
-              | uu____8235 -> FStar_Pervasives_Native.None)
-         | uu____8239 -> FStar_Pervasives_Native.None)
-    | uu____8245 -> FStar_Pervasives_Native.None
+                  let uu____8226 =
+                    let uu____8227 = e_list e_string  in
+                    embed uu____8227 bogus_cbs r  in
+                  FStar_Pervasives_Native.Some uu____8226
+              | uu____8237 -> FStar_Pervasives_Native.None)
+         | uu____8241 -> FStar_Pervasives_Native.None)
+    | uu____8247 -> FStar_Pervasives_Native.None
   
 let (string_index : args -> t FStar_Pervasives_Native.option) =
   fun args1  ->
     match args1 with
     | a1::a2::[] ->
-        let uu____8278 =
-          let uu____8288 = arg_as_string a1  in
-          let uu____8292 = arg_as_int a2  in (uu____8288, uu____8292)  in
-        (match uu____8278 with
+        let uu____8280 =
+          let uu____8290 = arg_as_string a1  in
+          let uu____8294 = arg_as_int a2  in (uu____8290, uu____8294)  in
+        (match uu____8280 with
          | (FStar_Pervasives_Native.Some s,FStar_Pervasives_Native.Some i) ->
              (try
-                (fun uu___1008_8316  ->
+                (fun uu___1008_8318  ->
                    match () with
                    | () ->
                        let r = FStar_String.index s i  in
-                       let uu____8321 = embed e_char bogus_cbs r  in
-                       FStar_Pervasives_Native.Some uu____8321) ()
-              with | uu___1007_8324 -> FStar_Pervasives_Native.None)
-         | uu____8327 -> FStar_Pervasives_Native.None)
-    | uu____8337 -> FStar_Pervasives_Native.None
+                       let uu____8323 = embed e_char bogus_cbs r  in
+                       FStar_Pervasives_Native.Some uu____8323) ()
+              with | uu___1007_8326 -> FStar_Pervasives_Native.None)
+         | uu____8329 -> FStar_Pervasives_Native.None)
+    | uu____8339 -> FStar_Pervasives_Native.None
   
 let (string_index_of : args -> t FStar_Pervasives_Native.option) =
   fun args1  ->
     match args1 with
     | a1::a2::[] ->
-        let uu____8370 =
-          let uu____8381 = arg_as_string a1  in
-          let uu____8385 = arg_as_char a2  in (uu____8381, uu____8385)  in
-        (match uu____8370 with
+        let uu____8372 =
+          let uu____8383 = arg_as_string a1  in
+          let uu____8387 = arg_as_char a2  in (uu____8383, uu____8387)  in
+        (match uu____8372 with
          | (FStar_Pervasives_Native.Some s,FStar_Pervasives_Native.Some c) ->
              (try
-                (fun uu___1026_8414  ->
+                (fun uu___1026_8416  ->
                    match () with
                    | () ->
                        let r = FStar_String.index_of s c  in
-                       let uu____8418 = embed e_int bogus_cbs r  in
-                       FStar_Pervasives_Native.Some uu____8418) ()
-              with | uu___1025_8420 -> FStar_Pervasives_Native.None)
-         | uu____8423 -> FStar_Pervasives_Native.None)
-    | uu____8434 -> FStar_Pervasives_Native.None
+                       let uu____8420 = embed e_int bogus_cbs r  in
+                       FStar_Pervasives_Native.Some uu____8420) ()
+              with | uu___1025_8422 -> FStar_Pervasives_Native.None)
+         | uu____8425 -> FStar_Pervasives_Native.None)
+    | uu____8436 -> FStar_Pervasives_Native.None
   
 let (string_substring' : args -> t FStar_Pervasives_Native.option) =
   fun args1  ->
     match args1 with
     | a1::a2::a3::[] ->
-        let uu____8476 =
-          let uu____8490 = arg_as_string a1  in
-          let uu____8494 = arg_as_int a2  in
-          let uu____8497 = arg_as_int a3  in
-          (uu____8490, uu____8494, uu____8497)  in
-        (match uu____8476 with
+        let uu____8478 =
+          let uu____8492 = arg_as_string a1  in
+          let uu____8496 = arg_as_int a2  in
+          let uu____8499 = arg_as_int a3  in
+          (uu____8492, uu____8496, uu____8499)  in
+        (match uu____8478 with
          | (FStar_Pervasives_Native.Some s1,FStar_Pervasives_Native.Some
             n1,FStar_Pervasives_Native.Some n2) ->
              let n11 = FStar_BigInt.to_int_fs n1  in
              let n21 = FStar_BigInt.to_int_fs n2  in
              (try
-                (fun uu___1049_8530  ->
+                (fun uu___1049_8532  ->
                    match () with
                    | () ->
                        let r = FStar_String.substring s1 n11 n21  in
-                       let uu____8535 = embed e_string bogus_cbs r  in
-                       FStar_Pervasives_Native.Some uu____8535) ()
-              with | uu___1048_8538 -> FStar_Pervasives_Native.None)
-         | uu____8541 -> FStar_Pervasives_Native.None)
-    | uu____8555 -> FStar_Pervasives_Native.None
+                       let uu____8537 = embed e_string bogus_cbs r  in
+                       FStar_Pervasives_Native.Some uu____8537) ()
+              with | uu___1048_8540 -> FStar_Pervasives_Native.None)
+         | uu____8543 -> FStar_Pervasives_Native.None)
+    | uu____8557 -> FStar_Pervasives_Native.None
   
 let (mk_range : args -> t FStar_Pervasives_Native.option) =
   fun args1  ->
     match args1 with
     | fn::from_line::from_col::to_line::to_col::[] ->
-        let uu____8615 =
-          let uu____8637 = arg_as_string fn  in
-          let uu____8641 = arg_as_int from_line  in
-          let uu____8644 = arg_as_int from_col  in
-          let uu____8647 = arg_as_int to_line  in
-          let uu____8650 = arg_as_int to_col  in
-          (uu____8637, uu____8641, uu____8644, uu____8647, uu____8650)  in
-        (match uu____8615 with
+        let uu____8617 =
+          let uu____8639 = arg_as_string fn  in
+          let uu____8643 = arg_as_int from_line  in
+          let uu____8646 = arg_as_int from_col  in
+          let uu____8649 = arg_as_int to_line  in
+          let uu____8652 = arg_as_int to_col  in
+          (uu____8639, uu____8643, uu____8646, uu____8649, uu____8652)  in
+        (match uu____8617 with
          | (FStar_Pervasives_Native.Some fn1,FStar_Pervasives_Native.Some
             from_l,FStar_Pervasives_Native.Some
             from_c,FStar_Pervasives_Native.Some
             to_l,FStar_Pervasives_Native.Some to_c) ->
              let r =
-               let uu____8685 =
-                 let uu____8686 = FStar_BigInt.to_int_fs from_l  in
-                 let uu____8688 = FStar_BigInt.to_int_fs from_c  in
-                 FStar_Range.mk_pos uu____8686 uu____8688  in
-               let uu____8690 =
-                 let uu____8691 = FStar_BigInt.to_int_fs to_l  in
-                 let uu____8693 = FStar_BigInt.to_int_fs to_c  in
-                 FStar_Range.mk_pos uu____8691 uu____8693  in
-               FStar_Range.mk_range fn1 uu____8685 uu____8690  in
-             let uu____8695 = embed e_range bogus_cbs r  in
-             FStar_Pervasives_Native.Some uu____8695
-         | uu____8696 -> FStar_Pervasives_Native.None)
-    | uu____8718 -> FStar_Pervasives_Native.None
+               let uu____8687 =
+                 let uu____8688 = FStar_BigInt.to_int_fs from_l  in
+                 let uu____8690 = FStar_BigInt.to_int_fs from_c  in
+                 FStar_Range.mk_pos uu____8688 uu____8690  in
+               let uu____8692 =
+                 let uu____8693 = FStar_BigInt.to_int_fs to_l  in
+                 let uu____8695 = FStar_BigInt.to_int_fs to_c  in
+                 FStar_Range.mk_pos uu____8693 uu____8695  in
+               FStar_Range.mk_range fn1 uu____8687 uu____8692  in
+             let uu____8697 = embed e_range bogus_cbs r  in
+             FStar_Pervasives_Native.Some uu____8697
+         | uu____8698 -> FStar_Pervasives_Native.None)
+    | uu____8720 -> FStar_Pervasives_Native.None
   
 let arrow_as_prim_step_1 :
   'a 'b .
@@ -1924,17 +1926,17 @@ let arrow_as_prim_step_1 :
           fun _fv_lid  ->
             fun cb  ->
               let f_wrapped args1 =
-                let uu____8808 = FStar_List.splitAt n_tvars args1  in
-                match uu____8808 with
+                let uu____8810 = FStar_List.splitAt n_tvars args1  in
+                match uu____8810 with
                 | (_tvar_args,rest_args) ->
-                    let uu____8857 = FStar_List.hd rest_args  in
-                    (match uu____8857 with
-                     | (x,uu____8869) ->
-                         let uu____8870 = unembed ea cb x  in
-                         FStar_Util.map_opt uu____8870
+                    let uu____8859 = FStar_List.hd rest_args  in
+                    (match uu____8859 with
+                     | (x,uu____8871) ->
+                         let uu____8872 = unembed ea cb x  in
+                         FStar_Util.map_opt uu____8872
                            (fun x1  ->
-                              let uu____8876 = f x1  in
-                              embed eb cb uu____8876))
+                              let uu____8878 = f x1  in
+                              embed eb cb uu____8878))
                  in
               f_wrapped
   
@@ -1956,28 +1958,28 @@ let arrow_as_prim_step_2 :
             fun _fv_lid  ->
               fun cb  ->
                 let f_wrapped args1 =
-                  let uu____8985 = FStar_List.splitAt n_tvars args1  in
-                  match uu____8985 with
+                  let uu____8987 = FStar_List.splitAt n_tvars args1  in
+                  match uu____8987 with
                   | (_tvar_args,rest_args) ->
-                      let uu____9034 = FStar_List.hd rest_args  in
-                      (match uu____9034 with
-                       | (x,uu____9046) ->
-                           let uu____9047 =
-                             let uu____9052 = FStar_List.tl rest_args  in
-                             FStar_List.hd uu____9052  in
-                           (match uu____9047 with
-                            | (y,uu____9070) ->
-                                let uu____9071 = unembed ea cb x  in
-                                FStar_Util.bind_opt uu____9071
+                      let uu____9036 = FStar_List.hd rest_args  in
+                      (match uu____9036 with
+                       | (x,uu____9048) ->
+                           let uu____9049 =
+                             let uu____9054 = FStar_List.tl rest_args  in
+                             FStar_List.hd uu____9054  in
+                           (match uu____9049 with
+                            | (y,uu____9072) ->
+                                let uu____9073 = unembed ea cb x  in
+                                FStar_Util.bind_opt uu____9073
                                   (fun x1  ->
-                                     let uu____9077 = unembed eb cb y  in
-                                     FStar_Util.bind_opt uu____9077
+                                     let uu____9079 = unembed eb cb y  in
+                                     FStar_Util.bind_opt uu____9079
                                        (fun y1  ->
-                                          let uu____9083 =
-                                            let uu____9084 = f x1 y1  in
-                                            embed ec cb uu____9084  in
+                                          let uu____9085 =
+                                            let uu____9086 = f x1 y1  in
+                                            embed ec cb uu____9086  in
                                           FStar_Pervasives_Native.Some
-                                            uu____9083))))
+                                            uu____9085))))
                    in
                 f_wrapped
   
@@ -2001,45 +2003,45 @@ let arrow_as_prim_step_3 :
               fun _fv_lid  ->
                 fun cb  ->
                   let f_wrapped args1 =
-                    let uu____9212 = FStar_List.splitAt n_tvars args1  in
-                    match uu____9212 with
+                    let uu____9214 = FStar_List.splitAt n_tvars args1  in
+                    match uu____9214 with
                     | (_tvar_args,rest_args) ->
-                        let uu____9261 = FStar_List.hd rest_args  in
-                        (match uu____9261 with
-                         | (x,uu____9273) ->
-                             let uu____9274 =
-                               let uu____9279 = FStar_List.tl rest_args  in
-                               FStar_List.hd uu____9279  in
-                             (match uu____9274 with
-                              | (y,uu____9297) ->
-                                  let uu____9298 =
-                                    let uu____9303 =
-                                      let uu____9310 =
+                        let uu____9263 = FStar_List.hd rest_args  in
+                        (match uu____9263 with
+                         | (x,uu____9275) ->
+                             let uu____9276 =
+                               let uu____9281 = FStar_List.tl rest_args  in
+                               FStar_List.hd uu____9281  in
+                             (match uu____9276 with
+                              | (y,uu____9299) ->
+                                  let uu____9300 =
+                                    let uu____9305 =
+                                      let uu____9312 =
                                         FStar_List.tl rest_args  in
-                                      FStar_List.tl uu____9310  in
-                                    FStar_List.hd uu____9303  in
-                                  (match uu____9298 with
-                                   | (z,uu____9332) ->
-                                       let uu____9333 = unembed ea cb x  in
-                                       FStar_Util.bind_opt uu____9333
+                                      FStar_List.tl uu____9312  in
+                                    FStar_List.hd uu____9305  in
+                                  (match uu____9300 with
+                                   | (z,uu____9334) ->
+                                       let uu____9335 = unembed ea cb x  in
+                                       FStar_Util.bind_opt uu____9335
                                          (fun x1  ->
-                                            let uu____9339 = unembed eb cb y
+                                            let uu____9341 = unembed eb cb y
                                                in
-                                            FStar_Util.bind_opt uu____9339
+                                            FStar_Util.bind_opt uu____9341
                                               (fun y1  ->
-                                                 let uu____9345 =
+                                                 let uu____9347 =
                                                    unembed ec cb z  in
                                                  FStar_Util.bind_opt
-                                                   uu____9345
+                                                   uu____9347
                                                    (fun z1  ->
-                                                      let uu____9351 =
-                                                        let uu____9352 =
+                                                      let uu____9353 =
+                                                        let uu____9354 =
                                                           f x1 y1 z1  in
                                                         embed ed cb
-                                                          uu____9352
+                                                          uu____9354
                                                          in
                                                       FStar_Pervasives_Native.Some
-                                                        uu____9351))))))
+                                                        uu____9353))))))
                      in
                   f_wrapped
   

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -5784,8 +5784,8 @@ and (reify_lift :
                 match uu____17162 with
                 | FStar_Pervasives_Native.None  ->
                     let uu____17165 =
-                      let uu____17167 = FStar_Ident.text_of_lid msrc  in
-                      let uu____17169 = FStar_Ident.text_of_lid mtgt  in
+                      let uu____17167 = FStar_Ident.string_of_lid msrc  in
+                      let uu____17169 = FStar_Ident.string_of_lid mtgt  in
                       FStar_Util.format2
                         "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
                         uu____17167 uu____17169
@@ -5800,8 +5800,8 @@ and (reify_lift :
                             FStar_Pervasives_Native.None ;_};_}
                     ->
                     let uu____17194 =
-                      let uu____17196 = FStar_Ident.text_of_lid msrc  in
-                      let uu____17198 = FStar_Ident.text_of_lid mtgt  in
+                      let uu____17196 = FStar_Ident.string_of_lid msrc  in
+                      let uu____17198 = FStar_Ident.string_of_lid mtgt  in
                       FStar_Util.format2
                         "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
                         uu____17196 uu____17198

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -2121,12 +2121,13 @@ let rec (maximal_prefix :
     fun bs'  ->
       match (bs, bs') with
       | ((b,i)::bs_tail,(b',i')::bs'_tail) ->
-          if FStar_Syntax_Syntax.bv_eq b b'
+          let uu____5886 = FStar_Syntax_Syntax.bv_eq b b'  in
+          if uu____5886
           then
-            let uu____5895 = maximal_prefix bs_tail bs'_tail  in
-            (match uu____5895 with | (pfx,rest) -> (((b, i) :: pfx), rest))
+            let uu____5897 = maximal_prefix bs_tail bs'_tail  in
+            (match uu____5897 with | (pfx,rest) -> (((b, i) :: pfx), rest))
           else ([], (bs, bs'))
-      | uu____5946 -> ([], (bs, bs'))
+      | uu____5948 -> ([], (bs, bs'))
   
 let (extend_gamma :
   FStar_Syntax_Syntax.gamma ->
@@ -2136,9 +2137,9 @@ let (extend_gamma :
     fun bs  ->
       FStar_List.fold_left
         (fun g1  ->
-           fun uu____6003  ->
-             match uu____6003 with
-             | (x,uu____6015) -> (FStar_Syntax_Syntax.Binding_var x) :: g1) g
+           fun uu____6005  ->
+             match uu____6005 with
+             | (x,uu____6017) -> (FStar_Syntax_Syntax.Binding_var x) :: g1) g
         bs
   
 let (gamma_until :
@@ -2147,21 +2148,21 @@ let (gamma_until :
   =
   fun g  ->
     fun bs  ->
-      let uu____6033 = FStar_List.last bs  in
-      match uu____6033 with
+      let uu____6035 = FStar_List.last bs  in
+      match uu____6035 with
       | FStar_Pervasives_Native.None  -> []
-      | FStar_Pervasives_Native.Some (x,uu____6057) ->
-          let uu____6068 =
+      | FStar_Pervasives_Native.Some (x,uu____6059) ->
+          let uu____6070 =
             FStar_Util.prefix_until
-              (fun uu___21_6083  ->
-                 match uu___21_6083 with
+              (fun uu___21_6085  ->
+                 match uu___21_6085 with
                  | FStar_Syntax_Syntax.Binding_var x' ->
                      FStar_Syntax_Syntax.bv_eq x x'
-                 | uu____6086 -> false) g
+                 | uu____6088 -> false) g
              in
-          (match uu____6068 with
+          (match uu____6070 with
            | FStar_Pervasives_Native.None  -> []
-           | FStar_Pervasives_Native.Some (uu____6100,bx,rest) -> bx :: rest)
+           | FStar_Pervasives_Native.Some (uu____6102,bx,rest) -> bx :: rest)
   
 let (restrict_ctx :
   FStar_Syntax_Syntax.ctx_uvar ->
@@ -2170,15 +2171,15 @@ let (restrict_ctx :
   fun tgt  ->
     fun src  ->
       fun wl  ->
-        let uu____6137 =
+        let uu____6139 =
           maximal_prefix tgt.FStar_Syntax_Syntax.ctx_uvar_binders
             src.FStar_Syntax_Syntax.ctx_uvar_binders
            in
-        match uu____6137 with
-        | (pfx,uu____6147) ->
+        match uu____6139 with
+        | (pfx,uu____6149) ->
             let g = gamma_until src.FStar_Syntax_Syntax.ctx_uvar_gamma pfx
                in
-            let uu____6159 =
+            let uu____6161 =
               new_uvar
                 (Prims.op_Hat "restrict:"
                    src.FStar_Syntax_Syntax.ctx_uvar_reason) wl
@@ -2187,8 +2188,8 @@ let (restrict_ctx :
                 src.FStar_Syntax_Syntax.ctx_uvar_should_check
                 src.FStar_Syntax_Syntax.ctx_uvar_meta
                in
-            (match uu____6159 with
-             | (uu____6167,src',wl1) ->
+            (match uu____6161 with
+             | (uu____6169,src',wl1) ->
                  (FStar_Syntax_Unionfind.change
                     src.FStar_Syntax_Syntax.ctx_uvar_head src';
                   wl1))
@@ -2225,68 +2226,68 @@ let (intersect_binders :
                  match b with
                  | FStar_Syntax_Syntax.Binding_var x ->
                      FStar_Util.set_add x out
-                 | uu____6281 -> out) FStar_Syntax_Syntax.no_names g
+                 | uu____6283 -> out) FStar_Syntax_Syntax.no_names g
            in
-        let uu____6282 =
+        let uu____6284 =
           FStar_All.pipe_right v2
             (FStar_List.fold_left
-               (fun uu____6346  ->
-                  fun uu____6347  ->
-                    match (uu____6346, uu____6347) with
+               (fun uu____6348  ->
+                  fun uu____6349  ->
+                    match (uu____6348, uu____6349) with
                     | ((isect,isect_set),(x,imp)) ->
-                        let uu____6450 =
-                          let uu____6452 = FStar_Util.set_mem x v1_set  in
-                          FStar_All.pipe_left Prims.op_Negation uu____6452
+                        let uu____6452 =
+                          let uu____6454 = FStar_Util.set_mem x v1_set  in
+                          FStar_All.pipe_left Prims.op_Negation uu____6454
                            in
-                        if uu____6450
+                        if uu____6452
                         then (isect, isect_set)
                         else
                           (let fvs =
                              FStar_Syntax_Free.names
                                x.FStar_Syntax_Syntax.sort
                               in
-                           let uu____6486 =
+                           let uu____6488 =
                              FStar_Util.set_is_subset_of fvs isect_set  in
-                           if uu____6486
+                           if uu____6488
                            then
-                             let uu____6503 = FStar_Util.set_add x isect_set
+                             let uu____6505 = FStar_Util.set_add x isect_set
                                 in
-                             (((x, imp) :: isect), uu____6503)
+                             (((x, imp) :: isect), uu____6505)
                            else (isect, isect_set))) ([], ctx_binders))
            in
-        match uu____6282 with | (isect,uu____6553) -> FStar_List.rev isect
+        match uu____6284 with | (isect,uu____6555) -> FStar_List.rev isect
   
 let binders_eq :
-  'uuuuuu6589 'uuuuuu6590 .
-    (FStar_Syntax_Syntax.bv * 'uuuuuu6589) Prims.list ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6590) Prims.list -> Prims.bool
+  'uuuuuu6591 'uuuuuu6592 .
+    (FStar_Syntax_Syntax.bv * 'uuuuuu6591) Prims.list ->
+      (FStar_Syntax_Syntax.bv * 'uuuuuu6592) Prims.list -> Prims.bool
   =
   fun v1  ->
     fun v2  ->
       ((FStar_List.length v1) = (FStar_List.length v2)) &&
         (FStar_List.forall2
-           (fun uu____6648  ->
-              fun uu____6649  ->
-                match (uu____6648, uu____6649) with
-                | ((a,uu____6668),(b,uu____6670)) ->
+           (fun uu____6650  ->
+              fun uu____6651  ->
+                match (uu____6650, uu____6651) with
+                | ((a,uu____6670),(b,uu____6672)) ->
                     FStar_Syntax_Syntax.bv_eq a b) v1 v2)
   
 let name_exists_in_binders :
-  'uuuuuu6686 .
+  'uuuuuu6688 .
     FStar_Syntax_Syntax.bv ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6686) Prims.list -> Prims.bool
+      (FStar_Syntax_Syntax.bv * 'uuuuuu6688) Prims.list -> Prims.bool
   =
   fun x  ->
     fun bs  ->
       FStar_Util.for_some
-        (fun uu____6717  ->
-           match uu____6717 with
-           | (y,uu____6724) -> FStar_Syntax_Syntax.bv_eq x y) bs
+        (fun uu____6719  ->
+           match uu____6719 with
+           | (y,uu____6726) -> FStar_Syntax_Syntax.bv_eq x y) bs
   
 let pat_vars :
-  'uuuuuu6734 .
+  'uuuuuu6736 .
     FStar_TypeChecker_Env.env ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6734) Prims.list ->
+      (FStar_Syntax_Syntax.bv * 'uuuuuu6736) Prims.list ->
         (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.arg_qualifier
           FStar_Pervasives_Native.option) Prims.list ->
           FStar_Syntax_Syntax.binders FStar_Pervasives_Native.option
@@ -2301,14 +2302,14 @@ let pat_vars :
               let hd = sn env arg  in
               (match hd.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_name a ->
-                   let uu____6896 =
+                   let uu____6898 =
                      (name_exists_in_binders a seen) ||
                        (name_exists_in_binders a ctx)
                       in
-                   if uu____6896
+                   if uu____6898
                    then FStar_Pervasives_Native.None
                    else aux ((a, i) :: seen) args2
-               | uu____6929 -> FStar_Pervasives_Native.None)
+               | uu____6931 -> FStar_Pervasives_Native.None)
            in
         aux [] args
   
@@ -2320,7 +2321,7 @@ type match_result =
   | FullMatch 
 let (uu___is_MisMatch : match_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MisMatch _0 -> true | uu____6981 -> false
+    match projectee with | MisMatch _0 -> true | uu____6983 -> false
   
 let (__proj__MisMatch__item___0 :
   match_result ->
@@ -2329,44 +2330,44 @@ let (__proj__MisMatch__item___0 :
   = fun projectee  -> match projectee with | MisMatch _0 -> _0 
 let (uu___is_HeadMatch : match_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | HeadMatch _0 -> true | uu____7025 -> false
+    match projectee with | HeadMatch _0 -> true | uu____7027 -> false
   
 let (__proj__HeadMatch__item___0 : match_result -> Prims.bool) =
   fun projectee  -> match projectee with | HeadMatch _0 -> _0 
 let (uu___is_FullMatch : match_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | FullMatch  -> true | uu____7046 -> false
+    match projectee with | FullMatch  -> true | uu____7048 -> false
   
 let (string_of_match_result : match_result -> Prims.string) =
-  fun uu___22_7054  ->
-    match uu___22_7054 with
+  fun uu___22_7056  ->
+    match uu___22_7056 with
     | MisMatch (d1,d2) ->
-        let uu____7066 =
-          let uu____7068 =
+        let uu____7068 =
+          let uu____7070 =
             FStar_Common.string_of_option
               FStar_Syntax_Print.delta_depth_to_string d1
              in
-          let uu____7070 =
-            let uu____7072 =
-              let uu____7074 =
+          let uu____7072 =
+            let uu____7074 =
+              let uu____7076 =
                 FStar_Common.string_of_option
                   FStar_Syntax_Print.delta_depth_to_string d2
                  in
-              Prims.op_Hat uu____7074 ")"  in
-            Prims.op_Hat ") (" uu____7072  in
-          Prims.op_Hat uu____7068 uu____7070  in
-        Prims.op_Hat "MisMatch (" uu____7066
+              Prims.op_Hat uu____7076 ")"  in
+            Prims.op_Hat ") (" uu____7074  in
+          Prims.op_Hat uu____7070 uu____7072  in
+        Prims.op_Hat "MisMatch (" uu____7068
     | HeadMatch u ->
-        let uu____7081 = FStar_Util.string_of_bool u  in
-        Prims.op_Hat "HeadMatch " uu____7081
+        let uu____7083 = FStar_Util.string_of_bool u  in
+        Prims.op_Hat "HeadMatch " uu____7083
     | FullMatch  -> "FullMatch"
   
 let (head_match : match_result -> match_result) =
-  fun uu___23_7090  ->
-    match uu___23_7090 with
+  fun uu___23_7092  ->
+    match uu___23_7092 with
     | MisMatch (i,j) -> MisMatch (i, j)
     | HeadMatch (true ) -> HeadMatch true
-    | uu____7107 -> HeadMatch false
+    | uu____7109 -> HeadMatch false
   
 let (fv_delta_depth :
   FStar_TypeChecker_Env.env ->
@@ -2377,24 +2378,30 @@ let (fv_delta_depth :
       let d = FStar_TypeChecker_Env.delta_depth_of_fv env fv  in
       match d with
       | FStar_Syntax_Syntax.Delta_abstract d1 ->
-          if
-            ((env.FStar_TypeChecker_Env.curmodule).FStar_Ident.str =
-               ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.nsstr)
-              && (Prims.op_Negation env.FStar_TypeChecker_Env.is_iface)
-          then d1
-          else FStar_Syntax_Syntax.delta_constant
+          let uu____7124 =
+            (let uu____7130 =
+               FStar_Ident.string_of_lid env.FStar_TypeChecker_Env.curmodule
+                in
+             let uu____7132 =
+               FStar_Ident.nsstr
+                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                in
+             uu____7130 = uu____7132) &&
+              (Prims.op_Negation env.FStar_TypeChecker_Env.is_iface)
+             in
+          if uu____7124 then d1 else FStar_Syntax_Syntax.delta_constant
       | FStar_Syntax_Syntax.Delta_constant_at_level i when i > Prims.int_zero
           ->
-          let uu____7129 =
+          let uu____7141 =
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Unfold
                  FStar_Syntax_Syntax.delta_constant] env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____7129 with
+          (match uu____7141 with
            | FStar_Pervasives_Native.None  ->
                FStar_Syntax_Syntax.delta_constant
-           | uu____7140 -> d)
+           | uu____7152 -> d)
       | d1 -> d1
   
 let rec (delta_depth_of_term :
@@ -2406,45 +2413,45 @@ let rec (delta_depth_of_term :
     fun t  ->
       let t1 = FStar_Syntax_Util.unmeta t  in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_meta uu____7164 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____7174 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_meta uu____7176 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____7186 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____7193 = FStar_Syntax_Util.unfold_lazy i  in
-          delta_depth_of_term env uu____7193
+          let uu____7205 = FStar_Syntax_Util.unfold_lazy i  in
+          delta_depth_of_term env uu____7205
       | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_bvar uu____7194 ->
+      | FStar_Syntax_Syntax.Tm_bvar uu____7206 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_name uu____7195 ->
+      | FStar_Syntax_Syntax.Tm_name uu____7207 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uvar uu____7196 ->
+      | FStar_Syntax_Syntax.Tm_uvar uu____7208 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_let uu____7209 -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_match uu____7223 ->
+      | FStar_Syntax_Syntax.Tm_let uu____7221 -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_match uu____7235 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uinst (t2,uu____7247) ->
+      | FStar_Syntax_Syntax.Tm_uinst (t2,uu____7259) ->
           delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____7253,uu____7254) ->
+      | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____7265,uu____7266) ->
           delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_app (t2,uu____7296) ->
+      | FStar_Syntax_Syntax.Tm_app (t2,uu____7308) ->
           delta_depth_of_term env t2
       | FStar_Syntax_Syntax.Tm_refine
-          ({ FStar_Syntax_Syntax.ppname = uu____7321;
-             FStar_Syntax_Syntax.index = uu____7322;
-             FStar_Syntax_Syntax.sort = t2;_},uu____7324)
+          ({ FStar_Syntax_Syntax.ppname = uu____7333;
+             FStar_Syntax_Syntax.index = uu____7334;
+             FStar_Syntax_Syntax.sort = t2;_},uu____7336)
           -> delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_constant uu____7332 ->
+      | FStar_Syntax_Syntax.Tm_constant uu____7344 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_type uu____7333 ->
+      | FStar_Syntax_Syntax.Tm_type uu____7345 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_arrow uu____7334 ->
+      | FStar_Syntax_Syntax.Tm_arrow uu____7346 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_quoted uu____7349 ->
+      | FStar_Syntax_Syntax.Tm_quoted uu____7361 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_abs uu____7356 ->
+      | FStar_Syntax_Syntax.Tm_abs uu____7368 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____7376 = fv_delta_depth env fv  in
-          FStar_Pervasives_Native.Some uu____7376
+          let uu____7388 = fv_delta_depth env fv  in
+          FStar_Pervasives_Native.Some uu____7388
   
 let rec (head_matches :
   FStar_TypeChecker_Env.env ->
@@ -2457,118 +2464,119 @@ let rec (head_matches :
         let t21 = FStar_Syntax_Util.unmeta t2  in
         match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
         | (FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu____7395;
+           { FStar_Syntax_Syntax.blob = uu____7407;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu____7396;
-             FStar_Syntax_Syntax.ltyp = uu____7397;
-             FStar_Syntax_Syntax.rng = uu____7398;_},uu____7399)
+               uu____7408;
+             FStar_Syntax_Syntax.ltyp = uu____7409;
+             FStar_Syntax_Syntax.rng = uu____7410;_},uu____7411)
             ->
-            let uu____7410 = FStar_Syntax_Util.unlazy t11  in
-            head_matches env uu____7410 t21
-        | (uu____7411,FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu____7412;
+            let uu____7422 = FStar_Syntax_Util.unlazy t11  in
+            head_matches env uu____7422 t21
+        | (uu____7423,FStar_Syntax_Syntax.Tm_lazy
+           { FStar_Syntax_Syntax.blob = uu____7424;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu____7413;
-             FStar_Syntax_Syntax.ltyp = uu____7414;
-             FStar_Syntax_Syntax.rng = uu____7415;_})
+               uu____7425;
+             FStar_Syntax_Syntax.ltyp = uu____7426;
+             FStar_Syntax_Syntax.rng = uu____7427;_})
             ->
-            let uu____7426 = FStar_Syntax_Util.unlazy t21  in
-            head_matches env t11 uu____7426
+            let uu____7438 = FStar_Syntax_Util.unlazy t21  in
+            head_matches env t11 uu____7438
         | (FStar_Syntax_Syntax.Tm_name x,FStar_Syntax_Syntax.Tm_name y) ->
-            if FStar_Syntax_Syntax.bv_eq x y
+            let uu____7441 = FStar_Syntax_Syntax.bv_eq x y  in
+            if uu____7441
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (FStar_Syntax_Syntax.Tm_fvar f,FStar_Syntax_Syntax.Tm_fvar g) ->
-            let uu____7438 = FStar_Syntax_Syntax.fv_eq f g  in
-            if uu____7438
+            let uu____7452 = FStar_Syntax_Syntax.fv_eq f g  in
+            if uu____7452
             then FullMatch
             else
-              (let uu____7443 =
-                 let uu____7452 =
-                   let uu____7455 = fv_delta_depth env f  in
-                   FStar_Pervasives_Native.Some uu____7455  in
-                 let uu____7456 =
-                   let uu____7459 = fv_delta_depth env g  in
-                   FStar_Pervasives_Native.Some uu____7459  in
-                 (uu____7452, uu____7456)  in
-               MisMatch uu____7443)
+              (let uu____7457 =
+                 let uu____7466 =
+                   let uu____7469 = fv_delta_depth env f  in
+                   FStar_Pervasives_Native.Some uu____7469  in
+                 let uu____7470 =
+                   let uu____7473 = fv_delta_depth env g  in
+                   FStar_Pervasives_Native.Some uu____7473  in
+                 (uu____7466, uu____7470)  in
+               MisMatch uu____7457)
         | (FStar_Syntax_Syntax.Tm_uinst
-           (f,uu____7465),FStar_Syntax_Syntax.Tm_uinst (g,uu____7467)) ->
-            let uu____7476 = head_matches env f g  in
-            FStar_All.pipe_right uu____7476 head_match
+           (f,uu____7479),FStar_Syntax_Syntax.Tm_uinst (g,uu____7481)) ->
+            let uu____7490 = head_matches env f g  in
+            FStar_All.pipe_right uu____7490 head_match
         | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify
            ),FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify )) ->
             FullMatch
         | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify
-           ),uu____7477) -> HeadMatch true
-        | (uu____7479,FStar_Syntax_Syntax.Tm_constant
+           ),uu____7491) -> HeadMatch true
+        | (uu____7493,FStar_Syntax_Syntax.Tm_constant
            (FStar_Const.Const_reify )) -> HeadMatch true
         | (FStar_Syntax_Syntax.Tm_constant c,FStar_Syntax_Syntax.Tm_constant
            d) ->
-            let uu____7483 = FStar_Const.eq_const c d  in
-            if uu____7483
+            let uu____7497 = FStar_Const.eq_const c d  in
+            if uu____7497
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (FStar_Syntax_Syntax.Tm_uvar
-           (uv,uu____7493),FStar_Syntax_Syntax.Tm_uvar (uv',uu____7495)) ->
-            let uu____7528 =
+           (uv,uu____7507),FStar_Syntax_Syntax.Tm_uvar (uv',uu____7509)) ->
+            let uu____7542 =
               FStar_Syntax_Unionfind.equiv
                 uv.FStar_Syntax_Syntax.ctx_uvar_head
                 uv'.FStar_Syntax_Syntax.ctx_uvar_head
                in
-            if uu____7528
+            if uu____7542
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (FStar_Syntax_Syntax.Tm_refine
-           (x,uu____7538),FStar_Syntax_Syntax.Tm_refine (y,uu____7540)) ->
-            let uu____7549 =
+           (x,uu____7552),FStar_Syntax_Syntax.Tm_refine (y,uu____7554)) ->
+            let uu____7563 =
               head_matches env x.FStar_Syntax_Syntax.sort
                 y.FStar_Syntax_Syntax.sort
                in
-            FStar_All.pipe_right uu____7549 head_match
-        | (FStar_Syntax_Syntax.Tm_refine (x,uu____7551),uu____7552) ->
-            let uu____7557 = head_matches env x.FStar_Syntax_Syntax.sort t21
+            FStar_All.pipe_right uu____7563 head_match
+        | (FStar_Syntax_Syntax.Tm_refine (x,uu____7565),uu____7566) ->
+            let uu____7571 = head_matches env x.FStar_Syntax_Syntax.sort t21
                in
-            FStar_All.pipe_right uu____7557 head_match
-        | (uu____7558,FStar_Syntax_Syntax.Tm_refine (x,uu____7560)) ->
-            let uu____7565 = head_matches env t11 x.FStar_Syntax_Syntax.sort
+            FStar_All.pipe_right uu____7571 head_match
+        | (uu____7572,FStar_Syntax_Syntax.Tm_refine (x,uu____7574)) ->
+            let uu____7579 = head_matches env t11 x.FStar_Syntax_Syntax.sort
                in
-            FStar_All.pipe_right uu____7565 head_match
-        | (FStar_Syntax_Syntax.Tm_type uu____7566,FStar_Syntax_Syntax.Tm_type
-           uu____7567) -> HeadMatch false
+            FStar_All.pipe_right uu____7579 head_match
+        | (FStar_Syntax_Syntax.Tm_type uu____7580,FStar_Syntax_Syntax.Tm_type
+           uu____7581) -> HeadMatch false
         | (FStar_Syntax_Syntax.Tm_arrow
-           uu____7569,FStar_Syntax_Syntax.Tm_arrow uu____7570) ->
+           uu____7583,FStar_Syntax_Syntax.Tm_arrow uu____7584) ->
             HeadMatch false
         | (FStar_Syntax_Syntax.Tm_app
-           (head,uu____7601),FStar_Syntax_Syntax.Tm_app (head',uu____7603))
+           (head,uu____7615),FStar_Syntax_Syntax.Tm_app (head',uu____7617))
             ->
-            let uu____7652 = head_matches env head head'  in
-            FStar_All.pipe_right uu____7652 head_match
-        | (FStar_Syntax_Syntax.Tm_app (head,uu____7654),uu____7655) ->
-            let uu____7680 = head_matches env head t21  in
-            FStar_All.pipe_right uu____7680 head_match
-        | (uu____7681,FStar_Syntax_Syntax.Tm_app (head,uu____7683)) ->
-            let uu____7708 = head_matches env t11 head  in
-            FStar_All.pipe_right uu____7708 head_match
-        | (FStar_Syntax_Syntax.Tm_let uu____7709,FStar_Syntax_Syntax.Tm_let
-           uu____7710) -> HeadMatch true
+            let uu____7666 = head_matches env head head'  in
+            FStar_All.pipe_right uu____7666 head_match
+        | (FStar_Syntax_Syntax.Tm_app (head,uu____7668),uu____7669) ->
+            let uu____7694 = head_matches env head t21  in
+            FStar_All.pipe_right uu____7694 head_match
+        | (uu____7695,FStar_Syntax_Syntax.Tm_app (head,uu____7697)) ->
+            let uu____7722 = head_matches env t11 head  in
+            FStar_All.pipe_right uu____7722 head_match
+        | (FStar_Syntax_Syntax.Tm_let uu____7723,FStar_Syntax_Syntax.Tm_let
+           uu____7724) -> HeadMatch true
         | (FStar_Syntax_Syntax.Tm_match
-           uu____7738,FStar_Syntax_Syntax.Tm_match uu____7739) ->
+           uu____7752,FStar_Syntax_Syntax.Tm_match uu____7753) ->
             HeadMatch true
-        | (FStar_Syntax_Syntax.Tm_abs uu____7785,FStar_Syntax_Syntax.Tm_abs
-           uu____7786) -> HeadMatch true
-        | uu____7824 ->
-            let uu____7829 =
-              let uu____7838 = delta_depth_of_term env t11  in
-              let uu____7841 = delta_depth_of_term env t21  in
-              (uu____7838, uu____7841)  in
-            MisMatch uu____7829
+        | (FStar_Syntax_Syntax.Tm_abs uu____7799,FStar_Syntax_Syntax.Tm_abs
+           uu____7800) -> HeadMatch true
+        | uu____7838 ->
+            let uu____7843 =
+              let uu____7852 = delta_depth_of_term env t11  in
+              let uu____7855 = delta_depth_of_term env t21  in
+              (uu____7852, uu____7855)  in
+            MisMatch uu____7843
   
 let (head_matches_delta :
   FStar_TypeChecker_Env.env ->
@@ -2584,46 +2592,46 @@ let (head_matches_delta :
         fun t2  ->
           let maybe_inline t =
             let head =
-              let uu____7910 = unrefine env t  in
-              FStar_Syntax_Util.head_of uu____7910  in
-            (let uu____7912 =
+              let uu____7924 = unrefine env t  in
+              FStar_Syntax_Util.head_of uu____7924  in
+            (let uu____7926 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "RelDelta")
                 in
-             if uu____7912
+             if uu____7926
              then
-               let uu____7917 = FStar_Syntax_Print.term_to_string t  in
-               let uu____7919 = FStar_Syntax_Print.term_to_string head  in
-               FStar_Util.print2 "Head of %s is %s\n" uu____7917 uu____7919
+               let uu____7931 = FStar_Syntax_Print.term_to_string t  in
+               let uu____7933 = FStar_Syntax_Print.term_to_string head  in
+               FStar_Util.print2 "Head of %s is %s\n" uu____7931 uu____7933
              else ());
-            (let uu____7924 =
-               let uu____7925 = FStar_Syntax_Util.un_uinst head  in
-               uu____7925.FStar_Syntax_Syntax.n  in
-             match uu____7924 with
+            (let uu____7938 =
+               let uu____7939 = FStar_Syntax_Util.un_uinst head  in
+               uu____7939.FStar_Syntax_Syntax.n  in
+             match uu____7938 with
              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                 let uu____7931 =
+                 let uu____7945 =
                    FStar_TypeChecker_Env.lookup_definition
                      [FStar_TypeChecker_Env.Unfold
                         FStar_Syntax_Syntax.delta_constant;
                      FStar_TypeChecker_Env.Eager_unfolding_only] env
                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                     in
-                 (match uu____7931 with
+                 (match uu____7945 with
                   | FStar_Pervasives_Native.None  ->
-                      ((let uu____7945 =
+                      ((let uu____7959 =
                           FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "RelDelta")
                            in
-                        if uu____7945
+                        if uu____7959
                         then
-                          let uu____7950 =
+                          let uu____7964 =
                             FStar_Syntax_Print.term_to_string head  in
                           FStar_Util.print1 "No definition found for %s\n"
-                            uu____7950
+                            uu____7964
                         else ());
                        FStar_Pervasives_Native.None)
-                  | FStar_Pervasives_Native.Some uu____7955 ->
+                  | FStar_Pervasives_Native.Some uu____7969 ->
                       let basic_steps =
                         [FStar_TypeChecker_Env.UnfoldUntil
                            FStar_Syntax_Syntax.delta_constant;
@@ -2646,28 +2654,28 @@ let (head_matches_delta :
                           "FStar.TypeChecker.Rel.norm_with_steps.1" steps env
                           t
                          in
-                      let uu____7973 =
-                        let uu____7975 = FStar_Syntax_Util.eq_tm t t'  in
-                        uu____7975 = FStar_Syntax_Util.Equal  in
-                      if uu____7973
+                      let uu____7987 =
+                        let uu____7989 = FStar_Syntax_Util.eq_tm t t'  in
+                        uu____7989 = FStar_Syntax_Util.Equal  in
+                      if uu____7987
                       then FStar_Pervasives_Native.None
                       else
-                        ((let uu____7982 =
+                        ((let uu____7996 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
                               (FStar_Options.Other "RelDelta")
                              in
-                          if uu____7982
+                          if uu____7996
                           then
-                            let uu____7987 =
+                            let uu____8001 =
                               FStar_Syntax_Print.term_to_string t  in
-                            let uu____7989 =
+                            let uu____8003 =
                               FStar_Syntax_Print.term_to_string t'  in
-                            FStar_Util.print2 "Inlined %s to %s\n" uu____7987
-                              uu____7989
+                            FStar_Util.print2 "Inlined %s to %s\n" uu____8001
+                              uu____8003
                           else ());
                          FStar_Pervasives_Native.Some t'))
-             | uu____7994 -> FStar_Pervasives_Native.None)
+             | uu____8008 -> FStar_Pervasives_Native.None)
              in
           let success d r t11 t21 =
             (r,
@@ -2683,22 +2691,22 @@ let (head_matches_delta :
              in
           let rec aux retry n_delta t11 t21 =
             let r = head_matches env t11 t21  in
-            (let uu____8146 =
+            (let uu____8160 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "RelDelta")
                 in
-             if uu____8146
+             if uu____8160
              then
-               let uu____8151 = FStar_Syntax_Print.term_to_string t11  in
-               let uu____8153 = FStar_Syntax_Print.term_to_string t21  in
-               let uu____8155 = string_of_match_result r  in
-               FStar_Util.print3 "head_matches (%s, %s) = %s\n" uu____8151
-                 uu____8153 uu____8155
+               let uu____8165 = FStar_Syntax_Print.term_to_string t11  in
+               let uu____8167 = FStar_Syntax_Print.term_to_string t21  in
+               let uu____8169 = string_of_match_result r  in
+               FStar_Util.print3 "head_matches (%s, %s) = %s\n" uu____8165
+                 uu____8167 uu____8169
              else ());
             (let reduce_one_and_try_again d1 d2 =
                let d1_greater_than_d2 =
                  FStar_TypeChecker_Common.delta_depth_greater_than d1 d2  in
-               let uu____8183 =
+               let uu____8197 =
                  if d1_greater_than_d2
                  then
                    let t1' =
@@ -2717,12 +2725,12 @@ let (head_matches_delta :
                        in
                     (t11, t2'))
                   in
-               match uu____8183 with
+               match uu____8197 with
                | (t12,t22) -> aux retry (n_delta + Prims.int_one) t12 t22  in
              let reduce_both_and_try_again d r1 =
-               let uu____8231 = FStar_TypeChecker_Common.decr_delta_depth d
+               let uu____8245 = FStar_TypeChecker_Common.decr_delta_depth d
                   in
-               match uu____8231 with
+               match uu____8245 with
                | FStar_Pervasives_Native.None  -> fail n_delta r1 t11 t21
                | FStar_Pervasives_Native.Some d1 ->
                    let t12 =
@@ -2754,16 +2762,16 @@ let (head_matches_delta :
              | MisMatch
                  (FStar_Pervasives_Native.Some
                   (FStar_Syntax_Syntax.Delta_equational_at_level
-                  uu____8269),uu____8270)
+                  uu____8283),uu____8284)
                  ->
                  if Prims.op_Negation retry
                  then fail n_delta r t11 t21
                  else
-                   (let uu____8291 =
-                      let uu____8300 = maybe_inline t11  in
-                      let uu____8303 = maybe_inline t21  in
-                      (uu____8300, uu____8303)  in
-                    match uu____8291 with
+                   (let uu____8305 =
+                      let uu____8314 = maybe_inline t11  in
+                      let uu____8317 = maybe_inline t21  in
+                      (uu____8314, uu____8317)  in
+                    match uu____8305 with
                     | (FStar_Pervasives_Native.None
                        ,FStar_Pervasives_Native.None ) ->
                         fail n_delta r t11 t21
@@ -2777,17 +2785,17 @@ let (head_matches_delta :
                        t12,FStar_Pervasives_Native.Some t22) ->
                         aux false (n_delta + Prims.int_one) t12 t22)
              | MisMatch
-                 (uu____8346,FStar_Pervasives_Native.Some
-                  (FStar_Syntax_Syntax.Delta_equational_at_level uu____8347))
+                 (uu____8360,FStar_Pervasives_Native.Some
+                  (FStar_Syntax_Syntax.Delta_equational_at_level uu____8361))
                  ->
                  if Prims.op_Negation retry
                  then fail n_delta r t11 t21
                  else
-                   (let uu____8368 =
-                      let uu____8377 = maybe_inline t11  in
-                      let uu____8380 = maybe_inline t21  in
-                      (uu____8377, uu____8380)  in
-                    match uu____8368 with
+                   (let uu____8382 =
+                      let uu____8391 = maybe_inline t11  in
+                      let uu____8394 = maybe_inline t21  in
+                      (uu____8391, uu____8394)  in
+                    match uu____8382 with
                     | (FStar_Pervasives_Native.None
                        ,FStar_Pervasives_Native.None ) ->
                         fail n_delta r t11 t21
@@ -2808,42 +2816,42 @@ let (head_matches_delta :
                  (FStar_Pervasives_Native.Some
                   d1,FStar_Pervasives_Native.Some d2)
                  -> reduce_one_and_try_again d1 d2
-             | MisMatch uu____8435 -> fail n_delta r t11 t21
-             | uu____8444 -> success n_delta r t11 t21)
+             | MisMatch uu____8449 -> fail n_delta r t11 t21
+             | uu____8458 -> success n_delta r t11 t21)
              in
           let r = aux true Prims.int_zero t1 t2  in
-          (let uu____8459 =
+          (let uu____8473 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "RelDelta")
               in
-           if uu____8459
+           if uu____8473
            then
-             let uu____8464 = FStar_Syntax_Print.term_to_string t1  in
-             let uu____8466 = FStar_Syntax_Print.term_to_string t2  in
-             let uu____8468 =
+             let uu____8478 = FStar_Syntax_Print.term_to_string t1  in
+             let uu____8480 = FStar_Syntax_Print.term_to_string t2  in
+             let uu____8482 =
                string_of_match_result (FStar_Pervasives_Native.fst r)  in
-             let uu____8476 =
+             let uu____8490 =
                if FStar_Option.isNone (FStar_Pervasives_Native.snd r)
                then "None"
                else
-                 (let uu____8493 =
+                 (let uu____8507 =
                     FStar_All.pipe_right (FStar_Pervasives_Native.snd r)
                       FStar_Util.must
                      in
-                  FStar_All.pipe_right uu____8493
-                    (fun uu____8528  ->
-                       match uu____8528 with
+                  FStar_All.pipe_right uu____8507
+                    (fun uu____8542  ->
+                       match uu____8542 with
                        | (t11,t21) ->
-                           let uu____8536 =
+                           let uu____8550 =
                              FStar_Syntax_Print.term_to_string t11  in
-                           let uu____8538 =
-                             let uu____8540 =
+                           let uu____8552 =
+                             let uu____8554 =
                                FStar_Syntax_Print.term_to_string t21  in
-                             Prims.op_Hat "; " uu____8540  in
-                           Prims.op_Hat uu____8536 uu____8538))
+                             Prims.op_Hat "; " uu____8554  in
+                           Prims.op_Hat uu____8550 uu____8552))
                 in
              FStar_Util.print4 "head_matches_delta (%s, %s) = %s (%s)\n"
-               uu____8464 uu____8466 uu____8468 uu____8476
+               uu____8478 uu____8480 uu____8482 uu____8490
            else ());
           r
   
@@ -2852,12 +2860,12 @@ let (kind_type :
   =
   fun binders  ->
     fun r  ->
-      let uu____8557 = FStar_Syntax_Util.type_u ()  in
-      FStar_All.pipe_right uu____8557 FStar_Pervasives_Native.fst
+      let uu____8571 = FStar_Syntax_Util.type_u ()  in
+      FStar_All.pipe_right uu____8571 FStar_Pervasives_Native.fst
   
 let (rank_t_num : FStar_TypeChecker_Common.rank_t -> Prims.int) =
-  fun uu___24_8572  ->
-    match uu___24_8572 with
+  fun uu___24_8586  ->
+    match uu___24_8586 with
     | FStar_TypeChecker_Common.Rigid_rigid  -> Prims.int_zero
     | FStar_TypeChecker_Common.Flex_rigid_eq  -> Prims.int_one
     | FStar_TypeChecker_Common.Flex_flex_pattern_eq  -> (Prims.of_int (2))
@@ -2880,28 +2888,28 @@ let (compress_tprob :
   =
   fun tcenv  ->
     fun p  ->
-      let uu___1215_8621 = p  in
-      let uu____8624 = whnf tcenv p.FStar_TypeChecker_Common.lhs  in
-      let uu____8625 = whnf tcenv p.FStar_TypeChecker_Common.rhs  in
+      let uu___1215_8635 = p  in
+      let uu____8638 = whnf tcenv p.FStar_TypeChecker_Common.lhs  in
+      let uu____8639 = whnf tcenv p.FStar_TypeChecker_Common.rhs  in
       {
         FStar_TypeChecker_Common.pid =
-          (uu___1215_8621.FStar_TypeChecker_Common.pid);
-        FStar_TypeChecker_Common.lhs = uu____8624;
+          (uu___1215_8635.FStar_TypeChecker_Common.pid);
+        FStar_TypeChecker_Common.lhs = uu____8638;
         FStar_TypeChecker_Common.relation =
-          (uu___1215_8621.FStar_TypeChecker_Common.relation);
-        FStar_TypeChecker_Common.rhs = uu____8625;
+          (uu___1215_8635.FStar_TypeChecker_Common.relation);
+        FStar_TypeChecker_Common.rhs = uu____8639;
         FStar_TypeChecker_Common.element =
-          (uu___1215_8621.FStar_TypeChecker_Common.element);
+          (uu___1215_8635.FStar_TypeChecker_Common.element);
         FStar_TypeChecker_Common.logical_guard =
-          (uu___1215_8621.FStar_TypeChecker_Common.logical_guard);
+          (uu___1215_8635.FStar_TypeChecker_Common.logical_guard);
         FStar_TypeChecker_Common.logical_guard_uvar =
-          (uu___1215_8621.FStar_TypeChecker_Common.logical_guard_uvar);
+          (uu___1215_8635.FStar_TypeChecker_Common.logical_guard_uvar);
         FStar_TypeChecker_Common.reason =
-          (uu___1215_8621.FStar_TypeChecker_Common.reason);
+          (uu___1215_8635.FStar_TypeChecker_Common.reason);
         FStar_TypeChecker_Common.loc =
-          (uu___1215_8621.FStar_TypeChecker_Common.loc);
+          (uu___1215_8635.FStar_TypeChecker_Common.loc);
         FStar_TypeChecker_Common.rank =
-          (uu___1215_8621.FStar_TypeChecker_Common.rank)
+          (uu___1215_8635.FStar_TypeChecker_Common.rank)
       }
   
 let (compress_prob :
@@ -2912,10 +2920,10 @@ let (compress_prob :
     fun p  ->
       match p with
       | FStar_TypeChecker_Common.TProb p1 ->
-          let uu____8640 = compress_tprob tcenv p1  in
-          FStar_All.pipe_right uu____8640
-            (fun uu____8645  -> FStar_TypeChecker_Common.TProb uu____8645)
-      | FStar_TypeChecker_Common.CProb uu____8646 -> p
+          let uu____8654 = compress_tprob tcenv p1  in
+          FStar_All.pipe_right uu____8654
+            (fun uu____8659  -> FStar_TypeChecker_Common.TProb uu____8659)
+      | FStar_TypeChecker_Common.CProb uu____8660 -> p
   
 let (rank :
   FStar_TypeChecker_Env.env ->
@@ -2925,27 +2933,27 @@ let (rank :
   fun tcenv  ->
     fun pr  ->
       let prob =
-        let uu____8669 = compress_prob tcenv pr  in
-        FStar_All.pipe_right uu____8669 maybe_invert_p  in
+        let uu____8683 = compress_prob tcenv pr  in
+        FStar_All.pipe_right uu____8683 maybe_invert_p  in
       match prob with
       | FStar_TypeChecker_Common.TProb tp ->
-          let uu____8677 =
+          let uu____8691 =
             FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs
              in
-          (match uu____8677 with
+          (match uu____8691 with
            | (lh,lhs_args) ->
-               let uu____8724 =
+               let uu____8738 =
                  FStar_Syntax_Util.head_and_args
                    tp.FStar_TypeChecker_Common.rhs
                   in
-               (match uu____8724 with
+               (match uu____8738 with
                 | (rh,rhs_args) ->
-                    let uu____8771 =
+                    let uu____8785 =
                       match ((lh.FStar_Syntax_Syntax.n),
                               (rh.FStar_Syntax_Syntax.n))
                       with
                       | (FStar_Syntax_Syntax.Tm_uvar
-                         uu____8784,FStar_Syntax_Syntax.Tm_uvar uu____8785)
+                         uu____8798,FStar_Syntax_Syntax.Tm_uvar uu____8799)
                           ->
                           (match (lhs_args, rhs_args) with
                            | ([],[]) when
@@ -2954,169 +2962,169 @@ let (rank :
                                ->
                                (FStar_TypeChecker_Common.Flex_flex_pattern_eq,
                                  tp)
-                           | uu____8874 ->
+                           | uu____8888 ->
                                (FStar_TypeChecker_Common.Flex_flex, tp))
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____8901,uu____8902)
+                      | (FStar_Syntax_Syntax.Tm_uvar uu____8915,uu____8916)
                           when
                           tp.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                           -> (FStar_TypeChecker_Common.Flex_rigid_eq, tp)
-                      | (uu____8917,FStar_Syntax_Syntax.Tm_uvar uu____8918)
+                      | (uu____8931,FStar_Syntax_Syntax.Tm_uvar uu____8932)
                           when
                           tp.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                           -> (FStar_TypeChecker_Common.Flex_rigid_eq, tp)
                       | (FStar_Syntax_Syntax.Tm_uvar
-                         uu____8933,FStar_Syntax_Syntax.Tm_arrow uu____8934)
+                         uu____8947,FStar_Syntax_Syntax.Tm_arrow uu____8948)
                           ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1266_8964 = tp  in
+                            (let uu___1266_8978 = tp  in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1266_8964.FStar_TypeChecker_Common.pid);
+                                 (uu___1266_8978.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1266_8964.FStar_TypeChecker_Common.lhs);
+                                 (uu___1266_8978.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1266_8964.FStar_TypeChecker_Common.rhs);
+                                 (uu___1266_8978.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1266_8964.FStar_TypeChecker_Common.element);
+                                 (uu___1266_8978.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1266_8964.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___1266_8978.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1266_8964.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___1266_8978.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1266_8964.FStar_TypeChecker_Common.reason);
+                                 (uu___1266_8978.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1266_8964.FStar_TypeChecker_Common.loc);
+                                 (uu___1266_8978.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1266_8964.FStar_TypeChecker_Common.rank)
+                                 (uu___1266_8978.FStar_TypeChecker_Common.rank)
                              }))
                       | (FStar_Syntax_Syntax.Tm_uvar
-                         uu____8967,FStar_Syntax_Syntax.Tm_type uu____8968)
+                         uu____8981,FStar_Syntax_Syntax.Tm_type uu____8982)
                           ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1266_8984 = tp  in
+                            (let uu___1266_8998 = tp  in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1266_8984.FStar_TypeChecker_Common.pid);
+                                 (uu___1266_8998.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1266_8984.FStar_TypeChecker_Common.lhs);
+                                 (uu___1266_8998.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1266_8984.FStar_TypeChecker_Common.rhs);
+                                 (uu___1266_8998.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1266_8984.FStar_TypeChecker_Common.element);
+                                 (uu___1266_8998.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1266_8984.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___1266_8998.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1266_8984.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___1266_8998.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1266_8984.FStar_TypeChecker_Common.reason);
+                                 (uu___1266_8998.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1266_8984.FStar_TypeChecker_Common.loc);
+                                 (uu___1266_8998.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1266_8984.FStar_TypeChecker_Common.rank)
+                                 (uu___1266_8998.FStar_TypeChecker_Common.rank)
                              }))
                       | (FStar_Syntax_Syntax.Tm_type
-                         uu____8987,FStar_Syntax_Syntax.Tm_uvar uu____8988)
+                         uu____9001,FStar_Syntax_Syntax.Tm_uvar uu____9002)
                           ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1266_9004 = tp  in
+                            (let uu___1266_9018 = tp  in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1266_9004.FStar_TypeChecker_Common.pid);
+                                 (uu___1266_9018.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1266_9004.FStar_TypeChecker_Common.lhs);
+                                 (uu___1266_9018.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1266_9004.FStar_TypeChecker_Common.rhs);
+                                 (uu___1266_9018.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1266_9004.FStar_TypeChecker_Common.element);
+                                 (uu___1266_9018.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1266_9004.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___1266_9018.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1266_9004.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___1266_9018.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1266_9004.FStar_TypeChecker_Common.reason);
+                                 (uu___1266_9018.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1266_9004.FStar_TypeChecker_Common.loc);
+                                 (uu___1266_9018.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1266_9004.FStar_TypeChecker_Common.rank)
+                                 (uu___1266_9018.FStar_TypeChecker_Common.rank)
                              }))
-                      | (uu____9007,FStar_Syntax_Syntax.Tm_uvar uu____9008)
+                      | (uu____9021,FStar_Syntax_Syntax.Tm_uvar uu____9022)
                           -> (FStar_TypeChecker_Common.Rigid_flex, tp)
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____9023,uu____9024)
+                      | (FStar_Syntax_Syntax.Tm_uvar uu____9037,uu____9038)
                           -> (FStar_TypeChecker_Common.Flex_rigid, tp)
-                      | (uu____9039,FStar_Syntax_Syntax.Tm_uvar uu____9040)
+                      | (uu____9053,FStar_Syntax_Syntax.Tm_uvar uu____9054)
                           -> (FStar_TypeChecker_Common.Rigid_flex, tp)
-                      | (uu____9055,uu____9056) ->
+                      | (uu____9069,uu____9070) ->
                           (FStar_TypeChecker_Common.Rigid_rigid, tp)
                        in
-                    (match uu____8771 with
+                    (match uu____8785 with
                      | (rank,tp1) ->
-                         let uu____9069 =
+                         let uu____9083 =
                            FStar_All.pipe_right
-                             (let uu___1286_9073 = tp1  in
+                             (let uu___1286_9087 = tp1  in
                               {
                                 FStar_TypeChecker_Common.pid =
-                                  (uu___1286_9073.FStar_TypeChecker_Common.pid);
+                                  (uu___1286_9087.FStar_TypeChecker_Common.pid);
                                 FStar_TypeChecker_Common.lhs =
-                                  (uu___1286_9073.FStar_TypeChecker_Common.lhs);
+                                  (uu___1286_9087.FStar_TypeChecker_Common.lhs);
                                 FStar_TypeChecker_Common.relation =
-                                  (uu___1286_9073.FStar_TypeChecker_Common.relation);
+                                  (uu___1286_9087.FStar_TypeChecker_Common.relation);
                                 FStar_TypeChecker_Common.rhs =
-                                  (uu___1286_9073.FStar_TypeChecker_Common.rhs);
+                                  (uu___1286_9087.FStar_TypeChecker_Common.rhs);
                                 FStar_TypeChecker_Common.element =
-                                  (uu___1286_9073.FStar_TypeChecker_Common.element);
+                                  (uu___1286_9087.FStar_TypeChecker_Common.element);
                                 FStar_TypeChecker_Common.logical_guard =
-                                  (uu___1286_9073.FStar_TypeChecker_Common.logical_guard);
+                                  (uu___1286_9087.FStar_TypeChecker_Common.logical_guard);
                                 FStar_TypeChecker_Common.logical_guard_uvar =
-                                  (uu___1286_9073.FStar_TypeChecker_Common.logical_guard_uvar);
+                                  (uu___1286_9087.FStar_TypeChecker_Common.logical_guard_uvar);
                                 FStar_TypeChecker_Common.reason =
-                                  (uu___1286_9073.FStar_TypeChecker_Common.reason);
+                                  (uu___1286_9087.FStar_TypeChecker_Common.reason);
                                 FStar_TypeChecker_Common.loc =
-                                  (uu___1286_9073.FStar_TypeChecker_Common.loc);
+                                  (uu___1286_9087.FStar_TypeChecker_Common.loc);
                                 FStar_TypeChecker_Common.rank =
                                   (FStar_Pervasives_Native.Some rank)
                               })
-                             (fun uu____9076  ->
-                                FStar_TypeChecker_Common.TProb uu____9076)
+                             (fun uu____9090  ->
+                                FStar_TypeChecker_Common.TProb uu____9090)
                             in
-                         (rank, uu____9069))))
+                         (rank, uu____9083))))
       | FStar_TypeChecker_Common.CProb cp ->
-          let uu____9080 =
+          let uu____9094 =
             FStar_All.pipe_right
-              (let uu___1290_9084 = cp  in
+              (let uu___1290_9098 = cp  in
                {
                  FStar_TypeChecker_Common.pid =
-                   (uu___1290_9084.FStar_TypeChecker_Common.pid);
+                   (uu___1290_9098.FStar_TypeChecker_Common.pid);
                  FStar_TypeChecker_Common.lhs =
-                   (uu___1290_9084.FStar_TypeChecker_Common.lhs);
+                   (uu___1290_9098.FStar_TypeChecker_Common.lhs);
                  FStar_TypeChecker_Common.relation =
-                   (uu___1290_9084.FStar_TypeChecker_Common.relation);
+                   (uu___1290_9098.FStar_TypeChecker_Common.relation);
                  FStar_TypeChecker_Common.rhs =
-                   (uu___1290_9084.FStar_TypeChecker_Common.rhs);
+                   (uu___1290_9098.FStar_TypeChecker_Common.rhs);
                  FStar_TypeChecker_Common.element =
-                   (uu___1290_9084.FStar_TypeChecker_Common.element);
+                   (uu___1290_9098.FStar_TypeChecker_Common.element);
                  FStar_TypeChecker_Common.logical_guard =
-                   (uu___1290_9084.FStar_TypeChecker_Common.logical_guard);
+                   (uu___1290_9098.FStar_TypeChecker_Common.logical_guard);
                  FStar_TypeChecker_Common.logical_guard_uvar =
-                   (uu___1290_9084.FStar_TypeChecker_Common.logical_guard_uvar);
+                   (uu___1290_9098.FStar_TypeChecker_Common.logical_guard_uvar);
                  FStar_TypeChecker_Common.reason =
-                   (uu___1290_9084.FStar_TypeChecker_Common.reason);
+                   (uu___1290_9098.FStar_TypeChecker_Common.reason);
                  FStar_TypeChecker_Common.loc =
-                   (uu___1290_9084.FStar_TypeChecker_Common.loc);
+                   (uu___1290_9098.FStar_TypeChecker_Common.loc);
                  FStar_TypeChecker_Common.rank =
                    (FStar_Pervasives_Native.Some
                       FStar_TypeChecker_Common.Rigid_rigid)
                })
-              (fun uu____9087  -> FStar_TypeChecker_Common.CProb uu____9087)
+              (fun uu____9101  -> FStar_TypeChecker_Common.CProb uu____9101)
              in
-          (FStar_TypeChecker_Common.Rigid_rigid, uu____9080)
+          (FStar_TypeChecker_Common.Rigid_rigid, uu____9094)
   
 let (next_prob :
   worklist ->
@@ -3124,8 +3132,8 @@ let (next_prob :
       * FStar_TypeChecker_Common.rank_t) FStar_Pervasives_Native.option)
   =
   fun wl  ->
-    let rec aux uu____9147 probs =
-      match uu____9147 with
+    let rec aux uu____9161 probs =
+      match uu____9161 with
       | (min_rank,min,out) ->
           (match probs with
            | [] ->
@@ -3133,10 +3141,10 @@ let (next_prob :
                 | (FStar_Pervasives_Native.Some
                    p,FStar_Pervasives_Native.Some r) ->
                     FStar_Pervasives_Native.Some (p, out, r)
-                | uu____9228 -> FStar_Pervasives_Native.None)
+                | uu____9242 -> FStar_Pervasives_Native.None)
            | hd::tl ->
-               let uu____9249 = rank wl.tcenv hd  in
-               (match uu____9249 with
+               let uu____9263 = rank wl.tcenv hd  in
+               (match uu____9263 with
                 | (rank1,hd1) ->
                     if rank_leq rank1 FStar_TypeChecker_Common.Flex_rigid_eq
                     then
@@ -3148,12 +3156,12 @@ let (next_prob :
                            FStar_Pervasives_Native.Some
                              (hd1, (FStar_List.append out (m :: tl)), rank1))
                     else
-                      (let uu____9310 =
+                      (let uu____9324 =
                          (min_rank = FStar_Pervasives_Native.None) ||
-                           (let uu____9315 = FStar_Option.get min_rank  in
-                            rank_less_than rank1 uu____9315)
+                           (let uu____9329 = FStar_Option.get min_rank  in
+                            rank_less_than rank1 uu____9329)
                           in
-                       if uu____9310
+                       if uu____9324
                        then
                          match min with
                          | FStar_Pervasives_Native.None  ->
@@ -3179,33 +3187,33 @@ let (flex_prob_closing :
     fun bs  ->
       fun p  ->
         let flex_will_be_closed t =
-          let uu____9388 = FStar_Syntax_Util.head_and_args t  in
-          match uu____9388 with
-          | (hd,uu____9407) ->
-              let uu____9432 =
-                let uu____9433 = FStar_Syntax_Subst.compress hd  in
-                uu____9433.FStar_Syntax_Syntax.n  in
-              (match uu____9432 with
-               | FStar_Syntax_Syntax.Tm_uvar (u,uu____9438) ->
+          let uu____9402 = FStar_Syntax_Util.head_and_args t  in
+          match uu____9402 with
+          | (hd,uu____9421) ->
+              let uu____9446 =
+                let uu____9447 = FStar_Syntax_Subst.compress hd  in
+                uu____9447.FStar_Syntax_Syntax.n  in
+              (match uu____9446 with
+               | FStar_Syntax_Syntax.Tm_uvar (u,uu____9452) ->
                    FStar_All.pipe_right
                      u.FStar_Syntax_Syntax.ctx_uvar_binders
                      (FStar_Util.for_some
-                        (fun uu____9473  ->
-                           match uu____9473 with
-                           | (y,uu____9482) ->
+                        (fun uu____9487  ->
+                           match uu____9487 with
+                           | (y,uu____9496) ->
                                FStar_All.pipe_right bs
                                  (FStar_Util.for_some
-                                    (fun uu____9505  ->
-                                       match uu____9505 with
-                                       | (x,uu____9514) ->
+                                    (fun uu____9519  ->
+                                       match uu____9519 with
+                                       | (x,uu____9528) ->
                                            FStar_Syntax_Syntax.bv_eq x y))))
-               | uu____9519 -> false)
+               | uu____9533 -> false)
            in
-        let uu____9521 = rank tcenv p  in
-        match uu____9521 with
+        let uu____9535 = rank tcenv p  in
+        match uu____9535 with
         | (r,p1) ->
             (match p1 with
-             | FStar_TypeChecker_Common.CProb uu____9530 -> true
+             | FStar_TypeChecker_Common.CProb uu____9544 -> true
              | FStar_TypeChecker_Common.TProb p2 ->
                  (match r with
                   | FStar_TypeChecker_Common.Rigid_rigid  -> true
@@ -3230,26 +3238,26 @@ type univ_eq_sol =
   | UFailed of lstring 
 let (uu___is_UDeferred : univ_eq_sol -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UDeferred _0 -> true | uu____9611 -> false
+    match projectee with | UDeferred _0 -> true | uu____9625 -> false
   
 let (__proj__UDeferred__item___0 : univ_eq_sol -> worklist) =
   fun projectee  -> match projectee with | UDeferred _0 -> _0 
 let (uu___is_USolved : univ_eq_sol -> Prims.bool) =
   fun projectee  ->
-    match projectee with | USolved _0 -> true | uu____9630 -> false
+    match projectee with | USolved _0 -> true | uu____9644 -> false
   
 let (__proj__USolved__item___0 : univ_eq_sol -> worklist) =
   fun projectee  -> match projectee with | USolved _0 -> _0 
 let (uu___is_UFailed : univ_eq_sol -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UFailed _0 -> true | uu____9649 -> false
+    match projectee with | UFailed _0 -> true | uu____9663 -> false
   
 let (__proj__UFailed__item___0 : univ_eq_sol -> lstring) =
   fun projectee  -> match projectee with | UFailed _0 -> _0 
 let (ufailed_simple : Prims.string -> univ_eq_sol) =
-  fun s  -> let uu____9666 = FStar_Thunk.mkv s  in UFailed uu____9666 
+  fun s  -> let uu____9680 = FStar_Thunk.mkv s  in UFailed uu____9680 
 let (ufailed_thunk : (unit -> Prims.string) -> univ_eq_sol) =
-  fun s  -> let uu____9681 = mklstr s  in UFailed uu____9681 
+  fun s  -> let uu____9695 = mklstr s  in UFailed uu____9695 
 let rec (really_solve_universe_eq :
   Prims.int ->
     worklist ->
@@ -3270,14 +3278,14 @@ let rec (really_solve_universe_eq :
                 FStar_All.pipe_right us
                   (FStar_Util.for_some
                      (fun u3  ->
-                        let uu____9732 = FStar_Syntax_Util.univ_kernel u3  in
-                        match uu____9732 with
-                        | (k,uu____9740) ->
+                        let uu____9746 = FStar_Syntax_Util.univ_kernel u3  in
+                        match uu____9746 with
+                        | (k,uu____9754) ->
                             (match k with
                              | FStar_Syntax_Syntax.U_unif v2 ->
                                  FStar_Syntax_Unionfind.univ_equiv v1 v2
-                             | uu____9753 -> false)))
-            | uu____9755 -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u])
+                             | uu____9767 -> false)))
+            | uu____9769 -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u])
              in
           let rec filter_out_common_univs u12 u22 =
             let common_elts =
@@ -3285,32 +3293,32 @@ let rec (really_solve_universe_eq :
                 (FStar_List.fold_left
                    (fun uvs  ->
                       fun uv1  ->
-                        let uu____9807 =
+                        let uu____9821 =
                           FStar_All.pipe_right u22
                             (FStar_List.existsML
                                (fun uv2  ->
-                                  let uu____9815 =
+                                  let uu____9829 =
                                     FStar_Syntax_Util.compare_univs uv1 uv2
                                      in
-                                  uu____9815 = Prims.int_zero))
+                                  uu____9829 = Prims.int_zero))
                            in
-                        if uu____9807 then uv1 :: uvs else uvs) [])
+                        if uu____9821 then uv1 :: uvs else uvs) [])
                in
             let filter =
               FStar_List.filter
                 (fun u  ->
-                   let uu____9836 =
+                   let uu____9850 =
                      FStar_All.pipe_right common_elts
                        (FStar_List.existsML
                           (fun u'  ->
-                             let uu____9844 =
+                             let uu____9858 =
                                FStar_Syntax_Util.compare_univs u u'  in
-                             uu____9844 = Prims.int_zero))
+                             uu____9858 = Prims.int_zero))
                       in
-                   Prims.op_Negation uu____9836)
+                   Prims.op_Negation uu____9850)
                in
-            let uu____9848 = filter u12  in
-            let uu____9851 = filter u22  in (uu____9848, uu____9851)  in
+            let uu____9862 = filter u12  in
+            let uu____9865 = filter u22  in (uu____9862, uu____9865)  in
           let try_umax_components u12 u22 msg =
             if Prims.op_Negation wl.umax_heuristic_ok
             then ufailed_simple "Unable to unify universe terms with umax"
@@ -3318,8 +3326,8 @@ let rec (really_solve_universe_eq :
               (match (u12, u22) with
                | (FStar_Syntax_Syntax.U_max us1,FStar_Syntax_Syntax.U_max
                   us2) ->
-                   let uu____9886 = filter_out_common_univs us1 us2  in
-                   (match uu____9886 with
+                   let uu____9900 = filter_out_common_univs us1 us2  in
+                   (match uu____9900 with
                     | (us11,us21) ->
                         if
                           (FStar_List.length us11) = (FStar_List.length us21)
@@ -3327,33 +3335,33 @@ let rec (really_solve_universe_eq :
                           let rec aux wl1 us12 us22 =
                             match (us12, us22) with
                             | (u13::us13,u23::us23) ->
-                                let uu____9946 =
+                                let uu____9960 =
                                   really_solve_universe_eq pid_orig wl1 u13
                                     u23
                                    in
-                                (match uu____9946 with
+                                (match uu____9960 with
                                  | USolved wl2 -> aux wl2 us13 us23
                                  | failed -> failed)
-                            | uu____9949 -> USolved wl1  in
+                            | uu____9963 -> USolved wl1  in
                           aux wl us11 us21
                         else
                           ufailed_thunk
-                            (fun uu____9966  ->
-                               let uu____9967 =
+                            (fun uu____9980  ->
+                               let uu____9981 =
                                  FStar_Syntax_Print.univ_to_string u12  in
-                               let uu____9969 =
+                               let uu____9983 =
                                  FStar_Syntax_Print.univ_to_string u22  in
                                FStar_Util.format2
                                  "Unable to unify universes: %s and %s"
-                                 uu____9967 uu____9969))
+                                 uu____9981 uu____9983))
                | (FStar_Syntax_Syntax.U_max us,u') ->
                    let rec aux wl1 us1 =
                      match us1 with
                      | [] -> USolved wl1
                      | u::us2 ->
-                         let uu____9995 =
+                         let uu____10009 =
                            really_solve_universe_eq pid_orig wl1 u u'  in
-                         (match uu____9995 with
+                         (match uu____10009 with
                           | USolved wl2 -> aux wl2 us2
                           | failed -> failed)
                       in
@@ -3363,63 +3371,67 @@ let rec (really_solve_universe_eq :
                      match us1 with
                      | [] -> USolved wl1
                      | u::us2 ->
-                         let uu____10021 =
+                         let uu____10035 =
                            really_solve_universe_eq pid_orig wl1 u u'  in
-                         (match uu____10021 with
+                         (match uu____10035 with
                           | USolved wl2 -> aux wl2 us2
                           | failed -> failed)
                       in
                    aux wl us
-               | uu____10024 ->
+               | uu____10038 ->
                    ufailed_thunk
-                     (fun uu____10035  ->
-                        let uu____10036 =
+                     (fun uu____10049  ->
+                        let uu____10050 =
                           FStar_Syntax_Print.univ_to_string u12  in
-                        let uu____10038 =
+                        let uu____10052 =
                           FStar_Syntax_Print.univ_to_string u22  in
                         FStar_Util.format3
                           "Unable to unify universes: %s and %s (%s)"
-                          uu____10036 uu____10038 msg))
+                          uu____10050 uu____10052 msg))
              in
           match (u11, u21) with
-          | (FStar_Syntax_Syntax.U_bvar uu____10041,uu____10042) ->
-              let uu____10044 =
-                let uu____10046 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____10048 = FStar_Syntax_Print.univ_to_string u21  in
+          | (FStar_Syntax_Syntax.U_bvar uu____10055,uu____10056) ->
+              let uu____10058 =
+                let uu____10060 = FStar_Syntax_Print.univ_to_string u11  in
+                let uu____10062 = FStar_Syntax_Print.univ_to_string u21  in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____10046 uu____10048
+                  uu____10060 uu____10062
                  in
-              failwith uu____10044
-          | (FStar_Syntax_Syntax.U_unknown ,uu____10051) ->
-              let uu____10052 =
-                let uu____10054 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____10056 = FStar_Syntax_Print.univ_to_string u21  in
+              failwith uu____10058
+          | (FStar_Syntax_Syntax.U_unknown ,uu____10065) ->
+              let uu____10066 =
+                let uu____10068 = FStar_Syntax_Print.univ_to_string u11  in
+                let uu____10070 = FStar_Syntax_Print.univ_to_string u21  in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____10054 uu____10056
+                  uu____10068 uu____10070
                  in
-              failwith uu____10052
-          | (uu____10059,FStar_Syntax_Syntax.U_bvar uu____10060) ->
-              let uu____10062 =
-                let uu____10064 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____10066 = FStar_Syntax_Print.univ_to_string u21  in
+              failwith uu____10066
+          | (uu____10073,FStar_Syntax_Syntax.U_bvar uu____10074) ->
+              let uu____10076 =
+                let uu____10078 = FStar_Syntax_Print.univ_to_string u11  in
+                let uu____10080 = FStar_Syntax_Print.univ_to_string u21  in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____10064 uu____10066
+                  uu____10078 uu____10080
                  in
-              failwith uu____10062
-          | (uu____10069,FStar_Syntax_Syntax.U_unknown ) ->
-              let uu____10070 =
-                let uu____10072 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____10074 = FStar_Syntax_Print.univ_to_string u21  in
+              failwith uu____10076
+          | (uu____10083,FStar_Syntax_Syntax.U_unknown ) ->
+              let uu____10084 =
+                let uu____10086 = FStar_Syntax_Print.univ_to_string u11  in
+                let uu____10088 = FStar_Syntax_Print.univ_to_string u21  in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____10072 uu____10074
+                  uu____10086 uu____10088
                  in
-              failwith uu____10070
+              failwith uu____10084
           | (FStar_Syntax_Syntax.U_name x,FStar_Syntax_Syntax.U_name y) ->
-              if x.FStar_Ident.idText = y.FStar_Ident.idText
+              let uu____10093 =
+                let uu____10095 = FStar_Ident.text_of_id x  in
+                let uu____10097 = FStar_Ident.text_of_id y  in
+                uu____10095 = uu____10097  in
+              if uu____10093
               then USolved wl
               else ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_zero ) ->
@@ -3427,85 +3439,85 @@ let rec (really_solve_universe_eq :
           | (FStar_Syntax_Syntax.U_succ u12,FStar_Syntax_Syntax.U_succ u22)
               -> really_solve_universe_eq pid_orig wl u12 u22
           | (FStar_Syntax_Syntax.U_unif v1,FStar_Syntax_Syntax.U_unif v2) ->
-              let uu____10104 = FStar_Syntax_Unionfind.univ_equiv v1 v2  in
-              if uu____10104
+              let uu____10124 = FStar_Syntax_Unionfind.univ_equiv v1 v2  in
+              if uu____10124
               then USolved wl
               else
                 (let wl1 = extend_solution pid_orig [UNIV (v1, u21)] wl  in
                  USolved wl1)
           | (FStar_Syntax_Syntax.U_unif v1,u) ->
               let u3 = norm_univ wl u  in
-              let uu____10121 = occurs_univ v1 u3  in
-              if uu____10121
+              let uu____10141 = occurs_univ v1 u3  in
+              if uu____10141
               then
-                let uu____10124 =
-                  let uu____10126 =
+                let uu____10144 =
+                  let uu____10146 =
                     FStar_Syntax_Print.univ_to_string
                       (FStar_Syntax_Syntax.U_unif v1)
                      in
-                  let uu____10128 = FStar_Syntax_Print.univ_to_string u3  in
+                  let uu____10148 = FStar_Syntax_Print.univ_to_string u3  in
                   FStar_Util.format2 "Failed occurs check: %s occurs in %s"
-                    uu____10126 uu____10128
+                    uu____10146 uu____10148
                    in
-                try_umax_components u11 u21 uu____10124
+                try_umax_components u11 u21 uu____10144
               else
-                (let uu____10133 =
+                (let uu____10153 =
                    extend_solution pid_orig [UNIV (v1, u3)] wl  in
-                 USolved uu____10133)
+                 USolved uu____10153)
           | (u,FStar_Syntax_Syntax.U_unif v1) ->
               let u3 = norm_univ wl u  in
-              let uu____10145 = occurs_univ v1 u3  in
-              if uu____10145
+              let uu____10165 = occurs_univ v1 u3  in
+              if uu____10165
               then
-                let uu____10148 =
-                  let uu____10150 =
+                let uu____10168 =
+                  let uu____10170 =
                     FStar_Syntax_Print.univ_to_string
                       (FStar_Syntax_Syntax.U_unif v1)
                      in
-                  let uu____10152 = FStar_Syntax_Print.univ_to_string u3  in
+                  let uu____10172 = FStar_Syntax_Print.univ_to_string u3  in
                   FStar_Util.format2 "Failed occurs check: %s occurs in %s"
-                    uu____10150 uu____10152
+                    uu____10170 uu____10172
                    in
-                try_umax_components u11 u21 uu____10148
+                try_umax_components u11 u21 uu____10168
               else
-                (let uu____10157 =
+                (let uu____10177 =
                    extend_solution pid_orig [UNIV (v1, u3)] wl  in
-                 USolved uu____10157)
-          | (FStar_Syntax_Syntax.U_max uu____10158,uu____10159) ->
+                 USolved uu____10177)
+          | (FStar_Syntax_Syntax.U_max uu____10178,uu____10179) ->
               if wl.defer_ok
               then UDeferred wl
               else
                 (let u12 = norm_univ wl u11  in
                  let u22 = norm_univ wl u21  in
-                 let uu____10167 = FStar_Syntax_Util.eq_univs u12 u22  in
-                 if uu____10167
+                 let uu____10187 = FStar_Syntax_Util.eq_univs u12 u22  in
+                 if uu____10187
                  then USolved wl
                  else try_umax_components u12 u22 "")
-          | (uu____10173,FStar_Syntax_Syntax.U_max uu____10174) ->
+          | (uu____10193,FStar_Syntax_Syntax.U_max uu____10194) ->
               if wl.defer_ok
               then UDeferred wl
               else
                 (let u12 = norm_univ wl u11  in
                  let u22 = norm_univ wl u21  in
-                 let uu____10182 = FStar_Syntax_Util.eq_univs u12 u22  in
-                 if uu____10182
+                 let uu____10202 = FStar_Syntax_Util.eq_univs u12 u22  in
+                 if uu____10202
                  then USolved wl
                  else try_umax_components u12 u22 "")
           | (FStar_Syntax_Syntax.U_succ
-             uu____10188,FStar_Syntax_Syntax.U_zero ) ->
+             uu____10208,FStar_Syntax_Syntax.U_zero ) ->
               ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_succ
-             uu____10190,FStar_Syntax_Syntax.U_name uu____10191) ->
+             uu____10210,FStar_Syntax_Syntax.U_name uu____10211) ->
               ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_succ
-             uu____10193) -> ufailed_simple "Incompatible universes"
+             uu____10213) -> ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_name
-             uu____10195) -> ufailed_simple "Incompatible universes"
+             uu____10215) -> ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_name
-             uu____10197,FStar_Syntax_Syntax.U_succ uu____10198) ->
+             uu____10217,FStar_Syntax_Syntax.U_succ uu____10218) ->
               ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_name
-             uu____10200,FStar_Syntax_Syntax.U_zero ) ->
+             uu____10220,FStar_Syntax_Syntax.U_zero ) ->
               ufailed_simple "Incompatible universes"
   
 let (solve_universe_eq :
@@ -3530,25 +3542,25 @@ let match_num_binders :
   =
   fun bc1  ->
     fun bc2  ->
-      let uu____10307 = bc1  in
-      match uu____10307 with
+      let uu____10327 = bc1  in
+      match uu____10327 with
       | (bs1,mk_cod1) ->
-          let uu____10351 = bc2  in
-          (match uu____10351 with
+          let uu____10371 = bc2  in
+          (match uu____10371 with
            | (bs2,mk_cod2) ->
                let rec aux bs11 bs21 =
                  match (bs11, bs21) with
                  | (x::xs,y::ys) ->
-                     let uu____10462 = aux xs ys  in
-                     (match uu____10462 with
+                     let uu____10482 = aux xs ys  in
+                     (match uu____10482 with
                       | ((xs1,xr),(ys1,yr)) ->
                           (((x :: xs1), xr), ((y :: ys1), yr)))
                  | (xs,ys) ->
-                     let uu____10545 =
-                       let uu____10552 = mk_cod1 xs  in ([], uu____10552)  in
-                     let uu____10555 =
-                       let uu____10562 = mk_cod2 ys  in ([], uu____10562)  in
-                     (uu____10545, uu____10555)
+                     let uu____10565 =
+                       let uu____10572 = mk_cod1 xs  in ([], uu____10572)  in
+                     let uu____10575 =
+                       let uu____10582 = mk_cod2 ys  in ([], uu____10582)  in
+                     (uu____10565, uu____10575)
                   in
                aux bs1 bs2)
   
@@ -3567,35 +3579,35 @@ let (guard_of_prob :
             let has_type_guard t11 t21 =
               match problem.FStar_TypeChecker_Common.element with
               | FStar_Pervasives_Native.Some t ->
-                  let uu____10631 = FStar_Syntax_Syntax.bv_to_name t  in
-                  FStar_Syntax_Util.mk_has_type t11 uu____10631 t21
+                  let uu____10651 = FStar_Syntax_Syntax.bv_to_name t  in
+                  FStar_Syntax_Util.mk_has_type t11 uu____10651 t21
               | FStar_Pervasives_Native.None  ->
                   let x =
                     FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
                       t11
                      in
                   let u_x = env.FStar_TypeChecker_Env.universe_of env t11  in
-                  let uu____10634 =
-                    let uu____10635 = FStar_Syntax_Syntax.bv_to_name x  in
-                    FStar_Syntax_Util.mk_has_type t11 uu____10635 t21  in
-                  FStar_Syntax_Util.mk_forall u_x x uu____10634
+                  let uu____10654 =
+                    let uu____10655 = FStar_Syntax_Syntax.bv_to_name x  in
+                    FStar_Syntax_Util.mk_has_type t11 uu____10655 t21  in
+                  FStar_Syntax_Util.mk_forall u_x x uu____10654
                in
             match problem.FStar_TypeChecker_Common.relation with
             | FStar_TypeChecker_Common.EQ  ->
                 mk_eq2 wl env (FStar_TypeChecker_Common.TProb problem) t1 t2
             | FStar_TypeChecker_Common.SUB  ->
-                let uu____10640 = has_type_guard t1 t2  in (uu____10640, wl)
+                let uu____10660 = has_type_guard t1 t2  in (uu____10660, wl)
             | FStar_TypeChecker_Common.SUBINV  ->
-                let uu____10641 = has_type_guard t2 t1  in (uu____10641, wl)
+                let uu____10661 = has_type_guard t2 t1  in (uu____10661, wl)
   
 let is_flex_pat :
-  'uuuuuu10651 'uuuuuu10652 'uuuuuu10653 .
-    ('uuuuuu10651 * 'uuuuuu10652 * 'uuuuuu10653 Prims.list) -> Prims.bool
+  'uuuuuu10671 'uuuuuu10672 'uuuuuu10673 .
+    ('uuuuuu10671 * 'uuuuuu10672 * 'uuuuuu10673 Prims.list) -> Prims.bool
   =
-  fun uu___25_10667  ->
-    match uu___25_10667 with
-    | (uu____10676,uu____10677,[]) -> true
-    | uu____10681 -> false
+  fun uu___25_10687  ->
+    match uu___25_10687 with
+    | (uu____10696,uu____10697,[]) -> true
+    | uu____10701 -> false
   
 let (quasi_pattern :
   FStar_TypeChecker_Env.env ->
@@ -3605,161 +3617,161 @@ let (quasi_pattern :
   =
   fun env  ->
     fun f  ->
-      let uu____10714 = f  in
-      match uu____10714 with
-      | (uu____10721,{ FStar_Syntax_Syntax.ctx_uvar_head = uu____10722;
-                       FStar_Syntax_Syntax.ctx_uvar_gamma = uu____10723;
+      let uu____10734 = f  in
+      match uu____10734 with
+      | (uu____10741,{ FStar_Syntax_Syntax.ctx_uvar_head = uu____10742;
+                       FStar_Syntax_Syntax.ctx_uvar_gamma = uu____10743;
                        FStar_Syntax_Syntax.ctx_uvar_binders = ctx;
                        FStar_Syntax_Syntax.ctx_uvar_typ = t_hd;
-                       FStar_Syntax_Syntax.ctx_uvar_reason = uu____10726;
+                       FStar_Syntax_Syntax.ctx_uvar_reason = uu____10746;
                        FStar_Syntax_Syntax.ctx_uvar_should_check =
-                         uu____10727;
-                       FStar_Syntax_Syntax.ctx_uvar_range = uu____10728;
-                       FStar_Syntax_Syntax.ctx_uvar_meta = uu____10729;_},args)
+                         uu____10747;
+                       FStar_Syntax_Syntax.ctx_uvar_range = uu____10748;
+                       FStar_Syntax_Syntax.ctx_uvar_meta = uu____10749;_},args)
           ->
           let name_exists_in x bs =
             FStar_Util.for_some
-              (fun uu____10799  ->
-                 match uu____10799 with
-                 | (y,uu____10808) -> FStar_Syntax_Syntax.bv_eq x y) bs
+              (fun uu____10819  ->
+                 match uu____10819 with
+                 | (y,uu____10828) -> FStar_Syntax_Syntax.bv_eq x y) bs
              in
           let rec aux pat_binders formals t_res args1 =
             match (formals, args1) with
             | ([],[]) ->
-                let uu____10962 =
-                  let uu____10977 =
-                    let uu____10980 = FStar_Syntax_Syntax.mk_Total t_res  in
-                    FStar_Syntax_Util.arrow formals uu____10980  in
-                  ((FStar_List.rev pat_binders), uu____10977)  in
-                FStar_Pervasives_Native.Some uu____10962
-            | (uu____11013,[]) ->
-                let uu____11044 =
-                  let uu____11059 =
-                    let uu____11062 = FStar_Syntax_Syntax.mk_Total t_res  in
-                    FStar_Syntax_Util.arrow formals uu____11062  in
-                  ((FStar_List.rev pat_binders), uu____11059)  in
-                FStar_Pervasives_Native.Some uu____11044
+                let uu____10982 =
+                  let uu____10997 =
+                    let uu____11000 = FStar_Syntax_Syntax.mk_Total t_res  in
+                    FStar_Syntax_Util.arrow formals uu____11000  in
+                  ((FStar_List.rev pat_binders), uu____10997)  in
+                FStar_Pervasives_Native.Some uu____10982
+            | (uu____11033,[]) ->
+                let uu____11064 =
+                  let uu____11079 =
+                    let uu____11082 = FStar_Syntax_Syntax.mk_Total t_res  in
+                    FStar_Syntax_Util.arrow formals uu____11082  in
+                  ((FStar_List.rev pat_binders), uu____11079)  in
+                FStar_Pervasives_Native.Some uu____11064
             | ((formal,formal_imp)::formals1,(a,a_imp)::args2) ->
-                let uu____11153 =
-                  let uu____11154 = FStar_Syntax_Subst.compress a  in
-                  uu____11154.FStar_Syntax_Syntax.n  in
-                (match uu____11153 with
+                let uu____11173 =
+                  let uu____11174 = FStar_Syntax_Subst.compress a  in
+                  uu____11174.FStar_Syntax_Syntax.n  in
+                (match uu____11173 with
                  | FStar_Syntax_Syntax.Tm_name x ->
-                     let uu____11174 =
+                     let uu____11194 =
                        (name_exists_in x ctx) ||
                          (name_exists_in x pat_binders)
                         in
-                     if uu____11174
+                     if uu____11194
                      then
                        aux ((formal, formal_imp) :: pat_binders) formals1
                          t_res args2
                      else
                        (let x1 =
-                          let uu___1618_11204 = x  in
+                          let uu___1618_11224 = x  in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___1618_11204.FStar_Syntax_Syntax.ppname);
+                              (uu___1618_11224.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___1618_11204.FStar_Syntax_Syntax.index);
+                              (uu___1618_11224.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort =
                               (formal.FStar_Syntax_Syntax.sort)
                           }  in
                         let subst =
-                          let uu____11208 =
-                            let uu____11209 =
-                              let uu____11216 =
+                          let uu____11228 =
+                            let uu____11229 =
+                              let uu____11236 =
                                 FStar_Syntax_Syntax.bv_to_name x1  in
-                              (formal, uu____11216)  in
-                            FStar_Syntax_Syntax.NT uu____11209  in
-                          [uu____11208]  in
+                              (formal, uu____11236)  in
+                            FStar_Syntax_Syntax.NT uu____11229  in
+                          [uu____11228]  in
                         let formals2 =
                           FStar_Syntax_Subst.subst_binders subst formals1  in
                         let t_res1 = FStar_Syntax_Subst.subst subst t_res  in
                         aux
-                          (((let uu___1624_11232 = x1  in
+                          (((let uu___1624_11252 = x1  in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___1624_11232.FStar_Syntax_Syntax.ppname);
+                                 (uu___1624_11252.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___1624_11232.FStar_Syntax_Syntax.index);
+                                 (uu___1624_11252.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort =
                                  (formal.FStar_Syntax_Syntax.sort)
                              }), a_imp) :: pat_binders) formals2 t_res1 args2)
-                 | uu____11233 ->
+                 | uu____11253 ->
                      aux ((formal, formal_imp) :: pat_binders) formals1 t_res
                        args2)
             | ([],args2) ->
-                let uu____11273 =
-                  let uu____11280 =
+                let uu____11293 =
+                  let uu____11300 =
                     FStar_TypeChecker_Normalize.unfold_whnf env t_res  in
-                  FStar_Syntax_Util.arrow_formals uu____11280  in
-                (match uu____11273 with
+                  FStar_Syntax_Util.arrow_formals uu____11300  in
+                (match uu____11293 with
                  | (more_formals,t_res1) ->
                      (match more_formals with
                       | [] -> FStar_Pervasives_Native.None
-                      | uu____11339 ->
+                      | uu____11359 ->
                           aux pat_binders more_formals t_res1 args2))
              in
           (match args with
            | [] -> FStar_Pervasives_Native.Some ([], t_hd)
-           | uu____11364 ->
-               let uu____11365 = FStar_Syntax_Util.arrow_formals t_hd  in
-               (match uu____11365 with
+           | uu____11384 ->
+               let uu____11385 = FStar_Syntax_Util.arrow_formals t_hd  in
+               (match uu____11385 with
                 | (formals,t_res) -> aux [] formals t_res args))
   
 let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
   fun env  ->
     fun probs  ->
-      (let uu____11661 =
+      (let uu____11681 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "Rel")
           in
-       if uu____11661
+       if uu____11681
        then
-         let uu____11666 = wl_to_string probs  in
-         FStar_Util.print1 "solve:\n\t%s\n" uu____11666
+         let uu____11686 = wl_to_string probs  in
+         FStar_Util.print1 "solve:\n\t%s\n" uu____11686
        else ());
-      (let uu____11672 =
+      (let uu____11692 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "ImplicitTrace")
           in
-       if uu____11672
+       if uu____11692
        then
-         let uu____11677 =
+         let uu____11697 =
            FStar_TypeChecker_Common.implicits_to_string probs.wl_implicits
             in
-         FStar_Util.print1 "solve: wl_implicits = %s\n" uu____11677
+         FStar_Util.print1 "solve: wl_implicits = %s\n" uu____11697
        else ());
-      (let uu____11682 = next_prob probs  in
-       match uu____11682 with
+      (let uu____11702 = next_prob probs  in
+       match uu____11702 with
        | FStar_Pervasives_Native.Some (hd,tl,rank1) ->
            let probs1 =
-             let uu___1651_11709 = probs  in
+             let uu___1651_11729 = probs  in
              {
                attempting = tl;
-               wl_deferred = (uu___1651_11709.wl_deferred);
-               ctr = (uu___1651_11709.ctr);
-               defer_ok = (uu___1651_11709.defer_ok);
-               smt_ok = (uu___1651_11709.smt_ok);
-               umax_heuristic_ok = (uu___1651_11709.umax_heuristic_ok);
-               tcenv = (uu___1651_11709.tcenv);
-               wl_implicits = (uu___1651_11709.wl_implicits)
+               wl_deferred = (uu___1651_11729.wl_deferred);
+               ctr = (uu___1651_11729.ctr);
+               defer_ok = (uu___1651_11729.defer_ok);
+               smt_ok = (uu___1651_11729.smt_ok);
+               umax_heuristic_ok = (uu___1651_11729.umax_heuristic_ok);
+               tcenv = (uu___1651_11729.tcenv);
+               wl_implicits = (uu___1651_11729.wl_implicits)
              }  in
            (def_check_prob "solve,hd" hd;
             (match hd with
              | FStar_TypeChecker_Common.CProb cp ->
                  solve_c env (maybe_invert cp) probs1
              | FStar_TypeChecker_Common.TProb tp ->
-                 let uu____11718 =
+                 let uu____11738 =
                    FStar_Util.physical_equality
                      tp.FStar_TypeChecker_Common.lhs
                      tp.FStar_TypeChecker_Common.rhs
                     in
-                 if uu____11718
+                 if uu____11738
                  then
-                   let uu____11721 =
+                   let uu____11741 =
                      solve_prob hd FStar_Pervasives_Native.None [] probs1  in
-                   solve env uu____11721
+                   solve env uu____11741
                  else
                    if
                      (rank1 = FStar_TypeChecker_Common.Rigid_rigid) ||
@@ -3770,38 +3782,38 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
                    else
                      if probs1.defer_ok
                      then
-                       (let uu____11728 =
+                       (let uu____11748 =
                           defer_lit
                             "deferring flex_rigid or flex_flex subtyping" hd
                             probs1
                            in
-                        solve env uu____11728)
+                        solve env uu____11748)
                      else
                        if rank1 = FStar_TypeChecker_Common.Flex_flex
                        then
                          solve_t env
-                           (let uu___1663_11734 = tp  in
+                           (let uu___1663_11754 = tp  in
                             {
                               FStar_TypeChecker_Common.pid =
-                                (uu___1663_11734.FStar_TypeChecker_Common.pid);
+                                (uu___1663_11754.FStar_TypeChecker_Common.pid);
                               FStar_TypeChecker_Common.lhs =
-                                (uu___1663_11734.FStar_TypeChecker_Common.lhs);
+                                (uu___1663_11754.FStar_TypeChecker_Common.lhs);
                               FStar_TypeChecker_Common.relation =
                                 FStar_TypeChecker_Common.EQ;
                               FStar_TypeChecker_Common.rhs =
-                                (uu___1663_11734.FStar_TypeChecker_Common.rhs);
+                                (uu___1663_11754.FStar_TypeChecker_Common.rhs);
                               FStar_TypeChecker_Common.element =
-                                (uu___1663_11734.FStar_TypeChecker_Common.element);
+                                (uu___1663_11754.FStar_TypeChecker_Common.element);
                               FStar_TypeChecker_Common.logical_guard =
-                                (uu___1663_11734.FStar_TypeChecker_Common.logical_guard);
+                                (uu___1663_11754.FStar_TypeChecker_Common.logical_guard);
                               FStar_TypeChecker_Common.logical_guard_uvar =
-                                (uu___1663_11734.FStar_TypeChecker_Common.logical_guard_uvar);
+                                (uu___1663_11754.FStar_TypeChecker_Common.logical_guard_uvar);
                               FStar_TypeChecker_Common.reason =
-                                (uu___1663_11734.FStar_TypeChecker_Common.reason);
+                                (uu___1663_11754.FStar_TypeChecker_Common.reason);
                               FStar_TypeChecker_Common.loc =
-                                (uu___1663_11734.FStar_TypeChecker_Common.loc);
+                                (uu___1663_11754.FStar_TypeChecker_Common.loc);
                               FStar_TypeChecker_Common.rank =
-                                (uu___1663_11734.FStar_TypeChecker_Common.rank)
+                                (uu___1663_11754.FStar_TypeChecker_Common.rank)
                             }) probs1
                        else
                          solve_rigid_flex_or_flex_rigid_subtyping rank1 env
@@ -3809,52 +3821,52 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
        | FStar_Pervasives_Native.None  ->
            (match probs.wl_deferred with
             | [] -> Success ([], (probs.wl_implicits))
-            | uu____11759 ->
-                let uu____11769 =
+            | uu____11779 ->
+                let uu____11789 =
                   FStar_All.pipe_right probs.wl_deferred
                     (FStar_List.partition
-                       (fun uu____11834  ->
-                          match uu____11834 with
-                          | (c,uu____11844,uu____11845) -> c < probs.ctr))
+                       (fun uu____11854  ->
+                          match uu____11854 with
+                          | (c,uu____11864,uu____11865) -> c < probs.ctr))
                    in
-                (match uu____11769 with
+                (match uu____11789 with
                  | (attempt1,rest) ->
                      (match attempt1 with
                       | [] ->
-                          let uu____11893 =
-                            let uu____11898 =
+                          let uu____11913 =
+                            let uu____11918 =
                               FStar_List.map
-                                (fun uu____11919  ->
-                                   match uu____11919 with
-                                   | (uu____11935,x,y) ->
-                                       let uu____11946 = FStar_Thunk.force x
+                                (fun uu____11939  ->
+                                   match uu____11939 with
+                                   | (uu____11955,x,y) ->
+                                       let uu____11966 = FStar_Thunk.force x
                                           in
-                                       (uu____11946, y)) probs.wl_deferred
+                                       (uu____11966, y)) probs.wl_deferred
                                in
-                            (uu____11898, (probs.wl_implicits))  in
-                          Success uu____11893
-                      | uu____11950 ->
-                          let uu____11960 =
-                            let uu___1681_11961 = probs  in
-                            let uu____11962 =
+                            (uu____11918, (probs.wl_implicits))  in
+                          Success uu____11913
+                      | uu____11970 ->
+                          let uu____11980 =
+                            let uu___1681_11981 = probs  in
+                            let uu____11982 =
                               FStar_All.pipe_right attempt1
                                 (FStar_List.map
-                                   (fun uu____11983  ->
-                                      match uu____11983 with
-                                      | (uu____11991,uu____11992,y) -> y))
+                                   (fun uu____12003  ->
+                                      match uu____12003 with
+                                      | (uu____12011,uu____12012,y) -> y))
                                in
                             {
-                              attempting = uu____11962;
+                              attempting = uu____11982;
                               wl_deferred = rest;
-                              ctr = (uu___1681_11961.ctr);
-                              defer_ok = (uu___1681_11961.defer_ok);
-                              smt_ok = (uu___1681_11961.smt_ok);
+                              ctr = (uu___1681_11981.ctr);
+                              defer_ok = (uu___1681_11981.defer_ok);
+                              smt_ok = (uu___1681_11981.smt_ok);
                               umax_heuristic_ok =
-                                (uu___1681_11961.umax_heuristic_ok);
-                              tcenv = (uu___1681_11961.tcenv);
-                              wl_implicits = (uu___1681_11961.wl_implicits)
+                                (uu___1681_11981.umax_heuristic_ok);
+                              tcenv = (uu___1681_11981.tcenv);
+                              wl_implicits = (uu___1681_11981.wl_implicits)
                             }  in
-                          solve env uu____11960))))
+                          solve env uu____11980))))
 
 and (solve_one_universe_eq :
   FStar_TypeChecker_Env.env ->
@@ -3867,16 +3879,16 @@ and (solve_one_universe_eq :
       fun u1  ->
         fun u2  ->
           fun wl  ->
-            let uu____12001 = solve_universe_eq (p_pid orig) wl u1 u2  in
-            match uu____12001 with
+            let uu____12021 = solve_universe_eq (p_pid orig) wl u1 u2  in
+            match uu____12021 with
             | USolved wl1 ->
-                let uu____12003 =
+                let uu____12023 =
                   solve_prob orig FStar_Pervasives_Native.None [] wl1  in
-                solve env uu____12003
+                solve env uu____12023
             | UFailed msg -> giveup env msg orig
             | UDeferred wl1 ->
-                let uu____12006 = defer_lit "" orig wl1  in
-                solve env uu____12006
+                let uu____12026 = defer_lit "" orig wl1  in
+                solve env uu____12026
 
 and (solve_maybe_uinsts :
   FStar_TypeChecker_Env.env ->
@@ -3893,12 +3905,12 @@ and (solve_maybe_uinsts :
               match (us1, us2) with
               | ([],[]) -> USolved wl1
               | (u1::us11,u2::us21) ->
-                  let uu____12057 = solve_universe_eq (p_pid orig) wl1 u1 u2
+                  let uu____12077 = solve_universe_eq (p_pid orig) wl1 u1 u2
                      in
-                  (match uu____12057 with
+                  (match uu____12077 with
                    | USolved wl2 -> aux wl2 us11 us21
                    | failed_or_deferred -> failed_or_deferred)
-              | uu____12060 -> ufailed_simple "Unequal number of universes"
+              | uu____12080 -> ufailed_simple "Unequal number of universes"
                in
             let t11 = whnf env t1  in
             let t21 = whnf env t2  in
@@ -3906,17 +3918,17 @@ and (solve_maybe_uinsts :
             with
             | (FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
-                  FStar_Syntax_Syntax.pos = uu____12073;
-                  FStar_Syntax_Syntax.vars = uu____12074;_},us1),FStar_Syntax_Syntax.Tm_uinst
+                  FStar_Syntax_Syntax.pos = uu____12093;
+                  FStar_Syntax_Syntax.vars = uu____12094;_},us1),FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar g;
-                  FStar_Syntax_Syntax.pos = uu____12077;
-                  FStar_Syntax_Syntax.vars = uu____12078;_},us2))
+                  FStar_Syntax_Syntax.pos = uu____12097;
+                  FStar_Syntax_Syntax.vars = uu____12098;_},us2))
                 -> let b = FStar_Syntax_Syntax.fv_eq f g  in aux wl us1 us2
-            | (FStar_Syntax_Syntax.Tm_uinst uu____12091,uu____12092) ->
+            | (FStar_Syntax_Syntax.Tm_uinst uu____12111,uu____12112) ->
                 failwith "Impossible: expect head symbols to match"
-            | (uu____12100,FStar_Syntax_Syntax.Tm_uinst uu____12101) ->
+            | (uu____12120,FStar_Syntax_Syntax.Tm_uinst uu____12121) ->
                 failwith "Impossible: expect head symbols to match"
-            | uu____12109 -> USolved wl
+            | uu____12129 -> USolved wl
 
 and (giveup_or_defer :
   FStar_TypeChecker_Env.env ->
@@ -3928,16 +3940,16 @@ and (giveup_or_defer :
         fun msg  ->
           if wl.defer_ok
           then
-            ((let uu____12120 =
+            ((let uu____12140 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                   (FStar_Options.Other "Rel")
                  in
-              if uu____12120
+              if uu____12140
               then
-                let uu____12125 = prob_to_string env orig  in
-                let uu____12127 = FStar_Thunk.force msg  in
+                let uu____12145 = prob_to_string env orig  in
+                let uu____12147 = FStar_Thunk.force msg  in
                 FStar_Util.print2 "\n\t\tDeferring %s\n\t\tBecause %s\n"
-                  uu____12125 uu____12127
+                  uu____12145 uu____12147
               else ());
              solve env (defer msg orig wl))
           else giveup env msg orig
@@ -3955,192 +3967,192 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
           (let flip = rank1 = FStar_TypeChecker_Common.Flex_rigid  in
            let meet_or_join op ts env1 wl1 =
              let eq_prob t1 t2 wl2 =
-               let uu____12220 =
+               let uu____12240 =
                  new_problem wl2 env1 t1 FStar_TypeChecker_Common.EQ t2
                    FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
                    "join/meet refinements"
                   in
-               match uu____12220 with
+               match uu____12240 with
                | (p,wl3) ->
                    (def_check_prob "meet_or_join"
                       (FStar_TypeChecker_Common.TProb p);
                     ((FStar_TypeChecker_Common.TProb p), wl3))
                 in
              let pairwise t1 t2 wl2 =
-               (let uu____12275 =
+               (let uu____12295 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                     (FStar_Options.Other "Rel")
                    in
-                if uu____12275
+                if uu____12295
                 then
-                  let uu____12280 = FStar_Syntax_Print.term_to_string t1  in
-                  let uu____12282 = FStar_Syntax_Print.term_to_string t2  in
+                  let uu____12300 = FStar_Syntax_Print.term_to_string t1  in
+                  let uu____12302 = FStar_Syntax_Print.term_to_string t2  in
                   FStar_Util.print2 "[meet/join]: pairwise: %s and %s\n"
-                    uu____12280 uu____12282
+                    uu____12300 uu____12302
                 else ());
-               (let uu____12287 = head_matches_delta env1 wl2 t1 t2  in
-                match uu____12287 with
+               (let uu____12307 = head_matches_delta env1 wl2 t1 t2  in
+                match uu____12307 with
                 | (mr,ts1) ->
                     (match mr with
                      | HeadMatch (true ) ->
-                         let uu____12333 = eq_prob t1 t2 wl2  in
-                         (match uu____12333 with | (p,wl3) -> (t1, [p], wl3))
-                     | MisMatch uu____12354 ->
-                         let uu____12363 = eq_prob t1 t2 wl2  in
-                         (match uu____12363 with | (p,wl3) -> (t1, [p], wl3))
+                         let uu____12353 = eq_prob t1 t2 wl2  in
+                         (match uu____12353 with | (p,wl3) -> (t1, [p], wl3))
+                     | MisMatch uu____12374 ->
+                         let uu____12383 = eq_prob t1 t2 wl2  in
+                         (match uu____12383 with | (p,wl3) -> (t1, [p], wl3))
                      | FullMatch  ->
                          (match ts1 with
                           | FStar_Pervasives_Native.None  -> (t1, [], wl2)
                           | FStar_Pervasives_Native.Some (t11,t21) ->
                               (t11, [], wl2))
                      | HeadMatch (false ) ->
-                         let uu____12413 =
+                         let uu____12433 =
                            match ts1 with
                            | FStar_Pervasives_Native.Some (t11,t21) ->
-                               let uu____12428 =
+                               let uu____12448 =
                                  FStar_Syntax_Subst.compress t11  in
-                               let uu____12429 =
+                               let uu____12449 =
                                  FStar_Syntax_Subst.compress t21  in
-                               (uu____12428, uu____12429)
+                               (uu____12448, uu____12449)
                            | FStar_Pervasives_Native.None  ->
-                               let uu____12434 =
+                               let uu____12454 =
                                  FStar_Syntax_Subst.compress t1  in
-                               let uu____12435 =
+                               let uu____12455 =
                                  FStar_Syntax_Subst.compress t2  in
-                               (uu____12434, uu____12435)
+                               (uu____12454, uu____12455)
                             in
-                         (match uu____12413 with
+                         (match uu____12433 with
                           | (t11,t21) ->
                               let try_eq t12 t22 wl3 =
-                                let uu____12466 =
+                                let uu____12486 =
                                   FStar_Syntax_Util.head_and_args t12  in
-                                match uu____12466 with
+                                match uu____12486 with
                                 | (t1_hd,t1_args) ->
-                                    let uu____12511 =
+                                    let uu____12531 =
                                       FStar_Syntax_Util.head_and_args t22  in
-                                    (match uu____12511 with
+                                    (match uu____12531 with
                                      | (t2_hd,t2_args) ->
                                          if
                                            (FStar_List.length t1_args) <>
                                              (FStar_List.length t2_args)
                                          then FStar_Pervasives_Native.None
                                          else
-                                           (let uu____12577 =
-                                              let uu____12584 =
-                                                let uu____12595 =
+                                           (let uu____12597 =
+                                              let uu____12604 =
+                                                let uu____12615 =
                                                   FStar_Syntax_Syntax.as_arg
                                                     t1_hd
                                                    in
-                                                uu____12595 :: t1_args  in
-                                              let uu____12612 =
-                                                let uu____12621 =
+                                                uu____12615 :: t1_args  in
+                                              let uu____12632 =
+                                                let uu____12641 =
                                                   FStar_Syntax_Syntax.as_arg
                                                     t2_hd
                                                    in
-                                                uu____12621 :: t2_args  in
+                                                uu____12641 :: t2_args  in
                                               FStar_List.fold_left2
-                                                (fun uu____12670  ->
-                                                   fun uu____12671  ->
-                                                     fun uu____12672  ->
-                                                       match (uu____12670,
-                                                               uu____12671,
-                                                               uu____12672)
+                                                (fun uu____12690  ->
+                                                   fun uu____12691  ->
+                                                     fun uu____12692  ->
+                                                       match (uu____12690,
+                                                               uu____12691,
+                                                               uu____12692)
                                                        with
                                                        | ((probs,wl4),
-                                                          (a1,uu____12722),
-                                                          (a2,uu____12724))
+                                                          (a1,uu____12742),
+                                                          (a2,uu____12744))
                                                            ->
-                                                           let uu____12761 =
+                                                           let uu____12781 =
                                                              eq_prob a1 a2
                                                                wl4
                                                               in
-                                                           (match uu____12761
+                                                           (match uu____12781
                                                             with
                                                             | (p,wl5) ->
                                                                 ((p ::
                                                                   probs),
                                                                   wl5)))
-                                                ([], wl3) uu____12584
-                                                uu____12612
+                                                ([], wl3) uu____12604
+                                                uu____12632
                                                in
-                                            match uu____12577 with
+                                            match uu____12597 with
                                             | (probs,wl4) ->
                                                 let wl' =
-                                                  let uu___1835_12787 = wl4
+                                                  let uu___1835_12807 = wl4
                                                      in
                                                   {
                                                     attempting = probs;
                                                     wl_deferred = [];
                                                     ctr =
-                                                      (uu___1835_12787.ctr);
+                                                      (uu___1835_12807.ctr);
                                                     defer_ok = false;
                                                     smt_ok = false;
                                                     umax_heuristic_ok =
-                                                      (uu___1835_12787.umax_heuristic_ok);
+                                                      (uu___1835_12807.umax_heuristic_ok);
                                                     tcenv =
-                                                      (uu___1835_12787.tcenv);
+                                                      (uu___1835_12807.tcenv);
                                                     wl_implicits = []
                                                   }  in
                                                 let tx =
                                                   FStar_Syntax_Unionfind.new_transaction
                                                     ()
                                                    in
-                                                let uu____12798 =
+                                                let uu____12818 =
                                                   solve env1 wl'  in
-                                                (match uu____12798 with
-                                                 | Success (uu____12801,imps)
+                                                (match uu____12818 with
+                                                 | Success (uu____12821,imps)
                                                      ->
                                                      (FStar_Syntax_Unionfind.commit
                                                         tx;
                                                       FStar_Pervasives_Native.Some
-                                                        ((let uu___1844_12805
+                                                        ((let uu___1844_12825
                                                             = wl4  in
                                                           {
                                                             attempting =
-                                                              (uu___1844_12805.attempting);
+                                                              (uu___1844_12825.attempting);
                                                             wl_deferred =
-                                                              (uu___1844_12805.wl_deferred);
+                                                              (uu___1844_12825.wl_deferred);
                                                             ctr =
-                                                              (uu___1844_12805.ctr);
+                                                              (uu___1844_12825.ctr);
                                                             defer_ok =
-                                                              (uu___1844_12805.defer_ok);
+                                                              (uu___1844_12825.defer_ok);
                                                             smt_ok =
-                                                              (uu___1844_12805.smt_ok);
+                                                              (uu___1844_12825.smt_ok);
                                                             umax_heuristic_ok
                                                               =
-                                                              (uu___1844_12805.umax_heuristic_ok);
+                                                              (uu___1844_12825.umax_heuristic_ok);
                                                             tcenv =
-                                                              (uu___1844_12805.tcenv);
+                                                              (uu___1844_12825.tcenv);
                                                             wl_implicits =
                                                               (FStar_List.append
                                                                  wl4.wl_implicits
                                                                  imps)
                                                           })))
-                                                 | Failed uu____12806 ->
+                                                 | Failed uu____12826 ->
                                                      (FStar_Syntax_Unionfind.rollback
                                                         tx;
                                                       FStar_Pervasives_Native.None))))
                                  in
                               let combine t12 t22 wl3 =
-                                let uu____12838 =
+                                let uu____12858 =
                                   base_and_refinement_maybe_delta false env1
                                     t12
                                    in
-                                match uu____12838 with
+                                match uu____12858 with
                                 | (t1_base,p1_opt) ->
-                                    let uu____12874 =
+                                    let uu____12894 =
                                       base_and_refinement_maybe_delta false
                                         env1 t22
                                        in
-                                    (match uu____12874 with
+                                    (match uu____12894 with
                                      | (t2_base,p2_opt) ->
                                          let combine_refinements t_base
                                            p1_opt1 p2_opt1 =
                                            let refine x t =
-                                             let uu____12973 =
+                                             let uu____12993 =
                                                FStar_Syntax_Util.is_t_true t
                                                 in
-                                             if uu____12973
+                                             if uu____12993
                                              then x.FStar_Syntax_Syntax.sort
                                              else
                                                FStar_Syntax_Util.refine x t
@@ -4165,9 +4177,9 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                  FStar_Syntax_Subst.subst
                                                    subst phi2
                                                   in
-                                               let uu____13026 =
+                                               let uu____13046 =
                                                  op phi11 phi21  in
-                                               refine x1 uu____13026
+                                               refine x1 uu____13046
                                            | (FStar_Pervasives_Native.None
                                               ,FStar_Pervasives_Native.Some
                                               (x,phi)) ->
@@ -4183,11 +4195,11 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                  FStar_Syntax_Subst.subst
                                                    subst phi
                                                   in
-                                               let uu____13058 =
+                                               let uu____13078 =
                                                  op FStar_Syntax_Util.t_true
                                                    phi1
                                                   in
-                                               refine x1 uu____13058
+                                               refine x1 uu____13078
                                            | (FStar_Pervasives_Native.Some
                                               (x,phi),FStar_Pervasives_Native.None
                                               ) ->
@@ -4203,40 +4215,40 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                  FStar_Syntax_Subst.subst
                                                    subst phi
                                                   in
-                                               let uu____13090 =
+                                               let uu____13110 =
                                                  op FStar_Syntax_Util.t_true
                                                    phi1
                                                   in
-                                               refine x1 uu____13090
-                                           | uu____13093 -> t_base  in
-                                         let uu____13110 =
+                                               refine x1 uu____13110
+                                           | uu____13113 -> t_base  in
+                                         let uu____13130 =
                                            try_eq t1_base t2_base wl3  in
-                                         (match uu____13110 with
+                                         (match uu____13130 with
                                           | FStar_Pervasives_Native.Some wl4
                                               ->
-                                              let uu____13124 =
+                                              let uu____13144 =
                                                 combine_refinements t1_base
                                                   p1_opt p2_opt
                                                  in
-                                              (uu____13124, [], wl4)
+                                              (uu____13144, [], wl4)
                                           | FStar_Pervasives_Native.None  ->
-                                              let uu____13131 =
+                                              let uu____13151 =
                                                 base_and_refinement_maybe_delta
                                                   true env1 t12
                                                  in
-                                              (match uu____13131 with
+                                              (match uu____13151 with
                                                | (t1_base1,p1_opt1) ->
-                                                   let uu____13167 =
+                                                   let uu____13187 =
                                                      base_and_refinement_maybe_delta
                                                        true env1 t22
                                                       in
-                                                   (match uu____13167 with
+                                                   (match uu____13187 with
                                                     | (t2_base1,p2_opt1) ->
-                                                        let uu____13203 =
+                                                        let uu____13223 =
                                                           eq_prob t1_base1
                                                             t2_base1 wl3
                                                            in
-                                                        (match uu____13203
+                                                        (match uu____13223
                                                          with
                                                          | (p,wl4) ->
                                                              let t =
@@ -4247,45 +4259,45 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                 in
                                                              (t, [p], wl4))))))
                                  in
-                              let uu____13227 = combine t11 t21 wl2  in
-                              (match uu____13227 with
+                              let uu____13247 = combine t11 t21 wl2  in
+                              (match uu____13247 with
                                | (t12,ps,wl3) ->
-                                   ((let uu____13260 =
+                                   ((let uu____13280 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env1)
                                          (FStar_Options.Other "Rel")
                                         in
-                                     if uu____13260
+                                     if uu____13280
                                      then
-                                       let uu____13265 =
+                                       let uu____13285 =
                                          FStar_Syntax_Print.term_to_string
                                            t12
                                           in
                                        FStar_Util.print1
                                          "pairwise fallback2 succeeded: %s"
-                                         uu____13265
+                                         uu____13285
                                      else ());
                                     (t12, ps, wl3))))))
                 in
-             let rec aux uu____13307 ts1 =
-               match uu____13307 with
+             let rec aux uu____13327 ts1 =
+               match uu____13327 with
                | (out,probs,wl2) ->
                    (match ts1 with
                     | [] -> (out, probs, wl2)
                     | t::ts2 ->
-                        let uu____13370 = pairwise out t wl2  in
-                        (match uu____13370 with
+                        let uu____13390 = pairwise out t wl2  in
+                        (match uu____13390 with
                          | (out1,probs',wl3) ->
                              aux
                                (out1, (FStar_List.append probs probs'), wl3)
                                ts2))
                 in
-             let uu____13406 =
-               let uu____13417 = FStar_List.hd ts  in (uu____13417, [], wl1)
+             let uu____13426 =
+               let uu____13437 = FStar_List.hd ts  in (uu____13437, [], wl1)
                 in
-             let uu____13426 = FStar_List.tl ts  in
-             aux uu____13406 uu____13426  in
-           let uu____13433 =
+             let uu____13446 = FStar_List.tl ts  in
+             aux uu____13426 uu____13446  in
+           let uu____13453 =
              if flip
              then
                ((tp.FStar_TypeChecker_Common.lhs),
@@ -4294,42 +4306,42 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                ((tp.FStar_TypeChecker_Common.rhs),
                  (tp.FStar_TypeChecker_Common.lhs))
               in
-           match uu____13433 with
+           match uu____13453 with
            | (this_flex,this_rigid) ->
-               let uu____13459 =
-                 let uu____13460 = FStar_Syntax_Subst.compress this_rigid  in
-                 uu____13460.FStar_Syntax_Syntax.n  in
-               (match uu____13459 with
+               let uu____13479 =
+                 let uu____13480 = FStar_Syntax_Subst.compress this_rigid  in
+                 uu____13480.FStar_Syntax_Syntax.n  in
+               (match uu____13479 with
                 | FStar_Syntax_Syntax.Tm_arrow (_bs,comp) ->
-                    let uu____13485 =
+                    let uu____13505 =
                       FStar_Syntax_Util.is_tot_or_gtot_comp comp  in
-                    if uu____13485
+                    if uu____13505
                     then
-                      let uu____13488 = destruct_flex_t this_flex wl  in
-                      (match uu____13488 with
+                      let uu____13508 = destruct_flex_t this_flex wl  in
+                      (match uu____13508 with
                        | (flex,wl1) ->
-                           let uu____13495 = quasi_pattern env flex  in
-                           (match uu____13495 with
+                           let uu____13515 = quasi_pattern env flex  in
+                           (match uu____13515 with
                             | FStar_Pervasives_Native.None  ->
                                 giveup_lit env
                                   "flex-arrow subtyping, not a quasi pattern"
                                   (FStar_TypeChecker_Common.TProb tp)
                             | FStar_Pervasives_Native.Some (flex_bs,flex_t1)
                                 ->
-                                ((let uu____13514 =
+                                ((let uu____13534 =
                                     FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug env)
                                       (FStar_Options.Other "Rel")
                                      in
-                                  if uu____13514
+                                  if uu____13534
                                   then
-                                    let uu____13519 =
+                                    let uu____13539 =
                                       FStar_Util.string_of_int
                                         tp.FStar_TypeChecker_Common.pid
                                        in
                                     FStar_Util.print1
                                       "Trying to solve by imitating arrow:%s\n"
-                                      uu____13519
+                                      uu____13539
                                   else ());
                                  imitate_arrow
                                    (FStar_TypeChecker_Common.TProb tp) env
@@ -4337,81 +4349,81 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                    tp.FStar_TypeChecker_Common.relation
                                    this_rigid)))
                     else
-                      (let uu____13526 =
+                      (let uu____13546 =
                          attempt
                            [FStar_TypeChecker_Common.TProb
-                              ((let uu___1946_13529 = tp  in
+                              ((let uu___1946_13549 = tp  in
                                 {
                                   FStar_TypeChecker_Common.pid =
-                                    (uu___1946_13529.FStar_TypeChecker_Common.pid);
+                                    (uu___1946_13549.FStar_TypeChecker_Common.pid);
                                   FStar_TypeChecker_Common.lhs =
-                                    (uu___1946_13529.FStar_TypeChecker_Common.lhs);
+                                    (uu___1946_13549.FStar_TypeChecker_Common.lhs);
                                   FStar_TypeChecker_Common.relation =
                                     FStar_TypeChecker_Common.EQ;
                                   FStar_TypeChecker_Common.rhs =
-                                    (uu___1946_13529.FStar_TypeChecker_Common.rhs);
+                                    (uu___1946_13549.FStar_TypeChecker_Common.rhs);
                                   FStar_TypeChecker_Common.element =
-                                    (uu___1946_13529.FStar_TypeChecker_Common.element);
+                                    (uu___1946_13549.FStar_TypeChecker_Common.element);
                                   FStar_TypeChecker_Common.logical_guard =
-                                    (uu___1946_13529.FStar_TypeChecker_Common.logical_guard);
+                                    (uu___1946_13549.FStar_TypeChecker_Common.logical_guard);
                                   FStar_TypeChecker_Common.logical_guard_uvar
                                     =
-                                    (uu___1946_13529.FStar_TypeChecker_Common.logical_guard_uvar);
+                                    (uu___1946_13549.FStar_TypeChecker_Common.logical_guard_uvar);
                                   FStar_TypeChecker_Common.reason =
-                                    (uu___1946_13529.FStar_TypeChecker_Common.reason);
+                                    (uu___1946_13549.FStar_TypeChecker_Common.reason);
                                   FStar_TypeChecker_Common.loc =
-                                    (uu___1946_13529.FStar_TypeChecker_Common.loc);
+                                    (uu___1946_13549.FStar_TypeChecker_Common.loc);
                                   FStar_TypeChecker_Common.rank =
-                                    (uu___1946_13529.FStar_TypeChecker_Common.rank)
+                                    (uu___1946_13549.FStar_TypeChecker_Common.rank)
                                 }))] wl
                           in
-                       solve env uu____13526)
-                | uu____13530 ->
-                    ((let uu____13532 =
+                       solve env uu____13546)
+                | uu____13550 ->
+                    ((let uu____13552 =
                         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                           (FStar_Options.Other "Rel")
                          in
-                      if uu____13532
+                      if uu____13552
                       then
-                        let uu____13537 =
+                        let uu____13557 =
                           FStar_Util.string_of_int
                             tp.FStar_TypeChecker_Common.pid
                            in
                         FStar_Util.print1
                           "Trying to solve by meeting refinements:%s\n"
-                          uu____13537
+                          uu____13557
                       else ());
-                     (let uu____13542 =
+                     (let uu____13562 =
                         FStar_Syntax_Util.head_and_args this_flex  in
-                      match uu____13542 with
+                      match uu____13562 with
                       | (u,_args) ->
-                          let uu____13585 =
-                            let uu____13586 = FStar_Syntax_Subst.compress u
+                          let uu____13605 =
+                            let uu____13606 = FStar_Syntax_Subst.compress u
                                in
-                            uu____13586.FStar_Syntax_Syntax.n  in
-                          (match uu____13585 with
+                            uu____13606.FStar_Syntax_Syntax.n  in
+                          (match uu____13605 with
                            | FStar_Syntax_Syntax.Tm_uvar (ctx_uvar,_subst) ->
                                let equiv t =
-                                 let uu____13614 =
+                                 let uu____13634 =
                                    FStar_Syntax_Util.head_and_args t  in
-                                 match uu____13614 with
-                                 | (u',uu____13633) ->
-                                     let uu____13658 =
-                                       let uu____13659 = whnf env u'  in
-                                       uu____13659.FStar_Syntax_Syntax.n  in
-                                     (match uu____13658 with
+                                 match uu____13634 with
+                                 | (u',uu____13653) ->
+                                     let uu____13678 =
+                                       let uu____13679 = whnf env u'  in
+                                       uu____13679.FStar_Syntax_Syntax.n  in
+                                     (match uu____13678 with
                                       | FStar_Syntax_Syntax.Tm_uvar
                                           (ctx_uvar',_subst') ->
                                           FStar_Syntax_Unionfind.equiv
                                             ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head
                                             ctx_uvar'.FStar_Syntax_Syntax.ctx_uvar_head
-                                      | uu____13681 -> false)
+                                      | uu____13701 -> false)
                                   in
-                               let uu____13683 =
+                               let uu____13703 =
                                  FStar_All.pipe_right wl.attempting
                                    (FStar_List.partition
-                                      (fun uu___26_13706  ->
-                                         match uu___26_13706 with
+                                      (fun uu___26_13726  ->
+                                         match uu___26_13726 with
                                          | FStar_TypeChecker_Common.TProb tp1
                                              ->
                                              let tp2 = maybe_invert tp1  in
@@ -4426,21 +4438,21 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                   else
                                                     equiv
                                                       tp2.FStar_TypeChecker_Common.rhs
-                                              | uu____13720 -> false)
-                                         | uu____13724 -> false))
+                                              | uu____13740 -> false)
+                                         | uu____13744 -> false))
                                   in
-                               (match uu____13683 with
+                               (match uu____13703 with
                                 | (bounds_probs,rest) ->
                                     let bounds_typs =
-                                      let uu____13739 = whnf env this_rigid
+                                      let uu____13759 = whnf env this_rigid
                                          in
-                                      let uu____13740 =
+                                      let uu____13760 =
                                         FStar_List.collect
-                                          (fun uu___27_13746  ->
-                                             match uu___27_13746 with
+                                          (fun uu___27_13766  ->
+                                             match uu___27_13766 with
                                              | FStar_TypeChecker_Common.TProb
                                                  p ->
-                                                 let uu____13752 =
+                                                 let uu____13772 =
                                                    if flip
                                                    then
                                                      whnf env
@@ -4449,48 +4461,48 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                      whnf env
                                                        (maybe_invert p).FStar_TypeChecker_Common.lhs
                                                     in
-                                                 [uu____13752]
-                                             | uu____13756 -> [])
+                                                 [uu____13772]
+                                             | uu____13776 -> [])
                                           bounds_probs
                                          in
-                                      uu____13739 :: uu____13740  in
-                                    let uu____13757 =
+                                      uu____13759 :: uu____13760  in
+                                    let uu____13777 =
                                       meet_or_join
                                         (if flip
                                          then FStar_Syntax_Util.mk_conj_simp
                                          else FStar_Syntax_Util.mk_disj_simp)
                                         bounds_typs env wl
                                        in
-                                    (match uu____13757 with
+                                    (match uu____13777 with
                                      | (bound,sub_probs,wl1) ->
-                                         let uu____13790 =
+                                         let uu____13810 =
                                            let flex_u =
                                              flex_uvar_head this_flex  in
                                            let bound1 =
-                                             let uu____13805 =
-                                               let uu____13806 =
+                                             let uu____13825 =
+                                               let uu____13826 =
                                                  FStar_Syntax_Subst.compress
                                                    bound
                                                   in
-                                               uu____13806.FStar_Syntax_Syntax.n
+                                               uu____13826.FStar_Syntax_Syntax.n
                                                 in
-                                             match uu____13805 with
+                                             match uu____13825 with
                                              | FStar_Syntax_Syntax.Tm_refine
                                                  (x,phi) when
                                                  (tp.FStar_TypeChecker_Common.relation
                                                     =
                                                     FStar_TypeChecker_Common.SUB)
                                                    &&
-                                                   (let uu____13818 =
+                                                   (let uu____13838 =
                                                       occurs flex_u
                                                         x.FStar_Syntax_Syntax.sort
                                                        in
                                                     FStar_Pervasives_Native.snd
-                                                      uu____13818)
+                                                      uu____13838)
                                                  ->
                                                  x.FStar_Syntax_Syntax.sort
-                                             | uu____13829 -> bound  in
-                                           let uu____13830 =
+                                             | uu____13849 -> bound  in
+                                           let uu____13850 =
                                              new_problem wl1 env bound1
                                                FStar_TypeChecker_Common.EQ
                                                this_flex
@@ -4500,23 +4512,23 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                 then "joining refinements"
                                                 else "meeting refinements")
                                               in
-                                           (bound1, uu____13830)  in
-                                         (match uu____13790 with
+                                           (bound1, uu____13850)  in
+                                         (match uu____13810 with
                                           | (bound_typ,(eq_prob,wl')) ->
                                               (def_check_prob "meet_or_join2"
                                                  (FStar_TypeChecker_Common.TProb
                                                     eq_prob);
-                                               (let uu____13865 =
+                                               (let uu____13885 =
                                                   FStar_All.pipe_left
                                                     (FStar_TypeChecker_Env.debug
                                                        env)
                                                     (FStar_Options.Other
                                                        "Rel")
                                                    in
-                                                if uu____13865
+                                                if uu____13885
                                                 then
                                                   let wl'1 =
-                                                    let uu___2006_13871 = wl1
+                                                    let uu___2006_13891 = wl1
                                                        in
                                                     {
                                                       attempting =
@@ -4524,91 +4536,91 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                             eq_prob) ::
                                                         sub_probs);
                                                       wl_deferred =
-                                                        (uu___2006_13871.wl_deferred);
+                                                        (uu___2006_13891.wl_deferred);
                                                       ctr =
-                                                        (uu___2006_13871.ctr);
+                                                        (uu___2006_13891.ctr);
                                                       defer_ok =
-                                                        (uu___2006_13871.defer_ok);
+                                                        (uu___2006_13891.defer_ok);
                                                       smt_ok =
-                                                        (uu___2006_13871.smt_ok);
+                                                        (uu___2006_13891.smt_ok);
                                                       umax_heuristic_ok =
-                                                        (uu___2006_13871.umax_heuristic_ok);
+                                                        (uu___2006_13891.umax_heuristic_ok);
                                                       tcenv =
-                                                        (uu___2006_13871.tcenv);
+                                                        (uu___2006_13891.tcenv);
                                                       wl_implicits =
-                                                        (uu___2006_13871.wl_implicits)
+                                                        (uu___2006_13891.wl_implicits)
                                                     }  in
-                                                  let uu____13872 =
+                                                  let uu____13892 =
                                                     wl_to_string wl'1  in
                                                   FStar_Util.print1
                                                     "After meet/join refinements: %s\n"
-                                                    uu____13872
+                                                    uu____13892
                                                 else ());
                                                (let tx =
                                                   FStar_Syntax_Unionfind.new_transaction
                                                     ()
                                                    in
-                                                let uu____13878 =
+                                                let uu____13898 =
                                                   solve_t env eq_prob
-                                                    (let uu___2011_13880 =
+                                                    (let uu___2011_13900 =
                                                        wl'  in
                                                      {
                                                        attempting = sub_probs;
                                                        wl_deferred =
-                                                         (uu___2011_13880.wl_deferred);
+                                                         (uu___2011_13900.wl_deferred);
                                                        ctr =
-                                                         (uu___2011_13880.ctr);
+                                                         (uu___2011_13900.ctr);
                                                        defer_ok = false;
                                                        smt_ok =
-                                                         (uu___2011_13880.smt_ok);
+                                                         (uu___2011_13900.smt_ok);
                                                        umax_heuristic_ok =
-                                                         (uu___2011_13880.umax_heuristic_ok);
+                                                         (uu___2011_13900.umax_heuristic_ok);
                                                        tcenv =
-                                                         (uu___2011_13880.tcenv);
+                                                         (uu___2011_13900.tcenv);
                                                        wl_implicits = []
                                                      })
                                                    in
-                                                match uu____13878 with
-                                                | Success (uu____13882,imps)
+                                                match uu____13898 with
+                                                | Success (uu____13902,imps)
                                                     ->
                                                     let wl2 =
-                                                      let uu___2017_13885 =
+                                                      let uu___2017_13905 =
                                                         wl'  in
                                                       {
                                                         attempting = rest;
                                                         wl_deferred =
-                                                          (uu___2017_13885.wl_deferred);
+                                                          (uu___2017_13905.wl_deferred);
                                                         ctr =
-                                                          (uu___2017_13885.ctr);
+                                                          (uu___2017_13905.ctr);
                                                         defer_ok =
-                                                          (uu___2017_13885.defer_ok);
+                                                          (uu___2017_13905.defer_ok);
                                                         smt_ok =
-                                                          (uu___2017_13885.smt_ok);
+                                                          (uu___2017_13905.smt_ok);
                                                         umax_heuristic_ok =
-                                                          (uu___2017_13885.umax_heuristic_ok);
+                                                          (uu___2017_13905.umax_heuristic_ok);
                                                         tcenv =
-                                                          (uu___2017_13885.tcenv);
+                                                          (uu___2017_13905.tcenv);
                                                         wl_implicits =
-                                                          (uu___2017_13885.wl_implicits)
+                                                          (uu___2017_13905.wl_implicits)
                                                       }  in
                                                     let wl3 =
-                                                      let uu___2020_13887 =
+                                                      let uu___2020_13907 =
                                                         wl2  in
                                                       {
                                                         attempting =
-                                                          (uu___2020_13887.attempting);
+                                                          (uu___2020_13907.attempting);
                                                         wl_deferred =
-                                                          (uu___2020_13887.wl_deferred);
+                                                          (uu___2020_13907.wl_deferred);
                                                         ctr =
-                                                          (uu___2020_13887.ctr);
+                                                          (uu___2020_13907.ctr);
                                                         defer_ok =
-                                                          (uu___2020_13887.defer_ok);
+                                                          (uu___2020_13907.defer_ok);
                                                         smt_ok =
-                                                          (uu___2020_13887.smt_ok);
+                                                          (uu___2020_13907.smt_ok);
                                                         umax_heuristic_ok =
-                                                          (uu___2020_13887.umax_heuristic_ok);
+                                                          (uu___2020_13907.umax_heuristic_ok);
                                                         tcenv =
-                                                          (uu___2020_13887.tcenv);
+                                                          (uu___2020_13907.tcenv);
                                                         wl_implicits =
                                                           (FStar_List.append
                                                              wl'.wl_implicits
@@ -4630,7 +4642,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                         (FStar_Pervasives_Native.Some
                                                            g) [] wl3
                                                        in
-                                                    let uu____13903 =
+                                                    let uu____13923 =
                                                       FStar_List.fold_left
                                                         (fun wl5  ->
                                                            fun p  ->
@@ -4644,17 +4656,17 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                        tx;
                                                      solve env wl4)
                                                 | Failed (p,msg) ->
-                                                    ((let uu____13915 =
+                                                    ((let uu____13935 =
                                                         FStar_All.pipe_left
                                                           (FStar_TypeChecker_Env.debug
                                                              env)
                                                           (FStar_Options.Other
                                                              "Rel")
                                                          in
-                                                      if uu____13915
+                                                      if uu____13935
                                                       then
-                                                        let uu____13920 =
-                                                          let uu____13922 =
+                                                        let uu____13940 =
+                                                          let uu____13942 =
                                                             FStar_List.map
                                                               (prob_to_string
                                                                  env)
@@ -4663,29 +4675,29 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                               sub_probs)
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____13922
+                                                            uu____13942
                                                             (FStar_String.concat
                                                                "\n")
                                                            in
                                                         FStar_Util.print1
                                                           "meet/join attempted and failed to solve problems:\n%s\n"
-                                                          uu____13920
+                                                          uu____13940
                                                       else ());
-                                                     (let uu____13935 =
-                                                        let uu____13950 =
+                                                     (let uu____13955 =
+                                                        let uu____13970 =
                                                           base_and_refinement
                                                             env bound_typ
                                                            in
-                                                        (rank1, uu____13950)
+                                                        (rank1, uu____13970)
                                                          in
-                                                      match uu____13935 with
+                                                      match uu____13955 with
                                                       | (FStar_TypeChecker_Common.Rigid_flex
                                                          ,(t_base,FStar_Pervasives_Native.Some
-                                                           uu____13972))
+                                                           uu____13992))
                                                           ->
                                                           (FStar_Syntax_Unionfind.rollback
                                                              tx;
-                                                           (let uu____13998 =
+                                                           (let uu____14018 =
                                                               new_problem wl1
                                                                 env t_base
                                                                 FStar_TypeChecker_Common.EQ
@@ -4694,7 +4706,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                 tp.FStar_TypeChecker_Common.loc
                                                                 "widened subtyping"
                                                                in
-                                                            match uu____13998
+                                                            match uu____14018
                                                             with
                                                             | (eq_prob1,wl2)
                                                                 ->
@@ -4713,7 +4725,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1)))
                                                                     [] wl2
                                                                      in
-                                                                  let uu____14018
+                                                                  let uu____14038
                                                                     =
                                                                     attempt
                                                                     [
@@ -4721,14 +4733,14 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1]
                                                                     wl3  in
                                                                   solve env
-                                                                    uu____14018))))
+                                                                    uu____14038))))
                                                       | (FStar_TypeChecker_Common.Flex_rigid
                                                          ,(t_base,FStar_Pervasives_Native.Some
                                                            (x,phi)))
                                                           ->
                                                           (FStar_Syntax_Unionfind.rollback
                                                              tx;
-                                                           (let uu____14043 =
+                                                           (let uu____14063 =
                                                               new_problem wl1
                                                                 env t_base
                                                                 FStar_TypeChecker_Common.EQ
@@ -4737,7 +4749,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                 tp.FStar_TypeChecker_Common.loc
                                                                 "widened subtyping"
                                                                in
-                                                            match uu____14043
+                                                            match uu____14063
                                                             with
                                                             | (eq_prob1,wl2)
                                                                 ->
@@ -4750,9 +4762,9 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     wl2 tp x
                                                                     phi  in
                                                                   let wl3 =
-                                                                    let uu____14063
+                                                                    let uu____14083
                                                                     =
-                                                                    let uu____14068
+                                                                    let uu____14088
                                                                     =
                                                                     FStar_Syntax_Util.mk_conj
                                                                     phi1
@@ -4761,16 +4773,16 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1))
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____14068
+                                                                    uu____14088
                                                                      in
                                                                     solve_prob'
                                                                     false
                                                                     (FStar_TypeChecker_Common.TProb
                                                                     tp)
-                                                                    uu____14063
+                                                                    uu____14083
                                                                     [] wl2
                                                                      in
-                                                                  let uu____14074
+                                                                  let uu____14094
                                                                     =
                                                                     attempt
                                                                     [
@@ -4778,9 +4790,9 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1]
                                                                     wl3  in
                                                                   solve env
-                                                                    uu____14074))))
-                                                      | uu____14075 ->
-                                                          let uu____14090 =
+                                                                    uu____14094))))
+                                                      | uu____14095 ->
+                                                          let uu____14110 =
                                                             FStar_Thunk.map
                                                               (fun s  ->
                                                                  Prims.op_Hat
@@ -4788,37 +4800,37 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                    s) msg
                                                              in
                                                           giveup env
-                                                            uu____14090 p)))))))
-                           | uu____14097 when flip ->
-                               let uu____14098 =
-                                 let uu____14100 =
+                                                            uu____14110 p)))))))
+                           | uu____14117 when flip ->
+                               let uu____14118 =
+                                 let uu____14120 =
                                    FStar_Util.string_of_int
                                      (rank_t_num rank1)
                                     in
-                                 let uu____14102 =
+                                 let uu____14122 =
                                    prob_to_string env
                                      (FStar_TypeChecker_Common.TProb tp)
                                     in
                                  FStar_Util.format2
                                    "Impossible: (rank=%s) Not a flex-rigid: %s"
-                                   uu____14100 uu____14102
+                                   uu____14120 uu____14122
                                   in
-                               failwith uu____14098
-                           | uu____14105 ->
-                               let uu____14106 =
-                                 let uu____14108 =
+                               failwith uu____14118
+                           | uu____14125 ->
+                               let uu____14126 =
+                                 let uu____14128 =
                                    FStar_Util.string_of_int
                                      (rank_t_num rank1)
                                     in
-                                 let uu____14110 =
+                                 let uu____14130 =
                                    prob_to_string env
                                      (FStar_TypeChecker_Common.TProb tp)
                                     in
                                  FStar_Util.format2
                                    "Impossible: (rank=%s) Not a rigid-flex: %s"
-                                   uu____14108 uu____14110
+                                   uu____14128 uu____14130
                                   in
-                               failwith uu____14106)))))
+                               failwith uu____14126)))))
 
 and (imitate_arrow :
   FStar_TypeChecker_Common.prob ->
@@ -4840,43 +4852,43 @@ and (imitate_arrow :
                 fun arrow  ->
                   let bs_lhs_args =
                     FStar_List.map
-                      (fun uu____14146  ->
-                         match uu____14146 with
+                      (fun uu____14166  ->
+                         match uu____14166 with
                          | (x,i) ->
-                             let uu____14165 =
+                             let uu____14185 =
                                FStar_Syntax_Syntax.bv_to_name x  in
-                             (uu____14165, i)) bs_lhs
+                             (uu____14185, i)) bs_lhs
                      in
-                  let uu____14168 = lhs  in
-                  match uu____14168 with
-                  | (uu____14169,u_lhs,uu____14171) ->
+                  let uu____14188 = lhs  in
+                  match uu____14188 with
+                  | (uu____14189,u_lhs,uu____14191) ->
                       let imitate_comp bs bs_terms c wl1 =
                         let imitate_tot_or_gtot t uopt f wl2 =
-                          let uu____14268 =
+                          let uu____14288 =
                             match uopt with
                             | FStar_Pervasives_Native.None  ->
                                 FStar_Syntax_Util.type_u ()
                             | FStar_Pervasives_Native.Some univ ->
-                                let uu____14278 =
+                                let uu____14298 =
                                   FStar_Syntax_Syntax.mk
                                     (FStar_Syntax_Syntax.Tm_type univ)
                                     FStar_Pervasives_Native.None
                                     t.FStar_Syntax_Syntax.pos
                                    in
-                                (uu____14278, univ)
+                                (uu____14298, univ)
                              in
-                          match uu____14268 with
+                          match uu____14288 with
                           | (k,univ) ->
-                              let uu____14285 =
+                              let uu____14305 =
                                 copy_uvar u_lhs (FStar_List.append bs_lhs bs)
                                   k wl2
                                  in
-                              (match uu____14285 with
-                               | (uu____14302,u,wl3) ->
-                                   let uu____14305 =
+                              (match uu____14305 with
+                               | (uu____14322,u,wl3) ->
+                                   let uu____14325 =
                                      f u (FStar_Pervasives_Native.Some univ)
                                       in
-                                   (uu____14305, wl3))
+                                   (uu____14325, wl3))
                            in
                         match c.FStar_Syntax_Syntax.n with
                         | FStar_Syntax_Syntax.Total (t,uopt) ->
@@ -4886,168 +4898,168 @@ and (imitate_arrow :
                             imitate_tot_or_gtot t uopt
                               FStar_Syntax_Syntax.mk_GTotal' wl1
                         | FStar_Syntax_Syntax.Comp ct ->
-                            let uu____14331 =
-                              let uu____14344 =
-                                let uu____14355 =
+                            let uu____14351 =
+                              let uu____14364 =
+                                let uu____14375 =
                                   FStar_Syntax_Syntax.as_arg
                                     ct.FStar_Syntax_Syntax.result_typ
                                    in
-                                uu____14355 ::
+                                uu____14375 ::
                                   (ct.FStar_Syntax_Syntax.effect_args)
                                  in
                               FStar_List.fold_right
-                                (fun uu____14406  ->
-                                   fun uu____14407  ->
-                                     match (uu____14406, uu____14407) with
+                                (fun uu____14426  ->
+                                   fun uu____14427  ->
+                                     match (uu____14426, uu____14427) with
                                      | ((a,i),(out_args,wl2)) ->
-                                         let uu____14508 =
-                                           let uu____14515 =
-                                             let uu____14518 =
+                                         let uu____14528 =
+                                           let uu____14535 =
+                                             let uu____14538 =
                                                FStar_Syntax_Util.type_u ()
                                                 in
                                              FStar_All.pipe_left
                                                FStar_Pervasives_Native.fst
-                                               uu____14518
+                                               uu____14538
                                               in
-                                           copy_uvar u_lhs [] uu____14515 wl2
+                                           copy_uvar u_lhs [] uu____14535 wl2
                                             in
-                                         (match uu____14508 with
-                                          | (uu____14547,t_a,wl3) ->
-                                              let uu____14550 =
+                                         (match uu____14528 with
+                                          | (uu____14567,t_a,wl3) ->
+                                              let uu____14570 =
                                                 copy_uvar u_lhs bs t_a wl3
                                                  in
-                                              (match uu____14550 with
-                                               | (uu____14569,a',wl4) ->
+                                              (match uu____14570 with
+                                               | (uu____14589,a',wl4) ->
                                                    (((a', i) :: out_args),
-                                                     wl4)))) uu____14344
+                                                     wl4)))) uu____14364
                                 ([], wl1)
                                in
-                            (match uu____14331 with
+                            (match uu____14351 with
                              | (out_args,wl2) ->
                                  let ct' =
-                                   let uu___2131_14625 = ct  in
-                                   let uu____14626 =
-                                     let uu____14629 = FStar_List.hd out_args
+                                   let uu___2131_14645 = ct  in
+                                   let uu____14646 =
+                                     let uu____14649 = FStar_List.hd out_args
                                         in
-                                     FStar_Pervasives_Native.fst uu____14629
+                                     FStar_Pervasives_Native.fst uu____14649
                                       in
-                                   let uu____14644 = FStar_List.tl out_args
+                                   let uu____14664 = FStar_List.tl out_args
                                       in
                                    {
                                      FStar_Syntax_Syntax.comp_univs =
-                                       (uu___2131_14625.FStar_Syntax_Syntax.comp_univs);
+                                       (uu___2131_14645.FStar_Syntax_Syntax.comp_univs);
                                      FStar_Syntax_Syntax.effect_name =
-                                       (uu___2131_14625.FStar_Syntax_Syntax.effect_name);
+                                       (uu___2131_14645.FStar_Syntax_Syntax.effect_name);
                                      FStar_Syntax_Syntax.result_typ =
-                                       uu____14626;
+                                       uu____14646;
                                      FStar_Syntax_Syntax.effect_args =
-                                       uu____14644;
+                                       uu____14664;
                                      FStar_Syntax_Syntax.flags =
-                                       (uu___2131_14625.FStar_Syntax_Syntax.flags)
+                                       (uu___2131_14645.FStar_Syntax_Syntax.flags)
                                    }  in
-                                 ((let uu___2134_14662 = c  in
+                                 ((let uu___2134_14682 = c  in
                                    {
                                      FStar_Syntax_Syntax.n =
                                        (FStar_Syntax_Syntax.Comp ct');
                                      FStar_Syntax_Syntax.pos =
-                                       (uu___2134_14662.FStar_Syntax_Syntax.pos);
+                                       (uu___2134_14682.FStar_Syntax_Syntax.pos);
                                      FStar_Syntax_Syntax.vars =
-                                       (uu___2134_14662.FStar_Syntax_Syntax.vars)
+                                       (uu___2134_14682.FStar_Syntax_Syntax.vars)
                                    }), wl2))
                          in
-                      let uu____14665 =
+                      let uu____14685 =
                         FStar_Syntax_Util.arrow_formals_comp arrow  in
-                      (match uu____14665 with
+                      (match uu____14685 with
                        | (formals,c) ->
                            let rec aux bs bs_terms formals1 wl1 =
                              match formals1 with
                              | [] ->
-                                 let uu____14703 =
+                                 let uu____14723 =
                                    imitate_comp bs bs_terms c wl1  in
-                                 (match uu____14703 with
+                                 (match uu____14723 with
                                   | (c',wl2) ->
                                       let lhs' =
                                         FStar_Syntax_Util.arrow bs c'  in
                                       let sol =
-                                        let uu____14714 =
-                                          let uu____14719 =
+                                        let uu____14734 =
+                                          let uu____14739 =
                                             FStar_Syntax_Util.abs bs_lhs lhs'
                                               (FStar_Pervasives_Native.Some
                                                  (FStar_Syntax_Util.residual_tot
                                                     t_res_lhs))
                                              in
-                                          (u_lhs, uu____14719)  in
-                                        TERM uu____14714  in
-                                      let uu____14720 =
+                                          (u_lhs, uu____14739)  in
+                                        TERM uu____14734  in
+                                      let uu____14740 =
                                         mk_t_problem wl2 [] orig lhs' rel
                                           arrow FStar_Pervasives_Native.None
                                           "arrow imitation"
                                          in
-                                      (match uu____14720 with
+                                      (match uu____14740 with
                                        | (sub_prob,wl3) ->
-                                           let uu____14734 =
-                                             let uu____14735 =
+                                           let uu____14754 =
+                                             let uu____14755 =
                                                solve_prob orig
                                                  FStar_Pervasives_Native.None
                                                  [sol] wl3
                                                 in
-                                             attempt [sub_prob] uu____14735
+                                             attempt [sub_prob] uu____14755
                                               in
-                                           solve env uu____14734))
+                                           solve env uu____14754))
                              | (x,imp)::formals2 ->
-                                 let uu____14757 =
-                                   let uu____14764 =
-                                     let uu____14767 =
+                                 let uu____14777 =
+                                   let uu____14784 =
+                                     let uu____14787 =
                                        FStar_Syntax_Util.type_u ()  in
-                                     FStar_All.pipe_right uu____14767
+                                     FStar_All.pipe_right uu____14787
                                        FStar_Pervasives_Native.fst
                                       in
                                    copy_uvar u_lhs
                                      (FStar_List.append bs_lhs bs)
-                                     uu____14764 wl1
+                                     uu____14784 wl1
                                     in
-                                 (match uu____14757 with
+                                 (match uu____14777 with
                                   | (_ctx_u_x,u_x,wl2) ->
                                       let y =
-                                        let uu____14788 =
-                                          let uu____14791 =
+                                        let uu____14808 =
+                                          let uu____14811 =
                                             FStar_Syntax_Syntax.range_of_bv x
                                              in
                                           FStar_Pervasives_Native.Some
-                                            uu____14791
+                                            uu____14811
                                            in
                                         FStar_Syntax_Syntax.new_bv
-                                          uu____14788 u_x
+                                          uu____14808 u_x
                                          in
-                                      let uu____14792 =
-                                        let uu____14795 =
-                                          let uu____14798 =
-                                            let uu____14799 =
+                                      let uu____14812 =
+                                        let uu____14815 =
+                                          let uu____14818 =
+                                            let uu____14819 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 y
                                                in
-                                            (uu____14799, imp)  in
-                                          [uu____14798]  in
+                                            (uu____14819, imp)  in
+                                          [uu____14818]  in
                                         FStar_List.append bs_terms
-                                          uu____14795
+                                          uu____14815
                                          in
                                       aux (FStar_List.append bs [(y, imp)])
-                                        uu____14792 formals2 wl2)
+                                        uu____14812 formals2 wl2)
                               in
-                           let uu____14826 = occurs_check u_lhs arrow  in
-                           (match uu____14826 with
-                            | (uu____14839,occurs_ok,msg) ->
+                           let uu____14846 = occurs_check u_lhs arrow  in
+                           (match uu____14846 with
+                            | (uu____14859,occurs_ok,msg) ->
                                 if Prims.op_Negation occurs_ok
                                 then
-                                  let uu____14855 =
+                                  let uu____14875 =
                                     mklstr
-                                      (fun uu____14860  ->
-                                         let uu____14861 =
+                                      (fun uu____14880  ->
+                                         let uu____14881 =
                                            FStar_Option.get msg  in
                                          Prims.op_Hat "occurs-check failed: "
-                                           uu____14861)
+                                           uu____14881)
                                      in
-                                  giveup_or_defer env orig wl uu____14855
+                                  giveup_or_defer env orig wl uu____14875
                                 else aux [] [] formals wl))
 
 and (solve_binders :
@@ -5069,139 +5081,139 @@ and (solve_binders :
         fun orig  ->
           fun wl  ->
             fun rhs  ->
-              (let uu____14894 =
+              (let uu____14914 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Rel")
                   in
-               if uu____14894
+               if uu____14914
                then
-                 let uu____14899 =
+                 let uu____14919 =
                    FStar_Syntax_Print.binders_to_string ", " bs1  in
-                 let uu____14902 =
+                 let uu____14922 =
                    FStar_Syntax_Print.binders_to_string ", " bs2  in
                  FStar_Util.print3 "solve_binders\n\t%s\n%s\n\t%s\n"
-                   uu____14899 (rel_to_string (p_rel orig)) uu____14902
+                   uu____14919 (rel_to_string (p_rel orig)) uu____14922
                else ());
               (let rec aux wl1 scope env1 subst xs ys =
                  match (xs, ys) with
                  | ([],[]) ->
-                     let uu____15033 = rhs wl1 scope env1 subst  in
-                     (match uu____15033 with
+                     let uu____15053 = rhs wl1 scope env1 subst  in
+                     (match uu____15053 with
                       | (rhs_prob,wl2) ->
-                          ((let uu____15056 =
+                          ((let uu____15076 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env1)
                                 (FStar_Options.Other "Rel")
                                in
-                            if uu____15056
+                            if uu____15076
                             then
-                              let uu____15061 = prob_to_string env1 rhs_prob
+                              let uu____15081 = prob_to_string env1 rhs_prob
                                  in
-                              FStar_Util.print1 "rhs_prob = %s\n" uu____15061
+                              FStar_Util.print1 "rhs_prob = %s\n" uu____15081
                             else ());
                            (let formula = p_guard rhs_prob  in
                             (env1, (FStar_Util.Inl ([rhs_prob], formula)),
                               wl2))))
                  | ((hd1,imp)::xs1,(hd2,imp')::ys1) when
-                     let uu____15139 = FStar_Syntax_Util.eq_aqual imp imp'
+                     let uu____15159 = FStar_Syntax_Util.eq_aqual imp imp'
                         in
-                     uu____15139 = FStar_Syntax_Util.Equal ->
+                     uu____15159 = FStar_Syntax_Util.Equal ->
                      let hd11 =
-                       let uu___2204_15141 = hd1  in
-                       let uu____15142 =
+                       let uu___2204_15161 = hd1  in
+                       let uu____15162 =
                          FStar_Syntax_Subst.subst subst
                            hd1.FStar_Syntax_Syntax.sort
                           in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___2204_15141.FStar_Syntax_Syntax.ppname);
+                           (uu___2204_15161.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___2204_15141.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu____15142
+                           (uu___2204_15161.FStar_Syntax_Syntax.index);
+                         FStar_Syntax_Syntax.sort = uu____15162
                        }  in
                      let hd21 =
-                       let uu___2207_15146 = hd2  in
-                       let uu____15147 =
+                       let uu___2207_15166 = hd2  in
+                       let uu____15167 =
                          FStar_Syntax_Subst.subst subst
                            hd2.FStar_Syntax_Syntax.sort
                           in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___2207_15146.FStar_Syntax_Syntax.ppname);
+                           (uu___2207_15166.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___2207_15146.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu____15147
+                           (uu___2207_15166.FStar_Syntax_Syntax.index);
+                         FStar_Syntax_Syntax.sort = uu____15167
                        }  in
-                     let uu____15150 =
-                       let uu____15155 =
+                     let uu____15170 =
+                       let uu____15175 =
                          FStar_All.pipe_left invert_rel (p_rel orig)  in
                        mk_t_problem wl1 scope orig
-                         hd11.FStar_Syntax_Syntax.sort uu____15155
+                         hd11.FStar_Syntax_Syntax.sort uu____15175
                          hd21.FStar_Syntax_Syntax.sort
                          FStar_Pervasives_Native.None "Formal parameter"
                         in
-                     (match uu____15150 with
+                     (match uu____15170 with
                       | (prob,wl2) ->
                           let hd12 = FStar_Syntax_Syntax.freshen_bv hd11  in
                           let subst1 =
-                            let uu____15178 =
+                            let uu____15198 =
                               FStar_Syntax_Subst.shift_subst Prims.int_one
                                 subst
                                in
                             (FStar_Syntax_Syntax.DB (Prims.int_zero, hd12))
-                              :: uu____15178
+                              :: uu____15198
                              in
                           let env2 = FStar_TypeChecker_Env.push_bv env1 hd12
                              in
-                          let uu____15185 =
+                          let uu____15205 =
                             aux wl2 (FStar_List.append scope [(hd12, imp)])
                               env2 subst1 xs1 ys1
                              in
-                          (match uu____15185 with
+                          (match uu____15205 with
                            | (env3,FStar_Util.Inl (sub_probs,phi),wl3) ->
                                let phi1 =
-                                 let uu____15257 =
+                                 let uu____15277 =
                                    FStar_TypeChecker_Env.close_forall env3
                                      [(hd12, imp)] phi
                                     in
                                  FStar_Syntax_Util.mk_conj (p_guard prob)
-                                   uu____15257
+                                   uu____15277
                                   in
-                               ((let uu____15275 =
+                               ((let uu____15295 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env3)
                                      (FStar_Options.Other "Rel")
                                     in
-                                 if uu____15275
+                                 if uu____15295
                                  then
-                                   let uu____15280 =
+                                   let uu____15300 =
                                      FStar_Syntax_Print.term_to_string phi1
                                       in
-                                   let uu____15282 =
+                                   let uu____15302 =
                                      FStar_Syntax_Print.bv_to_string hd12  in
                                    FStar_Util.print2
-                                     "Formula is %s\n\thd1=%s\n" uu____15280
-                                     uu____15282
+                                     "Formula is %s\n\thd1=%s\n" uu____15300
+                                     uu____15302
                                  else ());
                                 (env3,
                                   (FStar_Util.Inl ((prob :: sub_probs), phi1)),
                                   wl3))
                            | fail -> fail))
-                 | uu____15317 ->
+                 | uu____15337 ->
                      (env1,
                        (FStar_Util.Inr "arity or argument-qualifier mismatch"),
                        wl1)
                   in
-               let uu____15353 = aux wl [] env [] bs1 bs2  in
-               match uu____15353 with
+               let uu____15373 = aux wl [] env [] bs1 bs2  in
+               match uu____15373 with
                | (env1,FStar_Util.Inr msg,wl1) -> giveup_lit env1 msg orig
                | (env1,FStar_Util.Inl (sub_probs,phi),wl1) ->
                    let wl2 =
                      solve_prob orig (FStar_Pervasives_Native.Some phi) []
                        wl1
                       in
-                   let uu____15412 = attempt sub_probs wl2  in
-                   solve env1 uu____15412)
+                   let uu____15432 = attempt sub_probs wl2  in
+                   solve env1 uu____15432)
 
 and (try_solve_without_smt_or_else :
   FStar_TypeChecker_Env.env ->
@@ -5216,32 +5228,32 @@ and (try_solve_without_smt_or_else :
       fun try_solve  ->
         fun else_solve  ->
           let wl' =
-            let uu___2245_15432 = wl  in
+            let uu___2245_15452 = wl  in
             {
               attempting = [];
               wl_deferred = [];
-              ctr = (uu___2245_15432.ctr);
+              ctr = (uu___2245_15452.ctr);
               defer_ok = false;
               smt_ok = false;
               umax_heuristic_ok = false;
-              tcenv = (uu___2245_15432.tcenv);
+              tcenv = (uu___2245_15452.tcenv);
               wl_implicits = []
             }  in
           let tx = FStar_Syntax_Unionfind.new_transaction ()  in
-          let uu____15444 = try_solve env wl'  in
-          match uu____15444 with
-          | Success (uu____15445,imps) ->
+          let uu____15464 = try_solve env wl'  in
+          match uu____15464 with
+          | Success (uu____15465,imps) ->
               (FStar_Syntax_Unionfind.commit tx;
                (let wl1 =
-                  let uu___2254_15449 = wl  in
+                  let uu___2254_15469 = wl  in
                   {
-                    attempting = (uu___2254_15449.attempting);
-                    wl_deferred = (uu___2254_15449.wl_deferred);
-                    ctr = (uu___2254_15449.ctr);
-                    defer_ok = (uu___2254_15449.defer_ok);
-                    smt_ok = (uu___2254_15449.smt_ok);
-                    umax_heuristic_ok = (uu___2254_15449.umax_heuristic_ok);
-                    tcenv = (uu___2254_15449.tcenv);
+                    attempting = (uu___2254_15469.attempting);
+                    wl_deferred = (uu___2254_15469.wl_deferred);
+                    ctr = (uu___2254_15469.ctr);
+                    defer_ok = (uu___2254_15469.defer_ok);
+                    smt_ok = (uu___2254_15469.smt_ok);
+                    umax_heuristic_ok = (uu___2254_15469.umax_heuristic_ok);
+                    tcenv = (uu___2254_15469.tcenv);
                     wl_implicits = (FStar_List.append wl.wl_implicits imps)
                   }  in
                 solve env wl1))
@@ -5253,8 +5265,8 @@ and (solve_t : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
     fun problem  ->
       fun wl  ->
         def_check_prob "solve_t" (FStar_TypeChecker_Common.TProb problem);
-        (let uu____15458 = compress_tprob wl.tcenv problem  in
-         solve_t' env uu____15458 wl)
+        (let uu____15478 = compress_tprob wl.tcenv problem  in
+         solve_t' env uu____15478 wl)
 
 and (solve_t_flex_rigid_eq :
   FStar_TypeChecker_Env.env ->
@@ -5267,46 +5279,46 @@ and (solve_t_flex_rigid_eq :
         fun lhs  ->
           fun rhs  ->
             let binders_as_bv_set bs =
-              let uu____15472 = FStar_List.map FStar_Pervasives_Native.fst bs
+              let uu____15492 = FStar_List.map FStar_Pervasives_Native.fst bs
                  in
-              FStar_Util.as_set uu____15472 FStar_Syntax_Syntax.order_bv  in
+              FStar_Util.as_set uu____15492 FStar_Syntax_Syntax.order_bv  in
             let mk_solution env1 lhs1 bs rhs1 =
-              let uu____15506 = lhs1  in
-              match uu____15506 with
-              | (uu____15509,ctx_u,uu____15511) ->
+              let uu____15526 = lhs1  in
+              match uu____15526 with
+              | (uu____15529,ctx_u,uu____15531) ->
                   let sol =
                     match bs with
                     | [] -> rhs1
-                    | uu____15519 ->
-                        let uu____15520 = sn_binders env1 bs  in
+                    | uu____15539 ->
+                        let uu____15540 = sn_binders env1 bs  in
                         u_abs ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ
-                          uu____15520 rhs1
+                          uu____15540 rhs1
                      in
                   [TERM (ctx_u, sol)]
                in
             let try_quasi_pattern orig1 env1 wl1 lhs1 rhs1 =
-              let uu____15569 = quasi_pattern env1 lhs1  in
-              match uu____15569 with
+              let uu____15589 = quasi_pattern env1 lhs1  in
+              match uu____15589 with
               | FStar_Pervasives_Native.None  ->
                   ((FStar_Util.Inl "Not a quasi-pattern"), wl1)
-              | FStar_Pervasives_Native.Some (bs,uu____15603) ->
-                  let uu____15608 = lhs1  in
-                  (match uu____15608 with
+              | FStar_Pervasives_Native.Some (bs,uu____15623) ->
+                  let uu____15628 = lhs1  in
+                  (match uu____15628 with
                    | (t_lhs,ctx_u,args) ->
-                       let uu____15623 = occurs_check ctx_u rhs1  in
-                       (match uu____15623 with
+                       let uu____15643 = occurs_check ctx_u rhs1  in
+                       (match uu____15643 with
                         | (uvars,occurs_ok,msg) ->
                             if Prims.op_Negation occurs_ok
                             then
-                              let uu____15674 =
-                                let uu____15682 =
-                                  let uu____15684 = FStar_Option.get msg  in
+                              let uu____15694 =
+                                let uu____15702 =
+                                  let uu____15704 = FStar_Option.get msg  in
                                   Prims.op_Hat
                                     "quasi-pattern, occurs-check failed: "
-                                    uu____15684
+                                    uu____15704
                                    in
-                                FStar_Util.Inl uu____15682  in
-                              (uu____15674, wl1)
+                                FStar_Util.Inl uu____15702  in
+                              (uu____15694, wl1)
                             else
                               (let fvs_lhs =
                                  binders_as_bv_set
@@ -5315,114 +5327,114 @@ and (solve_t_flex_rigid_eq :
                                       bs)
                                   in
                                let fvs_rhs = FStar_Syntax_Free.names rhs1  in
-                               let uu____15712 =
-                                 let uu____15714 =
+                               let uu____15732 =
+                                 let uu____15734 =
                                    FStar_Util.set_is_subset_of fvs_rhs
                                      fvs_lhs
                                     in
-                                 Prims.op_Negation uu____15714  in
-                               if uu____15712
+                                 Prims.op_Negation uu____15734  in
+                               if uu____15732
                                then
                                  ((FStar_Util.Inl
                                      "quasi-pattern, free names on the RHS are not included in the LHS"),
                                    wl1)
                                else
-                                 (let uu____15741 =
-                                    let uu____15749 =
+                                 (let uu____15761 =
+                                    let uu____15769 =
                                       mk_solution env1 lhs1 bs rhs1  in
-                                    FStar_Util.Inr uu____15749  in
-                                  let uu____15755 =
+                                    FStar_Util.Inr uu____15769  in
+                                  let uu____15775 =
                                     restrict_all_uvars ctx_u uvars wl1  in
-                                  (uu____15741, uu____15755)))))
+                                  (uu____15761, uu____15775)))))
                in
             let imitate_app orig1 env1 wl1 lhs1 bs_lhs t_res_lhs rhs1 =
-              let uu____15799 = FStar_Syntax_Util.head_and_args rhs1  in
-              match uu____15799 with
+              let uu____15819 = FStar_Syntax_Util.head_and_args rhs1  in
+              match uu____15819 with
               | (rhs_hd,args) ->
-                  let uu____15842 = FStar_Util.prefix args  in
-                  (match uu____15842 with
+                  let uu____15862 = FStar_Util.prefix args  in
+                  (match uu____15862 with
                    | (args_rhs,last_arg_rhs) ->
                        let rhs' =
                          FStar_Syntax_Syntax.mk_Tm_app rhs_hd args_rhs
                            FStar_Pervasives_Native.None
                            rhs1.FStar_Syntax_Syntax.pos
                           in
-                       let uu____15914 = lhs1  in
-                       (match uu____15914 with
+                       let uu____15934 = lhs1  in
+                       (match uu____15934 with
                         | (t_lhs,u_lhs,_lhs_args) ->
-                            let uu____15918 =
-                              let uu____15929 =
-                                let uu____15936 =
-                                  let uu____15939 =
+                            let uu____15938 =
+                              let uu____15949 =
+                                let uu____15956 =
+                                  let uu____15959 =
                                     FStar_Syntax_Util.type_u ()  in
                                   FStar_All.pipe_left
-                                    FStar_Pervasives_Native.fst uu____15939
+                                    FStar_Pervasives_Native.fst uu____15959
                                    in
-                                copy_uvar u_lhs [] uu____15936 wl1  in
-                              match uu____15929 with
-                              | (uu____15966,t_last_arg,wl2) ->
-                                  let uu____15969 =
-                                    let uu____15976 =
-                                      let uu____15977 =
-                                        let uu____15986 =
+                                copy_uvar u_lhs [] uu____15956 wl1  in
+                              match uu____15949 with
+                              | (uu____15986,t_last_arg,wl2) ->
+                                  let uu____15989 =
+                                    let uu____15996 =
+                                      let uu____15997 =
+                                        let uu____16006 =
                                           FStar_Syntax_Syntax.null_binder
                                             t_last_arg
                                            in
-                                        [uu____15986]  in
-                                      FStar_List.append bs_lhs uu____15977
+                                        [uu____16006]  in
+                                      FStar_List.append bs_lhs uu____15997
                                        in
-                                    copy_uvar u_lhs uu____15976 t_res_lhs wl2
+                                    copy_uvar u_lhs uu____15996 t_res_lhs wl2
                                      in
-                                  (match uu____15969 with
-                                   | (uu____16021,lhs',wl3) ->
-                                       let uu____16024 =
+                                  (match uu____15989 with
+                                   | (uu____16041,lhs',wl3) ->
+                                       let uu____16044 =
                                          copy_uvar u_lhs bs_lhs t_last_arg
                                            wl3
                                           in
-                                       (match uu____16024 with
-                                        | (uu____16041,lhs'_last_arg,wl4) ->
+                                       (match uu____16044 with
+                                        | (uu____16061,lhs'_last_arg,wl4) ->
                                             (lhs', lhs'_last_arg, wl4)))
                                in
-                            (match uu____15918 with
+                            (match uu____15938 with
                              | (lhs',lhs'_last_arg,wl2) ->
                                  let sol =
-                                   let uu____16062 =
-                                     let uu____16063 =
-                                       let uu____16068 =
-                                         let uu____16069 =
-                                           let uu____16072 =
-                                             let uu____16077 =
-                                               let uu____16078 =
+                                   let uu____16082 =
+                                     let uu____16083 =
+                                       let uu____16088 =
+                                         let uu____16089 =
+                                           let uu____16092 =
+                                             let uu____16097 =
+                                               let uu____16098 =
                                                  FStar_Syntax_Syntax.as_arg
                                                    lhs'_last_arg
                                                   in
-                                               [uu____16078]  in
+                                               [uu____16098]  in
                                              FStar_Syntax_Syntax.mk_Tm_app
-                                               lhs' uu____16077
+                                               lhs' uu____16097
                                               in
-                                           uu____16072
+                                           uu____16092
                                              FStar_Pervasives_Native.None
                                              t_lhs.FStar_Syntax_Syntax.pos
                                             in
                                          FStar_Syntax_Util.abs bs_lhs
-                                           uu____16069
+                                           uu____16089
                                            (FStar_Pervasives_Native.Some
                                               (FStar_Syntax_Util.residual_tot
                                                  t_res_lhs))
                                           in
-                                       (u_lhs, uu____16068)  in
-                                     TERM uu____16063  in
-                                   [uu____16062]  in
-                                 let uu____16103 =
-                                   let uu____16110 =
+                                       (u_lhs, uu____16088)  in
+                                     TERM uu____16083  in
+                                   [uu____16082]  in
+                                 let uu____16123 =
+                                   let uu____16130 =
                                      mk_t_problem wl2 [] orig1 lhs'
                                        FStar_TypeChecker_Common.EQ rhs'
                                        FStar_Pervasives_Native.None
                                        "first-order lhs"
                                       in
-                                   match uu____16110 with
+                                   match uu____16130 with
                                    | (p1,wl3) ->
-                                       let uu____16130 =
+                                       let uu____16150 =
                                          mk_t_problem wl3 [] orig1
                                            lhs'_last_arg
                                            FStar_TypeChecker_Common.EQ
@@ -5431,65 +5443,65 @@ and (solve_t_flex_rigid_eq :
                                            FStar_Pervasives_Native.None
                                            "first-order rhs"
                                           in
-                                       (match uu____16130 with
+                                       (match uu____16150 with
                                         | (p2,wl4) -> ([p1; p2], wl4))
                                     in
-                                 (match uu____16103 with
+                                 (match uu____16123 with
                                   | (sub_probs,wl3) ->
-                                      let uu____16162 =
-                                        let uu____16163 =
+                                      let uu____16182 =
+                                        let uu____16183 =
                                           solve_prob orig1
                                             FStar_Pervasives_Native.None sol
                                             wl3
                                            in
-                                        attempt sub_probs uu____16163  in
-                                      solve env1 uu____16162))))
+                                        attempt sub_probs uu____16183  in
+                                      solve env1 uu____16182))))
                in
             let first_order orig1 env1 wl1 lhs1 rhs1 =
               let is_app rhs2 =
-                let uu____16197 = FStar_Syntax_Util.head_and_args rhs2  in
-                match uu____16197 with
-                | (uu____16215,args) ->
-                    (match args with | [] -> false | uu____16251 -> true)
+                let uu____16217 = FStar_Syntax_Util.head_and_args rhs2  in
+                match uu____16217 with
+                | (uu____16235,args) ->
+                    (match args with | [] -> false | uu____16271 -> true)
                  in
               let is_arrow rhs2 =
-                let uu____16270 =
-                  let uu____16271 = FStar_Syntax_Subst.compress rhs2  in
-                  uu____16271.FStar_Syntax_Syntax.n  in
-                match uu____16270 with
-                | FStar_Syntax_Syntax.Tm_arrow uu____16275 -> true
-                | uu____16291 -> false  in
-              let uu____16293 = quasi_pattern env1 lhs1  in
-              match uu____16293 with
+                let uu____16290 =
+                  let uu____16291 = FStar_Syntax_Subst.compress rhs2  in
+                  uu____16291.FStar_Syntax_Syntax.n  in
+                match uu____16290 with
+                | FStar_Syntax_Syntax.Tm_arrow uu____16295 -> true
+                | uu____16311 -> false  in
+              let uu____16313 = quasi_pattern env1 lhs1  in
+              match uu____16313 with
               | FStar_Pervasives_Native.None  ->
                   let msg =
                     mklstr
-                      (fun uu____16312  ->
-                         let uu____16313 = prob_to_string env1 orig1  in
+                      (fun uu____16332  ->
+                         let uu____16333 = prob_to_string env1 orig1  in
                          FStar_Util.format1
                            "first_order heuristic cannot solve %s; lhs not a quasi-pattern"
-                           uu____16313)
+                           uu____16333)
                      in
                   giveup_or_defer env1 orig1 wl1 msg
               | FStar_Pervasives_Native.Some (bs_lhs,t_res_lhs) ->
-                  let uu____16322 = is_app rhs1  in
-                  if uu____16322
+                  let uu____16342 = is_app rhs1  in
+                  if uu____16342
                   then imitate_app orig1 env1 wl1 lhs1 bs_lhs t_res_lhs rhs1
                   else
-                    (let uu____16327 = is_arrow rhs1  in
-                     if uu____16327
+                    (let uu____16347 = is_arrow rhs1  in
+                     if uu____16347
                      then
                        imitate_arrow orig1 env1 wl1 lhs1 bs_lhs t_res_lhs
                          FStar_TypeChecker_Common.EQ rhs1
                      else
                        (let msg =
                           mklstr
-                            (fun uu____16340  ->
-                               let uu____16341 = prob_to_string env1 orig1
+                            (fun uu____16360  ->
+                               let uu____16361 = prob_to_string env1 orig1
                                   in
                                FStar_Util.format1
                                  "first_order heuristic cannot solve %s; rhs not an app or arrow"
-                                 uu____16341)
+                                 uu____16361)
                            in
                         giveup_or_defer env1 orig1 wl1 msg))
                in
@@ -5497,36 +5509,36 @@ and (solve_t_flex_rigid_eq :
             | FStar_TypeChecker_Common.SUB  ->
                 if wl.defer_ok
                 then
-                  let uu____16345 = FStar_Thunk.mkv "flex-rigid subtyping"
+                  let uu____16365 = FStar_Thunk.mkv "flex-rigid subtyping"
                      in
-                  giveup_or_defer env orig wl uu____16345
+                  giveup_or_defer env orig wl uu____16365
                 else solve_t_flex_rigid_eq env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.SUBINV  ->
                 if wl.defer_ok
                 then
-                  let uu____16351 = FStar_Thunk.mkv "flex-rigid subtyping"
+                  let uu____16371 = FStar_Thunk.mkv "flex-rigid subtyping"
                      in
-                  giveup_or_defer env orig wl uu____16351
+                  giveup_or_defer env orig wl uu____16371
                 else solve_t_flex_rigid_eq env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.EQ  ->
-                let uu____16356 = lhs  in
-                (match uu____16356 with
+                let uu____16376 = lhs  in
+                (match uu____16376 with
                  | (_t1,ctx_uv,args_lhs) ->
-                     let uu____16360 =
+                     let uu____16380 =
                        pat_vars env
                          ctx_uv.FStar_Syntax_Syntax.ctx_uvar_binders args_lhs
                         in
-                     (match uu____16360 with
+                     (match uu____16380 with
                       | FStar_Pervasives_Native.Some lhs_binders ->
                           let rhs1 = sn env rhs  in
                           let names_to_string1 fvs =
-                            let uu____16378 =
-                              let uu____16382 = FStar_Util.set_elements fvs
+                            let uu____16398 =
+                              let uu____16402 = FStar_Util.set_elements fvs
                                  in
                               FStar_List.map FStar_Syntax_Print.bv_to_string
-                                uu____16382
+                                uu____16402
                                in
-                            FStar_All.pipe_right uu____16378
+                            FStar_All.pipe_right uu____16398
                               (FStar_String.concat ", ")
                              in
                           let fvs1 =
@@ -5536,48 +5548,48 @@ and (solve_t_flex_rigid_eq :
                                  lhs_binders)
                              in
                           let fvs2 = FStar_Syntax_Free.names rhs1  in
-                          let uu____16403 = occurs_check ctx_uv rhs1  in
-                          (match uu____16403 with
+                          let uu____16423 = occurs_check ctx_uv rhs1  in
+                          (match uu____16423 with
                            | (uvars,occurs_ok,msg) ->
                                if Prims.op_Negation occurs_ok
                                then
-                                 let uu____16432 =
-                                   let uu____16433 =
-                                     let uu____16435 = FStar_Option.get msg
+                                 let uu____16452 =
+                                   let uu____16453 =
+                                     let uu____16455 = FStar_Option.get msg
                                         in
                                      Prims.op_Hat "occurs-check failed: "
-                                       uu____16435
+                                       uu____16455
                                       in
                                    FStar_All.pipe_left FStar_Thunk.mkv
-                                     uu____16433
+                                     uu____16453
                                     in
-                                 giveup_or_defer env orig wl uu____16432
+                                 giveup_or_defer env orig wl uu____16452
                                else
-                                 (let uu____16443 =
+                                 (let uu____16463 =
                                     FStar_Util.set_is_subset_of fvs2 fvs1  in
-                                  if uu____16443
+                                  if uu____16463
                                   then
                                     let sol =
                                       mk_solution env lhs lhs_binders rhs1
                                        in
                                     let wl1 =
                                       restrict_all_uvars ctx_uv uvars wl  in
-                                    let uu____16450 =
+                                    let uu____16470 =
                                       solve_prob orig
                                         FStar_Pervasives_Native.None sol wl1
                                        in
-                                    solve env uu____16450
+                                    solve env uu____16470
                                   else
                                     if wl.defer_ok
                                     then
                                       (let msg1 =
                                          mklstr
-                                           (fun uu____16466  ->
-                                              let uu____16467 =
+                                           (fun uu____16486  ->
+                                              let uu____16487 =
                                                 names_to_string1 fvs2  in
-                                              let uu____16469 =
+                                              let uu____16489 =
                                                 names_to_string1 fvs1  in
-                                              let uu____16471 =
+                                              let uu____16491 =
                                                 FStar_Syntax_Print.binders_to_string
                                                   ", "
                                                   (FStar_List.append
@@ -5586,28 +5598,28 @@ and (solve_t_flex_rigid_eq :
                                                  in
                                               FStar_Util.format3
                                                 "free names in the RHS {%s} are out of scope for the LHS: {%s}, {%s}"
-                                                uu____16467 uu____16469
-                                                uu____16471)
+                                                uu____16487 uu____16489
+                                                uu____16491)
                                           in
                                        giveup_or_defer env orig wl msg1)
                                     else first_order orig env wl lhs rhs1))
-                      | uu____16483 ->
+                      | uu____16503 ->
                           if wl.defer_ok
                           then
-                            let uu____16487 = FStar_Thunk.mkv "Not a pattern"
+                            let uu____16507 = FStar_Thunk.mkv "Not a pattern"
                                in
-                            giveup_or_defer env orig wl uu____16487
+                            giveup_or_defer env orig wl uu____16507
                           else
-                            (let uu____16492 =
+                            (let uu____16512 =
                                try_quasi_pattern orig env wl lhs rhs  in
-                             match uu____16492 with
+                             match uu____16512 with
                              | (FStar_Util.Inr sol,wl1) ->
-                                 let uu____16518 =
+                                 let uu____16538 =
                                    solve_prob orig
                                      FStar_Pervasives_Native.None sol wl1
                                     in
-                                 solve env uu____16518
-                             | (FStar_Util.Inl msg,uu____16520) ->
+                                 solve env uu____16538
+                             | (FStar_Util.Inl msg,uu____16540) ->
                                  first_order orig env wl lhs rhs)))
 
 and (solve_t_flex_flex :
@@ -5623,14 +5635,14 @@ and (solve_t_flex_flex :
             | FStar_TypeChecker_Common.SUB  ->
                 if wl.defer_ok
                 then
-                  let uu____16538 = FStar_Thunk.mkv "flex-flex subtyping"  in
-                  giveup_or_defer env orig wl uu____16538
+                  let uu____16558 = FStar_Thunk.mkv "flex-flex subtyping"  in
+                  giveup_or_defer env orig wl uu____16558
                 else solve_t_flex_flex env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.SUBINV  ->
                 if wl.defer_ok
                 then
-                  let uu____16544 = FStar_Thunk.mkv "flex-flex subtyping"  in
-                  giveup_or_defer env orig wl uu____16544
+                  let uu____16564 = FStar_Thunk.mkv "flex-flex subtyping"  in
+                  giveup_or_defer env orig wl uu____16564
                 else solve_t_flex_flex env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.EQ  ->
                 if
@@ -5638,47 +5650,47 @@ and (solve_t_flex_flex :
                     ((Prims.op_Negation (is_flex_pat lhs)) ||
                        (Prims.op_Negation (is_flex_pat rhs)))
                 then
-                  let uu____16566 = FStar_Thunk.mkv "flex-flex non-pattern"
+                  let uu____16586 = FStar_Thunk.mkv "flex-flex non-pattern"
                      in
-                  giveup_or_defer env orig wl uu____16566
+                  giveup_or_defer env orig wl uu____16586
                 else
-                  (let uu____16571 =
-                     let uu____16588 = quasi_pattern env lhs  in
-                     let uu____16595 = quasi_pattern env rhs  in
-                     (uu____16588, uu____16595)  in
-                   match uu____16571 with
+                  (let uu____16591 =
+                     let uu____16608 = quasi_pattern env lhs  in
+                     let uu____16615 = quasi_pattern env rhs  in
+                     (uu____16608, uu____16615)  in
+                   match uu____16591 with
                    | (FStar_Pervasives_Native.Some
                       (binders_lhs,t_res_lhs),FStar_Pervasives_Native.Some
                       (binders_rhs,t_res_rhs)) ->
-                       let uu____16638 = lhs  in
-                       (match uu____16638 with
-                        | ({ FStar_Syntax_Syntax.n = uu____16639;
+                       let uu____16658 = lhs  in
+                       (match uu____16658 with
+                        | ({ FStar_Syntax_Syntax.n = uu____16659;
                              FStar_Syntax_Syntax.pos = range;
-                             FStar_Syntax_Syntax.vars = uu____16641;_},u_lhs,uu____16643)
+                             FStar_Syntax_Syntax.vars = uu____16661;_},u_lhs,uu____16663)
                             ->
-                            let uu____16646 = rhs  in
-                            (match uu____16646 with
-                             | (uu____16647,u_rhs,uu____16649) ->
-                                 let uu____16650 =
+                            let uu____16666 = rhs  in
+                            (match uu____16666 with
+                             | (uu____16667,u_rhs,uu____16669) ->
+                                 let uu____16670 =
                                    (FStar_Syntax_Unionfind.equiv
                                       u_lhs.FStar_Syntax_Syntax.ctx_uvar_head
                                       u_rhs.FStar_Syntax_Syntax.ctx_uvar_head)
                                      && (binders_eq binders_lhs binders_rhs)
                                     in
-                                 if uu____16650
+                                 if uu____16670
                                  then
-                                   let uu____16657 =
+                                   let uu____16677 =
                                      solve_prob orig
                                        FStar_Pervasives_Native.None [] wl
                                       in
-                                   solve env uu____16657
+                                   solve env uu____16677
                                  else
-                                   (let uu____16660 =
+                                   (let uu____16680 =
                                       maximal_prefix
                                         u_lhs.FStar_Syntax_Syntax.ctx_uvar_binders
                                         u_rhs.FStar_Syntax_Syntax.ctx_uvar_binders
                                        in
-                                    match uu____16660 with
+                                    match uu____16680 with
                                     | (ctx_w,(ctx_l,ctx_r)) ->
                                         let gamma_w =
                                           gamma_until
@@ -5692,14 +5704,14 @@ and (solve_t_flex_flex :
                                             (FStar_List.append ctx_r
                                                binders_rhs)
                                            in
-                                        let uu____16692 =
-                                          let uu____16699 =
-                                            let uu____16702 =
+                                        let uu____16712 =
+                                          let uu____16719 =
+                                            let uu____16722 =
                                               FStar_Syntax_Syntax.mk_Total
                                                 t_res_lhs
                                                in
                                             FStar_Syntax_Util.arrow zs
-                                              uu____16702
+                                              uu____16722
                                              in
                                           new_uvar
                                             (Prims.op_Hat "flex-flex quasi:"
@@ -5709,138 +5721,138 @@ and (solve_t_flex_flex :
                                                      (Prims.op_Hat "\trhs="
                                                         u_rhs.FStar_Syntax_Syntax.ctx_uvar_reason))))
                                             wl range gamma_w ctx_w
-                                            uu____16699
+                                            uu____16719
                                             FStar_Syntax_Syntax.Strict
                                             FStar_Pervasives_Native.None
                                            in
-                                        (match uu____16692 with
-                                         | (uu____16714,w,wl1) ->
+                                        (match uu____16712 with
+                                         | (uu____16734,w,wl1) ->
                                              let w_app =
-                                               let uu____16720 =
-                                                 let uu____16725 =
+                                               let uu____16740 =
+                                                 let uu____16745 =
                                                    FStar_List.map
-                                                     (fun uu____16736  ->
-                                                        match uu____16736
+                                                     (fun uu____16756  ->
+                                                        match uu____16756
                                                         with
-                                                        | (z,uu____16744) ->
-                                                            let uu____16749 =
+                                                        | (z,uu____16764) ->
+                                                            let uu____16769 =
                                                               FStar_Syntax_Syntax.bv_to_name
                                                                 z
                                                                in
                                                             FStar_Syntax_Syntax.as_arg
-                                                              uu____16749) zs
+                                                              uu____16769) zs
                                                     in
                                                  FStar_Syntax_Syntax.mk_Tm_app
-                                                   w uu____16725
+                                                   w uu____16745
                                                   in
-                                               uu____16720
+                                               uu____16740
                                                  FStar_Pervasives_Native.None
                                                  w.FStar_Syntax_Syntax.pos
                                                 in
-                                             ((let uu____16751 =
+                                             ((let uu____16771 =
                                                  FStar_All.pipe_left
                                                    (FStar_TypeChecker_Env.debug
                                                       env)
                                                    (FStar_Options.Other "Rel")
                                                   in
-                                               if uu____16751
+                                               if uu____16771
                                                then
-                                                 let uu____16756 =
-                                                   let uu____16760 =
+                                                 let uu____16776 =
+                                                   let uu____16780 =
                                                      flex_t_to_string lhs  in
-                                                   let uu____16762 =
-                                                     let uu____16766 =
+                                                   let uu____16782 =
+                                                     let uu____16786 =
                                                        flex_t_to_string rhs
                                                         in
-                                                     let uu____16768 =
-                                                       let uu____16772 =
+                                                     let uu____16788 =
+                                                       let uu____16792 =
                                                          term_to_string w  in
-                                                       let uu____16774 =
-                                                         let uu____16778 =
+                                                       let uu____16794 =
+                                                         let uu____16798 =
                                                            FStar_Syntax_Print.binders_to_string
                                                              ", "
                                                              (FStar_List.append
                                                                 ctx_l
                                                                 binders_lhs)
                                                             in
-                                                         let uu____16787 =
-                                                           let uu____16791 =
+                                                         let uu____16807 =
+                                                           let uu____16811 =
                                                              FStar_Syntax_Print.binders_to_string
                                                                ", "
                                                                (FStar_List.append
                                                                   ctx_r
                                                                   binders_rhs)
                                                               in
-                                                           let uu____16800 =
-                                                             let uu____16804
+                                                           let uu____16820 =
+                                                             let uu____16824
                                                                =
                                                                FStar_Syntax_Print.binders_to_string
                                                                  ", " zs
                                                                 in
-                                                             [uu____16804]
+                                                             [uu____16824]
                                                               in
-                                                           uu____16791 ::
-                                                             uu____16800
+                                                           uu____16811 ::
+                                                             uu____16820
                                                             in
-                                                         uu____16778 ::
-                                                           uu____16787
+                                                         uu____16798 ::
+                                                           uu____16807
                                                           in
-                                                       uu____16772 ::
-                                                         uu____16774
+                                                       uu____16792 ::
+                                                         uu____16794
                                                         in
-                                                     uu____16766 ::
-                                                       uu____16768
+                                                     uu____16786 ::
+                                                       uu____16788
                                                       in
-                                                   uu____16760 :: uu____16762
+                                                   uu____16780 :: uu____16782
                                                     in
                                                  FStar_Util.print
                                                    "flex-flex quasi:\n\tlhs=%s\n\trhs=%s\n\tsol=%s\n\tctx_l@binders_lhs=%s\n\tctx_r@binders_rhs=%s\n\tzs=%s\n"
-                                                   uu____16756
+                                                   uu____16776
                                                else ());
                                               (let sol =
                                                  let s1 =
-                                                   let uu____16821 =
-                                                     let uu____16826 =
+                                                   let uu____16841 =
+                                                     let uu____16846 =
                                                        FStar_Syntax_Util.abs
                                                          binders_lhs w_app
                                                          (FStar_Pervasives_Native.Some
                                                             (FStar_Syntax_Util.residual_tot
                                                                t_res_lhs))
                                                         in
-                                                     (u_lhs, uu____16826)  in
-                                                   TERM uu____16821  in
-                                                 let uu____16827 =
+                                                     (u_lhs, uu____16846)  in
+                                                   TERM uu____16841  in
+                                                 let uu____16847 =
                                                    FStar_Syntax_Unionfind.equiv
                                                      u_lhs.FStar_Syntax_Syntax.ctx_uvar_head
                                                      u_rhs.FStar_Syntax_Syntax.ctx_uvar_head
                                                     in
-                                                 if uu____16827
+                                                 if uu____16847
                                                  then [s1]
                                                  else
                                                    (let s2 =
-                                                      let uu____16835 =
-                                                        let uu____16840 =
+                                                      let uu____16855 =
+                                                        let uu____16860 =
                                                           FStar_Syntax_Util.abs
                                                             binders_rhs w_app
                                                             (FStar_Pervasives_Native.Some
                                                                (FStar_Syntax_Util.residual_tot
                                                                   t_res_lhs))
                                                            in
-                                                        (u_rhs, uu____16840)
+                                                        (u_rhs, uu____16860)
                                                          in
-                                                      TERM uu____16835  in
+                                                      TERM uu____16855  in
                                                     [s1; s2])
                                                   in
-                                               let uu____16841 =
+                                               let uu____16861 =
                                                  solve_prob orig
                                                    FStar_Pervasives_Native.None
                                                    sol wl1
                                                   in
-                                               solve env uu____16841))))))
-                   | uu____16842 ->
-                       let uu____16859 =
+                                               solve env uu____16861))))))
+                   | uu____16862 ->
+                       let uu____16879 =
                          FStar_Thunk.mkv "flex-flex: non-patterns"  in
-                       giveup_or_defer env orig wl uu____16859)
+                       giveup_or_defer env orig wl uu____16879)
 
 and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
   fun env  ->
@@ -5850,91 +5862,91 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
         (let giveup_or_defer1 orig msg = giveup_or_defer env orig wl msg  in
          let rigid_heads_match env1 need_unif torig wl1 t1 t2 =
            let orig = FStar_TypeChecker_Common.TProb torig  in
-           (let uu____16913 =
+           (let uu____16933 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                 (FStar_Options.Other "Rel")
                in
-            if uu____16913
+            if uu____16933
             then
-              let uu____16918 = FStar_Syntax_Print.term_to_string t1  in
-              let uu____16920 = FStar_Syntax_Print.tag_of_term t1  in
-              let uu____16922 = FStar_Syntax_Print.term_to_string t2  in
-              let uu____16924 = FStar_Syntax_Print.tag_of_term t2  in
+              let uu____16938 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____16940 = FStar_Syntax_Print.tag_of_term t1  in
+              let uu____16942 = FStar_Syntax_Print.term_to_string t2  in
+              let uu____16944 = FStar_Syntax_Print.tag_of_term t2  in
               FStar_Util.print5 "Heads %s: %s (%s) and %s (%s)\n"
                 (if need_unif then "need unification" else "match")
-                uu____16918 uu____16920 uu____16922 uu____16924
+                uu____16938 uu____16940 uu____16942 uu____16944
             else ());
-           (let uu____16935 = FStar_Syntax_Util.head_and_args t1  in
-            match uu____16935 with
+           (let uu____16955 = FStar_Syntax_Util.head_and_args t1  in
+            match uu____16955 with
             | (head1,args1) ->
-                let uu____16978 = FStar_Syntax_Util.head_and_args t2  in
-                (match uu____16978 with
+                let uu____16998 = FStar_Syntax_Util.head_and_args t2  in
+                (match uu____16998 with
                  | (head2,args2) ->
                      let solve_head_then wl2 k =
                        if need_unif
                        then k true wl2
                        else
-                         (let uu____17048 =
+                         (let uu____17068 =
                             solve_maybe_uinsts env1 orig head1 head2 wl2  in
-                          match uu____17048 with
+                          match uu____17068 with
                           | USolved wl3 -> k true wl3
                           | UFailed msg -> giveup env1 msg orig
                           | UDeferred wl3 ->
-                              let uu____17053 =
+                              let uu____17073 =
                                 defer_lit "universe constraints" orig wl3  in
-                              k false uu____17053)
+                              k false uu____17073)
                         in
                      let nargs = FStar_List.length args1  in
                      if nargs <> (FStar_List.length args2)
                      then
-                       let uu____17074 =
+                       let uu____17094 =
                          mklstr
-                           (fun uu____17085  ->
-                              let uu____17086 =
+                           (fun uu____17105  ->
+                              let uu____17106 =
                                 FStar_Syntax_Print.term_to_string head1  in
-                              let uu____17088 = args_to_string args1  in
-                              let uu____17092 =
+                              let uu____17108 = args_to_string args1  in
+                              let uu____17112 =
                                 FStar_Syntax_Print.term_to_string head2  in
-                              let uu____17094 = args_to_string args2  in
+                              let uu____17114 = args_to_string args2  in
                               FStar_Util.format4
                                 "unequal number of arguments: %s[%s] and %s[%s]"
-                                uu____17086 uu____17088 uu____17092
-                                uu____17094)
+                                uu____17106 uu____17108 uu____17112
+                                uu____17114)
                           in
-                       giveup env1 uu____17074 orig
+                       giveup env1 uu____17094 orig
                      else
-                       (let uu____17101 =
+                       (let uu____17121 =
                           (nargs = Prims.int_zero) ||
-                            (let uu____17106 =
+                            (let uu____17126 =
                                FStar_Syntax_Util.eq_args args1 args2  in
-                             uu____17106 = FStar_Syntax_Util.Equal)
+                             uu____17126 = FStar_Syntax_Util.Equal)
                            in
-                        if uu____17101
+                        if uu____17121
                         then
                           (if need_unif
                            then
                              solve_t env1
-                               (let uu___2510_17110 = problem  in
+                               (let uu___2510_17130 = problem  in
                                 {
                                   FStar_TypeChecker_Common.pid =
-                                    (uu___2510_17110.FStar_TypeChecker_Common.pid);
+                                    (uu___2510_17130.FStar_TypeChecker_Common.pid);
                                   FStar_TypeChecker_Common.lhs = head1;
                                   FStar_TypeChecker_Common.relation =
-                                    (uu___2510_17110.FStar_TypeChecker_Common.relation);
+                                    (uu___2510_17130.FStar_TypeChecker_Common.relation);
                                   FStar_TypeChecker_Common.rhs = head2;
                                   FStar_TypeChecker_Common.element =
-                                    (uu___2510_17110.FStar_TypeChecker_Common.element);
+                                    (uu___2510_17130.FStar_TypeChecker_Common.element);
                                   FStar_TypeChecker_Common.logical_guard =
-                                    (uu___2510_17110.FStar_TypeChecker_Common.logical_guard);
+                                    (uu___2510_17130.FStar_TypeChecker_Common.logical_guard);
                                   FStar_TypeChecker_Common.logical_guard_uvar
                                     =
-                                    (uu___2510_17110.FStar_TypeChecker_Common.logical_guard_uvar);
+                                    (uu___2510_17130.FStar_TypeChecker_Common.logical_guard_uvar);
                                   FStar_TypeChecker_Common.reason =
-                                    (uu___2510_17110.FStar_TypeChecker_Common.reason);
+                                    (uu___2510_17130.FStar_TypeChecker_Common.reason);
                                   FStar_TypeChecker_Common.loc =
-                                    (uu___2510_17110.FStar_TypeChecker_Common.loc);
+                                    (uu___2510_17130.FStar_TypeChecker_Common.loc);
                                   FStar_TypeChecker_Common.rank =
-                                    (uu___2510_17110.FStar_TypeChecker_Common.rank)
+                                    (uu___2510_17130.FStar_TypeChecker_Common.rank)
                                 }) wl1
                            else
                              solve_head_then wl1
@@ -5942,19 +5954,19 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                   fun wl2  ->
                                     if ok
                                     then
-                                      let uu____17120 =
+                                      let uu____17140 =
                                         solve_prob orig
                                           FStar_Pervasives_Native.None [] wl2
                                          in
-                                      solve env1 uu____17120
+                                      solve env1 uu____17140
                                     else solve env1 wl2))
                         else
-                          (let uu____17125 = base_and_refinement env1 t1  in
-                           match uu____17125 with
+                          (let uu____17145 = base_and_refinement env1 t1  in
+                           match uu____17145 with
                            | (base1,refinement1) ->
-                               let uu____17150 = base_and_refinement env1 t2
+                               let uu____17170 = base_and_refinement env1 t2
                                   in
-                               (match uu____17150 with
+                               (match uu____17170 with
                                 | (base2,refinement2) ->
                                     (match (refinement1, refinement2) with
                                      | (FStar_Pervasives_Native.None
@@ -5972,17 +5984,17 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                  :: args2)
                                              else FStar_List.zip args1 args2
                                               in
-                                           let uu____17315 =
+                                           let uu____17335 =
                                              FStar_List.fold_right
-                                               (fun uu____17355  ->
-                                                  fun uu____17356  ->
-                                                    match (uu____17355,
-                                                            uu____17356)
+                                               (fun uu____17375  ->
+                                                  fun uu____17376  ->
+                                                    match (uu____17375,
+                                                            uu____17376)
                                                     with
-                                                    | (((a1,uu____17408),
-                                                        (a2,uu____17410)),
+                                                    | (((a1,uu____17428),
+                                                        (a2,uu____17430)),
                                                        (probs,wl3)) ->
-                                                        let uu____17459 =
+                                                        let uu____17479 =
                                                           mk_problem wl3 []
                                                             orig a1
                                                             FStar_TypeChecker_Common.EQ
@@ -5990,7 +6002,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                             FStar_Pervasives_Native.None
                                                             "index"
                                                            in
-                                                        (match uu____17459
+                                                        (match uu____17479
                                                          with
                                                          | (prob',wl4) ->
                                                              (((FStar_TypeChecker_Common.TProb
@@ -5998,30 +6010,30 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                probs), wl4)))
                                                argp ([], wl2)
                                               in
-                                           match uu____17315 with
+                                           match uu____17335 with
                                            | (subprobs,wl3) ->
-                                               ((let uu____17502 =
+                                               ((let uu____17522 =
                                                    FStar_All.pipe_left
                                                      (FStar_TypeChecker_Env.debug
                                                         env1)
                                                      (FStar_Options.Other
                                                         "Rel")
                                                     in
-                                                 if uu____17502
+                                                 if uu____17522
                                                  then
-                                                   let uu____17507 =
+                                                   let uu____17527 =
                                                      FStar_Syntax_Print.list_to_string
                                                        (prob_to_string env1)
                                                        subprobs
                                                       in
                                                    FStar_Util.print1
                                                      "Adding subproblems for arguments: %s"
-                                                     uu____17507
+                                                     uu____17527
                                                  else ());
-                                                (let uu____17513 =
+                                                (let uu____17533 =
                                                    FStar_Options.defensive ()
                                                     in
-                                                 if uu____17513
+                                                 if uu____17533
                                                  then
                                                    FStar_List.iter
                                                      (def_check_prob
@@ -6037,19 +6049,19 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                   if Prims.op_Negation ok
                                                   then solve env2 wl3
                                                   else
-                                                    (let uu____17540 =
+                                                    (let uu____17560 =
                                                        mk_sub_probs wl3  in
-                                                     match uu____17540 with
+                                                     match uu____17560 with
                                                      | (subprobs,wl4) ->
                                                          let formula =
-                                                           let uu____17556 =
+                                                           let uu____17576 =
                                                              FStar_List.map
                                                                (fun p  ->
                                                                   p_guard p)
                                                                subprobs
                                                               in
                                                            FStar_Syntax_Util.mk_conj_l
-                                                             uu____17556
+                                                             uu____17576
                                                             in
                                                          let wl5 =
                                                            solve_prob orig
@@ -6057,120 +6069,120 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                 formula) []
                                                              wl4
                                                             in
-                                                         let uu____17564 =
+                                                         let uu____17584 =
                                                            attempt subprobs
                                                              wl5
                                                             in
                                                          solve env2
-                                                           uu____17564))
+                                                           uu____17584))
                                             in
                                          let solve_sub_probs_no_smt env2 wl2
                                            =
                                            solve_head_then wl2
                                              (fun ok  ->
                                                 fun wl3  ->
-                                                  let uu____17589 =
+                                                  let uu____17609 =
                                                     mk_sub_probs wl3  in
-                                                  match uu____17589 with
+                                                  match uu____17609 with
                                                   | (subprobs,wl4) ->
                                                       let formula =
-                                                        let uu____17605 =
+                                                        let uu____17625 =
                                                           FStar_List.map
                                                             (fun p  ->
                                                                p_guard p)
                                                             subprobs
                                                            in
                                                         FStar_Syntax_Util.mk_conj_l
-                                                          uu____17605
+                                                          uu____17625
                                                          in
                                                       let wl5 =
                                                         solve_prob orig
                                                           (FStar_Pervasives_Native.Some
                                                              formula) [] wl4
                                                          in
-                                                      let uu____17613 =
+                                                      let uu____17633 =
                                                         attempt subprobs wl5
                                                          in
-                                                      solve env2 uu____17613)
+                                                      solve env2 uu____17633)
                                             in
                                          let unfold_and_retry d env2 wl2
-                                           uu____17641 =
-                                           match uu____17641 with
+                                           uu____17661 =
+                                           match uu____17661 with
                                            | (prob,reason) ->
-                                               ((let uu____17658 =
+                                               ((let uu____17678 =
                                                    FStar_All.pipe_left
                                                      (FStar_TypeChecker_Env.debug
                                                         env2)
                                                      (FStar_Options.Other
                                                         "Rel")
                                                     in
-                                                 if uu____17658
+                                                 if uu____17678
                                                  then
-                                                   let uu____17663 =
+                                                   let uu____17683 =
                                                      prob_to_string env2 orig
                                                       in
-                                                   let uu____17665 =
+                                                   let uu____17685 =
                                                      FStar_Thunk.force reason
                                                       in
                                                    FStar_Util.print2
                                                      "Failed to solve %s because a sub-problem is not solvable without SMT because %s"
-                                                     uu____17663 uu____17665
+                                                     uu____17683 uu____17685
                                                  else ());
-                                                (let uu____17671 =
-                                                   let uu____17680 =
+                                                (let uu____17691 =
+                                                   let uu____17700 =
                                                      FStar_TypeChecker_Normalize.unfold_head_once
                                                        env2 t1
                                                       in
-                                                   let uu____17683 =
+                                                   let uu____17703 =
                                                      FStar_TypeChecker_Normalize.unfold_head_once
                                                        env2 t2
                                                       in
-                                                   (uu____17680, uu____17683)
+                                                   (uu____17700, uu____17703)
                                                     in
-                                                 match uu____17671 with
+                                                 match uu____17691 with
                                                  | (FStar_Pervasives_Native.Some
                                                     t1',FStar_Pervasives_Native.Some
                                                     t2') ->
-                                                     let uu____17696 =
+                                                     let uu____17716 =
                                                        FStar_Syntax_Util.head_and_args
                                                          t1'
                                                         in
-                                                     (match uu____17696 with
-                                                      | (head1',uu____17714)
+                                                     (match uu____17716 with
+                                                      | (head1',uu____17734)
                                                           ->
-                                                          let uu____17739 =
+                                                          let uu____17759 =
                                                             FStar_Syntax_Util.head_and_args
                                                               t2'
                                                              in
-                                                          (match uu____17739
+                                                          (match uu____17759
                                                            with
-                                                           | (head2',uu____17757)
+                                                           | (head2',uu____17777)
                                                                ->
-                                                               let uu____17782
+                                                               let uu____17802
                                                                  =
-                                                                 let uu____17787
+                                                                 let uu____17807
                                                                    =
                                                                    FStar_Syntax_Util.eq_tm
                                                                     head1'
                                                                     head1
                                                                     in
-                                                                 let uu____17788
+                                                                 let uu____17808
                                                                    =
                                                                    FStar_Syntax_Util.eq_tm
                                                                     head2'
                                                                     head2
                                                                     in
-                                                                 (uu____17787,
-                                                                   uu____17788)
+                                                                 (uu____17807,
+                                                                   uu____17808)
                                                                   in
-                                                               (match uu____17782
+                                                               (match uu____17802
                                                                 with
                                                                 | (FStar_Syntax_Util.Equal
                                                                    ,FStar_Syntax_Util.Equal
                                                                    ) ->
                                                                     (
                                                                     (
-                                                                    let uu____17790
+                                                                    let uu____17810
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -6179,72 +6191,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     "Rel")
                                                                      in
                                                                     if
-                                                                    uu____17790
+                                                                    uu____17810
                                                                     then
-                                                                    let uu____17795
+                                                                    let uu____17815
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t1  in
-                                                                    let uu____17797
+                                                                    let uu____17817
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t1'  in
-                                                                    let uu____17799
+                                                                    let uu____17819
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t2  in
-                                                                    let uu____17801
+                                                                    let uu____17821
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t2'  in
                                                                     FStar_Util.print4
                                                                     "Unfolding didn't make progress ... got %s ~> %s;\nand %s ~> %s\n"
-                                                                    uu____17795
-                                                                    uu____17797
-                                                                    uu____17799
-                                                                    uu____17801
+                                                                    uu____17815
+                                                                    uu____17817
+                                                                    uu____17819
+                                                                    uu____17821
                                                                     else ());
                                                                     solve_sub_probs
                                                                     env2 wl2)
-                                                                | uu____17806
+                                                                | uu____17826
                                                                     ->
                                                                     let torig'
                                                                     =
-                                                                    let uu___2598_17814
+                                                                    let uu___2598_17834
                                                                     = torig
                                                                      in
                                                                     {
                                                                     FStar_TypeChecker_Common.pid
                                                                     =
-                                                                    (uu___2598_17814.FStar_TypeChecker_Common.pid);
+                                                                    (uu___2598_17834.FStar_TypeChecker_Common.pid);
                                                                     FStar_TypeChecker_Common.lhs
                                                                     = t1';
                                                                     FStar_TypeChecker_Common.relation
                                                                     =
-                                                                    (uu___2598_17814.FStar_TypeChecker_Common.relation);
+                                                                    (uu___2598_17834.FStar_TypeChecker_Common.relation);
                                                                     FStar_TypeChecker_Common.rhs
                                                                     = t2';
                                                                     FStar_TypeChecker_Common.element
                                                                     =
-                                                                    (uu___2598_17814.FStar_TypeChecker_Common.element);
+                                                                    (uu___2598_17834.FStar_TypeChecker_Common.element);
                                                                     FStar_TypeChecker_Common.logical_guard
                                                                     =
-                                                                    (uu___2598_17814.FStar_TypeChecker_Common.logical_guard);
+                                                                    (uu___2598_17834.FStar_TypeChecker_Common.logical_guard);
                                                                     FStar_TypeChecker_Common.logical_guard_uvar
                                                                     =
-                                                                    (uu___2598_17814.FStar_TypeChecker_Common.logical_guard_uvar);
+                                                                    (uu___2598_17834.FStar_TypeChecker_Common.logical_guard_uvar);
                                                                     FStar_TypeChecker_Common.reason
                                                                     =
-                                                                    (uu___2598_17814.FStar_TypeChecker_Common.reason);
+                                                                    (uu___2598_17834.FStar_TypeChecker_Common.reason);
                                                                     FStar_TypeChecker_Common.loc
                                                                     =
-                                                                    (uu___2598_17814.FStar_TypeChecker_Common.loc);
+                                                                    (uu___2598_17834.FStar_TypeChecker_Common.loc);
                                                                     FStar_TypeChecker_Common.rank
                                                                     =
-                                                                    (uu___2598_17814.FStar_TypeChecker_Common.rank)
+                                                                    (uu___2598_17834.FStar_TypeChecker_Common.rank)
                                                                     }  in
                                                                     ((
-                                                                    let uu____17816
+                                                                    let uu____17836
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -6253,9 +6265,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     "Rel")
                                                                      in
                                                                     if
-                                                                    uu____17816
+                                                                    uu____17836
                                                                     then
-                                                                    let uu____17821
+                                                                    let uu____17841
                                                                     =
                                                                     prob_to_string
                                                                     env2
@@ -6264,20 +6276,20 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                      in
                                                                     FStar_Util.print1
                                                                     "Unfolded and now trying %s\n"
-                                                                    uu____17821
+                                                                    uu____17841
                                                                     else ());
                                                                     solve_t
                                                                     env2
                                                                     torig'
                                                                     wl2))))
-                                                 | uu____17826 ->
+                                                 | uu____17846 ->
                                                      solve_sub_probs env2 wl2))
                                             in
                                          let d =
-                                           let uu____17838 =
+                                           let uu____17858 =
                                              delta_depth_of_term env1 head1
                                               in
-                                           match uu____17838 with
+                                           match uu____17858 with
                                            | FStar_Pervasives_Native.None  ->
                                                FStar_Pervasives_Native.None
                                            | FStar_Pervasives_Native.Some d
@@ -6286,20 +6298,20 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                  d
                                             in
                                          let treat_as_injective =
-                                           let uu____17846 =
-                                             let uu____17847 =
+                                           let uu____17866 =
+                                             let uu____17867 =
                                                FStar_Syntax_Util.un_uinst
                                                  head1
                                                 in
-                                             uu____17847.FStar_Syntax_Syntax.n
+                                             uu____17867.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____17846 with
+                                           match uu____17866 with
                                            | FStar_Syntax_Syntax.Tm_fvar fv
                                                ->
                                                FStar_TypeChecker_Env.fv_has_attr
                                                  env1 fv
                                                  FStar_Parser_Const.unifier_hint_injective_lid
-                                           | uu____17852 -> false  in
+                                           | uu____17872 -> false  in
                                          (match d with
                                           | FStar_Pervasives_Native.Some d1
                                               when
@@ -6311,9 +6323,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                 env1 wl1
                                                 solve_sub_probs_no_smt
                                                 (unfold_and_retry d1)
-                                          | uu____17855 ->
+                                          | uu____17875 ->
                                               solve_sub_probs env1 wl1)
-                                     | uu____17858 ->
+                                     | uu____17878 ->
                                          let lhs =
                                            force_refinement
                                              (base1, refinement1)
@@ -6323,142 +6335,142 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                              (base2, refinement2)
                                             in
                                          solve_t env1
-                                           (let uu___2618_17894 = problem  in
+                                           (let uu___2618_17914 = problem  in
                                             {
                                               FStar_TypeChecker_Common.pid =
-                                                (uu___2618_17894.FStar_TypeChecker_Common.pid);
+                                                (uu___2618_17914.FStar_TypeChecker_Common.pid);
                                               FStar_TypeChecker_Common.lhs =
                                                 lhs;
                                               FStar_TypeChecker_Common.relation
                                                 =
-                                                (uu___2618_17894.FStar_TypeChecker_Common.relation);
+                                                (uu___2618_17914.FStar_TypeChecker_Common.relation);
                                               FStar_TypeChecker_Common.rhs =
                                                 rhs;
                                               FStar_TypeChecker_Common.element
                                                 =
-                                                (uu___2618_17894.FStar_TypeChecker_Common.element);
+                                                (uu___2618_17914.FStar_TypeChecker_Common.element);
                                               FStar_TypeChecker_Common.logical_guard
                                                 =
-                                                (uu___2618_17894.FStar_TypeChecker_Common.logical_guard);
+                                                (uu___2618_17914.FStar_TypeChecker_Common.logical_guard);
                                               FStar_TypeChecker_Common.logical_guard_uvar
                                                 =
-                                                (uu___2618_17894.FStar_TypeChecker_Common.logical_guard_uvar);
+                                                (uu___2618_17914.FStar_TypeChecker_Common.logical_guard_uvar);
                                               FStar_TypeChecker_Common.reason
                                                 =
-                                                (uu___2618_17894.FStar_TypeChecker_Common.reason);
+                                                (uu___2618_17914.FStar_TypeChecker_Common.reason);
                                               FStar_TypeChecker_Common.loc =
-                                                (uu___2618_17894.FStar_TypeChecker_Common.loc);
+                                                (uu___2618_17914.FStar_TypeChecker_Common.loc);
                                               FStar_TypeChecker_Common.rank =
-                                                (uu___2618_17894.FStar_TypeChecker_Common.rank)
+                                                (uu___2618_17914.FStar_TypeChecker_Common.rank)
                                             }) wl1))))))
             in
          let try_match_heuristic env1 orig wl1 s1 s2 t1t2_opt =
            let try_solve_branch scrutinee p =
-             let uu____17970 = destruct_flex_t scrutinee wl1  in
-             match uu____17970 with
+             let uu____17990 = destruct_flex_t scrutinee wl1  in
+             match uu____17990 with
              | ((_t,uv,_args),wl2) ->
-                 let uu____17981 =
+                 let uu____18001 =
                    FStar_TypeChecker_PatternUtils.pat_as_exp true env1 p  in
-                 (match uu____17981 with
-                  | (xs,pat_term,uu____17997,uu____17998) ->
-                      let uu____18003 =
+                 (match uu____18001 with
+                  | (xs,pat_term,uu____18017,uu____18018) ->
+                      let uu____18023 =
                         FStar_List.fold_left
-                          (fun uu____18026  ->
+                          (fun uu____18046  ->
                              fun x  ->
-                               match uu____18026 with
+                               match uu____18046 with
                                | (subst,wl3) ->
                                    let t_x =
                                      FStar_Syntax_Subst.subst subst
                                        x.FStar_Syntax_Syntax.sort
                                       in
-                                   let uu____18047 = copy_uvar uv [] t_x wl3
+                                   let uu____18067 = copy_uvar uv [] t_x wl3
                                       in
-                                   (match uu____18047 with
-                                    | (uu____18066,u,wl4) ->
+                                   (match uu____18067 with
+                                    | (uu____18086,u,wl4) ->
                                         let subst1 =
                                           (FStar_Syntax_Syntax.NT (x, u)) ::
                                           subst  in
                                         (subst1, wl4))) ([], wl2) xs
                          in
-                      (match uu____18003 with
+                      (match uu____18023 with
                        | (subst,wl3) ->
                            let pat_term1 =
                              FStar_Syntax_Subst.subst subst pat_term  in
-                           let uu____18087 =
+                           let uu____18107 =
                              new_problem wl3 env1 scrutinee
                                FStar_TypeChecker_Common.EQ pat_term1
                                FStar_Pervasives_Native.None
                                scrutinee.FStar_Syntax_Syntax.pos
                                "match heuristic"
                               in
-                           (match uu____18087 with
+                           (match uu____18107 with
                             | (prob,wl4) ->
                                 let wl' =
-                                  let uu___2658_18104 = wl4  in
+                                  let uu___2658_18124 = wl4  in
                                   {
                                     attempting =
                                       [FStar_TypeChecker_Common.TProb prob];
                                     wl_deferred = [];
-                                    ctr = (uu___2658_18104.ctr);
+                                    ctr = (uu___2658_18124.ctr);
                                     defer_ok = false;
                                     smt_ok = false;
                                     umax_heuristic_ok =
-                                      (uu___2658_18104.umax_heuristic_ok);
-                                    tcenv = (uu___2658_18104.tcenv);
+                                      (uu___2658_18124.umax_heuristic_ok);
+                                    tcenv = (uu___2658_18124.tcenv);
                                     wl_implicits = []
                                   }  in
                                 let tx =
                                   FStar_Syntax_Unionfind.new_transaction ()
                                    in
-                                let uu____18115 = solve env1 wl'  in
-                                (match uu____18115 with
-                                 | Success (uu____18118,imps) ->
+                                let uu____18135 = solve env1 wl'  in
+                                (match uu____18135 with
+                                 | Success (uu____18138,imps) ->
                                      let wl'1 =
-                                       let uu___2666_18121 = wl'  in
+                                       let uu___2666_18141 = wl'  in
                                        {
                                          attempting = [orig];
                                          wl_deferred =
-                                           (uu___2666_18121.wl_deferred);
-                                         ctr = (uu___2666_18121.ctr);
+                                           (uu___2666_18141.wl_deferred);
+                                         ctr = (uu___2666_18141.ctr);
                                          defer_ok =
-                                           (uu___2666_18121.defer_ok);
-                                         smt_ok = (uu___2666_18121.smt_ok);
+                                           (uu___2666_18141.defer_ok);
+                                         smt_ok = (uu___2666_18141.smt_ok);
                                          umax_heuristic_ok =
-                                           (uu___2666_18121.umax_heuristic_ok);
-                                         tcenv = (uu___2666_18121.tcenv);
+                                           (uu___2666_18141.umax_heuristic_ok);
+                                         tcenv = (uu___2666_18141.tcenv);
                                          wl_implicits =
-                                           (uu___2666_18121.wl_implicits)
+                                           (uu___2666_18141.wl_implicits)
                                        }  in
-                                     let uu____18122 = solve env1 wl'1  in
-                                     (match uu____18122 with
-                                      | Success (uu____18125,imps') ->
+                                     let uu____18142 = solve env1 wl'1  in
+                                     (match uu____18142 with
+                                      | Success (uu____18145,imps') ->
                                           (FStar_Syntax_Unionfind.commit tx;
                                            FStar_Pervasives_Native.Some
-                                             ((let uu___2674_18129 = wl4  in
+                                             ((let uu___2674_18149 = wl4  in
                                                {
                                                  attempting =
-                                                   (uu___2674_18129.attempting);
+                                                   (uu___2674_18149.attempting);
                                                  wl_deferred =
-                                                   (uu___2674_18129.wl_deferred);
-                                                 ctr = (uu___2674_18129.ctr);
+                                                   (uu___2674_18149.wl_deferred);
+                                                 ctr = (uu___2674_18149.ctr);
                                                  defer_ok =
-                                                   (uu___2674_18129.defer_ok);
+                                                   (uu___2674_18149.defer_ok);
                                                  smt_ok =
-                                                   (uu___2674_18129.smt_ok);
+                                                   (uu___2674_18149.smt_ok);
                                                  umax_heuristic_ok =
-                                                   (uu___2674_18129.umax_heuristic_ok);
+                                                   (uu___2674_18149.umax_heuristic_ok);
                                                  tcenv =
-                                                   (uu___2674_18129.tcenv);
+                                                   (uu___2674_18149.tcenv);
                                                  wl_implicits =
                                                    (FStar_List.append
                                                       wl4.wl_implicits
                                                       (FStar_List.append imps
                                                          imps'))
                                                })))
-                                      | Failed uu____18130 ->
+                                      | Failed uu____18150 ->
                                           (FStar_Syntax_Unionfind.rollback tx;
                                            FStar_Pervasives_Native.None))
-                                 | uu____18136 ->
+                                 | uu____18156 ->
                                      (FStar_Syntax_Unionfind.rollback tx;
                                       FStar_Pervasives_Native.None)))))
               in
@@ -6466,457 +6478,440 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
            | FStar_Pervasives_Native.None  ->
                FStar_Util.Inr FStar_Pervasives_Native.None
            | FStar_Pervasives_Native.Some (t1,t2) ->
-               ((let uu____18159 =
+               ((let uu____18179 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                      (FStar_Options.Other "Rel")
                     in
-                 if uu____18159
+                 if uu____18179
                  then
-                   let uu____18164 = FStar_Syntax_Print.term_to_string t1  in
-                   let uu____18166 = FStar_Syntax_Print.term_to_string t2  in
+                   let uu____18184 = FStar_Syntax_Print.term_to_string t1  in
+                   let uu____18186 = FStar_Syntax_Print.term_to_string t2  in
                    FStar_Util.print2 "Trying match heuristic for %s vs. %s\n"
-                     uu____18164 uu____18166
+                     uu____18184 uu____18186
                  else ());
-                (let uu____18171 =
-                   let uu____18192 =
-                     let uu____18201 = FStar_Syntax_Util.unmeta t1  in
-                     (s1, uu____18201)  in
-                   let uu____18208 =
-                     let uu____18217 = FStar_Syntax_Util.unmeta t2  in
-                     (s2, uu____18217)  in
-                   (uu____18192, uu____18208)  in
-                 match uu____18171 with
-                 | ((uu____18247,{
+                (let uu____18191 =
+                   let uu____18212 =
+                     let uu____18221 = FStar_Syntax_Util.unmeta t1  in
+                     (s1, uu____18221)  in
+                   let uu____18228 =
+                     let uu____18237 = FStar_Syntax_Util.unmeta t2  in
+                     (s2, uu____18237)  in
+                   (uu____18212, uu____18228)  in
+                 match uu____18191 with
+                 | ((uu____18267,{
                                    FStar_Syntax_Syntax.n =
                                      FStar_Syntax_Syntax.Tm_match
                                      (scrutinee,branches);
-                                   FStar_Syntax_Syntax.pos = uu____18250;
-                                   FStar_Syntax_Syntax.vars = uu____18251;_}),
+                                   FStar_Syntax_Syntax.pos = uu____18270;
+                                   FStar_Syntax_Syntax.vars = uu____18271;_}),
                     (s,t)) ->
-                     let uu____18322 =
-                       let uu____18324 = is_flex scrutinee  in
-                       Prims.op_Negation uu____18324  in
-                     if uu____18322
+                     let uu____18342 =
+                       let uu____18344 = is_flex scrutinee  in
+                       Prims.op_Negation uu____18344  in
+                     if uu____18342
                      then
-                       ((let uu____18335 =
+                       ((let uu____18355 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env1)
                              (FStar_Options.Other "Rel")
                             in
-                         if uu____18335
+                         if uu____18355
                          then
-                           let uu____18340 =
+                           let uu____18360 =
                              FStar_Syntax_Print.term_to_string scrutinee  in
                            FStar_Util.print1
-                             "match head %s is not a flex term\n" uu____18340
+                             "match head %s is not a flex term\n" uu____18360
                          else ());
                         FStar_Util.Inr FStar_Pervasives_Native.None)
                      else
                        if wl1.defer_ok
                        then
-                         ((let uu____18359 =
+                         ((let uu____18379 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel")
                               in
-                           if uu____18359
+                           if uu____18379
                            then FStar_Util.print_string "Deferring ... \n"
                            else ());
                           FStar_Util.Inl "defer")
                        else
-                         ((let uu____18374 =
+                         ((let uu____18394 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel")
                               in
-                           if uu____18374
+                           if uu____18394
                            then
-                             let uu____18379 =
+                             let uu____18399 =
                                FStar_Syntax_Print.term_to_string scrutinee
                                 in
-                             let uu____18381 =
+                             let uu____18401 =
                                FStar_Syntax_Print.term_to_string t  in
                              FStar_Util.print2
                                "Heuristic applicable with scrutinee %s and other side = %s\n"
-                               uu____18379 uu____18381
+                               uu____18399 uu____18401
                            else ());
-                          (let pat_discriminates uu___28_18406 =
-                             match uu___28_18406 with
+                          (let pat_discriminates uu___28_18426 =
+                             match uu___28_18426 with
                              | ({
                                   FStar_Syntax_Syntax.v =
                                     FStar_Syntax_Syntax.Pat_constant
-                                    uu____18422;
-                                  FStar_Syntax_Syntax.p = uu____18423;_},FStar_Pervasives_Native.None
-                                ,uu____18424) -> true
+                                    uu____18442;
+                                  FStar_Syntax_Syntax.p = uu____18443;_},FStar_Pervasives_Native.None
+                                ,uu____18444) -> true
                              | ({
                                   FStar_Syntax_Syntax.v =
-                                    FStar_Syntax_Syntax.Pat_cons uu____18438;
-                                  FStar_Syntax_Syntax.p = uu____18439;_},FStar_Pervasives_Native.None
-                                ,uu____18440) -> true
-                             | uu____18467 -> false  in
+                                    FStar_Syntax_Syntax.Pat_cons uu____18458;
+                                  FStar_Syntax_Syntax.p = uu____18459;_},FStar_Pervasives_Native.None
+                                ,uu____18460) -> true
+                             | uu____18487 -> false  in
                            let head_matching_branch =
                              FStar_All.pipe_right branches
                                (FStar_Util.try_find
                                   (fun b  ->
                                      if pat_discriminates b
                                      then
-                                       let uu____18570 =
+                                       let uu____18590 =
                                          FStar_Syntax_Subst.open_branch b  in
-                                       match uu____18570 with
-                                       | (uu____18572,uu____18573,t') ->
-                                           let uu____18591 =
+                                       match uu____18590 with
+                                       | (uu____18592,uu____18593,t') ->
+                                           let uu____18611 =
                                              head_matches_delta env1 wl1 s t'
                                               in
-                                           (match uu____18591 with
-                                            | (FullMatch ,uu____18603) ->
+                                           (match uu____18611 with
+                                            | (FullMatch ,uu____18623) ->
                                                 true
                                             | (HeadMatch
-                                               uu____18617,uu____18618) ->
+                                               uu____18637,uu____18638) ->
                                                 true
-                                            | uu____18633 -> false)
+                                            | uu____18653 -> false)
                                      else false))
                               in
                            match head_matching_branch with
                            | FStar_Pervasives_Native.None  ->
-                               ((let uu____18670 =
+                               ((let uu____18690 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env1)
                                      (FStar_Options.Other "Rel")
                                     in
-                                 if uu____18670
+                                 if uu____18690
                                  then
                                    FStar_Util.print_string
                                      "No head_matching branch\n"
                                  else ());
                                 (let try_branches =
-                                   let uu____18681 =
+                                   let uu____18701 =
                                      FStar_Util.prefix_until
                                        (fun b  ->
                                           Prims.op_Negation
                                             (pat_discriminates b)) branches
                                       in
-                                   match uu____18681 with
+                                   match uu____18701 with
                                    | FStar_Pervasives_Native.Some
-                                       (branches1,uu____18769,uu____18770) ->
+                                       (branches1,uu____18789,uu____18790) ->
                                        branches1
-                                   | uu____18915 -> branches  in
-                                 let uu____18970 =
+                                   | uu____18935 -> branches  in
+                                 let uu____18990 =
                                    FStar_Util.find_map try_branches
                                      (fun b  ->
-                                        let uu____18979 =
+                                        let uu____18999 =
                                           FStar_Syntax_Subst.open_branch b
                                            in
-                                        match uu____18979 with
-                                        | (p,uu____18983,uu____18984) ->
+                                        match uu____18999 with
+                                        | (p,uu____19003,uu____19004) ->
                                             try_solve_branch scrutinee p)
                                     in
                                  FStar_All.pipe_left
-                                   (fun uu____19013  ->
-                                      FStar_Util.Inr uu____19013) uu____18970))
+                                   (fun uu____19033  ->
+                                      FStar_Util.Inr uu____19033) uu____18990))
                            | FStar_Pervasives_Native.Some b ->
-                               let uu____19043 =
+                               let uu____19063 =
                                  FStar_Syntax_Subst.open_branch b  in
-                               (match uu____19043 with
-                                | (p,uu____19052,e) ->
-                                    ((let uu____19071 =
+                               (match uu____19063 with
+                                | (p,uu____19072,e) ->
+                                    ((let uu____19091 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env1)
                                           (FStar_Options.Other "Rel")
                                          in
-                                      if uu____19071
+                                      if uu____19091
                                       then
-                                        let uu____19076 =
+                                        let uu____19096 =
                                           FStar_Syntax_Print.pat_to_string p
                                            in
-                                        let uu____19078 =
+                                        let uu____19098 =
                                           FStar_Syntax_Print.term_to_string e
                                            in
                                         FStar_Util.print2
                                           "Found head matching branch %s -> %s\n"
-                                          uu____19076 uu____19078
+                                          uu____19096 uu____19098
                                       else ());
-                                     (let uu____19083 =
+                                     (let uu____19103 =
                                         try_solve_branch scrutinee p  in
                                       FStar_All.pipe_left
-                                        (fun uu____19098  ->
-                                           FStar_Util.Inr uu____19098)
-                                        uu____19083)))))
-                 | ((s,t),(uu____19101,{
+                                        (fun uu____19118  ->
+                                           FStar_Util.Inr uu____19118)
+                                        uu____19103)))))
+                 | ((s,t),(uu____19121,{
                                          FStar_Syntax_Syntax.n =
                                            FStar_Syntax_Syntax.Tm_match
                                            (scrutinee,branches);
                                          FStar_Syntax_Syntax.pos =
-                                           uu____19104;
+                                           uu____19124;
                                          FStar_Syntax_Syntax.vars =
-                                           uu____19105;_}))
+                                           uu____19125;_}))
                      ->
-                     let uu____19174 =
-                       let uu____19176 = is_flex scrutinee  in
-                       Prims.op_Negation uu____19176  in
-                     if uu____19174
+                     let uu____19194 =
+                       let uu____19196 = is_flex scrutinee  in
+                       Prims.op_Negation uu____19196  in
+                     if uu____19194
                      then
-                       ((let uu____19187 =
+                       ((let uu____19207 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env1)
                              (FStar_Options.Other "Rel")
                             in
-                         if uu____19187
+                         if uu____19207
                          then
-                           let uu____19192 =
+                           let uu____19212 =
                              FStar_Syntax_Print.term_to_string scrutinee  in
                            FStar_Util.print1
-                             "match head %s is not a flex term\n" uu____19192
+                             "match head %s is not a flex term\n" uu____19212
                          else ());
                         FStar_Util.Inr FStar_Pervasives_Native.None)
                      else
                        if wl1.defer_ok
                        then
-                         ((let uu____19211 =
+                         ((let uu____19231 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel")
                               in
-                           if uu____19211
+                           if uu____19231
                            then FStar_Util.print_string "Deferring ... \n"
                            else ());
                           FStar_Util.Inl "defer")
                        else
-                         ((let uu____19226 =
+                         ((let uu____19246 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel")
                               in
-                           if uu____19226
+                           if uu____19246
                            then
-                             let uu____19231 =
+                             let uu____19251 =
                                FStar_Syntax_Print.term_to_string scrutinee
                                 in
-                             let uu____19233 =
+                             let uu____19253 =
                                FStar_Syntax_Print.term_to_string t  in
                              FStar_Util.print2
                                "Heuristic applicable with scrutinee %s and other side = %s\n"
-                               uu____19231 uu____19233
+                               uu____19251 uu____19253
                            else ());
-                          (let pat_discriminates uu___28_19258 =
-                             match uu___28_19258 with
+                          (let pat_discriminates uu___28_19278 =
+                             match uu___28_19278 with
                              | ({
                                   FStar_Syntax_Syntax.v =
                                     FStar_Syntax_Syntax.Pat_constant
-                                    uu____19274;
-                                  FStar_Syntax_Syntax.p = uu____19275;_},FStar_Pervasives_Native.None
-                                ,uu____19276) -> true
+                                    uu____19294;
+                                  FStar_Syntax_Syntax.p = uu____19295;_},FStar_Pervasives_Native.None
+                                ,uu____19296) -> true
                              | ({
                                   FStar_Syntax_Syntax.v =
-                                    FStar_Syntax_Syntax.Pat_cons uu____19290;
-                                  FStar_Syntax_Syntax.p = uu____19291;_},FStar_Pervasives_Native.None
-                                ,uu____19292) -> true
-                             | uu____19319 -> false  in
+                                    FStar_Syntax_Syntax.Pat_cons uu____19310;
+                                  FStar_Syntax_Syntax.p = uu____19311;_},FStar_Pervasives_Native.None
+                                ,uu____19312) -> true
+                             | uu____19339 -> false  in
                            let head_matching_branch =
                              FStar_All.pipe_right branches
                                (FStar_Util.try_find
                                   (fun b  ->
                                      if pat_discriminates b
                                      then
-                                       let uu____19422 =
+                                       let uu____19442 =
                                          FStar_Syntax_Subst.open_branch b  in
-                                       match uu____19422 with
-                                       | (uu____19424,uu____19425,t') ->
-                                           let uu____19443 =
+                                       match uu____19442 with
+                                       | (uu____19444,uu____19445,t') ->
+                                           let uu____19463 =
                                              head_matches_delta env1 wl1 s t'
                                               in
-                                           (match uu____19443 with
-                                            | (FullMatch ,uu____19455) ->
+                                           (match uu____19463 with
+                                            | (FullMatch ,uu____19475) ->
                                                 true
                                             | (HeadMatch
-                                               uu____19469,uu____19470) ->
+                                               uu____19489,uu____19490) ->
                                                 true
-                                            | uu____19485 -> false)
+                                            | uu____19505 -> false)
                                      else false))
                               in
                            match head_matching_branch with
                            | FStar_Pervasives_Native.None  ->
-                               ((let uu____19522 =
+                               ((let uu____19542 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env1)
                                      (FStar_Options.Other "Rel")
                                     in
-                                 if uu____19522
+                                 if uu____19542
                                  then
                                    FStar_Util.print_string
                                      "No head_matching branch\n"
                                  else ());
                                 (let try_branches =
-                                   let uu____19533 =
+                                   let uu____19553 =
                                      FStar_Util.prefix_until
                                        (fun b  ->
                                           Prims.op_Negation
                                             (pat_discriminates b)) branches
                                       in
-                                   match uu____19533 with
+                                   match uu____19553 with
                                    | FStar_Pervasives_Native.Some
-                                       (branches1,uu____19621,uu____19622) ->
+                                       (branches1,uu____19641,uu____19642) ->
                                        branches1
-                                   | uu____19767 -> branches  in
-                                 let uu____19822 =
+                                   | uu____19787 -> branches  in
+                                 let uu____19842 =
                                    FStar_Util.find_map try_branches
                                      (fun b  ->
-                                        let uu____19831 =
+                                        let uu____19851 =
                                           FStar_Syntax_Subst.open_branch b
                                            in
-                                        match uu____19831 with
-                                        | (p,uu____19835,uu____19836) ->
+                                        match uu____19851 with
+                                        | (p,uu____19855,uu____19856) ->
                                             try_solve_branch scrutinee p)
                                     in
                                  FStar_All.pipe_left
-                                   (fun uu____19865  ->
-                                      FStar_Util.Inr uu____19865) uu____19822))
+                                   (fun uu____19885  ->
+                                      FStar_Util.Inr uu____19885) uu____19842))
                            | FStar_Pervasives_Native.Some b ->
-                               let uu____19895 =
+                               let uu____19915 =
                                  FStar_Syntax_Subst.open_branch b  in
-                               (match uu____19895 with
-                                | (p,uu____19904,e) ->
-                                    ((let uu____19923 =
+                               (match uu____19915 with
+                                | (p,uu____19924,e) ->
+                                    ((let uu____19943 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env1)
                                           (FStar_Options.Other "Rel")
                                          in
-                                      if uu____19923
+                                      if uu____19943
                                       then
-                                        let uu____19928 =
+                                        let uu____19948 =
                                           FStar_Syntax_Print.pat_to_string p
                                            in
-                                        let uu____19930 =
+                                        let uu____19950 =
                                           FStar_Syntax_Print.term_to_string e
                                            in
                                         FStar_Util.print2
                                           "Found head matching branch %s -> %s\n"
-                                          uu____19928 uu____19930
+                                          uu____19948 uu____19950
                                       else ());
-                                     (let uu____19935 =
+                                     (let uu____19955 =
                                         try_solve_branch scrutinee p  in
                                       FStar_All.pipe_left
-                                        (fun uu____19950  ->
-                                           FStar_Util.Inr uu____19950)
-                                        uu____19935)))))
-                 | uu____19951 ->
-                     ((let uu____19973 =
+                                        (fun uu____19970  ->
+                                           FStar_Util.Inr uu____19970)
+                                        uu____19955)))))
+                 | uu____19971 ->
+                     ((let uu____19993 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env1)
                            (FStar_Options.Other "Rel")
                           in
-                       if uu____19973
+                       if uu____19993
                        then
-                         let uu____19978 = FStar_Syntax_Print.tag_of_term t1
+                         let uu____19998 = FStar_Syntax_Print.tag_of_term t1
                             in
-                         let uu____19980 = FStar_Syntax_Print.tag_of_term t2
+                         let uu____20000 = FStar_Syntax_Print.tag_of_term t2
                             in
                          FStar_Util.print2
                            "Heuristic not applicable: tag lhs=%s, rhs=%s\n"
-                           uu____19978 uu____19980
+                           uu____19998 uu____20000
                        else ());
                       FStar_Util.Inr FStar_Pervasives_Native.None)))
             in
          let rigid_rigid_delta env1 torig wl1 head1 head2 t1 t2 =
            let orig = FStar_TypeChecker_Common.TProb torig  in
-           (let uu____20026 =
+           (let uu____20046 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                 (FStar_Options.Other "RelDelta")
                in
-            if uu____20026
+            if uu____20046
             then
-              let uu____20031 = FStar_Syntax_Print.tag_of_term t1  in
-              let uu____20033 = FStar_Syntax_Print.tag_of_term t2  in
-              let uu____20035 = FStar_Syntax_Print.term_to_string t1  in
-              let uu____20037 = FStar_Syntax_Print.term_to_string t2  in
+              let uu____20051 = FStar_Syntax_Print.tag_of_term t1  in
+              let uu____20053 = FStar_Syntax_Print.tag_of_term t2  in
+              let uu____20055 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____20057 = FStar_Syntax_Print.term_to_string t2  in
               FStar_Util.print4 "rigid_rigid_delta of %s-%s (%s, %s)\n"
-                uu____20031 uu____20033 uu____20035 uu____20037
+                uu____20051 uu____20053 uu____20055 uu____20057
             else ());
-           (let uu____20042 = head_matches_delta env1 wl1 t1 t2  in
-            match uu____20042 with
+           (let uu____20062 = head_matches_delta env1 wl1 t1 t2  in
+            match uu____20062 with
             | (m,o) ->
                 (match (m, o) with
-                 | (MisMatch uu____20073,uu____20074) ->
+                 | (MisMatch uu____20093,uu____20094) ->
                      let rec may_relate head =
-                       let uu____20102 =
-                         let uu____20103 = FStar_Syntax_Subst.compress head
+                       let uu____20122 =
+                         let uu____20123 = FStar_Syntax_Subst.compress head
                             in
-                         uu____20103.FStar_Syntax_Syntax.n  in
-                       match uu____20102 with
-                       | FStar_Syntax_Syntax.Tm_name uu____20107 -> true
-                       | FStar_Syntax_Syntax.Tm_match uu____20109 -> true
+                         uu____20123.FStar_Syntax_Syntax.n  in
+                       match uu____20122 with
+                       | FStar_Syntax_Syntax.Tm_name uu____20127 -> true
+                       | FStar_Syntax_Syntax.Tm_match uu____20129 -> true
                        | FStar_Syntax_Syntax.Tm_fvar fv ->
-                           let uu____20134 =
+                           let uu____20154 =
                              FStar_TypeChecker_Env.delta_depth_of_fv env1 fv
                               in
-                           (match uu____20134 with
+                           (match uu____20154 with
                             | FStar_Syntax_Syntax.Delta_equational_at_level
-                                uu____20136 -> true
-                            | FStar_Syntax_Syntax.Delta_abstract uu____20139
+                                uu____20156 -> true
+                            | FStar_Syntax_Syntax.Delta_abstract uu____20159
                                 ->
                                 problem.FStar_TypeChecker_Common.relation =
                                   FStar_TypeChecker_Common.EQ
-                            | uu____20140 -> false)
+                            | uu____20160 -> false)
                        | FStar_Syntax_Syntax.Tm_ascribed
-                           (t,uu____20143,uu____20144) -> may_relate t
-                       | FStar_Syntax_Syntax.Tm_uinst (t,uu____20186) ->
+                           (t,uu____20163,uu____20164) -> may_relate t
+                       | FStar_Syntax_Syntax.Tm_uinst (t,uu____20206) ->
                            may_relate t
-                       | FStar_Syntax_Syntax.Tm_meta (t,uu____20192) ->
+                       | FStar_Syntax_Syntax.Tm_meta (t,uu____20212) ->
                            may_relate t
-                       | uu____20197 -> false  in
-                     let uu____20199 =
+                       | uu____20217 -> false  in
+                     let uu____20219 =
                        try_match_heuristic env1 orig wl1 t1 t2 o  in
-                     (match uu____20199 with
+                     (match uu____20219 with
                       | FStar_Util.Inl _defer_ok ->
-                          let uu____20212 =
+                          let uu____20232 =
                             FStar_Thunk.mkv "delaying match heuristic"  in
-                          giveup_or_defer1 orig uu____20212
+                          giveup_or_defer1 orig uu____20232
                       | FStar_Util.Inr (FStar_Pervasives_Native.Some wl2) ->
                           solve env1 wl2
                       | FStar_Util.Inr (FStar_Pervasives_Native.None ) ->
-                          let uu____20222 =
+                          let uu____20242 =
                             ((may_relate head1) || (may_relate head2)) &&
                               wl1.smt_ok
                              in
-                          if uu____20222
+                          if uu____20242
                           then
-                            let uu____20225 =
+                            let uu____20245 =
                               guard_of_prob env1 wl1 problem t1 t2  in
-                            (match uu____20225 with
+                            (match uu____20245 with
                              | (guard,wl2) ->
-                                 let uu____20232 =
+                                 let uu____20252 =
                                    solve_prob orig
                                      (FStar_Pervasives_Native.Some guard) []
                                      wl2
                                     in
-                                 solve env1 uu____20232)
+                                 solve env1 uu____20252)
                           else
-                            (let uu____20235 =
+                            (let uu____20255 =
                                mklstr
-                                 (fun uu____20246  ->
-                                    let uu____20247 =
-                                      FStar_Syntax_Print.term_to_string head1
-                                       in
-                                    let uu____20249 =
-                                      let uu____20251 =
-                                        let uu____20255 =
-                                          delta_depth_of_term env1 head1  in
-                                        FStar_Util.bind_opt uu____20255
-                                          (fun x  ->
-                                             let uu____20262 =
-                                               FStar_Syntax_Print.delta_depth_to_string
-                                                 x
-                                                in
-                                             FStar_Pervasives_Native.Some
-                                               uu____20262)
-                                         in
-                                      FStar_Util.dflt "" uu____20251  in
+                                 (fun uu____20266  ->
                                     let uu____20267 =
-                                      FStar_Syntax_Print.term_to_string head2
+                                      FStar_Syntax_Print.term_to_string head1
                                        in
                                     let uu____20269 =
                                       let uu____20271 =
                                         let uu____20275 =
-                                          delta_depth_of_term env1 head2  in
+                                          delta_depth_of_term env1 head1  in
                                         FStar_Util.bind_opt uu____20275
                                           (fun x  ->
                                              let uu____20282 =
@@ -6927,62 +6922,79 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                uu____20282)
                                          in
                                       FStar_Util.dflt "" uu____20271  in
+                                    let uu____20287 =
+                                      FStar_Syntax_Print.term_to_string head2
+                                       in
+                                    let uu____20289 =
+                                      let uu____20291 =
+                                        let uu____20295 =
+                                          delta_depth_of_term env1 head2  in
+                                        FStar_Util.bind_opt uu____20295
+                                          (fun x  ->
+                                             let uu____20302 =
+                                               FStar_Syntax_Print.delta_depth_to_string
+                                                 x
+                                                in
+                                             FStar_Pervasives_Native.Some
+                                               uu____20302)
+                                         in
+                                      FStar_Util.dflt "" uu____20291  in
                                     FStar_Util.format4
                                       "head mismatch (%s (%s) vs %s (%s))"
-                                      uu____20247 uu____20249 uu____20267
-                                      uu____20269)
+                                      uu____20267 uu____20269 uu____20287
+                                      uu____20289)
                                 in
-                             giveup env1 uu____20235 orig))
-                 | (HeadMatch (true ),uu____20288) when
+                             giveup env1 uu____20255 orig))
+                 | (HeadMatch (true ),uu____20308) when
                      problem.FStar_TypeChecker_Common.relation <>
                        FStar_TypeChecker_Common.EQ
                      ->
                      if wl1.smt_ok
                      then
-                       let uu____20303 = guard_of_prob env1 wl1 problem t1 t2
+                       let uu____20323 = guard_of_prob env1 wl1 problem t1 t2
                           in
-                       (match uu____20303 with
+                       (match uu____20323 with
                         | (guard,wl2) ->
-                            let uu____20310 =
+                            let uu____20330 =
                               solve_prob orig
                                 (FStar_Pervasives_Native.Some guard) [] wl2
                                in
-                            solve env1 uu____20310)
+                            solve env1 uu____20330)
                      else
-                       (let uu____20313 =
+                       (let uu____20333 =
                           mklstr
-                            (fun uu____20320  ->
-                               let uu____20321 =
+                            (fun uu____20340  ->
+                               let uu____20341 =
                                  FStar_Syntax_Print.term_to_string t1  in
-                               let uu____20323 =
+                               let uu____20343 =
                                  FStar_Syntax_Print.term_to_string t2  in
                                FStar_Util.format2
                                  "head mismatch for subtyping (%s vs %s)"
-                                 uu____20321 uu____20323)
+                                 uu____20341 uu____20343)
                            in
-                        giveup env1 uu____20313 orig)
-                 | (uu____20326,FStar_Pervasives_Native.Some (t11,t21)) ->
+                        giveup env1 uu____20333 orig)
+                 | (uu____20346,FStar_Pervasives_Native.Some (t11,t21)) ->
                      solve_t env1
-                       (let uu___2849_20340 = problem  in
+                       (let uu___2849_20360 = problem  in
                         {
                           FStar_TypeChecker_Common.pid =
-                            (uu___2849_20340.FStar_TypeChecker_Common.pid);
+                            (uu___2849_20360.FStar_TypeChecker_Common.pid);
                           FStar_TypeChecker_Common.lhs = t11;
                           FStar_TypeChecker_Common.relation =
-                            (uu___2849_20340.FStar_TypeChecker_Common.relation);
+                            (uu___2849_20360.FStar_TypeChecker_Common.relation);
                           FStar_TypeChecker_Common.rhs = t21;
                           FStar_TypeChecker_Common.element =
-                            (uu___2849_20340.FStar_TypeChecker_Common.element);
+                            (uu___2849_20360.FStar_TypeChecker_Common.element);
                           FStar_TypeChecker_Common.logical_guard =
-                            (uu___2849_20340.FStar_TypeChecker_Common.logical_guard);
+                            (uu___2849_20360.FStar_TypeChecker_Common.logical_guard);
                           FStar_TypeChecker_Common.logical_guard_uvar =
-                            (uu___2849_20340.FStar_TypeChecker_Common.logical_guard_uvar);
+                            (uu___2849_20360.FStar_TypeChecker_Common.logical_guard_uvar);
                           FStar_TypeChecker_Common.reason =
-                            (uu___2849_20340.FStar_TypeChecker_Common.reason);
+                            (uu___2849_20360.FStar_TypeChecker_Common.reason);
                           FStar_TypeChecker_Common.loc =
-                            (uu___2849_20340.FStar_TypeChecker_Common.loc);
+                            (uu___2849_20360.FStar_TypeChecker_Common.loc);
                           FStar_TypeChecker_Common.rank =
-                            (uu___2849_20340.FStar_TypeChecker_Common.rank)
+                            (uu___2849_20360.FStar_TypeChecker_Common.rank)
                         }) wl1
                  | (HeadMatch need_unif,FStar_Pervasives_Native.None ) ->
                      rigid_heads_match env1 need_unif torig wl1 t1 t2
@@ -6991,197 +7003,197 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
             in
          let orig = FStar_TypeChecker_Common.TProb problem  in
          def_check_prob "solve_t'.2" orig;
-         (let uu____20367 =
+         (let uu____20387 =
             FStar_Util.physical_equality problem.FStar_TypeChecker_Common.lhs
               problem.FStar_TypeChecker_Common.rhs
              in
-          if uu____20367
+          if uu____20387
           then
-            let uu____20370 =
+            let uu____20390 =
               solve_prob orig FStar_Pervasives_Native.None [] wl  in
-            solve env uu____20370
+            solve env uu____20390
           else
             (let t1 = problem.FStar_TypeChecker_Common.lhs  in
              let t2 = problem.FStar_TypeChecker_Common.rhs  in
-             (let uu____20376 =
-                let uu____20379 = p_scope orig  in
-                FStar_List.map FStar_Pervasives_Native.fst uu____20379  in
+             (let uu____20396 =
+                let uu____20399 = p_scope orig  in
+                FStar_List.map FStar_Pervasives_Native.fst uu____20399  in
               FStar_TypeChecker_Env.def_check_closed_in (p_loc orig) "ref.t1"
-                uu____20376 t1);
-             (let uu____20398 =
-                let uu____20401 = p_scope orig  in
-                FStar_List.map FStar_Pervasives_Native.fst uu____20401  in
+                uu____20396 t1);
+             (let uu____20418 =
+                let uu____20421 = p_scope orig  in
+                FStar_List.map FStar_Pervasives_Native.fst uu____20421  in
               FStar_TypeChecker_Env.def_check_closed_in (p_loc orig) "ref.t2"
-                uu____20398 t2);
-             (let uu____20420 =
+                uu____20418 t2);
+             (let uu____20440 =
                 FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel")
                  in
-              if uu____20420
+              if uu____20440
               then
-                let uu____20424 =
+                let uu____20444 =
                   FStar_Util.string_of_int
                     problem.FStar_TypeChecker_Common.pid
                    in
-                let uu____20426 =
-                  let uu____20428 = FStar_Syntax_Print.tag_of_term t1  in
-                  let uu____20430 =
-                    let uu____20432 = FStar_Syntax_Print.term_to_string t1
+                let uu____20446 =
+                  let uu____20448 = FStar_Syntax_Print.tag_of_term t1  in
+                  let uu____20450 =
+                    let uu____20452 = FStar_Syntax_Print.term_to_string t1
                        in
-                    Prims.op_Hat "::" uu____20432  in
-                  Prims.op_Hat uu____20428 uu____20430  in
-                let uu____20435 =
-                  let uu____20437 = FStar_Syntax_Print.tag_of_term t2  in
-                  let uu____20439 =
-                    let uu____20441 = FStar_Syntax_Print.term_to_string t2
+                    Prims.op_Hat "::" uu____20452  in
+                  Prims.op_Hat uu____20448 uu____20450  in
+                let uu____20455 =
+                  let uu____20457 = FStar_Syntax_Print.tag_of_term t2  in
+                  let uu____20459 =
+                    let uu____20461 = FStar_Syntax_Print.term_to_string t2
                        in
-                    Prims.op_Hat "::" uu____20441  in
-                  Prims.op_Hat uu____20437 uu____20439  in
+                    Prims.op_Hat "::" uu____20461  in
+                  Prims.op_Hat uu____20457 uu____20459  in
                 FStar_Util.print4 "Attempting %s (%s vs %s); rel = (%s)\n"
-                  uu____20424 uu____20426 uu____20435
+                  uu____20444 uu____20446 uu____20455
                   (rel_to_string problem.FStar_TypeChecker_Common.relation)
               else ());
              (let r = FStar_TypeChecker_Env.get_range env  in
               match ((t1.FStar_Syntax_Syntax.n), (t2.FStar_Syntax_Syntax.n))
               with
-              | (FStar_Syntax_Syntax.Tm_delayed uu____20448,uu____20449) ->
+              | (FStar_Syntax_Syntax.Tm_delayed uu____20468,uu____20469) ->
                   failwith "Impossible: terms were not compressed"
-              | (uu____20465,FStar_Syntax_Syntax.Tm_delayed uu____20466) ->
+              | (uu____20485,FStar_Syntax_Syntax.Tm_delayed uu____20486) ->
                   failwith "Impossible: terms were not compressed"
-              | (FStar_Syntax_Syntax.Tm_ascribed uu____20482,uu____20483) ->
-                  let uu____20510 =
-                    let uu___2880_20511 = problem  in
-                    let uu____20512 = FStar_Syntax_Util.unascribe t1  in
+              | (FStar_Syntax_Syntax.Tm_ascribed uu____20502,uu____20503) ->
+                  let uu____20530 =
+                    let uu___2880_20531 = problem  in
+                    let uu____20532 = FStar_Syntax_Util.unascribe t1  in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___2880_20511.FStar_TypeChecker_Common.pid);
-                      FStar_TypeChecker_Common.lhs = uu____20512;
+                        (uu___2880_20531.FStar_TypeChecker_Common.pid);
+                      FStar_TypeChecker_Common.lhs = uu____20532;
                       FStar_TypeChecker_Common.relation =
-                        (uu___2880_20511.FStar_TypeChecker_Common.relation);
+                        (uu___2880_20531.FStar_TypeChecker_Common.relation);
                       FStar_TypeChecker_Common.rhs =
-                        (uu___2880_20511.FStar_TypeChecker_Common.rhs);
+                        (uu___2880_20531.FStar_TypeChecker_Common.rhs);
                       FStar_TypeChecker_Common.element =
-                        (uu___2880_20511.FStar_TypeChecker_Common.element);
+                        (uu___2880_20531.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___2880_20511.FStar_TypeChecker_Common.logical_guard);
+                        (uu___2880_20531.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___2880_20511.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___2880_20531.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___2880_20511.FStar_TypeChecker_Common.reason);
+                        (uu___2880_20531.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___2880_20511.FStar_TypeChecker_Common.loc);
+                        (uu___2880_20531.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___2880_20511.FStar_TypeChecker_Common.rank)
+                        (uu___2880_20531.FStar_TypeChecker_Common.rank)
                     }  in
-                  solve_t' env uu____20510 wl
-              | (FStar_Syntax_Syntax.Tm_meta uu____20513,uu____20514) ->
-                  let uu____20521 =
-                    let uu___2886_20522 = problem  in
-                    let uu____20523 = FStar_Syntax_Util.unmeta t1  in
+                  solve_t' env uu____20530 wl
+              | (FStar_Syntax_Syntax.Tm_meta uu____20533,uu____20534) ->
+                  let uu____20541 =
+                    let uu___2886_20542 = problem  in
+                    let uu____20543 = FStar_Syntax_Util.unmeta t1  in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___2886_20522.FStar_TypeChecker_Common.pid);
-                      FStar_TypeChecker_Common.lhs = uu____20523;
+                        (uu___2886_20542.FStar_TypeChecker_Common.pid);
+                      FStar_TypeChecker_Common.lhs = uu____20543;
                       FStar_TypeChecker_Common.relation =
-                        (uu___2886_20522.FStar_TypeChecker_Common.relation);
+                        (uu___2886_20542.FStar_TypeChecker_Common.relation);
                       FStar_TypeChecker_Common.rhs =
-                        (uu___2886_20522.FStar_TypeChecker_Common.rhs);
+                        (uu___2886_20542.FStar_TypeChecker_Common.rhs);
                       FStar_TypeChecker_Common.element =
-                        (uu___2886_20522.FStar_TypeChecker_Common.element);
+                        (uu___2886_20542.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___2886_20522.FStar_TypeChecker_Common.logical_guard);
+                        (uu___2886_20542.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___2886_20522.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___2886_20542.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___2886_20522.FStar_TypeChecker_Common.reason);
+                        (uu___2886_20542.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___2886_20522.FStar_TypeChecker_Common.loc);
+                        (uu___2886_20542.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___2886_20522.FStar_TypeChecker_Common.rank)
+                        (uu___2886_20542.FStar_TypeChecker_Common.rank)
                     }  in
-                  solve_t' env uu____20521 wl
-              | (uu____20524,FStar_Syntax_Syntax.Tm_ascribed uu____20525) ->
-                  let uu____20552 =
-                    let uu___2892_20553 = problem  in
-                    let uu____20554 = FStar_Syntax_Util.unascribe t2  in
+                  solve_t' env uu____20541 wl
+              | (uu____20544,FStar_Syntax_Syntax.Tm_ascribed uu____20545) ->
+                  let uu____20572 =
+                    let uu___2892_20573 = problem  in
+                    let uu____20574 = FStar_Syntax_Util.unascribe t2  in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___2892_20553.FStar_TypeChecker_Common.pid);
+                        (uu___2892_20573.FStar_TypeChecker_Common.pid);
                       FStar_TypeChecker_Common.lhs =
-                        (uu___2892_20553.FStar_TypeChecker_Common.lhs);
+                        (uu___2892_20573.FStar_TypeChecker_Common.lhs);
                       FStar_TypeChecker_Common.relation =
-                        (uu___2892_20553.FStar_TypeChecker_Common.relation);
-                      FStar_TypeChecker_Common.rhs = uu____20554;
+                        (uu___2892_20573.FStar_TypeChecker_Common.relation);
+                      FStar_TypeChecker_Common.rhs = uu____20574;
                       FStar_TypeChecker_Common.element =
-                        (uu___2892_20553.FStar_TypeChecker_Common.element);
+                        (uu___2892_20573.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___2892_20553.FStar_TypeChecker_Common.logical_guard);
+                        (uu___2892_20573.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___2892_20553.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___2892_20573.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___2892_20553.FStar_TypeChecker_Common.reason);
+                        (uu___2892_20573.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___2892_20553.FStar_TypeChecker_Common.loc);
+                        (uu___2892_20573.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___2892_20553.FStar_TypeChecker_Common.rank)
+                        (uu___2892_20573.FStar_TypeChecker_Common.rank)
                     }  in
-                  solve_t' env uu____20552 wl
-              | (uu____20555,FStar_Syntax_Syntax.Tm_meta uu____20556) ->
-                  let uu____20563 =
-                    let uu___2898_20564 = problem  in
-                    let uu____20565 = FStar_Syntax_Util.unmeta t2  in
+                  solve_t' env uu____20572 wl
+              | (uu____20575,FStar_Syntax_Syntax.Tm_meta uu____20576) ->
+                  let uu____20583 =
+                    let uu___2898_20584 = problem  in
+                    let uu____20585 = FStar_Syntax_Util.unmeta t2  in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___2898_20564.FStar_TypeChecker_Common.pid);
+                        (uu___2898_20584.FStar_TypeChecker_Common.pid);
                       FStar_TypeChecker_Common.lhs =
-                        (uu___2898_20564.FStar_TypeChecker_Common.lhs);
+                        (uu___2898_20584.FStar_TypeChecker_Common.lhs);
                       FStar_TypeChecker_Common.relation =
-                        (uu___2898_20564.FStar_TypeChecker_Common.relation);
-                      FStar_TypeChecker_Common.rhs = uu____20565;
+                        (uu___2898_20584.FStar_TypeChecker_Common.relation);
+                      FStar_TypeChecker_Common.rhs = uu____20585;
                       FStar_TypeChecker_Common.element =
-                        (uu___2898_20564.FStar_TypeChecker_Common.element);
+                        (uu___2898_20584.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___2898_20564.FStar_TypeChecker_Common.logical_guard);
+                        (uu___2898_20584.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___2898_20564.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___2898_20584.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___2898_20564.FStar_TypeChecker_Common.reason);
+                        (uu___2898_20584.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___2898_20564.FStar_TypeChecker_Common.loc);
+                        (uu___2898_20584.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___2898_20564.FStar_TypeChecker_Common.rank)
+                        (uu___2898_20584.FStar_TypeChecker_Common.rank)
                     }  in
-                  solve_t' env uu____20563 wl
+                  solve_t' env uu____20583 wl
               | (FStar_Syntax_Syntax.Tm_quoted
-                 (t11,uu____20567),FStar_Syntax_Syntax.Tm_quoted
-                 (t21,uu____20569)) ->
-                  let uu____20578 =
+                 (t11,uu____20587),FStar_Syntax_Syntax.Tm_quoted
+                 (t21,uu____20589)) ->
+                  let uu____20598 =
                     solve_prob orig FStar_Pervasives_Native.None [] wl  in
-                  solve env uu____20578
-              | (FStar_Syntax_Syntax.Tm_bvar uu____20579,uu____20580) ->
+                  solve env uu____20598
+              | (FStar_Syntax_Syntax.Tm_bvar uu____20599,uu____20600) ->
                   failwith
                     "Only locally nameless! We should never see a de Bruijn variable"
-              | (uu____20582,FStar_Syntax_Syntax.Tm_bvar uu____20583) ->
+              | (uu____20602,FStar_Syntax_Syntax.Tm_bvar uu____20603) ->
                   failwith
                     "Only locally nameless! We should never see a de Bruijn variable"
               | (FStar_Syntax_Syntax.Tm_type u1,FStar_Syntax_Syntax.Tm_type
                  u2) -> solve_one_universe_eq env orig u1 u2 wl
               | (FStar_Syntax_Syntax.Tm_arrow
                  (bs1,c1),FStar_Syntax_Syntax.Tm_arrow (bs2,c2)) ->
-                  let mk_c c uu___29_20653 =
-                    match uu___29_20653 with
+                  let mk_c c uu___29_20673 =
+                    match uu___29_20673 with
                     | [] -> c
                     | bs ->
-                        let uu____20681 =
+                        let uu____20701 =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_arrow (bs, c))
                             FStar_Pervasives_Native.None
                             c.FStar_Syntax_Syntax.pos
                            in
-                        FStar_Syntax_Syntax.mk_Total uu____20681
+                        FStar_Syntax_Syntax.mk_Total uu____20701
                      in
-                  let uu____20692 =
+                  let uu____20712 =
                     match_num_binders (bs1, (mk_c c1)) (bs2, (mk_c c2))  in
-                  (match uu____20692 with
+                  (match uu____20712 with
                    | ((bs11,c11),(bs21,c21)) ->
                        solve_binders env bs11 bs21 orig wl
                          (fun wl1  ->
@@ -7195,10 +7207,10 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                     FStar_Syntax_Subst.subst_comp subst c21
                                      in
                                   let rel =
-                                    let uu____20841 =
+                                    let uu____20861 =
                                       FStar_Options.use_eq_at_higher_order ()
                                        in
-                                    if uu____20841
+                                    if uu____20861
                                     then FStar_TypeChecker_Common.EQ
                                     else
                                       problem.FStar_TypeChecker_Common.relation
@@ -7209,8 +7221,8 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
               | (FStar_Syntax_Syntax.Tm_abs
                  (bs1,tbody1,lopt1),FStar_Syntax_Syntax.Tm_abs
                  (bs2,tbody2,lopt2)) ->
-                  let mk_t t l uu___30_20930 =
-                    match uu___30_20930 with
+                  let mk_t t l uu___30_20950 =
+                    match uu___30_20950 with
                     | [] -> t
                     | bs ->
                         FStar_Syntax_Syntax.mk
@@ -7218,32 +7230,32 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_Pervasives_Native.None
                           t.FStar_Syntax_Syntax.pos
                      in
-                  let uu____20972 =
+                  let uu____20992 =
                     match_num_binders (bs1, (mk_t tbody1 lopt1))
                       (bs2, (mk_t tbody2 lopt2))
                      in
-                  (match uu____20972 with
+                  (match uu____20992 with
                    | ((bs11,tbody11),(bs21,tbody21)) ->
                        solve_binders env bs11 bs21 orig wl
                          (fun wl1  ->
                             fun scope  ->
                               fun env1  ->
                                 fun subst  ->
-                                  let uu____21117 =
+                                  let uu____21137 =
                                     FStar_Syntax_Subst.subst subst tbody11
                                      in
-                                  let uu____21118 =
+                                  let uu____21138 =
                                     FStar_Syntax_Subst.subst subst tbody21
                                      in
-                                  mk_t_problem wl1 scope orig uu____21117
+                                  mk_t_problem wl1 scope orig uu____21137
                                     problem.FStar_TypeChecker_Common.relation
-                                    uu____21118 FStar_Pervasives_Native.None
+                                    uu____21138 FStar_Pervasives_Native.None
                                     "lambda co-domain"))
-              | (FStar_Syntax_Syntax.Tm_abs uu____21120,uu____21121) ->
+              | (FStar_Syntax_Syntax.Tm_abs uu____21140,uu____21141) ->
                   let is_abs t =
                     match t.FStar_Syntax_Syntax.n with
-                    | FStar_Syntax_Syntax.Tm_abs uu____21152 -> true
-                    | uu____21172 -> false  in
+                    | FStar_Syntax_Syntax.Tm_abs uu____21172 -> true
+                    | uu____21192 -> false  in
                   let maybe_eta t =
                     if is_abs t
                     then FStar_Util.Inl t
@@ -7259,190 +7271,190 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     if is_abs t
                     then t
                     else
-                      (let uu____21232 =
+                      (let uu____21252 =
                          env.FStar_TypeChecker_Env.type_of
-                           (let uu___3000_21240 = env  in
+                           (let uu___3000_21260 = env  in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___3000_21240.FStar_TypeChecker_Env.solver);
+                                (uu___3000_21260.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___3000_21240.FStar_TypeChecker_Env.range);
+                                (uu___3000_21260.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___3000_21240.FStar_TypeChecker_Env.curmodule);
+                                (uu___3000_21260.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___3000_21240.FStar_TypeChecker_Env.gamma);
+                                (uu___3000_21260.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___3000_21240.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___3000_21260.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___3000_21240.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___3000_21260.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___3000_21240.FStar_TypeChecker_Env.modules);
+                                (uu___3000_21260.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
                                 FStar_Pervasives_Native.None;
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___3000_21240.FStar_TypeChecker_Env.sigtab);
+                                (uu___3000_21260.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___3000_21240.FStar_TypeChecker_Env.attrtab);
+                                (uu___3000_21260.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___3000_21240.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___3000_21260.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___3000_21240.FStar_TypeChecker_Env.effects);
+                                (uu___3000_21260.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___3000_21240.FStar_TypeChecker_Env.generalize);
+                                (uu___3000_21260.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___3000_21240.FStar_TypeChecker_Env.letrecs);
+                                (uu___3000_21260.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___3000_21240.FStar_TypeChecker_Env.top_level);
+                                (uu___3000_21260.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___3000_21240.FStar_TypeChecker_Env.check_uvars);
+                                (uu___3000_21260.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___3000_21240.FStar_TypeChecker_Env.use_eq);
+                                (uu___3000_21260.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___3000_21240.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___3000_21260.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___3000_21240.FStar_TypeChecker_Env.is_iface);
+                                (uu___3000_21260.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___3000_21240.FStar_TypeChecker_Env.admit);
+                                (uu___3000_21260.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___3000_21240.FStar_TypeChecker_Env.lax_universes);
+                                (uu___3000_21260.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 =
-                                (uu___3000_21240.FStar_TypeChecker_Env.phase1);
+                                (uu___3000_21260.FStar_TypeChecker_Env.phase1);
                               FStar_TypeChecker_Env.failhard =
-                                (uu___3000_21240.FStar_TypeChecker_Env.failhard);
+                                (uu___3000_21260.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___3000_21240.FStar_TypeChecker_Env.nosynth);
+                                (uu___3000_21260.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___3000_21240.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___3000_21260.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___3000_21240.FStar_TypeChecker_Env.tc_term);
+                                (uu___3000_21260.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___3000_21240.FStar_TypeChecker_Env.type_of);
+                                (uu___3000_21260.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___3000_21240.FStar_TypeChecker_Env.universe_of);
+                                (uu___3000_21260.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___3000_21240.FStar_TypeChecker_Env.check_type_of);
+                                (uu___3000_21260.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts = true;
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___3000_21240.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___3000_21260.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___3000_21240.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___3000_21260.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___3000_21240.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___3000_21260.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___3000_21240.FStar_TypeChecker_Env.proof_ns);
+                                (uu___3000_21260.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___3000_21240.FStar_TypeChecker_Env.synth_hook);
+                                (uu___3000_21260.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___3000_21240.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___3000_21260.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___3000_21240.FStar_TypeChecker_Env.splice);
+                                (uu___3000_21260.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___3000_21240.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___3000_21260.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___3000_21240.FStar_TypeChecker_Env.postprocess);
+                                (uu___3000_21260.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.is_native_tactic =
-                                (uu___3000_21240.FStar_TypeChecker_Env.is_native_tactic);
+                                (uu___3000_21260.FStar_TypeChecker_Env.is_native_tactic);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___3000_21240.FStar_TypeChecker_Env.identifier_info);
+                                (uu___3000_21260.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___3000_21240.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___3000_21260.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___3000_21240.FStar_TypeChecker_Env.dsenv);
+                                (uu___3000_21260.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___3000_21240.FStar_TypeChecker_Env.nbe);
+                                (uu___3000_21260.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___3000_21240.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___3000_21260.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___3000_21240.FStar_TypeChecker_Env.erasable_types_tab)
+                                (uu___3000_21260.FStar_TypeChecker_Env.erasable_types_tab)
                             }) t
                           in
-                       match uu____21232 with
-                       | (uu____21245,ty,uu____21247) ->
+                       match uu____21252 with
+                       | (uu____21265,ty,uu____21267) ->
                            let ty1 =
                              let rec aux ty1 =
                                let ty2 =
                                  FStar_TypeChecker_Normalize.unfold_whnf env
                                    ty1
                                   in
-                               let uu____21256 =
-                                 let uu____21257 =
+                               let uu____21276 =
+                                 let uu____21277 =
                                    FStar_Syntax_Subst.compress ty2  in
-                                 uu____21257.FStar_Syntax_Syntax.n  in
-                               match uu____21256 with
-                               | FStar_Syntax_Syntax.Tm_refine uu____21260 ->
-                                   let uu____21267 =
+                                 uu____21277.FStar_Syntax_Syntax.n  in
+                               match uu____21276 with
+                               | FStar_Syntax_Syntax.Tm_refine uu____21280 ->
+                                   let uu____21287 =
                                      FStar_Syntax_Util.unrefine ty2  in
-                                   aux uu____21267
-                               | uu____21268 -> ty2  in
+                                   aux uu____21287
+                               | uu____21288 -> ty2  in
                              aux ty  in
                            let r1 =
                              FStar_TypeChecker_Normalize.eta_expand_with_type
                                env t ty1
                               in
-                           ((let uu____21271 =
+                           ((let uu____21291 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug wl.tcenv)
                                  (FStar_Options.Other "Rel")
                                 in
-                             if uu____21271
+                             if uu____21291
                              then
-                               let uu____21276 =
+                               let uu____21296 =
                                  FStar_Syntax_Print.term_to_string t  in
-                               let uu____21278 =
-                                 let uu____21280 =
+                               let uu____21298 =
+                                 let uu____21300 =
                                    FStar_TypeChecker_Normalize.unfold_whnf
                                      env ty1
                                     in
                                  FStar_Syntax_Print.term_to_string
-                                   uu____21280
+                                   uu____21300
                                   in
-                               let uu____21281 =
+                               let uu____21301 =
                                  FStar_Syntax_Print.term_to_string r1  in
                                FStar_Util.print3
                                  "force_eta of (%s) at type (%s) = %s\n"
-                                 uu____21276 uu____21278 uu____21281
+                                 uu____21296 uu____21298 uu____21301
                              else ());
                             r1))
                      in
-                  let uu____21286 =
-                    let uu____21303 = maybe_eta t1  in
-                    let uu____21310 = maybe_eta t2  in
-                    (uu____21303, uu____21310)  in
-                  (match uu____21286 with
+                  let uu____21306 =
+                    let uu____21323 = maybe_eta t1  in
+                    let uu____21330 = maybe_eta t2  in
+                    (uu____21323, uu____21330)  in
+                  (match uu____21306 with
                    | (FStar_Util.Inl t11,FStar_Util.Inl t21) ->
                        solve_t env
-                         (let uu___3021_21352 = problem  in
+                         (let uu___3021_21372 = problem  in
                           {
                             FStar_TypeChecker_Common.pid =
-                              (uu___3021_21352.FStar_TypeChecker_Common.pid);
+                              (uu___3021_21372.FStar_TypeChecker_Common.pid);
                             FStar_TypeChecker_Common.lhs = t11;
                             FStar_TypeChecker_Common.relation =
-                              (uu___3021_21352.FStar_TypeChecker_Common.relation);
+                              (uu___3021_21372.FStar_TypeChecker_Common.relation);
                             FStar_TypeChecker_Common.rhs = t21;
                             FStar_TypeChecker_Common.element =
-                              (uu___3021_21352.FStar_TypeChecker_Common.element);
+                              (uu___3021_21372.FStar_TypeChecker_Common.element);
                             FStar_TypeChecker_Common.logical_guard =
-                              (uu___3021_21352.FStar_TypeChecker_Common.logical_guard);
+                              (uu___3021_21372.FStar_TypeChecker_Common.logical_guard);
                             FStar_TypeChecker_Common.logical_guard_uvar =
-                              (uu___3021_21352.FStar_TypeChecker_Common.logical_guard_uvar);
+                              (uu___3021_21372.FStar_TypeChecker_Common.logical_guard_uvar);
                             FStar_TypeChecker_Common.reason =
-                              (uu___3021_21352.FStar_TypeChecker_Common.reason);
+                              (uu___3021_21372.FStar_TypeChecker_Common.reason);
                             FStar_TypeChecker_Common.loc =
-                              (uu___3021_21352.FStar_TypeChecker_Common.loc);
+                              (uu___3021_21372.FStar_TypeChecker_Common.loc);
                             FStar_TypeChecker_Common.rank =
-                              (uu___3021_21352.FStar_TypeChecker_Common.rank)
+                              (uu___3021_21372.FStar_TypeChecker_Common.rank)
                           }) wl
                    | (FStar_Util.Inl t_abs,FStar_Util.Inr not_abs) ->
-                       let uu____21373 =
+                       let uu____21393 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
                           in
-                       if uu____21373
+                       if uu____21393
                        then
-                         let uu____21376 = destruct_flex_t not_abs wl  in
-                         (match uu____21376 with
+                         let uu____21396 = destruct_flex_t not_abs wl  in
+                         (match uu____21396 with
                           | (flex,wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7451,43 +7463,43 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3038_21393 = problem  in
+                              (let uu___3038_21413 = problem  in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3038_21393.FStar_TypeChecker_Common.pid);
+                                   (uu___3038_21413.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3038_21393.FStar_TypeChecker_Common.relation);
+                                   (uu___3038_21413.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3038_21393.FStar_TypeChecker_Common.element);
+                                   (uu___3038_21413.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3038_21393.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3038_21413.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3038_21393.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3038_21413.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3038_21393.FStar_TypeChecker_Common.reason);
+                                   (uu___3038_21413.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3038_21393.FStar_TypeChecker_Common.loc);
+                                   (uu___3038_21413.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3038_21393.FStar_TypeChecker_Common.rank)
+                                   (uu___3038_21413.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____21396 =
+                            (let uu____21416 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction"
                                 in
-                             giveup env uu____21396 orig))
+                             giveup env uu____21416 orig))
                    | (FStar_Util.Inr not_abs,FStar_Util.Inl t_abs) ->
-                       let uu____21419 =
+                       let uu____21439 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
                           in
-                       if uu____21419
+                       if uu____21439
                        then
-                         let uu____21422 = destruct_flex_t not_abs wl  in
-                         (match uu____21422 with
+                         let uu____21442 = destruct_flex_t not_abs wl  in
+                         (match uu____21442 with
                           | (flex,wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7496,42 +7508,42 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3038_21439 = problem  in
+                              (let uu___3038_21459 = problem  in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3038_21439.FStar_TypeChecker_Common.pid);
+                                   (uu___3038_21459.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3038_21439.FStar_TypeChecker_Common.relation);
+                                   (uu___3038_21459.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3038_21439.FStar_TypeChecker_Common.element);
+                                   (uu___3038_21459.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3038_21439.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3038_21459.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3038_21439.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3038_21459.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3038_21439.FStar_TypeChecker_Common.reason);
+                                   (uu___3038_21459.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3038_21439.FStar_TypeChecker_Common.loc);
+                                   (uu___3038_21459.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3038_21439.FStar_TypeChecker_Common.rank)
+                                   (uu___3038_21459.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____21442 =
+                            (let uu____21462 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction"
                                 in
-                             giveup env uu____21442 orig))
-                   | uu____21445 ->
+                             giveup env uu____21462 orig))
+                   | uu____21465 ->
                        failwith
                          "Impossible: at least one side is an abstraction")
-              | (uu____21463,FStar_Syntax_Syntax.Tm_abs uu____21464) ->
+              | (uu____21483,FStar_Syntax_Syntax.Tm_abs uu____21484) ->
                   let is_abs t =
                     match t.FStar_Syntax_Syntax.n with
-                    | FStar_Syntax_Syntax.Tm_abs uu____21495 -> true
-                    | uu____21515 -> false  in
+                    | FStar_Syntax_Syntax.Tm_abs uu____21515 -> true
+                    | uu____21535 -> false  in
                   let maybe_eta t =
                     if is_abs t
                     then FStar_Util.Inl t
@@ -7547,190 +7559,190 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     if is_abs t
                     then t
                     else
-                      (let uu____21575 =
+                      (let uu____21595 =
                          env.FStar_TypeChecker_Env.type_of
-                           (let uu___3000_21583 = env  in
+                           (let uu___3000_21603 = env  in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___3000_21583.FStar_TypeChecker_Env.solver);
+                                (uu___3000_21603.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___3000_21583.FStar_TypeChecker_Env.range);
+                                (uu___3000_21603.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___3000_21583.FStar_TypeChecker_Env.curmodule);
+                                (uu___3000_21603.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___3000_21583.FStar_TypeChecker_Env.gamma);
+                                (uu___3000_21603.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___3000_21583.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___3000_21603.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___3000_21583.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___3000_21603.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___3000_21583.FStar_TypeChecker_Env.modules);
+                                (uu___3000_21603.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
                                 FStar_Pervasives_Native.None;
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___3000_21583.FStar_TypeChecker_Env.sigtab);
+                                (uu___3000_21603.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___3000_21583.FStar_TypeChecker_Env.attrtab);
+                                (uu___3000_21603.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___3000_21583.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___3000_21603.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___3000_21583.FStar_TypeChecker_Env.effects);
+                                (uu___3000_21603.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___3000_21583.FStar_TypeChecker_Env.generalize);
+                                (uu___3000_21603.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___3000_21583.FStar_TypeChecker_Env.letrecs);
+                                (uu___3000_21603.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___3000_21583.FStar_TypeChecker_Env.top_level);
+                                (uu___3000_21603.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___3000_21583.FStar_TypeChecker_Env.check_uvars);
+                                (uu___3000_21603.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___3000_21583.FStar_TypeChecker_Env.use_eq);
+                                (uu___3000_21603.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___3000_21583.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___3000_21603.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___3000_21583.FStar_TypeChecker_Env.is_iface);
+                                (uu___3000_21603.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___3000_21583.FStar_TypeChecker_Env.admit);
+                                (uu___3000_21603.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___3000_21583.FStar_TypeChecker_Env.lax_universes);
+                                (uu___3000_21603.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 =
-                                (uu___3000_21583.FStar_TypeChecker_Env.phase1);
+                                (uu___3000_21603.FStar_TypeChecker_Env.phase1);
                               FStar_TypeChecker_Env.failhard =
-                                (uu___3000_21583.FStar_TypeChecker_Env.failhard);
+                                (uu___3000_21603.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___3000_21583.FStar_TypeChecker_Env.nosynth);
+                                (uu___3000_21603.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___3000_21583.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___3000_21603.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___3000_21583.FStar_TypeChecker_Env.tc_term);
+                                (uu___3000_21603.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___3000_21583.FStar_TypeChecker_Env.type_of);
+                                (uu___3000_21603.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___3000_21583.FStar_TypeChecker_Env.universe_of);
+                                (uu___3000_21603.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___3000_21583.FStar_TypeChecker_Env.check_type_of);
+                                (uu___3000_21603.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts = true;
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___3000_21583.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___3000_21603.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___3000_21583.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___3000_21603.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___3000_21583.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___3000_21603.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___3000_21583.FStar_TypeChecker_Env.proof_ns);
+                                (uu___3000_21603.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___3000_21583.FStar_TypeChecker_Env.synth_hook);
+                                (uu___3000_21603.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___3000_21583.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___3000_21603.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___3000_21583.FStar_TypeChecker_Env.splice);
+                                (uu___3000_21603.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___3000_21583.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___3000_21603.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___3000_21583.FStar_TypeChecker_Env.postprocess);
+                                (uu___3000_21603.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.is_native_tactic =
-                                (uu___3000_21583.FStar_TypeChecker_Env.is_native_tactic);
+                                (uu___3000_21603.FStar_TypeChecker_Env.is_native_tactic);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___3000_21583.FStar_TypeChecker_Env.identifier_info);
+                                (uu___3000_21603.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___3000_21583.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___3000_21603.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___3000_21583.FStar_TypeChecker_Env.dsenv);
+                                (uu___3000_21603.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___3000_21583.FStar_TypeChecker_Env.nbe);
+                                (uu___3000_21603.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___3000_21583.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___3000_21603.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___3000_21583.FStar_TypeChecker_Env.erasable_types_tab)
+                                (uu___3000_21603.FStar_TypeChecker_Env.erasable_types_tab)
                             }) t
                           in
-                       match uu____21575 with
-                       | (uu____21588,ty,uu____21590) ->
+                       match uu____21595 with
+                       | (uu____21608,ty,uu____21610) ->
                            let ty1 =
                              let rec aux ty1 =
                                let ty2 =
                                  FStar_TypeChecker_Normalize.unfold_whnf env
                                    ty1
                                   in
-                               let uu____21599 =
-                                 let uu____21600 =
+                               let uu____21619 =
+                                 let uu____21620 =
                                    FStar_Syntax_Subst.compress ty2  in
-                                 uu____21600.FStar_Syntax_Syntax.n  in
-                               match uu____21599 with
-                               | FStar_Syntax_Syntax.Tm_refine uu____21603 ->
-                                   let uu____21610 =
+                                 uu____21620.FStar_Syntax_Syntax.n  in
+                               match uu____21619 with
+                               | FStar_Syntax_Syntax.Tm_refine uu____21623 ->
+                                   let uu____21630 =
                                      FStar_Syntax_Util.unrefine ty2  in
-                                   aux uu____21610
-                               | uu____21611 -> ty2  in
+                                   aux uu____21630
+                               | uu____21631 -> ty2  in
                              aux ty  in
                            let r1 =
                              FStar_TypeChecker_Normalize.eta_expand_with_type
                                env t ty1
                               in
-                           ((let uu____21614 =
+                           ((let uu____21634 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug wl.tcenv)
                                  (FStar_Options.Other "Rel")
                                 in
-                             if uu____21614
+                             if uu____21634
                              then
-                               let uu____21619 =
+                               let uu____21639 =
                                  FStar_Syntax_Print.term_to_string t  in
-                               let uu____21621 =
-                                 let uu____21623 =
+                               let uu____21641 =
+                                 let uu____21643 =
                                    FStar_TypeChecker_Normalize.unfold_whnf
                                      env ty1
                                     in
                                  FStar_Syntax_Print.term_to_string
-                                   uu____21623
+                                   uu____21643
                                   in
-                               let uu____21624 =
+                               let uu____21644 =
                                  FStar_Syntax_Print.term_to_string r1  in
                                FStar_Util.print3
                                  "force_eta of (%s) at type (%s) = %s\n"
-                                 uu____21619 uu____21621 uu____21624
+                                 uu____21639 uu____21641 uu____21644
                              else ());
                             r1))
                      in
-                  let uu____21629 =
-                    let uu____21646 = maybe_eta t1  in
-                    let uu____21653 = maybe_eta t2  in
-                    (uu____21646, uu____21653)  in
-                  (match uu____21629 with
+                  let uu____21649 =
+                    let uu____21666 = maybe_eta t1  in
+                    let uu____21673 = maybe_eta t2  in
+                    (uu____21666, uu____21673)  in
+                  (match uu____21649 with
                    | (FStar_Util.Inl t11,FStar_Util.Inl t21) ->
                        solve_t env
-                         (let uu___3021_21695 = problem  in
+                         (let uu___3021_21715 = problem  in
                           {
                             FStar_TypeChecker_Common.pid =
-                              (uu___3021_21695.FStar_TypeChecker_Common.pid);
+                              (uu___3021_21715.FStar_TypeChecker_Common.pid);
                             FStar_TypeChecker_Common.lhs = t11;
                             FStar_TypeChecker_Common.relation =
-                              (uu___3021_21695.FStar_TypeChecker_Common.relation);
+                              (uu___3021_21715.FStar_TypeChecker_Common.relation);
                             FStar_TypeChecker_Common.rhs = t21;
                             FStar_TypeChecker_Common.element =
-                              (uu___3021_21695.FStar_TypeChecker_Common.element);
+                              (uu___3021_21715.FStar_TypeChecker_Common.element);
                             FStar_TypeChecker_Common.logical_guard =
-                              (uu___3021_21695.FStar_TypeChecker_Common.logical_guard);
+                              (uu___3021_21715.FStar_TypeChecker_Common.logical_guard);
                             FStar_TypeChecker_Common.logical_guard_uvar =
-                              (uu___3021_21695.FStar_TypeChecker_Common.logical_guard_uvar);
+                              (uu___3021_21715.FStar_TypeChecker_Common.logical_guard_uvar);
                             FStar_TypeChecker_Common.reason =
-                              (uu___3021_21695.FStar_TypeChecker_Common.reason);
+                              (uu___3021_21715.FStar_TypeChecker_Common.reason);
                             FStar_TypeChecker_Common.loc =
-                              (uu___3021_21695.FStar_TypeChecker_Common.loc);
+                              (uu___3021_21715.FStar_TypeChecker_Common.loc);
                             FStar_TypeChecker_Common.rank =
-                              (uu___3021_21695.FStar_TypeChecker_Common.rank)
+                              (uu___3021_21715.FStar_TypeChecker_Common.rank)
                           }) wl
                    | (FStar_Util.Inl t_abs,FStar_Util.Inr not_abs) ->
-                       let uu____21716 =
+                       let uu____21736 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
                           in
-                       if uu____21716
+                       if uu____21736
                        then
-                         let uu____21719 = destruct_flex_t not_abs wl  in
-                         (match uu____21719 with
+                         let uu____21739 = destruct_flex_t not_abs wl  in
+                         (match uu____21739 with
                           | (flex,wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7739,43 +7751,43 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3038_21736 = problem  in
+                              (let uu___3038_21756 = problem  in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3038_21736.FStar_TypeChecker_Common.pid);
+                                   (uu___3038_21756.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3038_21736.FStar_TypeChecker_Common.relation);
+                                   (uu___3038_21756.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3038_21736.FStar_TypeChecker_Common.element);
+                                   (uu___3038_21756.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3038_21736.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3038_21756.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3038_21736.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3038_21756.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3038_21736.FStar_TypeChecker_Common.reason);
+                                   (uu___3038_21756.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3038_21736.FStar_TypeChecker_Common.loc);
+                                   (uu___3038_21756.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3038_21736.FStar_TypeChecker_Common.rank)
+                                   (uu___3038_21756.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____21739 =
+                            (let uu____21759 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction"
                                 in
-                             giveup env uu____21739 orig))
+                             giveup env uu____21759 orig))
                    | (FStar_Util.Inr not_abs,FStar_Util.Inl t_abs) ->
-                       let uu____21762 =
+                       let uu____21782 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
                           in
-                       if uu____21762
+                       if uu____21782
                        then
-                         let uu____21765 = destruct_flex_t not_abs wl  in
-                         (match uu____21765 with
+                         let uu____21785 = destruct_flex_t not_abs wl  in
+                         (match uu____21785 with
                           | (flex,wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7784,127 +7796,127 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3038_21782 = problem  in
+                              (let uu___3038_21802 = problem  in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3038_21782.FStar_TypeChecker_Common.pid);
+                                   (uu___3038_21802.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3038_21782.FStar_TypeChecker_Common.relation);
+                                   (uu___3038_21802.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3038_21782.FStar_TypeChecker_Common.element);
+                                   (uu___3038_21802.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3038_21782.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3038_21802.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3038_21782.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3038_21802.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3038_21782.FStar_TypeChecker_Common.reason);
+                                   (uu___3038_21802.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3038_21782.FStar_TypeChecker_Common.loc);
+                                   (uu___3038_21802.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3038_21782.FStar_TypeChecker_Common.rank)
+                                   (uu___3038_21802.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____21785 =
+                            (let uu____21805 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction"
                                 in
-                             giveup env uu____21785 orig))
-                   | uu____21788 ->
+                             giveup env uu____21805 orig))
+                   | uu____21808 ->
                        failwith
                          "Impossible: at least one side is an abstraction")
               | (FStar_Syntax_Syntax.Tm_refine
                  (x1,phi1),FStar_Syntax_Syntax.Tm_refine (x2,phi2)) ->
-                  let uu____21818 =
-                    let uu____21823 =
+                  let uu____21838 =
+                    let uu____21843 =
                       head_matches_delta env wl x1.FStar_Syntax_Syntax.sort
                         x2.FStar_Syntax_Syntax.sort
                        in
-                    match uu____21823 with
+                    match uu____21843 with
                     | (FullMatch ,FStar_Pervasives_Native.Some (t11,t21)) ->
-                        ((let uu___3061_21851 = x1  in
+                        ((let uu___3061_21871 = x1  in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___3061_21851.FStar_Syntax_Syntax.ppname);
+                              (uu___3061_21871.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___3061_21851.FStar_Syntax_Syntax.index);
+                              (uu___3061_21871.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t11
                           }),
-                          (let uu___3063_21853 = x2  in
+                          (let uu___3063_21873 = x2  in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___3063_21853.FStar_Syntax_Syntax.ppname);
+                               (uu___3063_21873.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___3063_21853.FStar_Syntax_Syntax.index);
+                               (uu___3063_21873.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = t21
                            }))
-                    | (HeadMatch uu____21854,FStar_Pervasives_Native.Some
+                    | (HeadMatch uu____21874,FStar_Pervasives_Native.Some
                        (t11,t21)) ->
-                        ((let uu___3061_21869 = x1  in
+                        ((let uu___3061_21889 = x1  in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___3061_21869.FStar_Syntax_Syntax.ppname);
+                              (uu___3061_21889.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___3061_21869.FStar_Syntax_Syntax.index);
+                              (uu___3061_21889.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t11
                           }),
-                          (let uu___3063_21871 = x2  in
+                          (let uu___3063_21891 = x2  in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___3063_21871.FStar_Syntax_Syntax.ppname);
+                               (uu___3063_21891.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___3063_21871.FStar_Syntax_Syntax.index);
+                               (uu___3063_21891.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = t21
                            }))
-                    | uu____21872 -> (x1, x2)  in
-                  (match uu____21818 with
+                    | uu____21892 -> (x1, x2)  in
+                  (match uu____21838 with
                    | (x11,x21) ->
                        let t11 = FStar_Syntax_Util.refine x11 phi1  in
                        let t21 = FStar_Syntax_Util.refine x21 phi2  in
-                       let uu____21891 = as_refinement false env t11  in
-                       (match uu____21891 with
+                       let uu____21911 = as_refinement false env t11  in
+                       (match uu____21911 with
                         | (x12,phi11) ->
-                            let uu____21899 = as_refinement false env t21  in
-                            (match uu____21899 with
+                            let uu____21919 = as_refinement false env t21  in
+                            (match uu____21919 with
                              | (x22,phi21) ->
-                                 ((let uu____21908 =
+                                 ((let uu____21928 =
                                      FStar_TypeChecker_Env.debug env
                                        (FStar_Options.Other "Rel")
                                       in
-                                   if uu____21908
+                                   if uu____21928
                                    then
-                                     ((let uu____21913 =
+                                     ((let uu____21933 =
                                          FStar_Syntax_Print.bv_to_string x12
                                           in
-                                       let uu____21915 =
+                                       let uu____21935 =
                                          FStar_Syntax_Print.term_to_string
                                            x12.FStar_Syntax_Syntax.sort
                                           in
-                                       let uu____21917 =
+                                       let uu____21937 =
                                          FStar_Syntax_Print.term_to_string
                                            phi11
                                           in
                                        FStar_Util.print3
-                                         "ref1 = (%s):(%s){%s}\n" uu____21913
-                                         uu____21915 uu____21917);
-                                      (let uu____21920 =
+                                         "ref1 = (%s):(%s){%s}\n" uu____21933
+                                         uu____21935 uu____21937);
+                                      (let uu____21940 =
                                          FStar_Syntax_Print.bv_to_string x22
                                           in
-                                       let uu____21922 =
+                                       let uu____21942 =
                                          FStar_Syntax_Print.term_to_string
                                            x22.FStar_Syntax_Syntax.sort
                                           in
-                                       let uu____21924 =
+                                       let uu____21944 =
                                          FStar_Syntax_Print.term_to_string
                                            phi21
                                           in
                                        FStar_Util.print3
-                                         "ref2 = (%s):(%s){%s}\n" uu____21920
-                                         uu____21922 uu____21924))
+                                         "ref2 = (%s):(%s){%s}\n" uu____21940
+                                         uu____21942 uu____21944))
                                    else ());
-                                  (let uu____21929 =
+                                  (let uu____21949 =
                                      mk_t_problem wl [] orig
                                        x12.FStar_Syntax_Syntax.sort
                                        problem.FStar_TypeChecker_Common.relation
@@ -7912,7 +7924,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                        problem.FStar_TypeChecker_Common.element
                                        "refinement base type"
                                       in
-                                   match uu____21929 with
+                                   match uu____21949 with
                                    | (base_prob,wl1) ->
                                        let x13 =
                                          FStar_Syntax_Syntax.freshen_bv x12
@@ -7932,12 +7944,12 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                            x13
                                           in
                                        let mk_imp imp phi13 phi23 =
-                                         let uu____22000 = imp phi13 phi23
+                                         let uu____22020 = imp phi13 phi23
                                             in
-                                         FStar_All.pipe_right uu____22000
+                                         FStar_All.pipe_right uu____22020
                                            (guard_on_element wl1 problem x13)
                                           in
-                                       let fallback uu____22012 =
+                                       let fallback uu____22032 =
                                          let impl =
                                            if
                                              problem.FStar_TypeChecker_Common.relation
@@ -7953,52 +7965,52 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                            FStar_Syntax_Util.mk_conj
                                              (p_guard base_prob) impl
                                             in
-                                         (let uu____22025 =
-                                            let uu____22028 = p_scope orig
+                                         (let uu____22045 =
+                                            let uu____22048 = p_scope orig
                                                in
                                             FStar_List.map
                                               FStar_Pervasives_Native.fst
-                                              uu____22028
+                                              uu____22048
                                              in
                                           FStar_TypeChecker_Env.def_check_closed_in
-                                            (p_loc orig) "ref.1" uu____22025
+                                            (p_loc orig) "ref.1" uu____22045
                                             (p_guard base_prob));
-                                         (let uu____22047 =
-                                            let uu____22050 = p_scope orig
+                                         (let uu____22067 =
+                                            let uu____22070 = p_scope orig
                                                in
                                             FStar_List.map
                                               FStar_Pervasives_Native.fst
-                                              uu____22050
+                                              uu____22070
                                              in
                                           FStar_TypeChecker_Env.def_check_closed_in
-                                            (p_loc orig) "ref.2" uu____22047
+                                            (p_loc orig) "ref.2" uu____22067
                                             impl);
                                          (let wl2 =
                                             solve_prob orig
                                               (FStar_Pervasives_Native.Some
                                                  guard) [] wl1
                                              in
-                                          let uu____22069 =
+                                          let uu____22089 =
                                             attempt [base_prob] wl2  in
-                                          solve env1 uu____22069)
+                                          solve env1 uu____22089)
                                           in
                                        let has_uvars =
-                                         (let uu____22074 =
-                                            let uu____22076 =
+                                         (let uu____22094 =
+                                            let uu____22096 =
                                               FStar_Syntax_Free.uvars phi12
                                                in
                                             FStar_Util.set_is_empty
-                                              uu____22076
+                                              uu____22096
                                              in
-                                          Prims.op_Negation uu____22074) ||
-                                           (let uu____22080 =
-                                              let uu____22082 =
+                                          Prims.op_Negation uu____22094) ||
+                                           (let uu____22100 =
+                                              let uu____22102 =
                                                 FStar_Syntax_Free.uvars phi22
                                                  in
                                               FStar_Util.set_is_empty
-                                                uu____22082
+                                                uu____22102
                                                in
-                                            Prims.op_Negation uu____22080)
+                                            Prims.op_Negation uu____22100)
                                           in
                                        if
                                          (problem.FStar_TypeChecker_Common.relation
@@ -8008,47 +8020,47 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                env1.FStar_TypeChecker_Env.uvar_subtyping)
                                               && has_uvars)
                                        then
-                                         let uu____22086 =
-                                           let uu____22091 =
-                                             let uu____22100 =
+                                         let uu____22106 =
+                                           let uu____22111 =
+                                             let uu____22120 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  x13
                                                 in
-                                             [uu____22100]  in
-                                           mk_t_problem wl1 uu____22091 orig
+                                             [uu____22120]  in
+                                           mk_t_problem wl1 uu____22111 orig
                                              phi12
                                              FStar_TypeChecker_Common.EQ
                                              phi22
                                              FStar_Pervasives_Native.None
                                              "refinement formula"
                                             in
-                                         (match uu____22086 with
+                                         (match uu____22106 with
                                           | (ref_prob,wl2) ->
                                               let tx =
                                                 FStar_Syntax_Unionfind.new_transaction
                                                   ()
                                                  in
-                                              let uu____22123 =
+                                              let uu____22143 =
                                                 solve env1
-                                                  (let uu___3106_22125 = wl2
+                                                  (let uu___3106_22145 = wl2
                                                       in
                                                    {
                                                      attempting = [ref_prob];
                                                      wl_deferred = [];
                                                      ctr =
-                                                       (uu___3106_22125.ctr);
+                                                       (uu___3106_22145.ctr);
                                                      defer_ok = false;
                                                      smt_ok =
-                                                       (uu___3106_22125.smt_ok);
+                                                       (uu___3106_22145.smt_ok);
                                                      umax_heuristic_ok =
-                                                       (uu___3106_22125.umax_heuristic_ok);
+                                                       (uu___3106_22145.umax_heuristic_ok);
                                                      tcenv =
-                                                       (uu___3106_22125.tcenv);
+                                                       (uu___3106_22145.tcenv);
                                                      wl_implicits =
-                                                       (uu___3106_22125.wl_implicits)
+                                                       (uu___3106_22145.wl_implicits)
                                                    })
                                                  in
-                                              (match uu____22123 with
+                                              (match uu____22143 with
                                                | Failed (prob,msg) ->
                                                    (FStar_Syntax_Unionfind.rollback
                                                       tx;
@@ -8061,11 +8073,11 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                            wl2.smt_ok)
                                                     then giveup env1 msg prob
                                                     else fallback ())
-                                               | Success uu____22140 ->
+                                               | Success uu____22160 ->
                                                    (FStar_Syntax_Unionfind.commit
                                                       tx;
                                                     (let guard =
-                                                       let uu____22149 =
+                                                       let uu____22169 =
                                                          FStar_All.pipe_right
                                                            (p_guard ref_prob)
                                                            (guard_on_element
@@ -8073,7 +8085,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                           in
                                                        FStar_Syntax_Util.mk_conj
                                                          (p_guard base_prob)
-                                                         uu____22149
+                                                         uu____22169
                                                         in
                                                      let wl3 =
                                                        solve_prob orig
@@ -8081,294 +8093,294 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                             guard) [] wl2
                                                         in
                                                      let wl4 =
-                                                       let uu___3119_22158 =
+                                                       let uu___3119_22178 =
                                                          wl3  in
                                                        {
                                                          attempting =
-                                                           (uu___3119_22158.attempting);
+                                                           (uu___3119_22178.attempting);
                                                          wl_deferred =
-                                                           (uu___3119_22158.wl_deferred);
+                                                           (uu___3119_22178.wl_deferred);
                                                          ctr =
                                                            (wl3.ctr +
                                                               Prims.int_one);
                                                          defer_ok =
-                                                           (uu___3119_22158.defer_ok);
+                                                           (uu___3119_22178.defer_ok);
                                                          smt_ok =
-                                                           (uu___3119_22158.smt_ok);
+                                                           (uu___3119_22178.smt_ok);
                                                          umax_heuristic_ok =
-                                                           (uu___3119_22158.umax_heuristic_ok);
+                                                           (uu___3119_22178.umax_heuristic_ok);
                                                          tcenv =
-                                                           (uu___3119_22158.tcenv);
+                                                           (uu___3119_22178.tcenv);
                                                          wl_implicits =
-                                                           (uu___3119_22158.wl_implicits)
+                                                           (uu___3119_22178.wl_implicits)
                                                        }  in
-                                                     let uu____22160 =
+                                                     let uu____22180 =
                                                        attempt [base_prob]
                                                          wl4
                                                         in
-                                                     solve env1 uu____22160))))
+                                                     solve env1 uu____22180))))
                                        else fallback ())))))
               | (FStar_Syntax_Syntax.Tm_uvar
-                 uu____22163,FStar_Syntax_Syntax.Tm_uvar uu____22164) ->
-                  let uu____22189 = destruct_flex_t t1 wl  in
-                  (match uu____22189 with
+                 uu____22183,FStar_Syntax_Syntax.Tm_uvar uu____22184) ->
+                  let uu____22209 = destruct_flex_t t1 wl  in
+                  (match uu____22209 with
                    | (f1,wl1) ->
-                       let uu____22196 = destruct_flex_t t2 wl1  in
-                       (match uu____22196 with
+                       let uu____22216 = destruct_flex_t t2 wl1  in
+                       (match uu____22216 with
                         | (f2,wl2) -> solve_t_flex_flex env orig wl2 f1 f2))
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22203;
-                    FStar_Syntax_Syntax.pos = uu____22204;
-                    FStar_Syntax_Syntax.vars = uu____22205;_},uu____22206),FStar_Syntax_Syntax.Tm_uvar
-                 uu____22207) ->
-                  let uu____22256 = destruct_flex_t t1 wl  in
-                  (match uu____22256 with
+                      uu____22223;
+                    FStar_Syntax_Syntax.pos = uu____22224;
+                    FStar_Syntax_Syntax.vars = uu____22225;_},uu____22226),FStar_Syntax_Syntax.Tm_uvar
+                 uu____22227) ->
+                  let uu____22276 = destruct_flex_t t1 wl  in
+                  (match uu____22276 with
                    | (f1,wl1) ->
-                       let uu____22263 = destruct_flex_t t2 wl1  in
-                       (match uu____22263 with
+                       let uu____22283 = destruct_flex_t t2 wl1  in
+                       (match uu____22283 with
                         | (f2,wl2) -> solve_t_flex_flex env orig wl2 f1 f2))
               | (FStar_Syntax_Syntax.Tm_uvar
-                 uu____22270,FStar_Syntax_Syntax.Tm_app
+                 uu____22290,FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22271;
-                    FStar_Syntax_Syntax.pos = uu____22272;
-                    FStar_Syntax_Syntax.vars = uu____22273;_},uu____22274))
+                      uu____22291;
+                    FStar_Syntax_Syntax.pos = uu____22292;
+                    FStar_Syntax_Syntax.vars = uu____22293;_},uu____22294))
                   ->
-                  let uu____22323 = destruct_flex_t t1 wl  in
-                  (match uu____22323 with
+                  let uu____22343 = destruct_flex_t t1 wl  in
+                  (match uu____22343 with
                    | (f1,wl1) ->
-                       let uu____22330 = destruct_flex_t t2 wl1  in
-                       (match uu____22330 with
+                       let uu____22350 = destruct_flex_t t2 wl1  in
+                       (match uu____22350 with
                         | (f2,wl2) -> solve_t_flex_flex env orig wl2 f1 f2))
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22337;
-                    FStar_Syntax_Syntax.pos = uu____22338;
-                    FStar_Syntax_Syntax.vars = uu____22339;_},uu____22340),FStar_Syntax_Syntax.Tm_app
+                      uu____22357;
+                    FStar_Syntax_Syntax.pos = uu____22358;
+                    FStar_Syntax_Syntax.vars = uu____22359;_},uu____22360),FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22341;
-                    FStar_Syntax_Syntax.pos = uu____22342;
-                    FStar_Syntax_Syntax.vars = uu____22343;_},uu____22344))
+                      uu____22361;
+                    FStar_Syntax_Syntax.pos = uu____22362;
+                    FStar_Syntax_Syntax.vars = uu____22363;_},uu____22364))
                   ->
-                  let uu____22417 = destruct_flex_t t1 wl  in
-                  (match uu____22417 with
+                  let uu____22437 = destruct_flex_t t1 wl  in
+                  (match uu____22437 with
                    | (f1,wl1) ->
-                       let uu____22424 = destruct_flex_t t2 wl1  in
-                       (match uu____22424 with
+                       let uu____22444 = destruct_flex_t t2 wl1  in
+                       (match uu____22444 with
                         | (f2,wl2) -> solve_t_flex_flex env orig wl2 f1 f2))
-              | (FStar_Syntax_Syntax.Tm_uvar uu____22431,uu____22432) when
+              | (FStar_Syntax_Syntax.Tm_uvar uu____22451,uu____22452) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   ->
-                  let uu____22445 = destruct_flex_t t1 wl  in
-                  (match uu____22445 with
+                  let uu____22465 = destruct_flex_t t1 wl  in
+                  (match uu____22465 with
                    | (f1,wl1) -> solve_t_flex_rigid_eq env orig wl1 f1 t2)
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22452;
-                    FStar_Syntax_Syntax.pos = uu____22453;
-                    FStar_Syntax_Syntax.vars = uu____22454;_},uu____22455),uu____22456)
+                      uu____22472;
+                    FStar_Syntax_Syntax.pos = uu____22473;
+                    FStar_Syntax_Syntax.vars = uu____22474;_},uu____22475),uu____22476)
                   when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   ->
-                  let uu____22493 = destruct_flex_t t1 wl  in
-                  (match uu____22493 with
+                  let uu____22513 = destruct_flex_t t1 wl  in
+                  (match uu____22513 with
                    | (f1,wl1) -> solve_t_flex_rigid_eq env orig wl1 f1 t2)
-              | (uu____22500,FStar_Syntax_Syntax.Tm_uvar uu____22501) when
+              | (uu____22520,FStar_Syntax_Syntax.Tm_uvar uu____22521) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   -> solve_t env (invert problem) wl
-              | (uu____22514,FStar_Syntax_Syntax.Tm_app
+              | (uu____22534,FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22515;
-                    FStar_Syntax_Syntax.pos = uu____22516;
-                    FStar_Syntax_Syntax.vars = uu____22517;_},uu____22518))
+                      uu____22535;
+                    FStar_Syntax_Syntax.pos = uu____22536;
+                    FStar_Syntax_Syntax.vars = uu____22537;_},uu____22538))
                   when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   -> solve_t env (invert problem) wl
               | (FStar_Syntax_Syntax.Tm_uvar
-                 uu____22555,FStar_Syntax_Syntax.Tm_arrow uu____22556) ->
+                 uu____22575,FStar_Syntax_Syntax.Tm_arrow uu____22576) ->
                   solve_t' env
-                    (let uu___3219_22584 = problem  in
+                    (let uu___3219_22604 = problem  in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3219_22584.FStar_TypeChecker_Common.pid);
+                         (uu___3219_22604.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3219_22584.FStar_TypeChecker_Common.lhs);
+                         (uu___3219_22604.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
                          FStar_TypeChecker_Common.EQ;
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3219_22584.FStar_TypeChecker_Common.rhs);
+                         (uu___3219_22604.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3219_22584.FStar_TypeChecker_Common.element);
+                         (uu___3219_22604.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3219_22584.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3219_22604.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3219_22584.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3219_22604.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3219_22584.FStar_TypeChecker_Common.reason);
+                         (uu___3219_22604.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3219_22584.FStar_TypeChecker_Common.loc);
+                         (uu___3219_22604.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3219_22584.FStar_TypeChecker_Common.rank)
+                         (uu___3219_22604.FStar_TypeChecker_Common.rank)
                      }) wl
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22585;
-                    FStar_Syntax_Syntax.pos = uu____22586;
-                    FStar_Syntax_Syntax.vars = uu____22587;_},uu____22588),FStar_Syntax_Syntax.Tm_arrow
-                 uu____22589) ->
+                      uu____22605;
+                    FStar_Syntax_Syntax.pos = uu____22606;
+                    FStar_Syntax_Syntax.vars = uu____22607;_},uu____22608),FStar_Syntax_Syntax.Tm_arrow
+                 uu____22609) ->
                   solve_t' env
-                    (let uu___3219_22641 = problem  in
+                    (let uu___3219_22661 = problem  in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3219_22641.FStar_TypeChecker_Common.pid);
+                         (uu___3219_22661.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3219_22641.FStar_TypeChecker_Common.lhs);
+                         (uu___3219_22661.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
                          FStar_TypeChecker_Common.EQ;
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3219_22641.FStar_TypeChecker_Common.rhs);
+                         (uu___3219_22661.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3219_22641.FStar_TypeChecker_Common.element);
+                         (uu___3219_22661.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3219_22641.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3219_22661.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3219_22641.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3219_22661.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3219_22641.FStar_TypeChecker_Common.reason);
+                         (uu___3219_22661.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3219_22641.FStar_TypeChecker_Common.loc);
+                         (uu___3219_22661.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3219_22641.FStar_TypeChecker_Common.rank)
+                         (uu___3219_22661.FStar_TypeChecker_Common.rank)
                      }) wl
-              | (uu____22642,FStar_Syntax_Syntax.Tm_uvar uu____22643) ->
-                  let uu____22656 =
+              | (uu____22662,FStar_Syntax_Syntax.Tm_uvar uu____22663) ->
+                  let uu____22676 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl  in
-                  solve env uu____22656
-              | (uu____22657,FStar_Syntax_Syntax.Tm_app
+                  solve env uu____22676
+              | (uu____22677,FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22658;
-                    FStar_Syntax_Syntax.pos = uu____22659;
-                    FStar_Syntax_Syntax.vars = uu____22660;_},uu____22661))
+                      uu____22678;
+                    FStar_Syntax_Syntax.pos = uu____22679;
+                    FStar_Syntax_Syntax.vars = uu____22680;_},uu____22681))
                   ->
-                  let uu____22698 =
+                  let uu____22718 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl  in
-                  solve env uu____22698
-              | (FStar_Syntax_Syntax.Tm_uvar uu____22699,uu____22700) ->
-                  let uu____22713 =
+                  solve env uu____22718
+              | (FStar_Syntax_Syntax.Tm_uvar uu____22719,uu____22720) ->
+                  let uu____22733 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl  in
-                  solve env uu____22713
+                  solve env uu____22733
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22714;
-                    FStar_Syntax_Syntax.pos = uu____22715;
-                    FStar_Syntax_Syntax.vars = uu____22716;_},uu____22717),uu____22718)
+                      uu____22734;
+                    FStar_Syntax_Syntax.pos = uu____22735;
+                    FStar_Syntax_Syntax.vars = uu____22736;_},uu____22737),uu____22738)
                   ->
-                  let uu____22755 =
+                  let uu____22775 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl  in
-                  solve env uu____22755
-              | (FStar_Syntax_Syntax.Tm_refine uu____22756,uu____22757) ->
+                  solve env uu____22775
+              | (FStar_Syntax_Syntax.Tm_refine uu____22776,uu____22777) ->
                   let t21 =
-                    let uu____22765 = base_and_refinement env t2  in
-                    FStar_All.pipe_left force_refinement uu____22765  in
+                    let uu____22785 = base_and_refinement env t2  in
+                    FStar_All.pipe_left force_refinement uu____22785  in
                   solve_t env
-                    (let uu___3254_22791 = problem  in
+                    (let uu___3254_22811 = problem  in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3254_22791.FStar_TypeChecker_Common.pid);
+                         (uu___3254_22811.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3254_22791.FStar_TypeChecker_Common.lhs);
+                         (uu___3254_22811.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
-                         (uu___3254_22791.FStar_TypeChecker_Common.relation);
+                         (uu___3254_22811.FStar_TypeChecker_Common.relation);
                        FStar_TypeChecker_Common.rhs = t21;
                        FStar_TypeChecker_Common.element =
-                         (uu___3254_22791.FStar_TypeChecker_Common.element);
+                         (uu___3254_22811.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3254_22791.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3254_22811.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3254_22791.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3254_22811.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3254_22791.FStar_TypeChecker_Common.reason);
+                         (uu___3254_22811.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3254_22791.FStar_TypeChecker_Common.loc);
+                         (uu___3254_22811.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3254_22791.FStar_TypeChecker_Common.rank)
+                         (uu___3254_22811.FStar_TypeChecker_Common.rank)
                      }) wl
-              | (uu____22792,FStar_Syntax_Syntax.Tm_refine uu____22793) ->
+              | (uu____22812,FStar_Syntax_Syntax.Tm_refine uu____22813) ->
                   let t11 =
-                    let uu____22801 = base_and_refinement env t1  in
-                    FStar_All.pipe_left force_refinement uu____22801  in
+                    let uu____22821 = base_and_refinement env t1  in
+                    FStar_All.pipe_left force_refinement uu____22821  in
                   solve_t env
-                    (let uu___3261_22827 = problem  in
+                    (let uu___3261_22847 = problem  in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3261_22827.FStar_TypeChecker_Common.pid);
+                         (uu___3261_22847.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs = t11;
                        FStar_TypeChecker_Common.relation =
-                         (uu___3261_22827.FStar_TypeChecker_Common.relation);
+                         (uu___3261_22847.FStar_TypeChecker_Common.relation);
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3261_22827.FStar_TypeChecker_Common.rhs);
+                         (uu___3261_22847.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3261_22827.FStar_TypeChecker_Common.element);
+                         (uu___3261_22847.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3261_22827.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3261_22847.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3261_22827.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3261_22847.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3261_22827.FStar_TypeChecker_Common.reason);
+                         (uu___3261_22847.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3261_22827.FStar_TypeChecker_Common.loc);
+                         (uu___3261_22847.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3261_22827.FStar_TypeChecker_Common.rank)
+                         (uu___3261_22847.FStar_TypeChecker_Common.rank)
                      }) wl
               | (FStar_Syntax_Syntax.Tm_match
                  (s1,brs1),FStar_Syntax_Syntax.Tm_match (s2,brs2)) ->
-                  let by_smt uu____22909 =
-                    let uu____22910 = guard_of_prob env wl problem t1 t2  in
-                    match uu____22910 with
+                  let by_smt uu____22929 =
+                    let uu____22930 = guard_of_prob env wl problem t1 t2  in
+                    match uu____22930 with
                     | (guard,wl1) ->
-                        let uu____22917 =
+                        let uu____22937 =
                           solve_prob orig
                             (FStar_Pervasives_Native.Some guard) [] wl1
                            in
-                        solve env uu____22917
+                        solve env uu____22937
                      in
                   let rec solve_branches wl1 brs11 brs21 =
                     match (brs11, brs21) with
                     | (br1::rs1,br2::rs2) ->
-                        let uu____23136 = br1  in
-                        (match uu____23136 with
-                         | (p1,w1,uu____23165) ->
-                             let uu____23182 = br2  in
-                             (match uu____23182 with
-                              | (p2,w2,uu____23205) ->
-                                  let uu____23210 =
-                                    let uu____23212 =
+                        let uu____23156 = br1  in
+                        (match uu____23156 with
+                         | (p1,w1,uu____23185) ->
+                             let uu____23202 = br2  in
+                             (match uu____23202 with
+                              | (p2,w2,uu____23225) ->
+                                  let uu____23230 =
+                                    let uu____23232 =
                                       FStar_Syntax_Syntax.eq_pat p1 p2  in
-                                    Prims.op_Negation uu____23212  in
-                                  if uu____23210
+                                    Prims.op_Negation uu____23232  in
+                                  if uu____23230
                                   then FStar_Pervasives_Native.None
                                   else
-                                    (let uu____23239 =
+                                    (let uu____23259 =
                                        FStar_Syntax_Subst.open_branch' br1
                                         in
-                                     match uu____23239 with
+                                     match uu____23259 with
                                      | ((p11,w11,e1),s) ->
-                                         let uu____23276 = br2  in
-                                         (match uu____23276 with
+                                         let uu____23296 = br2  in
+                                         (match uu____23296 with
                                           | (p21,w21,e2) ->
                                               let w22 =
                                                 FStar_Util.map_opt w21
@@ -8378,24 +8390,24 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                 FStar_Syntax_Subst.subst s e2
                                                  in
                                               let scope =
-                                                let uu____23309 =
+                                                let uu____23329 =
                                                   FStar_Syntax_Syntax.pat_bvs
                                                     p11
                                                    in
                                                 FStar_All.pipe_left
                                                   (FStar_List.map
                                                      FStar_Syntax_Syntax.mk_binder)
-                                                  uu____23309
+                                                  uu____23329
                                                  in
-                                              let uu____23314 =
+                                              let uu____23334 =
                                                 match (w11, w22) with
                                                 | (FStar_Pervasives_Native.Some
-                                                   uu____23345,FStar_Pervasives_Native.None
+                                                   uu____23365,FStar_Pervasives_Native.None
                                                    ) ->
                                                     FStar_Pervasives_Native.None
                                                 | (FStar_Pervasives_Native.None
                                                    ,FStar_Pervasives_Native.Some
-                                                   uu____23366) ->
+                                                   uu____23386) ->
                                                     FStar_Pervasives_Native.None
                                                 | (FStar_Pervasives_Native.None
                                                    ,FStar_Pervasives_Native.None
@@ -8405,7 +8417,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                 | (FStar_Pervasives_Native.Some
                                                    w12,FStar_Pervasives_Native.Some
                                                    w23) ->
-                                                    let uu____23425 =
+                                                    let uu____23445 =
                                                       mk_t_problem wl1 scope
                                                         orig w12
                                                         FStar_TypeChecker_Common.EQ
@@ -8413,17 +8425,17 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                         FStar_Pervasives_Native.None
                                                         "when clause"
                                                        in
-                                                    (match uu____23425 with
+                                                    (match uu____23445 with
                                                      | (p,wl2) ->
                                                          FStar_Pervasives_Native.Some
                                                            ([(scope, p)],
                                                              wl2))
                                                  in
-                                              FStar_Util.bind_opt uu____23314
-                                                (fun uu____23497  ->
-                                                   match uu____23497 with
+                                              FStar_Util.bind_opt uu____23334
+                                                (fun uu____23517  ->
+                                                   match uu____23517 with
                                                    | (wprobs,wl2) ->
-                                                       let uu____23534 =
+                                                       let uu____23554 =
                                                          mk_t_problem wl2
                                                            scope orig e1
                                                            FStar_TypeChecker_Common.EQ
@@ -8431,10 +8443,10 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                            FStar_Pervasives_Native.None
                                                            "branch body"
                                                           in
-                                                       (match uu____23534
+                                                       (match uu____23554
                                                         with
                                                         | (prob,wl3) ->
-                                                            ((let uu____23555
+                                                            ((let uu____23575
                                                                 =
                                                                 FStar_All.pipe_left
                                                                   (FStar_TypeChecker_Env.debug
@@ -8442,14 +8454,14 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                   (FStar_Options.Other
                                                                     "Rel")
                                                                  in
-                                                              if uu____23555
+                                                              if uu____23575
                                                               then
-                                                                let uu____23560
+                                                                let uu____23580
                                                                   =
                                                                   prob_to_string
                                                                     env prob
                                                                    in
-                                                                let uu____23562
+                                                                let uu____23582
                                                                   =
                                                                   FStar_Syntax_Print.binders_to_string
                                                                     ", "
@@ -8457,20 +8469,20 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                    in
                                                                 FStar_Util.print2
                                                                   "Created problem for branches %s with scope %s\n"
-                                                                  uu____23560
-                                                                  uu____23562
+                                                                  uu____23580
+                                                                  uu____23582
                                                               else ());
-                                                             (let uu____23568
+                                                             (let uu____23588
                                                                 =
                                                                 solve_branches
                                                                   wl3 rs1 rs2
                                                                  in
                                                               FStar_Util.bind_opt
-                                                                uu____23568
+                                                                uu____23588
                                                                 (fun
-                                                                   uu____23604
+                                                                   uu____23624
                                                                     ->
-                                                                   match uu____23604
+                                                                   match uu____23624
                                                                    with
                                                                    | 
                                                                    (r1,wl4)
@@ -8482,115 +8494,115 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     wprobs r1)),
                                                                     wl4))))))))))
                     | ([],[]) -> FStar_Pervasives_Native.Some ([], wl1)
-                    | uu____23733 -> FStar_Pervasives_Native.None  in
-                  let uu____23774 = solve_branches wl brs1 brs2  in
-                  (match uu____23774 with
+                    | uu____23753 -> FStar_Pervasives_Native.None  in
+                  let uu____23794 = solve_branches wl brs1 brs2  in
+                  (match uu____23794 with
                    | FStar_Pervasives_Native.None  ->
                        if wl.smt_ok
                        then by_smt ()
                        else
-                         (let uu____23800 =
+                         (let uu____23820 =
                             FStar_Thunk.mkv "Tm_match branches don't match"
                              in
-                          giveup env uu____23800 orig)
+                          giveup env uu____23820 orig)
                    | FStar_Pervasives_Native.Some (sub_probs,wl1) ->
-                       let uu____23827 =
+                       let uu____23847 =
                          mk_t_problem wl1 [] orig s1
                            FStar_TypeChecker_Common.EQ s2
                            FStar_Pervasives_Native.None "match scrutinee"
                           in
-                       (match uu____23827 with
+                       (match uu____23847 with
                         | (sc_prob,wl2) ->
                             let sub_probs1 = ([], sc_prob) :: sub_probs  in
                             let formula =
-                              let uu____23861 =
+                              let uu____23881 =
                                 FStar_List.map
-                                  (fun uu____23873  ->
-                                     match uu____23873 with
+                                  (fun uu____23893  ->
+                                     match uu____23893 with
                                      | (scope,p) ->
                                          FStar_TypeChecker_Env.close_forall
                                            wl2.tcenv scope (p_guard p))
                                   sub_probs1
                                  in
-                              FStar_Syntax_Util.mk_conj_l uu____23861  in
+                              FStar_Syntax_Util.mk_conj_l uu____23881  in
                             let tx =
                               FStar_Syntax_Unionfind.new_transaction ()  in
                             let wl3 =
                               solve_prob orig
                                 (FStar_Pervasives_Native.Some formula) [] wl2
                                in
-                            let uu____23882 =
-                              let uu____23883 =
-                                let uu____23884 =
+                            let uu____23902 =
+                              let uu____23903 =
+                                let uu____23904 =
                                   FStar_List.map FStar_Pervasives_Native.snd
                                     sub_probs1
                                    in
-                                attempt uu____23884
-                                  (let uu___3360_23892 = wl3  in
+                                attempt uu____23904
+                                  (let uu___3360_23912 = wl3  in
                                    {
                                      attempting =
-                                       (uu___3360_23892.attempting);
+                                       (uu___3360_23912.attempting);
                                      wl_deferred =
-                                       (uu___3360_23892.wl_deferred);
-                                     ctr = (uu___3360_23892.ctr);
-                                     defer_ok = (uu___3360_23892.defer_ok);
+                                       (uu___3360_23912.wl_deferred);
+                                     ctr = (uu___3360_23912.ctr);
+                                     defer_ok = (uu___3360_23912.defer_ok);
                                      smt_ok = false;
                                      umax_heuristic_ok =
-                                       (uu___3360_23892.umax_heuristic_ok);
-                                     tcenv = (uu___3360_23892.tcenv);
+                                       (uu___3360_23912.umax_heuristic_ok);
+                                     tcenv = (uu___3360_23912.tcenv);
                                      wl_implicits =
-                                       (uu___3360_23892.wl_implicits)
+                                       (uu___3360_23912.wl_implicits)
                                    })
                                  in
-                              solve env uu____23883  in
-                            (match uu____23882 with
+                              solve env uu____23903  in
+                            (match uu____23902 with
                              | Success (ds,imp) ->
                                  (FStar_Syntax_Unionfind.commit tx;
                                   Success (ds, imp))
-                             | Failed uu____23897 ->
+                             | Failed uu____23917 ->
                                  (FStar_Syntax_Unionfind.rollback tx;
                                   if wl3.smt_ok
                                   then by_smt ()
                                   else
-                                    (let uu____23906 =
+                                    (let uu____23926 =
                                        FStar_Thunk.mkv
                                          "Could not unify matches without SMT"
                                         in
-                                     giveup env uu____23906 orig)))))
-              | (FStar_Syntax_Syntax.Tm_match uu____23909,uu____23910) ->
+                                     giveup env uu____23926 orig)))))
+              | (FStar_Syntax_Syntax.Tm_match uu____23929,uu____23930) ->
                   let head1 =
-                    let uu____23934 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____23934
+                    let uu____23954 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____23954
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____23980 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____23980
+                    let uu____24000 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____24000
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____24026 =
+                  ((let uu____24046 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____24026
+                    if uu____24046
                     then
-                      let uu____24030 =
+                      let uu____24050 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____24032 =
+                      let uu____24052 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____24034 =
+                      let uu____24054 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24030 uu____24032 uu____24034
+                        uu____24050 uu____24052 uu____24054
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24048 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____24048) &&
-                        (let uu____24052 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____24052)
+                      (let uu____24068 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____24068) &&
+                        (let uu____24072 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____24072)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -8613,9 +8625,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____24071 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____24071 = FStar_Syntax_Util.Equal  in
-                    let uu____24072 =
+                      let uu____24091 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____24091 = FStar_Syntax_Util.Equal  in
+                    let uu____24092 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8624,72 +8636,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____24072
+                    if uu____24092
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24076 = equal t1 t2  in
-                         (if uu____24076
+                         let uu____24096 = equal t1 t2  in
+                         (if uu____24096
                           then
-                            let uu____24079 =
+                            let uu____24099 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____24079
+                            solve env uu____24099
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24084 =
-                            let uu____24091 = equal t1 t2  in
-                            if uu____24091
+                         (let uu____24104 =
+                            let uu____24111 = equal t1 t2  in
+                            if uu____24111
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24104 = mk_eq2 wl env orig t1 t2  in
-                               match uu____24104 with
+                              (let uu____24124 = mk_eq2 wl env orig t1 t2  in
+                               match uu____24124 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____24084 with
+                          match uu____24104 with
                           | (guard,wl1) ->
-                              let uu____24125 = solve_prob orig guard [] wl1
+                              let uu____24145 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____24125))
+                              solve env uu____24145))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_uinst uu____24128,uu____24129) ->
+              | (FStar_Syntax_Syntax.Tm_uinst uu____24148,uu____24149) ->
                   let head1 =
-                    let uu____24137 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____24137
+                    let uu____24157 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____24157
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____24183 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____24183
+                    let uu____24203 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____24203
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____24229 =
+                  ((let uu____24249 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____24229
+                    if uu____24249
                     then
-                      let uu____24233 =
+                      let uu____24253 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____24235 =
+                      let uu____24255 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____24237 =
+                      let uu____24257 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24233 uu____24235 uu____24237
+                        uu____24253 uu____24255 uu____24257
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24251 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____24251) &&
-                        (let uu____24255 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____24255)
+                      (let uu____24271 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____24271) &&
+                        (let uu____24275 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____24275)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -8712,9 +8724,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____24274 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____24274 = FStar_Syntax_Util.Equal  in
-                    let uu____24275 =
+                      let uu____24294 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____24294 = FStar_Syntax_Util.Equal  in
+                    let uu____24295 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8723,72 +8735,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____24275
+                    if uu____24295
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24279 = equal t1 t2  in
-                         (if uu____24279
+                         let uu____24299 = equal t1 t2  in
+                         (if uu____24299
                           then
-                            let uu____24282 =
+                            let uu____24302 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____24282
+                            solve env uu____24302
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24287 =
-                            let uu____24294 = equal t1 t2  in
-                            if uu____24294
+                         (let uu____24307 =
+                            let uu____24314 = equal t1 t2  in
+                            if uu____24314
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24307 = mk_eq2 wl env orig t1 t2  in
-                               match uu____24307 with
+                              (let uu____24327 = mk_eq2 wl env orig t1 t2  in
+                               match uu____24327 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____24287 with
+                          match uu____24307 with
                           | (guard,wl1) ->
-                              let uu____24328 = solve_prob orig guard [] wl1
+                              let uu____24348 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____24328))
+                              solve env uu____24348))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_name uu____24331,uu____24332) ->
+              | (FStar_Syntax_Syntax.Tm_name uu____24351,uu____24352) ->
                   let head1 =
-                    let uu____24334 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____24334
+                    let uu____24354 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____24354
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____24380 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____24380
+                    let uu____24400 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____24400
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____24426 =
+                  ((let uu____24446 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____24426
+                    if uu____24446
                     then
-                      let uu____24430 =
+                      let uu____24450 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____24432 =
+                      let uu____24452 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____24434 =
+                      let uu____24454 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24430 uu____24432 uu____24434
+                        uu____24450 uu____24452 uu____24454
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24448 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____24448) &&
-                        (let uu____24452 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____24452)
+                      (let uu____24468 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____24468) &&
+                        (let uu____24472 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____24472)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -8811,9 +8823,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____24471 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____24471 = FStar_Syntax_Util.Equal  in
-                    let uu____24472 =
+                      let uu____24491 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____24491 = FStar_Syntax_Util.Equal  in
+                    let uu____24492 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8822,72 +8834,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____24472
+                    if uu____24492
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24476 = equal t1 t2  in
-                         (if uu____24476
+                         let uu____24496 = equal t1 t2  in
+                         (if uu____24496
                           then
-                            let uu____24479 =
+                            let uu____24499 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____24479
+                            solve env uu____24499
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24484 =
-                            let uu____24491 = equal t1 t2  in
-                            if uu____24491
+                         (let uu____24504 =
+                            let uu____24511 = equal t1 t2  in
+                            if uu____24511
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24504 = mk_eq2 wl env orig t1 t2  in
-                               match uu____24504 with
+                              (let uu____24524 = mk_eq2 wl env orig t1 t2  in
+                               match uu____24524 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____24484 with
+                          match uu____24504 with
                           | (guard,wl1) ->
-                              let uu____24525 = solve_prob orig guard [] wl1
+                              let uu____24545 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____24525))
+                              solve env uu____24545))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_constant uu____24528,uu____24529) ->
+              | (FStar_Syntax_Syntax.Tm_constant uu____24548,uu____24549) ->
                   let head1 =
-                    let uu____24531 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____24531
+                    let uu____24551 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____24551
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____24577 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____24577
+                    let uu____24597 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____24597
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____24623 =
+                  ((let uu____24643 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____24623
+                    if uu____24643
                     then
-                      let uu____24627 =
+                      let uu____24647 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____24629 =
+                      let uu____24649 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____24631 =
+                      let uu____24651 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24627 uu____24629 uu____24631
+                        uu____24647 uu____24649 uu____24651
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24645 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____24645) &&
-                        (let uu____24649 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____24649)
+                      (let uu____24665 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____24665) &&
+                        (let uu____24669 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____24669)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -8910,9 +8922,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____24668 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____24668 = FStar_Syntax_Util.Equal  in
-                    let uu____24669 =
+                      let uu____24688 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____24688 = FStar_Syntax_Util.Equal  in
+                    let uu____24689 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8921,72 +8933,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____24669
+                    if uu____24689
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24673 = equal t1 t2  in
-                         (if uu____24673
+                         let uu____24693 = equal t1 t2  in
+                         (if uu____24693
                           then
-                            let uu____24676 =
+                            let uu____24696 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____24676
+                            solve env uu____24696
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24681 =
-                            let uu____24688 = equal t1 t2  in
-                            if uu____24688
+                         (let uu____24701 =
+                            let uu____24708 = equal t1 t2  in
+                            if uu____24708
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24701 = mk_eq2 wl env orig t1 t2  in
-                               match uu____24701 with
+                              (let uu____24721 = mk_eq2 wl env orig t1 t2  in
+                               match uu____24721 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____24681 with
+                          match uu____24701 with
                           | (guard,wl1) ->
-                              let uu____24722 = solve_prob orig guard [] wl1
+                              let uu____24742 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____24722))
+                              solve env uu____24742))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_fvar uu____24725,uu____24726) ->
+              | (FStar_Syntax_Syntax.Tm_fvar uu____24745,uu____24746) ->
                   let head1 =
-                    let uu____24728 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____24728
+                    let uu____24748 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____24748
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____24774 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____24774
+                    let uu____24794 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____24794
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____24820 =
+                  ((let uu____24840 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____24820
+                    if uu____24840
                     then
-                      let uu____24824 =
+                      let uu____24844 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____24826 =
+                      let uu____24846 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____24828 =
+                      let uu____24848 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24824 uu____24826 uu____24828
+                        uu____24844 uu____24846 uu____24848
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24842 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____24842) &&
-                        (let uu____24846 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____24846)
+                      (let uu____24862 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____24862) &&
+                        (let uu____24866 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____24866)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9009,9 +9021,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____24865 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____24865 = FStar_Syntax_Util.Equal  in
-                    let uu____24866 =
+                      let uu____24885 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____24885 = FStar_Syntax_Util.Equal  in
+                    let uu____24886 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9020,72 +9032,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____24866
+                    if uu____24886
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24870 = equal t1 t2  in
-                         (if uu____24870
+                         let uu____24890 = equal t1 t2  in
+                         (if uu____24890
                           then
-                            let uu____24873 =
+                            let uu____24893 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____24873
+                            solve env uu____24893
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24878 =
-                            let uu____24885 = equal t1 t2  in
-                            if uu____24885
+                         (let uu____24898 =
+                            let uu____24905 = equal t1 t2  in
+                            if uu____24905
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24898 = mk_eq2 wl env orig t1 t2  in
-                               match uu____24898 with
+                              (let uu____24918 = mk_eq2 wl env orig t1 t2  in
+                               match uu____24918 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____24878 with
+                          match uu____24898 with
                           | (guard,wl1) ->
-                              let uu____24919 = solve_prob orig guard [] wl1
+                              let uu____24939 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____24919))
+                              solve env uu____24939))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_app uu____24922,uu____24923) ->
+              | (FStar_Syntax_Syntax.Tm_app uu____24942,uu____24943) ->
                   let head1 =
-                    let uu____24941 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____24941
+                    let uu____24961 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____24961
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____24987 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____24987
+                    let uu____25007 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____25007
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____25033 =
+                  ((let uu____25053 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____25033
+                    if uu____25053
                     then
-                      let uu____25037 =
+                      let uu____25057 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____25039 =
+                      let uu____25059 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____25041 =
+                      let uu____25061 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____25037 uu____25039 uu____25041
+                        uu____25057 uu____25059 uu____25061
                     else ());
                    (let no_free_uvars t =
-                      (let uu____25055 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____25055) &&
-                        (let uu____25059 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____25059)
+                      (let uu____25075 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____25075) &&
+                        (let uu____25079 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____25079)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9108,9 +9120,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____25078 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____25078 = FStar_Syntax_Util.Equal  in
-                    let uu____25079 =
+                      let uu____25098 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____25098 = FStar_Syntax_Util.Equal  in
+                    let uu____25099 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9119,72 +9131,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____25079
+                    if uu____25099
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____25083 = equal t1 t2  in
-                         (if uu____25083
+                         let uu____25103 = equal t1 t2  in
+                         (if uu____25103
                           then
-                            let uu____25086 =
+                            let uu____25106 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____25086
+                            solve env uu____25106
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____25091 =
-                            let uu____25098 = equal t1 t2  in
-                            if uu____25098
+                         (let uu____25111 =
+                            let uu____25118 = equal t1 t2  in
+                            if uu____25118
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____25111 = mk_eq2 wl env orig t1 t2  in
-                               match uu____25111 with
+                              (let uu____25131 = mk_eq2 wl env orig t1 t2  in
+                               match uu____25131 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____25091 with
+                          match uu____25111 with
                           | (guard,wl1) ->
-                              let uu____25132 = solve_prob orig guard [] wl1
+                              let uu____25152 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____25132))
+                              solve env uu____25152))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____25135,FStar_Syntax_Syntax.Tm_match uu____25136) ->
+              | (uu____25155,FStar_Syntax_Syntax.Tm_match uu____25156) ->
                   let head1 =
-                    let uu____25160 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____25160
+                    let uu____25180 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____25180
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____25206 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____25206
+                    let uu____25226 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____25226
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____25252 =
+                  ((let uu____25272 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____25252
+                    if uu____25272
                     then
-                      let uu____25256 =
+                      let uu____25276 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____25258 =
+                      let uu____25278 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____25260 =
+                      let uu____25280 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____25256 uu____25258 uu____25260
+                        uu____25276 uu____25278 uu____25280
                     else ());
                    (let no_free_uvars t =
-                      (let uu____25274 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____25274) &&
-                        (let uu____25278 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____25278)
+                      (let uu____25294 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____25294) &&
+                        (let uu____25298 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____25298)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9207,9 +9219,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____25297 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____25297 = FStar_Syntax_Util.Equal  in
-                    let uu____25298 =
+                      let uu____25317 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____25317 = FStar_Syntax_Util.Equal  in
+                    let uu____25318 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9218,72 +9230,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____25298
+                    if uu____25318
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____25302 = equal t1 t2  in
-                         (if uu____25302
+                         let uu____25322 = equal t1 t2  in
+                         (if uu____25322
                           then
-                            let uu____25305 =
+                            let uu____25325 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____25305
+                            solve env uu____25325
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____25310 =
-                            let uu____25317 = equal t1 t2  in
-                            if uu____25317
+                         (let uu____25330 =
+                            let uu____25337 = equal t1 t2  in
+                            if uu____25337
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____25330 = mk_eq2 wl env orig t1 t2  in
-                               match uu____25330 with
+                              (let uu____25350 = mk_eq2 wl env orig t1 t2  in
+                               match uu____25350 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____25310 with
+                          match uu____25330 with
                           | (guard,wl1) ->
-                              let uu____25351 = solve_prob orig guard [] wl1
+                              let uu____25371 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____25351))
+                              solve env uu____25371))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____25354,FStar_Syntax_Syntax.Tm_uinst uu____25355) ->
+              | (uu____25374,FStar_Syntax_Syntax.Tm_uinst uu____25375) ->
                   let head1 =
-                    let uu____25363 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____25363
+                    let uu____25383 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____25383
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____25409 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____25409
+                    let uu____25429 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____25429
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____25455 =
+                  ((let uu____25475 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____25455
+                    if uu____25475
                     then
-                      let uu____25459 =
+                      let uu____25479 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____25461 =
+                      let uu____25481 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____25463 =
+                      let uu____25483 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____25459 uu____25461 uu____25463
+                        uu____25479 uu____25481 uu____25483
                     else ());
                    (let no_free_uvars t =
-                      (let uu____25477 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____25477) &&
-                        (let uu____25481 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____25481)
+                      (let uu____25497 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____25497) &&
+                        (let uu____25501 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____25501)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9306,9 +9318,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____25500 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____25500 = FStar_Syntax_Util.Equal  in
-                    let uu____25501 =
+                      let uu____25520 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____25520 = FStar_Syntax_Util.Equal  in
+                    let uu____25521 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9317,72 +9329,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____25501
+                    if uu____25521
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____25505 = equal t1 t2  in
-                         (if uu____25505
+                         let uu____25525 = equal t1 t2  in
+                         (if uu____25525
                           then
-                            let uu____25508 =
+                            let uu____25528 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____25508
+                            solve env uu____25528
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____25513 =
-                            let uu____25520 = equal t1 t2  in
-                            if uu____25520
+                         (let uu____25533 =
+                            let uu____25540 = equal t1 t2  in
+                            if uu____25540
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____25533 = mk_eq2 wl env orig t1 t2  in
-                               match uu____25533 with
+                              (let uu____25553 = mk_eq2 wl env orig t1 t2  in
+                               match uu____25553 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____25513 with
+                          match uu____25533 with
                           | (guard,wl1) ->
-                              let uu____25554 = solve_prob orig guard [] wl1
+                              let uu____25574 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____25554))
+                              solve env uu____25574))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____25557,FStar_Syntax_Syntax.Tm_name uu____25558) ->
+              | (uu____25577,FStar_Syntax_Syntax.Tm_name uu____25578) ->
                   let head1 =
-                    let uu____25560 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____25560
+                    let uu____25580 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____25580
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____25606 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____25606
+                    let uu____25626 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____25626
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____25646 =
+                  ((let uu____25666 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____25646
+                    if uu____25666
                     then
-                      let uu____25650 =
+                      let uu____25670 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____25652 =
+                      let uu____25672 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____25654 =
+                      let uu____25674 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____25650 uu____25652 uu____25654
+                        uu____25670 uu____25672 uu____25674
                     else ());
                    (let no_free_uvars t =
-                      (let uu____25668 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____25668) &&
-                        (let uu____25672 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____25672)
+                      (let uu____25688 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____25688) &&
+                        (let uu____25692 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____25692)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9405,9 +9417,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____25691 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____25691 = FStar_Syntax_Util.Equal  in
-                    let uu____25692 =
+                      let uu____25711 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____25711 = FStar_Syntax_Util.Equal  in
+                    let uu____25712 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9416,72 +9428,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____25692
+                    if uu____25712
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____25696 = equal t1 t2  in
-                         (if uu____25696
+                         let uu____25716 = equal t1 t2  in
+                         (if uu____25716
                           then
-                            let uu____25699 =
+                            let uu____25719 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____25699
+                            solve env uu____25719
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____25704 =
-                            let uu____25711 = equal t1 t2  in
-                            if uu____25711
+                         (let uu____25724 =
+                            let uu____25731 = equal t1 t2  in
+                            if uu____25731
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____25724 = mk_eq2 wl env orig t1 t2  in
-                               match uu____25724 with
+                              (let uu____25744 = mk_eq2 wl env orig t1 t2  in
+                               match uu____25744 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____25704 with
+                          match uu____25724 with
                           | (guard,wl1) ->
-                              let uu____25745 = solve_prob orig guard [] wl1
+                              let uu____25765 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____25745))
+                              solve env uu____25765))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____25748,FStar_Syntax_Syntax.Tm_constant uu____25749) ->
+              | (uu____25768,FStar_Syntax_Syntax.Tm_constant uu____25769) ->
                   let head1 =
-                    let uu____25751 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____25751
+                    let uu____25771 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____25771
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____25791 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____25791
+                    let uu____25811 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____25811
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____25831 =
+                  ((let uu____25851 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____25831
+                    if uu____25851
                     then
-                      let uu____25835 =
+                      let uu____25855 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____25837 =
+                      let uu____25857 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____25839 =
+                      let uu____25859 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____25835 uu____25837 uu____25839
+                        uu____25855 uu____25857 uu____25859
                     else ());
                    (let no_free_uvars t =
-                      (let uu____25853 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____25853) &&
-                        (let uu____25857 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____25857)
+                      (let uu____25873 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____25873) &&
+                        (let uu____25877 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____25877)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9504,9 +9516,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____25876 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____25876 = FStar_Syntax_Util.Equal  in
-                    let uu____25877 =
+                      let uu____25896 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____25896 = FStar_Syntax_Util.Equal  in
+                    let uu____25897 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9515,72 +9527,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____25877
+                    if uu____25897
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____25881 = equal t1 t2  in
-                         (if uu____25881
+                         let uu____25901 = equal t1 t2  in
+                         (if uu____25901
                           then
-                            let uu____25884 =
+                            let uu____25904 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____25884
+                            solve env uu____25904
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____25889 =
-                            let uu____25896 = equal t1 t2  in
-                            if uu____25896
+                         (let uu____25909 =
+                            let uu____25916 = equal t1 t2  in
+                            if uu____25916
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____25909 = mk_eq2 wl env orig t1 t2  in
-                               match uu____25909 with
+                              (let uu____25929 = mk_eq2 wl env orig t1 t2  in
+                               match uu____25929 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____25889 with
+                          match uu____25909 with
                           | (guard,wl1) ->
-                              let uu____25930 = solve_prob orig guard [] wl1
+                              let uu____25950 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____25930))
+                              solve env uu____25950))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____25933,FStar_Syntax_Syntax.Tm_fvar uu____25934) ->
+              | (uu____25953,FStar_Syntax_Syntax.Tm_fvar uu____25954) ->
                   let head1 =
-                    let uu____25936 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____25936
+                    let uu____25956 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____25956
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____25982 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____25982
+                    let uu____26002 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____26002
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____26028 =
+                  ((let uu____26048 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____26028
+                    if uu____26048
                     then
-                      let uu____26032 =
+                      let uu____26052 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____26034 =
+                      let uu____26054 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____26036 =
+                      let uu____26056 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____26032 uu____26034 uu____26036
+                        uu____26052 uu____26054 uu____26056
                     else ());
                    (let no_free_uvars t =
-                      (let uu____26050 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____26050) &&
-                        (let uu____26054 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____26054)
+                      (let uu____26070 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____26070) &&
+                        (let uu____26074 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____26074)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9603,9 +9615,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____26073 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____26073 = FStar_Syntax_Util.Equal  in
-                    let uu____26074 =
+                      let uu____26093 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____26093 = FStar_Syntax_Util.Equal  in
+                    let uu____26094 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9614,72 +9626,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____26074
+                    if uu____26094
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____26078 = equal t1 t2  in
-                         (if uu____26078
+                         let uu____26098 = equal t1 t2  in
+                         (if uu____26098
                           then
-                            let uu____26081 =
+                            let uu____26101 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____26081
+                            solve env uu____26101
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____26086 =
-                            let uu____26093 = equal t1 t2  in
-                            if uu____26093
+                         (let uu____26106 =
+                            let uu____26113 = equal t1 t2  in
+                            if uu____26113
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____26106 = mk_eq2 wl env orig t1 t2  in
-                               match uu____26106 with
+                              (let uu____26126 = mk_eq2 wl env orig t1 t2  in
+                               match uu____26126 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____26086 with
+                          match uu____26106 with
                           | (guard,wl1) ->
-                              let uu____26127 = solve_prob orig guard [] wl1
+                              let uu____26147 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____26127))
+                              solve env uu____26147))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____26130,FStar_Syntax_Syntax.Tm_app uu____26131) ->
+              | (uu____26150,FStar_Syntax_Syntax.Tm_app uu____26151) ->
                   let head1 =
-                    let uu____26149 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____26149
+                    let uu____26169 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____26169
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____26189 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____26189
+                    let uu____26209 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____26209
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____26229 =
+                  ((let uu____26249 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____26229
+                    if uu____26249
                     then
-                      let uu____26233 =
+                      let uu____26253 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____26235 =
+                      let uu____26255 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____26237 =
+                      let uu____26257 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____26233 uu____26235 uu____26237
+                        uu____26253 uu____26255 uu____26257
                     else ());
                    (let no_free_uvars t =
-                      (let uu____26251 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____26251) &&
-                        (let uu____26255 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____26255)
+                      (let uu____26271 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____26271) &&
+                        (let uu____26275 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____26275)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9702,9 +9714,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____26274 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____26274 = FStar_Syntax_Util.Equal  in
-                    let uu____26275 =
+                      let uu____26294 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____26294 = FStar_Syntax_Util.Equal  in
+                    let uu____26295 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9713,88 +9725,88 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____26275
+                    if uu____26295
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____26279 = equal t1 t2  in
-                         (if uu____26279
+                         let uu____26299 = equal t1 t2  in
+                         (if uu____26299
                           then
-                            let uu____26282 =
+                            let uu____26302 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____26282
+                            solve env uu____26302
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____26287 =
-                            let uu____26294 = equal t1 t2  in
-                            if uu____26294
+                         (let uu____26307 =
+                            let uu____26314 = equal t1 t2  in
+                            if uu____26314
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____26307 = mk_eq2 wl env orig t1 t2  in
-                               match uu____26307 with
+                              (let uu____26327 = mk_eq2 wl env orig t1 t2  in
+                               match uu____26327 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____26287 with
+                          match uu____26307 with
                           | (guard,wl1) ->
-                              let uu____26328 = solve_prob orig guard [] wl1
+                              let uu____26348 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____26328))
+                              solve env uu____26348))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
               | (FStar_Syntax_Syntax.Tm_let
-                 uu____26331,FStar_Syntax_Syntax.Tm_let uu____26332) ->
-                  let uu____26359 = FStar_Syntax_Util.term_eq t1 t2  in
-                  if uu____26359
+                 uu____26351,FStar_Syntax_Syntax.Tm_let uu____26352) ->
+                  let uu____26379 = FStar_Syntax_Util.term_eq t1 t2  in
+                  if uu____26379
                   then
-                    let uu____26362 =
+                    let uu____26382 =
                       solve_prob orig FStar_Pervasives_Native.None [] wl  in
-                    solve env uu____26362
+                    solve env uu____26382
                   else
-                    (let uu____26365 = FStar_Thunk.mkv "Tm_let mismatch"  in
-                     giveup env uu____26365 orig)
-              | (FStar_Syntax_Syntax.Tm_let uu____26368,uu____26369) ->
-                  let uu____26383 =
-                    let uu____26389 =
-                      let uu____26391 = FStar_Syntax_Print.tag_of_term t1  in
-                      let uu____26393 = FStar_Syntax_Print.tag_of_term t2  in
-                      let uu____26395 = FStar_Syntax_Print.term_to_string t1
+                    (let uu____26385 = FStar_Thunk.mkv "Tm_let mismatch"  in
+                     giveup env uu____26385 orig)
+              | (FStar_Syntax_Syntax.Tm_let uu____26388,uu____26389) ->
+                  let uu____26403 =
+                    let uu____26409 =
+                      let uu____26411 = FStar_Syntax_Print.tag_of_term t1  in
+                      let uu____26413 = FStar_Syntax_Print.tag_of_term t2  in
+                      let uu____26415 = FStar_Syntax_Print.term_to_string t1
                          in
-                      let uu____26397 = FStar_Syntax_Print.term_to_string t2
-                         in
-                      FStar_Util.format4
-                        "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
-                        uu____26391 uu____26393 uu____26395 uu____26397
-                       in
-                    (FStar_Errors.Fatal_UnificationNotWellFormed,
-                      uu____26389)
-                     in
-                  FStar_Errors.raise_error uu____26383
-                    t1.FStar_Syntax_Syntax.pos
-              | (uu____26401,FStar_Syntax_Syntax.Tm_let uu____26402) ->
-                  let uu____26416 =
-                    let uu____26422 =
-                      let uu____26424 = FStar_Syntax_Print.tag_of_term t1  in
-                      let uu____26426 = FStar_Syntax_Print.tag_of_term t2  in
-                      let uu____26428 = FStar_Syntax_Print.term_to_string t1
-                         in
-                      let uu____26430 = FStar_Syntax_Print.term_to_string t2
+                      let uu____26417 = FStar_Syntax_Print.term_to_string t2
                          in
                       FStar_Util.format4
                         "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
-                        uu____26424 uu____26426 uu____26428 uu____26430
+                        uu____26411 uu____26413 uu____26415 uu____26417
                        in
                     (FStar_Errors.Fatal_UnificationNotWellFormed,
-                      uu____26422)
+                      uu____26409)
                      in
-                  FStar_Errors.raise_error uu____26416
+                  FStar_Errors.raise_error uu____26403
                     t1.FStar_Syntax_Syntax.pos
-              | uu____26434 ->
-                  let uu____26439 = FStar_Thunk.mkv "head tag mismatch"  in
-                  giveup env uu____26439 orig))))
+              | (uu____26421,FStar_Syntax_Syntax.Tm_let uu____26422) ->
+                  let uu____26436 =
+                    let uu____26442 =
+                      let uu____26444 = FStar_Syntax_Print.tag_of_term t1  in
+                      let uu____26446 = FStar_Syntax_Print.tag_of_term t2  in
+                      let uu____26448 = FStar_Syntax_Print.term_to_string t1
+                         in
+                      let uu____26450 = FStar_Syntax_Print.term_to_string t2
+                         in
+                      FStar_Util.format4
+                        "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
+                        uu____26444 uu____26446 uu____26448 uu____26450
+                       in
+                    (FStar_Errors.Fatal_UnificationNotWellFormed,
+                      uu____26442)
+                     in
+                  FStar_Errors.raise_error uu____26436
+                    t1.FStar_Syntax_Syntax.pos
+              | uu____26454 ->
+                  let uu____26459 = FStar_Thunk.mkv "head tag mismatch"  in
+                  giveup env uu____26459 orig))))
 
 and (solve_c :
   FStar_TypeChecker_Env.env ->
@@ -9812,154 +9824,154 @@ and (solve_c :
             reason
            in
         let solve_eq c1_comp c2_comp g_lift =
-          (let uu____26505 =
+          (let uu____26525 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "EQ")
               in
-           if uu____26505
+           if uu____26525
            then
-             let uu____26510 =
-               let uu____26512 = FStar_Syntax_Syntax.mk_Comp c1_comp  in
-               FStar_Syntax_Print.comp_to_string uu____26512  in
-             let uu____26513 =
-               let uu____26515 = FStar_Syntax_Syntax.mk_Comp c2_comp  in
-               FStar_Syntax_Print.comp_to_string uu____26515  in
+             let uu____26530 =
+               let uu____26532 = FStar_Syntax_Syntax.mk_Comp c1_comp  in
+               FStar_Syntax_Print.comp_to_string uu____26532  in
+             let uu____26533 =
+               let uu____26535 = FStar_Syntax_Syntax.mk_Comp c2_comp  in
+               FStar_Syntax_Print.comp_to_string uu____26535  in
              FStar_Util.print2
                "solve_c is using an equality constraint (%s vs %s)\n"
-               uu____26510 uu____26513
+               uu____26530 uu____26533
            else ());
-          (let uu____26519 =
-             let uu____26521 =
+          (let uu____26539 =
+             let uu____26541 =
                FStar_Ident.lid_equals c1_comp.FStar_Syntax_Syntax.effect_name
                  c2_comp.FStar_Syntax_Syntax.effect_name
                 in
-             Prims.op_Negation uu____26521  in
-           if uu____26519
+             Prims.op_Negation uu____26541  in
+           if uu____26539
            then
-             let uu____26524 =
+             let uu____26544 =
                mklstr
-                 (fun uu____26531  ->
-                    let uu____26532 =
+                 (fun uu____26551  ->
+                    let uu____26552 =
                       FStar_Syntax_Print.lid_to_string
                         c1_comp.FStar_Syntax_Syntax.effect_name
                        in
-                    let uu____26534 =
+                    let uu____26554 =
                       FStar_Syntax_Print.lid_to_string
                         c2_comp.FStar_Syntax_Syntax.effect_name
                        in
                     FStar_Util.format2 "incompatible effects: %s <> %s"
-                      uu____26532 uu____26534)
+                      uu____26552 uu____26554)
                 in
-             giveup env uu____26524 orig
+             giveup env uu____26544 orig
            else
              if
                (FStar_List.length c1_comp.FStar_Syntax_Syntax.effect_args) <>
                  (FStar_List.length c2_comp.FStar_Syntax_Syntax.effect_args)
              then
-               (let uu____26556 =
+               (let uu____26576 =
                   mklstr
-                    (fun uu____26563  ->
-                       let uu____26564 =
+                    (fun uu____26583  ->
+                       let uu____26584 =
                          FStar_Syntax_Print.args_to_string
                            c1_comp.FStar_Syntax_Syntax.effect_args
                           in
-                       let uu____26566 =
+                       let uu____26586 =
                          FStar_Syntax_Print.args_to_string
                            c2_comp.FStar_Syntax_Syntax.effect_args
                           in
                        FStar_Util.format2
                          "incompatible effect arguments: %s <> %s"
-                         uu____26564 uu____26566)
+                         uu____26584 uu____26586)
                    in
-                giveup env uu____26556 orig)
+                giveup env uu____26576 orig)
              else
-               (let uu____26571 =
+               (let uu____26591 =
                   FStar_List.fold_left2
-                    (fun uu____26592  ->
+                    (fun uu____26612  ->
                        fun u1  ->
                          fun u2  ->
-                           match uu____26592 with
+                           match uu____26612 with
                            | (univ_sub_probs,wl1) ->
-                               let uu____26613 =
-                                 let uu____26618 =
+                               let uu____26633 =
+                                 let uu____26638 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_type u1)
                                      FStar_Pervasives_Native.None
                                      FStar_Range.dummyRange
                                     in
-                                 let uu____26619 =
+                                 let uu____26639 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_type u2)
                                      FStar_Pervasives_Native.None
                                      FStar_Range.dummyRange
                                     in
-                                 sub_prob wl1 uu____26618
-                                   FStar_TypeChecker_Common.EQ uu____26619
+                                 sub_prob wl1 uu____26638
+                                   FStar_TypeChecker_Common.EQ uu____26639
                                    "effect universes"
                                   in
-                               (match uu____26613 with
+                               (match uu____26633 with
                                 | (p,wl2) ->
                                     ((FStar_List.append univ_sub_probs [p]),
                                       wl2))) ([], wl)
                     c1_comp.FStar_Syntax_Syntax.comp_univs
                     c2_comp.FStar_Syntax_Syntax.comp_univs
                    in
-                match uu____26571 with
+                match uu____26591 with
                 | (univ_sub_probs,wl1) ->
-                    let uu____26639 =
+                    let uu____26659 =
                       sub_prob wl1 c1_comp.FStar_Syntax_Syntax.result_typ
                         FStar_TypeChecker_Common.EQ
                         c2_comp.FStar_Syntax_Syntax.result_typ
                         "effect ret type"
                        in
-                    (match uu____26639 with
+                    (match uu____26659 with
                      | (ret_sub_prob,wl2) ->
-                         let uu____26647 =
+                         let uu____26667 =
                            FStar_List.fold_right2
-                             (fun uu____26684  ->
-                                fun uu____26685  ->
-                                  fun uu____26686  ->
-                                    match (uu____26684, uu____26685,
-                                            uu____26686)
+                             (fun uu____26704  ->
+                                fun uu____26705  ->
+                                  fun uu____26706  ->
+                                    match (uu____26704, uu____26705,
+                                            uu____26706)
                                     with
-                                    | ((a1,uu____26730),(a2,uu____26732),
+                                    | ((a1,uu____26750),(a2,uu____26752),
                                        (arg_sub_probs,wl3)) ->
-                                        let uu____26765 =
+                                        let uu____26785 =
                                           sub_prob wl3 a1
                                             FStar_TypeChecker_Common.EQ a2
                                             "effect arg"
                                            in
-                                        (match uu____26765 with
+                                        (match uu____26785 with
                                          | (p,wl4) ->
                                              ((p :: arg_sub_probs), wl4)))
                              c1_comp.FStar_Syntax_Syntax.effect_args
                              c2_comp.FStar_Syntax_Syntax.effect_args
                              ([], wl2)
                             in
-                         (match uu____26647 with
+                         (match uu____26667 with
                           | (arg_sub_probs,wl3) ->
                               let sub_probs =
-                                let uu____26792 =
-                                  let uu____26795 =
-                                    let uu____26798 =
+                                let uu____26812 =
+                                  let uu____26815 =
+                                    let uu____26818 =
                                       FStar_All.pipe_right
                                         g_lift.FStar_TypeChecker_Common.deferred
                                         (FStar_List.map
                                            FStar_Pervasives_Native.snd)
                                        in
                                     FStar_List.append arg_sub_probs
-                                      uu____26798
+                                      uu____26818
                                      in
                                   FStar_List.append [ret_sub_prob]
-                                    uu____26795
+                                    uu____26815
                                    in
-                                FStar_List.append univ_sub_probs uu____26792
+                                FStar_List.append univ_sub_probs uu____26812
                                  in
                               let guard =
                                 let guard =
-                                  let uu____26820 =
+                                  let uu____26840 =
                                     FStar_List.map p_guard sub_probs  in
-                                  FStar_Syntax_Util.mk_conj_l uu____26820  in
+                                  FStar_Syntax_Util.mk_conj_l uu____26840  in
                                 match g_lift.FStar_TypeChecker_Common.guard_f
                                 with
                                 | FStar_TypeChecker_Common.Trivial  -> guard
@@ -9967,16 +9979,16 @@ and (solve_c :
                                     FStar_Syntax_Util.mk_conj guard f
                                  in
                               let wl4 =
-                                let uu___3512_26829 = wl3  in
+                                let uu___3512_26849 = wl3  in
                                 {
-                                  attempting = (uu___3512_26829.attempting);
-                                  wl_deferred = (uu___3512_26829.wl_deferred);
-                                  ctr = (uu___3512_26829.ctr);
-                                  defer_ok = (uu___3512_26829.defer_ok);
-                                  smt_ok = (uu___3512_26829.smt_ok);
+                                  attempting = (uu___3512_26849.attempting);
+                                  wl_deferred = (uu___3512_26849.wl_deferred);
+                                  ctr = (uu___3512_26849.ctr);
+                                  defer_ok = (uu___3512_26849.defer_ok);
+                                  smt_ok = (uu___3512_26849.smt_ok);
                                   umax_heuristic_ok =
-                                    (uu___3512_26829.umax_heuristic_ok);
-                                  tcenv = (uu___3512_26829.tcenv);
+                                    (uu___3512_26849.umax_heuristic_ok);
+                                  tcenv = (uu___3512_26849.tcenv);
                                   wl_implicits =
                                     (FStar_List.append
                                        g_lift.FStar_TypeChecker_Common.implicits
@@ -9986,72 +9998,72 @@ and (solve_c :
                                 solve_prob orig
                                   (FStar_Pervasives_Native.Some guard) [] wl4
                                  in
-                              let uu____26831 = attempt sub_probs wl5  in
-                              solve env uu____26831))))
+                              let uu____26851 = attempt sub_probs wl5  in
+                              solve env uu____26851))))
            in
         let solve_layered_sub c11 edge c21 =
-          (let uu____26849 =
+          (let uu____26869 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "LayeredEffects")
               in
-           if uu____26849
+           if uu____26869
            then
-             let uu____26854 =
-               let uu____26856 =
+             let uu____26874 =
+               let uu____26876 =
                  FStar_All.pipe_right c11 FStar_Syntax_Syntax.mk_Comp  in
-               FStar_All.pipe_right uu____26856
+               FStar_All.pipe_right uu____26876
                  FStar_Syntax_Print.comp_to_string
                 in
-             let uu____26858 =
-               let uu____26860 =
+             let uu____26878 =
+               let uu____26880 =
                  FStar_All.pipe_right c21 FStar_Syntax_Syntax.mk_Comp  in
-               FStar_All.pipe_right uu____26860
+               FStar_All.pipe_right uu____26880
                  FStar_Syntax_Print.comp_to_string
                 in
              FStar_Util.print2 "solve_layered_sub c1: %s and c2: %s\n"
-               uu____26854 uu____26858
+               uu____26874 uu____26878
            else ());
-          (let uu____26865 =
-             let uu____26870 =
-               let uu____26875 =
+          (let uu____26885 =
+             let uu____26890 =
+               let uu____26895 =
                  FStar_All.pipe_right c11 FStar_Syntax_Syntax.mk_Comp  in
-               FStar_All.pipe_right uu____26875
+               FStar_All.pipe_right uu____26895
                  ((edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
                     env)
                 in
-             FStar_All.pipe_right uu____26870
-               (fun uu____26892  ->
-                  match uu____26892 with
+             FStar_All.pipe_right uu____26890
+               (fun uu____26912  ->
+                  match uu____26912 with
                   | (c,g) ->
-                      let uu____26903 = FStar_Syntax_Util.comp_to_comp_typ c
+                      let uu____26923 = FStar_Syntax_Util.comp_to_comp_typ c
                          in
-                      (uu____26903, g))
+                      (uu____26923, g))
               in
-           match uu____26865 with
+           match uu____26885 with
            | (c12,g_lift) ->
-               ((let uu____26907 =
+               ((let uu____26927 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                      (FStar_Options.Other "LayeredEffects")
                     in
-                 if uu____26907
+                 if uu____26927
                  then
-                   let uu____26912 =
-                     let uu____26914 =
+                   let uu____26932 =
+                     let uu____26934 =
                        FStar_All.pipe_right c12 FStar_Syntax_Syntax.mk_Comp
                         in
-                     FStar_All.pipe_right uu____26914
+                     FStar_All.pipe_right uu____26934
                        FStar_Syntax_Print.comp_to_string
                       in
-                   let uu____26916 =
-                     let uu____26918 =
+                   let uu____26936 =
+                     let uu____26938 =
                        FStar_All.pipe_right c21 FStar_Syntax_Syntax.mk_Comp
                         in
-                     FStar_All.pipe_right uu____26918
+                     FStar_All.pipe_right uu____26938
                        FStar_Syntax_Print.comp_to_string
                       in
                    FStar_Util.print2
                      "solve_layered_sub after lift c1: %s and c2: %s\n"
-                     uu____26912 uu____26916
+                     uu____26932 uu____26936
                  else ());
                 if
                   problem.FStar_TypeChecker_Common.relation =
@@ -10060,246 +10072,246 @@ and (solve_c :
                 else
                   (let r = FStar_TypeChecker_Env.get_range env  in
                    let wl1 =
-                     let uu___3532_26928 = wl  in
+                     let uu___3532_26948 = wl  in
                      {
-                       attempting = (uu___3532_26928.attempting);
-                       wl_deferred = (uu___3532_26928.wl_deferred);
-                       ctr = (uu___3532_26928.ctr);
-                       defer_ok = (uu___3532_26928.defer_ok);
-                       smt_ok = (uu___3532_26928.smt_ok);
+                       attempting = (uu___3532_26948.attempting);
+                       wl_deferred = (uu___3532_26948.wl_deferred);
+                       ctr = (uu___3532_26948.ctr);
+                       defer_ok = (uu___3532_26948.defer_ok);
+                       smt_ok = (uu___3532_26948.smt_ok);
                        umax_heuristic_ok =
-                         (uu___3532_26928.umax_heuristic_ok);
-                       tcenv = (uu___3532_26928.tcenv);
+                         (uu___3532_26948.umax_heuristic_ok);
+                       tcenv = (uu___3532_26948.tcenv);
                        wl_implicits =
                          (FStar_List.append
                             g_lift.FStar_TypeChecker_Common.implicits
                             wl.wl_implicits)
                      }  in
-                   let uu____26929 =
+                   let uu____26949 =
                      let rec is_uvar t =
-                       let uu____26943 =
-                         let uu____26944 = FStar_Syntax_Subst.compress t  in
-                         uu____26944.FStar_Syntax_Syntax.n  in
-                       match uu____26943 with
-                       | FStar_Syntax_Syntax.Tm_uvar uu____26948 -> true
-                       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____26963) ->
+                       let uu____26963 =
+                         let uu____26964 = FStar_Syntax_Subst.compress t  in
+                         uu____26964.FStar_Syntax_Syntax.n  in
+                       match uu____26963 with
+                       | FStar_Syntax_Syntax.Tm_uvar uu____26968 -> true
+                       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____26983) ->
                            is_uvar t1
-                       | FStar_Syntax_Syntax.Tm_app (t1,uu____26969) ->
+                       | FStar_Syntax_Syntax.Tm_app (t1,uu____26989) ->
                            is_uvar t1
-                       | uu____26994 -> false  in
+                       | uu____27014 -> false  in
                      FStar_List.fold_right2
-                       (fun uu____27028  ->
-                          fun uu____27029  ->
-                            fun uu____27030  ->
-                              match (uu____27028, uu____27029, uu____27030)
+                       (fun uu____27048  ->
+                          fun uu____27049  ->
+                            fun uu____27050  ->
+                              match (uu____27048, uu____27049, uu____27050)
                               with
-                              | ((a1,uu____27074),(a2,uu____27076),(is_sub_probs,wl2))
+                              | ((a1,uu____27094),(a2,uu____27096),(is_sub_probs,wl2))
                                   ->
-                                  let uu____27109 = is_uvar a1  in
-                                  if uu____27109
+                                  let uu____27129 = is_uvar a1  in
+                                  if uu____27129
                                   then
-                                    ((let uu____27119 =
+                                    ((let uu____27139 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env)
                                           (FStar_Options.Other
                                              "LayeredEffects")
                                          in
-                                      if uu____27119
+                                      if uu____27139
                                       then
-                                        let uu____27124 =
+                                        let uu____27144 =
                                           FStar_Syntax_Print.term_to_string
                                             a1
                                            in
-                                        let uu____27126 =
+                                        let uu____27146 =
                                           FStar_Syntax_Print.term_to_string
                                             a2
                                            in
                                         FStar_Util.print2
                                           "solve_layered_sub: adding index equality for %s and %s (since a1 uvar)\n"
-                                          uu____27124 uu____27126
+                                          uu____27144 uu____27146
                                       else ());
-                                     (let uu____27131 =
+                                     (let uu____27151 =
                                         sub_prob wl2 a1
                                           FStar_TypeChecker_Common.EQ a2
                                           "l.h.s. effect index uvar"
                                          in
-                                      match uu____27131 with
+                                      match uu____27151 with
                                       | (p,wl3) -> ((p :: is_sub_probs), wl3)))
                                   else (is_sub_probs, wl2))
                        c12.FStar_Syntax_Syntax.effect_args
                        c21.FStar_Syntax_Syntax.effect_args ([], wl1)
                       in
-                   match uu____26929 with
+                   match uu____26949 with
                    | (is_sub_probs,wl2) ->
-                       let uu____27159 =
+                       let uu____27179 =
                          sub_prob wl2 c12.FStar_Syntax_Syntax.result_typ
                            problem.FStar_TypeChecker_Common.relation
                            c21.FStar_Syntax_Syntax.result_typ "result type"
                           in
-                       (match uu____27159 with
+                       (match uu____27179 with
                         | (ret_sub_prob,wl3) ->
-                            let uu____27167 =
-                              let uu____27172 =
-                                let uu____27173 =
+                            let uu____27187 =
+                              let uu____27192 =
+                                let uu____27193 =
                                   FStar_All.pipe_right
                                     c21.FStar_Syntax_Syntax.effect_name
                                     (FStar_TypeChecker_Env.get_effect_decl
                                        env)
                                    in
-                                FStar_All.pipe_right uu____27173
+                                FStar_All.pipe_right uu____27193
                                   FStar_Syntax_Util.get_stronger_vc_combinator
                                  in
-                              FStar_All.pipe_right uu____27172
+                              FStar_All.pipe_right uu____27192
                                 (fun ts  ->
                                    FStar_TypeChecker_Env.inst_tscheme_with ts
                                      c21.FStar_Syntax_Syntax.comp_univs)
                                in
-                            (match uu____27167 with
-                             | (uu____27180,stronger_t) ->
+                            (match uu____27187 with
+                             | (uu____27200,stronger_t) ->
                                  let stronger_t_shape_error s =
-                                   let uu____27191 =
+                                   let uu____27211 =
                                      FStar_Ident.string_of_lid
                                        c21.FStar_Syntax_Syntax.effect_name
                                       in
-                                   let uu____27193 =
+                                   let uu____27213 =
                                      FStar_Syntax_Print.term_to_string
                                        stronger_t
                                       in
                                    FStar_Util.format3
                                      "Unexpected shape of stronger for %s, reason: %s (t:%s)"
-                                     uu____27191 s uu____27193
+                                     uu____27211 s uu____27213
                                     in
-                                 let uu____27196 =
-                                   let uu____27225 =
-                                     let uu____27226 =
+                                 let uu____27216 =
+                                   let uu____27245 =
+                                     let uu____27246 =
                                        FStar_Syntax_Subst.compress stronger_t
                                         in
-                                     uu____27226.FStar_Syntax_Syntax.n  in
-                                   match uu____27225 with
+                                     uu____27246.FStar_Syntax_Syntax.n  in
+                                   match uu____27245 with
                                    | FStar_Syntax_Syntax.Tm_arrow (bs,c) when
                                        (FStar_List.length bs) >=
                                          (Prims.of_int (2))
                                        ->
-                                       let uu____27286 =
+                                       let uu____27306 =
                                          FStar_Syntax_Subst.open_comp bs c
                                           in
-                                       (match uu____27286 with
+                                       (match uu____27306 with
                                         | (bs',c3) ->
                                             let a = FStar_List.hd bs'  in
                                             let bs1 = FStar_List.tail bs'  in
-                                            let uu____27349 =
-                                              let uu____27368 =
+                                            let uu____27369 =
+                                              let uu____27388 =
                                                 FStar_All.pipe_right bs1
                                                   (FStar_List.splitAt
                                                      ((FStar_List.length bs1)
                                                         - Prims.int_one))
                                                  in
                                               FStar_All.pipe_right
-                                                uu____27368
-                                                (fun uu____27472  ->
-                                                   match uu____27472 with
+                                                uu____27388
+                                                (fun uu____27492  ->
+                                                   match uu____27492 with
                                                    | (l1,l2) ->
-                                                       let uu____27545 =
+                                                       let uu____27565 =
                                                          FStar_List.hd l2  in
-                                                       (l1, uu____27545))
+                                                       (l1, uu____27565))
                                                in
-                                            (match uu____27349 with
+                                            (match uu____27369 with
                                              | (rest_bs,f_b) ->
                                                  (a, rest_bs, f_b, c3)))
-                                   | uu____27650 ->
-                                       let uu____27651 =
-                                         let uu____27657 =
+                                   | uu____27670 ->
+                                       let uu____27671 =
+                                         let uu____27677 =
                                            stronger_t_shape_error
                                              "not an arrow or not enough binders"
                                             in
                                          (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                           uu____27657)
+                                           uu____27677)
                                           in
-                                       FStar_Errors.raise_error uu____27651 r
+                                       FStar_Errors.raise_error uu____27671 r
                                     in
-                                 (match uu____27196 with
+                                 (match uu____27216 with
                                   | (a_b,rest_bs,f_b,stronger_c) ->
-                                      let uu____27733 =
-                                        let uu____27740 =
-                                          let uu____27741 =
-                                            let uu____27742 =
-                                              let uu____27749 =
+                                      let uu____27753 =
+                                        let uu____27760 =
+                                          let uu____27761 =
+                                            let uu____27762 =
+                                              let uu____27769 =
                                                 FStar_All.pipe_right a_b
                                                   FStar_Pervasives_Native.fst
                                                  in
-                                              (uu____27749,
+                                              (uu____27769,
                                                 (c21.FStar_Syntax_Syntax.result_typ))
                                                in
                                             FStar_Syntax_Syntax.NT
-                                              uu____27742
+                                              uu____27762
                                              in
-                                          [uu____27741]  in
+                                          [uu____27761]  in
                                         FStar_TypeChecker_Env.uvars_for_binders
-                                          env rest_bs uu____27740
+                                          env rest_bs uu____27760
                                           (fun b  ->
-                                             let uu____27765 =
+                                             let uu____27785 =
                                                FStar_Syntax_Print.binder_to_string
                                                  b
                                                 in
-                                             let uu____27767 =
+                                             let uu____27787 =
                                                FStar_Ident.string_of_lid
                                                  c21.FStar_Syntax_Syntax.effect_name
                                                 in
-                                             let uu____27769 =
+                                             let uu____27789 =
                                                FStar_Range.string_of_range r
                                                 in
                                              FStar_Util.format3
                                                "implicit for binder %s in stronger of %s at %s"
-                                               uu____27765 uu____27767
-                                               uu____27769) r
+                                               uu____27785 uu____27787
+                                               uu____27789) r
                                          in
-                                      (match uu____27733 with
+                                      (match uu____27753 with
                                        | (rest_bs_uvars,g_uvars) ->
-                                           ((let uu____27779 =
+                                           ((let uu____27799 =
                                                FStar_All.pipe_left
                                                  (FStar_TypeChecker_Env.debug
                                                     env)
                                                  (FStar_Options.Other
                                                     "LayeredEffects")
                                                 in
-                                             if uu____27779
+                                             if uu____27799
                                              then
-                                               let uu____27784 =
+                                               let uu____27804 =
                                                  FStar_List.fold_left
                                                    (fun s  ->
                                                       fun u  ->
-                                                        let uu____27793 =
-                                                          let uu____27795 =
+                                                        let uu____27813 =
+                                                          let uu____27815 =
                                                             FStar_Syntax_Print.term_to_string
                                                               u
                                                              in
                                                           Prims.op_Hat ";;;;"
-                                                            uu____27795
+                                                            uu____27815
                                                            in
                                                         Prims.op_Hat s
-                                                          uu____27793) ""
+                                                          uu____27813) ""
                                                    rest_bs_uvars
                                                   in
                                                FStar_Util.print1
                                                  "Introduced uvars for subcomp: %s\n"
-                                                 uu____27784
+                                                 uu____27804
                                              else ());
                                             (let wl4 =
-                                               let uu___3604_27803 = wl3  in
+                                               let uu___3604_27823 = wl3  in
                                                {
                                                  attempting =
-                                                   (uu___3604_27803.attempting);
+                                                   (uu___3604_27823.attempting);
                                                  wl_deferred =
-                                                   (uu___3604_27803.wl_deferred);
-                                                 ctr = (uu___3604_27803.ctr);
+                                                   (uu___3604_27823.wl_deferred);
+                                                 ctr = (uu___3604_27823.ctr);
                                                  defer_ok =
-                                                   (uu___3604_27803.defer_ok);
+                                                   (uu___3604_27823.defer_ok);
                                                  smt_ok =
-                                                   (uu___3604_27803.smt_ok);
+                                                   (uu___3604_27823.smt_ok);
                                                  umax_heuristic_ok =
-                                                   (uu___3604_27803.umax_heuristic_ok);
+                                                   (uu___3604_27823.umax_heuristic_ok);
                                                  tcenv =
-                                                   (uu___3604_27803.tcenv);
+                                                   (uu___3604_27823.tcenv);
                                                  wl_implicits =
                                                    (FStar_List.append
                                                       g_uvars.FStar_TypeChecker_Common.implicits
@@ -10309,84 +10321,84 @@ and (solve_c :
                                                FStar_List.map2
                                                  (fun b  ->
                                                     fun t  ->
-                                                      let uu____27828 =
-                                                        let uu____27835 =
+                                                      let uu____27848 =
+                                                        let uu____27855 =
                                                           FStar_All.pipe_right
                                                             b
                                                             FStar_Pervasives_Native.fst
                                                            in
-                                                        (uu____27835, t)  in
+                                                        (uu____27855, t)  in
                                                       FStar_Syntax_Syntax.NT
-                                                        uu____27828) (a_b ::
+                                                        uu____27848) (a_b ::
                                                  rest_bs)
                                                  ((c21.FStar_Syntax_Syntax.result_typ)
                                                  :: rest_bs_uvars)
                                                 in
-                                             let uu____27852 =
+                                             let uu____27872 =
                                                let f_sort_is =
-                                                 let uu____27862 =
-                                                   let uu____27863 =
-                                                     let uu____27866 =
-                                                       let uu____27867 =
+                                                 let uu____27882 =
+                                                   let uu____27883 =
+                                                     let uu____27886 =
+                                                       let uu____27887 =
                                                          FStar_All.pipe_right
                                                            f_b
                                                            FStar_Pervasives_Native.fst
                                                           in
-                                                       uu____27867.FStar_Syntax_Syntax.sort
+                                                       uu____27887.FStar_Syntax_Syntax.sort
                                                         in
                                                      FStar_Syntax_Subst.compress
-                                                       uu____27866
+                                                       uu____27886
                                                       in
-                                                   uu____27863.FStar_Syntax_Syntax.n
+                                                   uu____27883.FStar_Syntax_Syntax.n
                                                     in
-                                                 match uu____27862 with
+                                                 match uu____27882 with
                                                  | FStar_Syntax_Syntax.Tm_app
-                                                     (uu____27878,uu____27879::is)
+                                                     (uu____27898,uu____27899::is)
                                                      ->
-                                                     let uu____27921 =
+                                                     let uu____27941 =
                                                        FStar_All.pipe_right
                                                          is
                                                          (FStar_List.map
                                                             FStar_Pervasives_Native.fst)
                                                         in
                                                      FStar_All.pipe_right
-                                                       uu____27921
+                                                       uu____27941
                                                        (FStar_List.map
                                                           (FStar_Syntax_Subst.subst
                                                              substs))
-                                                 | uu____27954 ->
-                                                     let uu____27955 =
-                                                       let uu____27961 =
+                                                 | uu____27974 ->
+                                                     let uu____27975 =
+                                                       let uu____27981 =
                                                          stronger_t_shape_error
                                                            "type of f is not a repr type"
                                                           in
                                                        (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                                         uu____27961)
+                                                         uu____27981)
                                                         in
                                                      FStar_Errors.raise_error
-                                                       uu____27955 r
+                                                       uu____27975 r
                                                   in
-                                               let uu____27967 =
+                                               let uu____27987 =
                                                  FStar_All.pipe_right
                                                    c12.FStar_Syntax_Syntax.effect_args
                                                    (FStar_List.map
                                                       FStar_Pervasives_Native.fst)
                                                   in
                                                FStar_List.fold_left2
-                                                 (fun uu____28002  ->
+                                                 (fun uu____28022  ->
                                                     fun f_sort_i  ->
                                                       fun c1_i  ->
-                                                        match uu____28002
+                                                        match uu____28022
                                                         with
                                                         | (ps,wl5) ->
-                                                            let uu____28023 =
+                                                            let uu____28043 =
                                                               sub_prob wl5
                                                                 f_sort_i
                                                                 FStar_TypeChecker_Common.EQ
                                                                 c1_i
                                                                 "indices of c1"
                                                                in
-                                                            (match uu____28023
+                                                            (match uu____28043
                                                              with
                                                              | (p,wl6) ->
                                                                  ((FStar_List.append
@@ -10394,64 +10406,64 @@ and (solve_c :
                                                                     [p]),
                                                                    wl6)))
                                                  ([], wl4) f_sort_is
-                                                 uu____27967
+                                                 uu____27987
                                                 in
-                                             match uu____27852 with
+                                             match uu____27872 with
                                              | (f_sub_probs,wl5) ->
                                                  let stronger_ct =
-                                                   let uu____28048 =
+                                                   let uu____28068 =
                                                      FStar_All.pipe_right
                                                        stronger_c
                                                        (FStar_Syntax_Subst.subst_comp
                                                           substs)
                                                       in
                                                    FStar_All.pipe_right
-                                                     uu____28048
+                                                     uu____28068
                                                      FStar_Syntax_Util.comp_to_comp_typ
                                                     in
-                                                 let uu____28049 =
+                                                 let uu____28069 =
                                                    let g_sort_is =
-                                                     let uu____28059 =
-                                                       let uu____28060 =
+                                                     let uu____28079 =
+                                                       let uu____28080 =
                                                          FStar_Syntax_Subst.compress
                                                            stronger_ct.FStar_Syntax_Syntax.result_typ
                                                           in
-                                                       uu____28060.FStar_Syntax_Syntax.n
+                                                       uu____28080.FStar_Syntax_Syntax.n
                                                         in
-                                                     match uu____28059 with
+                                                     match uu____28079 with
                                                      | FStar_Syntax_Syntax.Tm_app
-                                                         (uu____28065,uu____28066::is)
+                                                         (uu____28085,uu____28086::is)
                                                          ->
                                                          FStar_All.pipe_right
                                                            is
                                                            (FStar_List.map
                                                               FStar_Pervasives_Native.fst)
-                                                     | uu____28126 ->
-                                                         let uu____28127 =
-                                                           let uu____28133 =
+                                                     | uu____28146 ->
+                                                         let uu____28147 =
+                                                           let uu____28153 =
                                                              stronger_t_shape_error
                                                                "return type is not a repr type"
                                                               in
                                                            (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                                             uu____28133)
+                                                             uu____28153)
                                                             in
                                                          FStar_Errors.raise_error
-                                                           uu____28127 r
+                                                           uu____28147 r
                                                       in
-                                                   let uu____28139 =
+                                                   let uu____28159 =
                                                      FStar_All.pipe_right
                                                        c21.FStar_Syntax_Syntax.effect_args
                                                        (FStar_List.map
                                                           FStar_Pervasives_Native.fst)
                                                       in
                                                    FStar_List.fold_left2
-                                                     (fun uu____28174  ->
+                                                     (fun uu____28194  ->
                                                         fun g_sort_i  ->
                                                           fun c2_i  ->
-                                                            match uu____28174
+                                                            match uu____28194
                                                             with
                                                             | (ps,wl6) ->
-                                                                let uu____28195
+                                                                let uu____28215
                                                                   =
                                                                   sub_prob
                                                                     wl6
@@ -10460,35 +10472,35 @@ and (solve_c :
                                                                     c2_i
                                                                     "indices of c2"
                                                                    in
-                                                                (match uu____28195
+                                                                (match uu____28215
                                                                  with
                                                                  | (p,wl7) ->
                                                                     ((FStar_List.append
                                                                     ps [p]),
                                                                     wl7)))
                                                      ([], wl5) g_sort_is
-                                                     uu____28139
+                                                     uu____28159
                                                     in
-                                                 (match uu____28049 with
+                                                 (match uu____28069 with
                                                   | (g_sub_probs,wl6) ->
                                                       let fml =
-                                                        let uu____28222 =
-                                                          let uu____28227 =
+                                                        let uu____28242 =
+                                                          let uu____28247 =
                                                             FStar_List.hd
                                                               stronger_ct.FStar_Syntax_Syntax.comp_univs
                                                              in
-                                                          let uu____28228 =
-                                                            let uu____28229 =
+                                                          let uu____28248 =
+                                                            let uu____28249 =
                                                               FStar_List.hd
                                                                 stronger_ct.FStar_Syntax_Syntax.effect_args
                                                                in
                                                             FStar_Pervasives_Native.fst
-                                                              uu____28229
+                                                              uu____28249
                                                              in
-                                                          (uu____28227,
-                                                            uu____28228)
+                                                          (uu____28247,
+                                                            uu____28248)
                                                            in
-                                                        match uu____28222
+                                                        match uu____28242
                                                         with
                                                         | (u,wp) ->
                                                             FStar_TypeChecker_Env.pure_precondition_for_trivial_post
@@ -10498,10 +10510,10 @@ and (solve_c :
                                                               FStar_Range.dummyRange
                                                          in
                                                       let sub_probs =
-                                                        let uu____28257 =
-                                                          let uu____28260 =
-                                                            let uu____28263 =
-                                                              let uu____28266
+                                                        let uu____28277 =
+                                                          let uu____28280 =
+                                                            let uu____28283 =
+                                                              let uu____28286
                                                                 =
                                                                 FStar_All.pipe_right
                                                                   g_lift.FStar_TypeChecker_Common.deferred
@@ -10510,28 +10522,28 @@ and (solve_c :
                                                                  in
                                                               FStar_List.append
                                                                 g_sub_probs
-                                                                uu____28266
+                                                                uu____28286
                                                                in
                                                             FStar_List.append
                                                               f_sub_probs
-                                                              uu____28263
+                                                              uu____28283
                                                              in
                                                           FStar_List.append
                                                             is_sub_probs
-                                                            uu____28260
+                                                            uu____28280
                                                            in
                                                         ret_sub_prob ::
-                                                          uu____28257
+                                                          uu____28277
                                                          in
                                                       let guard =
                                                         let guard =
-                                                          let uu____28290 =
+                                                          let uu____28310 =
                                                             FStar_List.map
                                                               p_guard
                                                               sub_probs
                                                              in
                                                           FStar_Syntax_Util.mk_conj_l
-                                                            uu____28290
+                                                            uu____28310
                                                            in
                                                         match g_lift.FStar_TypeChecker_Common.guard_f
                                                         with
@@ -10543,263 +10555,263 @@ and (solve_c :
                                                               guard f
                                                          in
                                                       let wl7 =
-                                                        let uu____28301 =
-                                                          let uu____28304 =
+                                                        let uu____28321 =
+                                                          let uu____28324 =
                                                             FStar_Syntax_Util.mk_conj
                                                               guard fml
                                                              in
                                                           FStar_All.pipe_left
-                                                            (fun uu____28307 
+                                                            (fun uu____28327 
                                                                ->
                                                                FStar_Pervasives_Native.Some
-                                                                 uu____28307)
-                                                            uu____28304
+                                                                 uu____28327)
+                                                            uu____28324
                                                            in
                                                         solve_prob orig
-                                                          uu____28301 [] wl6
+                                                          uu____28321 [] wl6
                                                          in
-                                                      let uu____28308 =
+                                                      let uu____28328 =
                                                         attempt sub_probs wl7
                                                          in
-                                                      solve env uu____28308))))))))))
+                                                      solve env uu____28328))))))))))
            in
         let solve_sub c11 edge c21 =
           let r = FStar_TypeChecker_Env.get_range env  in
-          let lift_c1 uu____28331 =
+          let lift_c1 uu____28351 =
             let univs =
               match c11.FStar_Syntax_Syntax.comp_univs with
               | [] ->
-                  let uu____28333 =
+                  let uu____28353 =
                     env.FStar_TypeChecker_Env.universe_of env
                       c11.FStar_Syntax_Syntax.result_typ
                      in
-                  [uu____28333]
+                  [uu____28353]
               | x -> x  in
             let c12 =
-              let uu___3670_28336 = c11  in
+              let uu___3670_28356 = c11  in
               {
                 FStar_Syntax_Syntax.comp_univs = univs;
                 FStar_Syntax_Syntax.effect_name =
-                  (uu___3670_28336.FStar_Syntax_Syntax.effect_name);
+                  (uu___3670_28356.FStar_Syntax_Syntax.effect_name);
                 FStar_Syntax_Syntax.result_typ =
-                  (uu___3670_28336.FStar_Syntax_Syntax.result_typ);
+                  (uu___3670_28356.FStar_Syntax_Syntax.result_typ);
                 FStar_Syntax_Syntax.effect_args =
-                  (uu___3670_28336.FStar_Syntax_Syntax.effect_args);
+                  (uu___3670_28356.FStar_Syntax_Syntax.effect_args);
                 FStar_Syntax_Syntax.flags =
-                  (uu___3670_28336.FStar_Syntax_Syntax.flags)
+                  (uu___3670_28356.FStar_Syntax_Syntax.flags)
               }  in
-            let uu____28337 =
-              let uu____28342 =
+            let uu____28357 =
+              let uu____28362 =
                 FStar_All.pipe_right
-                  (let uu___3673_28344 = c12  in
+                  (let uu___3673_28364 = c12  in
                    {
                      FStar_Syntax_Syntax.comp_univs = univs;
                      FStar_Syntax_Syntax.effect_name =
-                       (uu___3673_28344.FStar_Syntax_Syntax.effect_name);
+                       (uu___3673_28364.FStar_Syntax_Syntax.effect_name);
                      FStar_Syntax_Syntax.result_typ =
-                       (uu___3673_28344.FStar_Syntax_Syntax.result_typ);
+                       (uu___3673_28364.FStar_Syntax_Syntax.result_typ);
                      FStar_Syntax_Syntax.effect_args =
-                       (uu___3673_28344.FStar_Syntax_Syntax.effect_args);
+                       (uu___3673_28364.FStar_Syntax_Syntax.effect_args);
                      FStar_Syntax_Syntax.flags =
-                       (uu___3673_28344.FStar_Syntax_Syntax.flags)
+                       (uu___3673_28364.FStar_Syntax_Syntax.flags)
                    }) FStar_Syntax_Syntax.mk_Comp
                  in
-              FStar_All.pipe_right uu____28342
+              FStar_All.pipe_right uu____28362
                 ((edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
                    env)
                in
-            FStar_All.pipe_right uu____28337
-              (fun uu____28358  ->
-                 match uu____28358 with
+            FStar_All.pipe_right uu____28357
+              (fun uu____28378  ->
+                 match uu____28378 with
                  | (c,g) ->
-                     let uu____28365 =
-                       let uu____28367 = FStar_TypeChecker_Env.is_trivial g
+                     let uu____28385 =
+                       let uu____28387 = FStar_TypeChecker_Env.is_trivial g
                           in
-                       Prims.op_Negation uu____28367  in
-                     if uu____28365
+                       Prims.op_Negation uu____28387  in
+                     if uu____28385
                      then
-                       let uu____28370 =
-                         let uu____28376 =
-                           let uu____28378 =
+                       let uu____28390 =
+                         let uu____28396 =
+                           let uu____28398 =
                              FStar_Ident.string_of_lid
                                c12.FStar_Syntax_Syntax.effect_name
                               in
-                           let uu____28380 =
+                           let uu____28400 =
                              FStar_Ident.string_of_lid
                                c21.FStar_Syntax_Syntax.effect_name
                               in
                            FStar_Util.format2
                              "Lift between wp-effects (%s~>%s) should not have returned a non-trivial guard"
-                             uu____28378 uu____28380
+                             uu____28398 uu____28400
                             in
-                         (FStar_Errors.Fatal_UnexpectedEffect, uu____28376)
+                         (FStar_Errors.Fatal_UnexpectedEffect, uu____28396)
                           in
-                       FStar_Errors.raise_error uu____28370 r
+                       FStar_Errors.raise_error uu____28390 r
                      else FStar_Syntax_Util.comp_to_comp_typ c)
              in
-          let uu____28386 =
+          let uu____28406 =
             FStar_TypeChecker_Env.is_layered_effect env
               c21.FStar_Syntax_Syntax.effect_name
              in
-          if uu____28386
+          if uu____28406
           then solve_layered_sub c11 edge c21
           else
             if
               problem.FStar_TypeChecker_Common.relation =
                 FStar_TypeChecker_Common.EQ
             then
-              (let uu____28392 = lift_c1 ()  in
-               solve_eq uu____28392 c21 FStar_TypeChecker_Env.trivial_guard)
+              (let uu____28412 = lift_c1 ()  in
+               solve_eq uu____28412 c21 FStar_TypeChecker_Env.trivial_guard)
             else
               (let is_null_wp_2 =
                  FStar_All.pipe_right c21.FStar_Syntax_Syntax.flags
                    (FStar_Util.for_some
-                      (fun uu___31_28401  ->
-                         match uu___31_28401 with
+                      (fun uu___31_28421  ->
+                         match uu___31_28421 with
                          | FStar_Syntax_Syntax.TOTAL  -> true
                          | FStar_Syntax_Syntax.MLEFFECT  -> true
                          | FStar_Syntax_Syntax.SOMETRIVIAL  -> true
-                         | uu____28406 -> false))
+                         | uu____28426 -> false))
                   in
-               let uu____28408 =
+               let uu____28428 =
                  match ((c11.FStar_Syntax_Syntax.effect_args),
                          (c21.FStar_Syntax_Syntax.effect_args))
                  with
-                 | ((wp1,uu____28438)::uu____28439,(wp2,uu____28441)::uu____28442)
+                 | ((wp1,uu____28458)::uu____28459,(wp2,uu____28461)::uu____28462)
                      -> (wp1, wp2)
-                 | uu____28515 ->
-                     let uu____28540 =
-                       let uu____28546 =
-                         let uu____28548 =
+                 | uu____28535 ->
+                     let uu____28560 =
+                       let uu____28566 =
+                         let uu____28568 =
                            FStar_Syntax_Print.lid_to_string
                              c11.FStar_Syntax_Syntax.effect_name
                             in
-                         let uu____28550 =
+                         let uu____28570 =
                            FStar_Syntax_Print.lid_to_string
                              c21.FStar_Syntax_Syntax.effect_name
                             in
                          FStar_Util.format2
                            "Got effects %s and %s, expected normalized effects"
-                           uu____28548 uu____28550
+                           uu____28568 uu____28570
                           in
                        (FStar_Errors.Fatal_ExpectNormalizedEffect,
-                         uu____28546)
+                         uu____28566)
                         in
-                     FStar_Errors.raise_error uu____28540
+                     FStar_Errors.raise_error uu____28560
                        env.FStar_TypeChecker_Env.range
                   in
-               match uu____28408 with
+               match uu____28428 with
                | (wpc1,wpc2) ->
-                   let uu____28560 = FStar_Util.physical_equality wpc1 wpc2
+                   let uu____28580 = FStar_Util.physical_equality wpc1 wpc2
                       in
-                   if uu____28560
+                   if uu____28580
                    then
-                     let uu____28563 =
+                     let uu____28583 =
                        problem_using_guard orig
                          c11.FStar_Syntax_Syntax.result_typ
                          problem.FStar_TypeChecker_Common.relation
                          c21.FStar_Syntax_Syntax.result_typ
                          FStar_Pervasives_Native.None "result type"
                         in
-                     solve_t env uu____28563 wl
+                     solve_t env uu____28583 wl
                    else
-                     (let uu____28567 =
-                        let uu____28574 =
+                     (let uu____28587 =
+                        let uu____28594 =
                           FStar_TypeChecker_Env.effect_decl_opt env
                             c21.FStar_Syntax_Syntax.effect_name
                            in
-                        FStar_Util.must uu____28574  in
-                      match uu____28567 with
+                        FStar_Util.must uu____28594  in
+                      match uu____28587 with
                       | (c2_decl,qualifiers) ->
-                          let uu____28595 =
+                          let uu____28615 =
                             FStar_All.pipe_right qualifiers
                               (FStar_List.contains
                                  FStar_Syntax_Syntax.Reifiable)
                              in
-                          if uu____28595
+                          if uu____28615
                           then
                             let c1_repr =
-                              let uu____28602 =
-                                let uu____28603 =
-                                  let uu____28604 = lift_c1 ()  in
-                                  FStar_Syntax_Syntax.mk_Comp uu____28604  in
-                                let uu____28605 =
+                              let uu____28622 =
+                                let uu____28623 =
+                                  let uu____28624 = lift_c1 ()  in
+                                  FStar_Syntax_Syntax.mk_Comp uu____28624  in
+                                let uu____28625 =
                                   env.FStar_TypeChecker_Env.universe_of env
                                     c11.FStar_Syntax_Syntax.result_typ
                                    in
                                 FStar_TypeChecker_Env.reify_comp env
-                                  uu____28603 uu____28605
+                                  uu____28623 uu____28625
                                  in
                               norm_with_steps
                                 "FStar.TypeChecker.Rel.norm_with_steps.4"
                                 [FStar_TypeChecker_Env.UnfoldUntil
                                    FStar_Syntax_Syntax.delta_constant;
                                 FStar_TypeChecker_Env.Weak;
-                                FStar_TypeChecker_Env.HNF] env uu____28602
+                                FStar_TypeChecker_Env.HNF] env uu____28622
                                in
                             let c2_repr =
-                              let uu____28608 =
-                                let uu____28609 =
+                              let uu____28628 =
+                                let uu____28629 =
                                   FStar_Syntax_Syntax.mk_Comp c21  in
-                                let uu____28610 =
+                                let uu____28630 =
                                   env.FStar_TypeChecker_Env.universe_of env
                                     c21.FStar_Syntax_Syntax.result_typ
                                    in
                                 FStar_TypeChecker_Env.reify_comp env
-                                  uu____28609 uu____28610
+                                  uu____28629 uu____28630
                                  in
                               norm_with_steps
                                 "FStar.TypeChecker.Rel.norm_with_steps.5"
                                 [FStar_TypeChecker_Env.UnfoldUntil
                                    FStar_Syntax_Syntax.delta_constant;
                                 FStar_TypeChecker_Env.Weak;
-                                FStar_TypeChecker_Env.HNF] env uu____28608
+                                FStar_TypeChecker_Env.HNF] env uu____28628
                                in
-                            let uu____28612 =
-                              let uu____28617 =
-                                let uu____28619 =
+                            let uu____28632 =
+                              let uu____28637 =
+                                let uu____28639 =
                                   FStar_Syntax_Print.term_to_string c1_repr
                                    in
-                                let uu____28621 =
+                                let uu____28641 =
                                   FStar_Syntax_Print.term_to_string c2_repr
                                    in
                                 FStar_Util.format2
-                                  "sub effect repr: %s <: %s" uu____28619
-                                  uu____28621
+                                  "sub effect repr: %s <: %s" uu____28639
+                                  uu____28641
                                  in
                               sub_prob wl c1_repr
                                 problem.FStar_TypeChecker_Common.relation
-                                c2_repr uu____28617
+                                c2_repr uu____28637
                                in
-                            (match uu____28612 with
+                            (match uu____28632 with
                              | (prob,wl1) ->
                                  let wl2 =
                                    solve_prob orig
                                      (FStar_Pervasives_Native.Some
                                         (p_guard prob)) [] wl1
                                     in
-                                 let uu____28627 = attempt [prob] wl2  in
-                                 solve env uu____28627)
+                                 let uu____28647 = attempt [prob] wl2  in
+                                 solve env uu____28647)
                           else
                             (let g =
                                if env.FStar_TypeChecker_Env.lax
                                then FStar_Syntax_Util.t_true
                                else
                                  (let wpc1_2 =
-                                    let uu____28647 = lift_c1 ()  in
-                                    FStar_All.pipe_right uu____28647
+                                    let uu____28667 = lift_c1 ()  in
+                                    FStar_All.pipe_right uu____28667
                                       (fun ct  ->
                                          FStar_List.hd
                                            ct.FStar_Syntax_Syntax.effect_args)
                                      in
                                   if is_null_wp_2
                                   then
-                                    ((let uu____28670 =
+                                    ((let uu____28690 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env)
                                           (FStar_Options.Other "Rel")
                                          in
-                                      if uu____28670
+                                      if uu____28690
                                       then
                                         FStar_Util.print_string
                                           "Using trivial wp ... \n"
@@ -10810,36 +10822,36 @@ and (solve_c :
                                           c11.FStar_Syntax_Syntax.result_typ
                                          in
                                       let trivial =
-                                        let uu____28680 =
+                                        let uu____28700 =
                                           FStar_All.pipe_right c2_decl
                                             FStar_Syntax_Util.get_wp_trivial_combinator
                                            in
-                                        match uu____28680 with
+                                        match uu____28700 with
                                         | FStar_Pervasives_Native.None  ->
                                             failwith
                                               "Rel doesn't yet handle undefined trivial combinator in an effect"
                                         | FStar_Pervasives_Native.Some t -> t
                                          in
-                                      let uu____28687 =
-                                        let uu____28694 =
-                                          let uu____28695 =
-                                            let uu____28712 =
+                                      let uu____28707 =
+                                        let uu____28714 =
+                                          let uu____28715 =
+                                            let uu____28732 =
                                               FStar_TypeChecker_Env.inst_effect_fun_with
                                                 [c1_univ] env c2_decl trivial
                                                in
-                                            let uu____28715 =
-                                              let uu____28726 =
+                                            let uu____28735 =
+                                              let uu____28746 =
                                                 FStar_Syntax_Syntax.as_arg
                                                   c11.FStar_Syntax_Syntax.result_typ
                                                  in
-                                              [uu____28726; wpc1_2]  in
-                                            (uu____28712, uu____28715)  in
+                                              [uu____28746; wpc1_2]  in
+                                            (uu____28732, uu____28735)  in
                                           FStar_Syntax_Syntax.Tm_app
-                                            uu____28695
+                                            uu____28715
                                            in
-                                        FStar_Syntax_Syntax.mk uu____28694
+                                        FStar_Syntax_Syntax.mk uu____28714
                                          in
-                                      uu____28687
+                                      uu____28707
                                         FStar_Pervasives_Native.None r))
                                   else
                                     (let c2_univ =
@@ -10851,42 +10863,42 @@ and (solve_c :
                                        FStar_All.pipe_right c2_decl
                                          FStar_Syntax_Util.get_stronger_vc_combinator
                                         in
-                                     let uu____28775 =
-                                       let uu____28782 =
-                                         let uu____28783 =
-                                           let uu____28800 =
+                                     let uu____28795 =
+                                       let uu____28802 =
+                                         let uu____28803 =
+                                           let uu____28820 =
                                              FStar_TypeChecker_Env.inst_effect_fun_with
                                                [c2_univ] env c2_decl stronger
                                               in
-                                           let uu____28803 =
-                                             let uu____28814 =
+                                           let uu____28823 =
+                                             let uu____28834 =
                                                FStar_Syntax_Syntax.as_arg
                                                  c21.FStar_Syntax_Syntax.result_typ
                                                 in
-                                             let uu____28823 =
-                                               let uu____28834 =
+                                             let uu____28843 =
+                                               let uu____28854 =
                                                  FStar_Syntax_Syntax.as_arg
                                                    wpc2
                                                   in
-                                               [uu____28834; wpc1_2]  in
-                                             uu____28814 :: uu____28823  in
-                                           (uu____28800, uu____28803)  in
+                                               [uu____28854; wpc1_2]  in
+                                             uu____28834 :: uu____28843  in
+                                           (uu____28820, uu____28823)  in
                                          FStar_Syntax_Syntax.Tm_app
-                                           uu____28783
+                                           uu____28803
                                           in
-                                       FStar_Syntax_Syntax.mk uu____28782  in
-                                     uu____28775 FStar_Pervasives_Native.None
+                                       FStar_Syntax_Syntax.mk uu____28802  in
+                                     uu____28795 FStar_Pervasives_Native.None
                                        r))
                                 in
-                             (let uu____28888 =
+                             (let uu____28908 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   (FStar_Options.Other "Rel")
                                  in
-                              if uu____28888
+                              if uu____28908
                               then
-                                let uu____28893 =
-                                  let uu____28895 =
+                                let uu____28913 =
+                                  let uu____28915 =
                                     FStar_TypeChecker_Normalize.normalize
                                       [FStar_TypeChecker_Env.Iota;
                                       FStar_TypeChecker_Env.Eager_unfolding;
@@ -10894,250 +10906,250 @@ and (solve_c :
                                       FStar_TypeChecker_Env.Simplify] env g
                                      in
                                   FStar_Syntax_Print.term_to_string
-                                    uu____28895
+                                    uu____28915
                                    in
                                 FStar_Util.print1
                                   "WP guard (simplifed) is (%s)\n"
-                                  uu____28893
+                                  uu____28913
                               else ());
-                             (let uu____28899 =
+                             (let uu____28919 =
                                 sub_prob wl
                                   c11.FStar_Syntax_Syntax.result_typ
                                   problem.FStar_TypeChecker_Common.relation
                                   c21.FStar_Syntax_Syntax.result_typ
                                   "result type"
                                  in
-                              match uu____28899 with
+                              match uu____28919 with
                               | (base_prob,wl1) ->
                                   let wl2 =
-                                    let uu____28908 =
-                                      let uu____28911 =
+                                    let uu____28928 =
+                                      let uu____28931 =
                                         FStar_Syntax_Util.mk_conj
                                           (p_guard base_prob) g
                                          in
                                       FStar_All.pipe_left
-                                        (fun uu____28914  ->
+                                        (fun uu____28934  ->
                                            FStar_Pervasives_Native.Some
-                                             uu____28914) uu____28911
+                                             uu____28934) uu____28931
                                        in
-                                    solve_prob orig uu____28908 [] wl1  in
-                                  let uu____28915 = attempt [base_prob] wl2
+                                    solve_prob orig uu____28928 [] wl1  in
+                                  let uu____28935 = attempt [base_prob] wl2
                                      in
-                                  solve env uu____28915))))
+                                  solve env uu____28935))))
            in
-        let uu____28916 = FStar_Util.physical_equality c1 c2  in
-        if uu____28916
+        let uu____28936 = FStar_Util.physical_equality c1 c2  in
+        if uu____28936
         then
-          let uu____28919 =
+          let uu____28939 =
             solve_prob orig FStar_Pervasives_Native.None [] wl  in
-          solve env uu____28919
+          solve env uu____28939
         else
-          ((let uu____28923 =
+          ((let uu____28943 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                 (FStar_Options.Other "Rel")
                in
-            if uu____28923
+            if uu____28943
             then
-              let uu____28928 = FStar_Syntax_Print.comp_to_string c1  in
-              let uu____28930 = FStar_Syntax_Print.comp_to_string c2  in
-              FStar_Util.print3 "solve_c %s %s %s\n" uu____28928
+              let uu____28948 = FStar_Syntax_Print.comp_to_string c1  in
+              let uu____28950 = FStar_Syntax_Print.comp_to_string c2  in
+              FStar_Util.print3 "solve_c %s %s %s\n" uu____28948
                 (rel_to_string problem.FStar_TypeChecker_Common.relation)
-                uu____28930
+                uu____28950
             else ());
-           (let uu____28935 =
-              let uu____28944 =
+           (let uu____28955 =
+              let uu____28964 =
                 FStar_TypeChecker_Normalize.ghost_to_pure env c1  in
-              let uu____28947 =
+              let uu____28967 =
                 FStar_TypeChecker_Normalize.ghost_to_pure env c2  in
-              (uu____28944, uu____28947)  in
-            match uu____28935 with
+              (uu____28964, uu____28967)  in
+            match uu____28955 with
             | (c11,c21) ->
                 (match ((c11.FStar_Syntax_Syntax.n),
                          (c21.FStar_Syntax_Syntax.n))
                  with
                  | (FStar_Syntax_Syntax.GTotal
-                    (t1,uu____28965),FStar_Syntax_Syntax.Total
-                    (t2,uu____28967)) when
+                    (t1,uu____28985),FStar_Syntax_Syntax.Total
+                    (t2,uu____28987)) when
                      FStar_TypeChecker_Env.non_informative env t2 ->
-                     let uu____28984 =
+                     let uu____29004 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type"
                         in
-                     solve_t env uu____28984 wl
+                     solve_t env uu____29004 wl
                  | (FStar_Syntax_Syntax.GTotal
-                    uu____28986,FStar_Syntax_Syntax.Total uu____28987) ->
-                     let uu____29004 =
+                    uu____29006,FStar_Syntax_Syntax.Total uu____29007) ->
+                     let uu____29024 =
                        FStar_Thunk.mkv
                          "incompatible monad ordering: GTot </: Tot"
                         in
-                     giveup env uu____29004 orig
+                     giveup env uu____29024 orig
                  | (FStar_Syntax_Syntax.Total
-                    (t1,uu____29008),FStar_Syntax_Syntax.Total
-                    (t2,uu____29010)) ->
-                     let uu____29027 =
+                    (t1,uu____29028),FStar_Syntax_Syntax.Total
+                    (t2,uu____29030)) ->
+                     let uu____29047 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type"
                         in
-                     solve_t env uu____29027 wl
+                     solve_t env uu____29047 wl
                  | (FStar_Syntax_Syntax.GTotal
-                    (t1,uu____29030),FStar_Syntax_Syntax.GTotal
-                    (t2,uu____29032)) ->
-                     let uu____29049 =
+                    (t1,uu____29050),FStar_Syntax_Syntax.GTotal
+                    (t2,uu____29052)) ->
+                     let uu____29069 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type"
                         in
-                     solve_t env uu____29049 wl
+                     solve_t env uu____29069 wl
                  | (FStar_Syntax_Syntax.Total
-                    (t1,uu____29052),FStar_Syntax_Syntax.GTotal
-                    (t2,uu____29054)) when
+                    (t1,uu____29072),FStar_Syntax_Syntax.GTotal
+                    (t2,uu____29074)) when
                      problem.FStar_TypeChecker_Common.relation =
                        FStar_TypeChecker_Common.SUB
                      ->
-                     let uu____29071 =
+                     let uu____29091 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type"
                         in
-                     solve_t env uu____29071 wl
+                     solve_t env uu____29091 wl
                  | (FStar_Syntax_Syntax.Total
-                    (t1,uu____29074),FStar_Syntax_Syntax.GTotal
-                    (t2,uu____29076)) ->
-                     let uu____29093 = FStar_Thunk.mkv "GTot =/= Tot"  in
-                     giveup env uu____29093 orig
+                    (t1,uu____29094),FStar_Syntax_Syntax.GTotal
+                    (t2,uu____29096)) ->
+                     let uu____29113 = FStar_Thunk.mkv "GTot =/= Tot"  in
+                     giveup env uu____29113 orig
                  | (FStar_Syntax_Syntax.GTotal
-                    uu____29096,FStar_Syntax_Syntax.Comp uu____29097) ->
-                     let uu____29106 =
-                       let uu___3797_29109 = problem  in
-                       let uu____29112 =
-                         let uu____29113 =
+                    uu____29116,FStar_Syntax_Syntax.Comp uu____29117) ->
+                     let uu____29126 =
+                       let uu___3797_29129 = problem  in
+                       let uu____29132 =
+                         let uu____29133 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c11  in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____29113
+                           uu____29133
                           in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3797_29109.FStar_TypeChecker_Common.pid);
-                         FStar_TypeChecker_Common.lhs = uu____29112;
+                           (uu___3797_29129.FStar_TypeChecker_Common.pid);
+                         FStar_TypeChecker_Common.lhs = uu____29132;
                          FStar_TypeChecker_Common.relation =
-                           (uu___3797_29109.FStar_TypeChecker_Common.relation);
+                           (uu___3797_29129.FStar_TypeChecker_Common.relation);
                          FStar_TypeChecker_Common.rhs =
-                           (uu___3797_29109.FStar_TypeChecker_Common.rhs);
+                           (uu___3797_29129.FStar_TypeChecker_Common.rhs);
                          FStar_TypeChecker_Common.element =
-                           (uu___3797_29109.FStar_TypeChecker_Common.element);
+                           (uu___3797_29129.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3797_29109.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3797_29129.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3797_29109.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3797_29129.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3797_29109.FStar_TypeChecker_Common.reason);
+                           (uu___3797_29129.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3797_29109.FStar_TypeChecker_Common.loc);
+                           (uu___3797_29129.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3797_29109.FStar_TypeChecker_Common.rank)
+                           (uu___3797_29129.FStar_TypeChecker_Common.rank)
                        }  in
-                     solve_c env uu____29106 wl
+                     solve_c env uu____29126 wl
                  | (FStar_Syntax_Syntax.Total
-                    uu____29114,FStar_Syntax_Syntax.Comp uu____29115) ->
-                     let uu____29124 =
-                       let uu___3797_29127 = problem  in
-                       let uu____29130 =
-                         let uu____29131 =
+                    uu____29134,FStar_Syntax_Syntax.Comp uu____29135) ->
+                     let uu____29144 =
+                       let uu___3797_29147 = problem  in
+                       let uu____29150 =
+                         let uu____29151 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c11  in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____29131
+                           uu____29151
                           in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3797_29127.FStar_TypeChecker_Common.pid);
-                         FStar_TypeChecker_Common.lhs = uu____29130;
+                           (uu___3797_29147.FStar_TypeChecker_Common.pid);
+                         FStar_TypeChecker_Common.lhs = uu____29150;
                          FStar_TypeChecker_Common.relation =
-                           (uu___3797_29127.FStar_TypeChecker_Common.relation);
+                           (uu___3797_29147.FStar_TypeChecker_Common.relation);
                          FStar_TypeChecker_Common.rhs =
-                           (uu___3797_29127.FStar_TypeChecker_Common.rhs);
+                           (uu___3797_29147.FStar_TypeChecker_Common.rhs);
                          FStar_TypeChecker_Common.element =
-                           (uu___3797_29127.FStar_TypeChecker_Common.element);
+                           (uu___3797_29147.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3797_29127.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3797_29147.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3797_29127.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3797_29147.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3797_29127.FStar_TypeChecker_Common.reason);
+                           (uu___3797_29147.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3797_29127.FStar_TypeChecker_Common.loc);
+                           (uu___3797_29147.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3797_29127.FStar_TypeChecker_Common.rank)
+                           (uu___3797_29147.FStar_TypeChecker_Common.rank)
                        }  in
-                     solve_c env uu____29124 wl
+                     solve_c env uu____29144 wl
                  | (FStar_Syntax_Syntax.Comp
-                    uu____29132,FStar_Syntax_Syntax.GTotal uu____29133) ->
-                     let uu____29142 =
-                       let uu___3809_29145 = problem  in
-                       let uu____29148 =
-                         let uu____29149 =
+                    uu____29152,FStar_Syntax_Syntax.GTotal uu____29153) ->
+                     let uu____29162 =
+                       let uu___3809_29165 = problem  in
+                       let uu____29168 =
+                         let uu____29169 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c21  in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____29149
+                           uu____29169
                           in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3809_29145.FStar_TypeChecker_Common.pid);
+                           (uu___3809_29165.FStar_TypeChecker_Common.pid);
                          FStar_TypeChecker_Common.lhs =
-                           (uu___3809_29145.FStar_TypeChecker_Common.lhs);
+                           (uu___3809_29165.FStar_TypeChecker_Common.lhs);
                          FStar_TypeChecker_Common.relation =
-                           (uu___3809_29145.FStar_TypeChecker_Common.relation);
-                         FStar_TypeChecker_Common.rhs = uu____29148;
+                           (uu___3809_29165.FStar_TypeChecker_Common.relation);
+                         FStar_TypeChecker_Common.rhs = uu____29168;
                          FStar_TypeChecker_Common.element =
-                           (uu___3809_29145.FStar_TypeChecker_Common.element);
+                           (uu___3809_29165.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3809_29145.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3809_29165.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3809_29145.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3809_29165.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3809_29145.FStar_TypeChecker_Common.reason);
+                           (uu___3809_29165.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3809_29145.FStar_TypeChecker_Common.loc);
+                           (uu___3809_29165.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3809_29145.FStar_TypeChecker_Common.rank)
+                           (uu___3809_29165.FStar_TypeChecker_Common.rank)
                        }  in
-                     solve_c env uu____29142 wl
+                     solve_c env uu____29162 wl
                  | (FStar_Syntax_Syntax.Comp
-                    uu____29150,FStar_Syntax_Syntax.Total uu____29151) ->
-                     let uu____29160 =
-                       let uu___3809_29163 = problem  in
-                       let uu____29166 =
-                         let uu____29167 =
+                    uu____29170,FStar_Syntax_Syntax.Total uu____29171) ->
+                     let uu____29180 =
+                       let uu___3809_29183 = problem  in
+                       let uu____29186 =
+                         let uu____29187 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c21  in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____29167
+                           uu____29187
                           in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3809_29163.FStar_TypeChecker_Common.pid);
+                           (uu___3809_29183.FStar_TypeChecker_Common.pid);
                          FStar_TypeChecker_Common.lhs =
-                           (uu___3809_29163.FStar_TypeChecker_Common.lhs);
+                           (uu___3809_29183.FStar_TypeChecker_Common.lhs);
                          FStar_TypeChecker_Common.relation =
-                           (uu___3809_29163.FStar_TypeChecker_Common.relation);
-                         FStar_TypeChecker_Common.rhs = uu____29166;
+                           (uu___3809_29183.FStar_TypeChecker_Common.relation);
+                         FStar_TypeChecker_Common.rhs = uu____29186;
                          FStar_TypeChecker_Common.element =
-                           (uu___3809_29163.FStar_TypeChecker_Common.element);
+                           (uu___3809_29183.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3809_29163.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3809_29183.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3809_29163.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3809_29183.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3809_29163.FStar_TypeChecker_Common.reason);
+                           (uu___3809_29183.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3809_29163.FStar_TypeChecker_Common.loc);
+                           (uu___3809_29183.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3809_29163.FStar_TypeChecker_Common.rank)
+                           (uu___3809_29183.FStar_TypeChecker_Common.rank)
                        }  in
-                     solve_c env uu____29160 wl
+                     solve_c env uu____29180 wl
                  | (FStar_Syntax_Syntax.Comp
-                    uu____29168,FStar_Syntax_Syntax.Comp uu____29169) ->
-                     let uu____29170 =
+                    uu____29188,FStar_Syntax_Syntax.Comp uu____29189) ->
+                     let uu____29190 =
                        (((FStar_Syntax_Util.is_ml_comp c11) &&
                            (FStar_Syntax_Util.is_ml_comp c21))
                           ||
@@ -11150,16 +11162,16 @@ and (solve_c :
                             (problem.FStar_TypeChecker_Common.relation =
                                FStar_TypeChecker_Common.SUB))
                         in
-                     if uu____29170
+                     if uu____29190
                      then
-                       let uu____29173 =
+                       let uu____29193 =
                          problem_using_guard orig
                            (FStar_Syntax_Util.comp_result c11)
                            problem.FStar_TypeChecker_Common.relation
                            (FStar_Syntax_Util.comp_result c21)
                            FStar_Pervasives_Native.None "result type"
                           in
-                       solve_t env uu____29173 wl
+                       solve_t env uu____29193 wl
                      else
                        (let c1_comp =
                           FStar_TypeChecker_Env.comp_to_comp_typ env c11  in
@@ -11169,26 +11181,26 @@ and (solve_c :
                           problem.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                         then
-                          let uu____29180 =
-                            let uu____29185 =
+                          let uu____29200 =
+                            let uu____29205 =
                               FStar_Ident.lid_equals
                                 c1_comp.FStar_Syntax_Syntax.effect_name
                                 c2_comp.FStar_Syntax_Syntax.effect_name
                                in
-                            if uu____29185
+                            if uu____29205
                             then (c1_comp, c2_comp)
                             else
-                              (let uu____29194 =
+                              (let uu____29214 =
                                  FStar_TypeChecker_Env.unfold_effect_abbrev
                                    env c11
                                   in
-                               let uu____29195 =
+                               let uu____29215 =
                                  FStar_TypeChecker_Env.unfold_effect_abbrev
                                    env c21
                                   in
-                               (uu____29194, uu____29195))
+                               (uu____29214, uu____29215))
                              in
-                          match uu____29180 with
+                          match uu____29200 with
                           | (c1_comp1,c2_comp1) ->
                               solve_eq c1_comp1 c2_comp1
                                 FStar_TypeChecker_Env.trivial_guard
@@ -11201,54 +11213,61 @@ and (solve_c :
                              FStar_TypeChecker_Env.unfold_effect_abbrev env
                                c21
                               in
-                           (let uu____29203 =
+                           (let uu____29223 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "Rel")
                                in
-                            if uu____29203
+                            if uu____29223
                             then
+                              let uu____29228 =
+                                FStar_Ident.string_of_lid
+                                  c12.FStar_Syntax_Syntax.effect_name
+                                 in
+                              let uu____29230 =
+                                FStar_Ident.string_of_lid
+                                  c22.FStar_Syntax_Syntax.effect_name
+                                 in
                               FStar_Util.print2 "solve_c for %s and %s\n"
-                                (c12.FStar_Syntax_Syntax.effect_name).FStar_Ident.str
-                                (c22.FStar_Syntax_Syntax.effect_name).FStar_Ident.str
+                                uu____29228 uu____29230
                             else ());
-                           (let uu____29211 =
+                           (let uu____29235 =
                               FStar_TypeChecker_Env.monad_leq env
                                 c12.FStar_Syntax_Syntax.effect_name
                                 c22.FStar_Syntax_Syntax.effect_name
                                in
-                            match uu____29211 with
+                            match uu____29235 with
                             | FStar_Pervasives_Native.None  ->
-                                let uu____29214 =
+                                let uu____29238 =
                                   mklstr
-                                    (fun uu____29221  ->
-                                       let uu____29222 =
+                                    (fun uu____29245  ->
+                                       let uu____29246 =
                                          FStar_Syntax_Print.lid_to_string
                                            c12.FStar_Syntax_Syntax.effect_name
                                           in
-                                       let uu____29224 =
+                                       let uu____29248 =
                                          FStar_Syntax_Print.lid_to_string
                                            c22.FStar_Syntax_Syntax.effect_name
                                           in
                                        FStar_Util.format2
                                          "incompatible monad ordering: %s </: %s"
-                                         uu____29222 uu____29224)
+                                         uu____29246 uu____29248)
                                    in
-                                giveup env uu____29214 orig
+                                giveup env uu____29238 orig
                             | FStar_Pervasives_Native.Some edge ->
                                 solve_sub c12 edge c22))))))
 
 let (print_pending_implicits :
   FStar_TypeChecker_Common.guard_t -> Prims.string) =
   fun g  ->
-    let uu____29235 =
+    let uu____29259 =
       FStar_All.pipe_right g.FStar_TypeChecker_Common.implicits
         (FStar_List.map
            (fun i  ->
               FStar_Syntax_Print.term_to_string
                 i.FStar_TypeChecker_Common.imp_tm))
        in
-    FStar_All.pipe_right uu____29235 (FStar_String.concat ", ")
+    FStar_All.pipe_right uu____29259 (FStar_String.concat ", ")
   
 let (ineqs_to_string :
   (FStar_Syntax_Syntax.universe Prims.list * (FStar_Syntax_Syntax.universe *
@@ -11256,25 +11275,25 @@ let (ineqs_to_string :
   =
   fun ineqs  ->
     let vars =
-      let uu____29285 =
+      let uu____29309 =
         FStar_All.pipe_right (FStar_Pervasives_Native.fst ineqs)
           (FStar_List.map FStar_Syntax_Print.univ_to_string)
          in
-      FStar_All.pipe_right uu____29285 (FStar_String.concat ", ")  in
+      FStar_All.pipe_right uu____29309 (FStar_String.concat ", ")  in
     let ineqs1 =
-      let uu____29310 =
+      let uu____29334 =
         FStar_All.pipe_right (FStar_Pervasives_Native.snd ineqs)
           (FStar_List.map
-             (fun uu____29341  ->
-                match uu____29341 with
+             (fun uu____29365  ->
+                match uu____29365 with
                 | (u1,u2) ->
-                    let uu____29349 = FStar_Syntax_Print.univ_to_string u1
+                    let uu____29373 = FStar_Syntax_Print.univ_to_string u1
                        in
-                    let uu____29351 = FStar_Syntax_Print.univ_to_string u2
+                    let uu____29375 = FStar_Syntax_Print.univ_to_string u2
                        in
-                    FStar_Util.format2 "%s < %s" uu____29349 uu____29351))
+                    FStar_Util.format2 "%s < %s" uu____29373 uu____29375))
          in
-      FStar_All.pipe_right uu____29310 (FStar_String.concat ", ")  in
+      FStar_All.pipe_right uu____29334 (FStar_String.concat ", ")  in
     FStar_Util.format2 "Solving for {%s}; inequalities are {%s}" vars ineqs1
   
 let (guard_to_string :
@@ -11287,15 +11306,15 @@ let (guard_to_string :
               (g.FStar_TypeChecker_Common.deferred),
               (g.FStar_TypeChecker_Common.univ_ineqs))
       with
-      | (FStar_TypeChecker_Common.Trivial ,[],(uu____29388,[])) when
-          let uu____29415 = FStar_Options.print_implicits ()  in
-          Prims.op_Negation uu____29415 -> "{}"
-      | uu____29418 ->
+      | (FStar_TypeChecker_Common.Trivial ,[],(uu____29412,[])) when
+          let uu____29439 = FStar_Options.print_implicits ()  in
+          Prims.op_Negation uu____29439 -> "{}"
+      | uu____29442 ->
           let form =
             match g.FStar_TypeChecker_Common.guard_f with
             | FStar_TypeChecker_Common.Trivial  -> "trivial"
             | FStar_TypeChecker_Common.NonTrivial f ->
-                let uu____29445 =
+                let uu____29469 =
                   ((FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                       (FStar_Options.Other "Rel"))
                      ||
@@ -11303,25 +11322,25 @@ let (guard_to_string :
                         FStar_Options.Extreme))
                     || (FStar_Options.print_implicits ())
                    in
-                if uu____29445
+                if uu____29469
                 then FStar_TypeChecker_Normalize.term_to_string env f
                 else "non-trivial"
              in
           let carry =
-            let uu____29457 =
+            let uu____29481 =
               FStar_List.map
-                (fun uu____29470  ->
-                   match uu____29470 with
-                   | (uu____29477,x) -> prob_to_string env x)
+                (fun uu____29494  ->
+                   match uu____29494 with
+                   | (uu____29501,x) -> prob_to_string env x)
                 g.FStar_TypeChecker_Common.deferred
                in
-            FStar_All.pipe_right uu____29457 (FStar_String.concat ",\n")  in
+            FStar_All.pipe_right uu____29481 (FStar_String.concat ",\n")  in
           let imps = print_pending_implicits g  in
-          let uu____29488 =
+          let uu____29512 =
             ineqs_to_string g.FStar_TypeChecker_Common.univ_ineqs  in
           FStar_Util.format4
             "\n\t{guard_f=%s;\n\t deferred={\n%s};\n\t univ_ineqs={%s};\n\t implicits={%s}}\n"
-            form carry uu____29488 imps
+            form carry uu____29512 imps
   
 let (new_t_problem :
   worklist ->
@@ -11340,25 +11359,25 @@ let (new_t_problem :
             fun elt  ->
               fun loc  ->
                 let reason =
-                  let uu____29545 =
+                  let uu____29569 =
                     (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                        (FStar_Options.Other "ExplainRel"))
                       ||
                       (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "Rel"))
                      in
-                  if uu____29545
+                  if uu____29569
                   then
-                    let uu____29553 =
+                    let uu____29577 =
                       FStar_TypeChecker_Normalize.term_to_string env lhs  in
-                    let uu____29555 =
+                    let uu____29579 =
                       FStar_TypeChecker_Normalize.term_to_string env rhs  in
-                    FStar_Util.format3 "Top-level:\n%s\n\t%s\n%s" uu____29553
-                      (rel_to_string rel) uu____29555
+                    FStar_Util.format3 "Top-level:\n%s\n\t%s\n%s" uu____29577
+                      (rel_to_string rel) uu____29579
                   else "TOP"  in
-                let uu____29561 =
+                let uu____29585 =
                   new_problem wl env lhs rel rhs elt loc reason  in
-                match uu____29561 with
+                match uu____29585 with
                 | (p,wl1) ->
                     (def_check_prob (Prims.op_Hat "new_t_problem." reason)
                        (FStar_TypeChecker_Common.TProb p);
@@ -11379,19 +11398,19 @@ let (new_t_prob :
         fun rel  ->
           fun t2  ->
             let x =
-              let uu____29621 =
-                let uu____29624 = FStar_TypeChecker_Env.get_range env  in
+              let uu____29645 =
+                let uu____29648 = FStar_TypeChecker_Env.get_range env  in
                 FStar_All.pipe_left
-                  (fun uu____29627  ->
-                     FStar_Pervasives_Native.Some uu____29627) uu____29624
+                  (fun uu____29651  ->
+                     FStar_Pervasives_Native.Some uu____29651) uu____29648
                  in
-              FStar_Syntax_Syntax.new_bv uu____29621 t1  in
-            let uu____29628 =
-              let uu____29633 = FStar_TypeChecker_Env.get_range env  in
+              FStar_Syntax_Syntax.new_bv uu____29645 t1  in
+            let uu____29652 =
+              let uu____29657 = FStar_TypeChecker_Env.get_range env  in
               new_t_problem wl env t1 rel t2 (FStar_Pervasives_Native.Some x)
-                uu____29633
+                uu____29657
                in
-            match uu____29628 with | (p,wl1) -> (p, x, wl1)
+            match uu____29652 with | (p,wl1) -> (p, x, wl1)
   
 let (solve_and_commit :
   FStar_TypeChecker_Env.env ->
@@ -11407,55 +11426,55 @@ let (solve_and_commit :
     fun probs  ->
       fun err  ->
         let tx = FStar_Syntax_Unionfind.new_transaction ()  in
-        (let uu____29691 =
+        (let uu____29715 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "RelBench")
             in
-         if uu____29691
+         if uu____29715
          then
-           let uu____29696 =
+           let uu____29720 =
              FStar_Common.string_of_list
                (fun p  -> FStar_Util.string_of_int (p_pid p))
                probs.attempting
               in
-           FStar_Util.print1 "solving problems %s {\n" uu____29696
+           FStar_Util.print1 "solving problems %s {\n" uu____29720
          else ());
-        (let uu____29703 =
-           FStar_Util.record_time (fun uu____29710  -> solve env probs)  in
-         match uu____29703 with
+        (let uu____29727 =
+           FStar_Util.record_time (fun uu____29734  -> solve env probs)  in
+         match uu____29727 with
          | (sol,ms) ->
-             ((let uu____29722 =
+             ((let uu____29746 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "RelBench")
                   in
-               if uu____29722
+               if uu____29746
                then
-                 let uu____29727 = FStar_Util.string_of_int ms  in
-                 FStar_Util.print1 "} solved in %s ms\n" uu____29727
+                 let uu____29751 = FStar_Util.string_of_int ms  in
+                 FStar_Util.print1 "} solved in %s ms\n" uu____29751
                else ());
               (match sol with
                | Success (deferred,implicits) ->
-                   let uu____29740 =
+                   let uu____29764 =
                      FStar_Util.record_time
-                       (fun uu____29747  -> FStar_Syntax_Unionfind.commit tx)
+                       (fun uu____29771  -> FStar_Syntax_Unionfind.commit tx)
                       in
-                   (match uu____29740 with
+                   (match uu____29764 with
                     | ((),ms1) ->
-                        ((let uu____29758 =
+                        ((let uu____29782 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
                               (FStar_Options.Other "RelBench")
                              in
-                          if uu____29758
+                          if uu____29782
                           then
-                            let uu____29763 = FStar_Util.string_of_int ms1
+                            let uu____29787 = FStar_Util.string_of_int ms1
                                in
                             FStar_Util.print1 "committed in %s ms\n"
-                              uu____29763
+                              uu____29787
                           else ());
                          FStar_Pervasives_Native.Some (deferred, implicits)))
                | Failed (d,s) ->
-                   ((let uu____29775 =
+                   ((let uu____29799 =
                        (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                           (FStar_Options.Other "ExplainRel"))
                          ||
@@ -11463,11 +11482,11 @@ let (solve_and_commit :
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "Rel"))
                         in
-                     if uu____29775
+                     if uu____29799
                      then
-                       let uu____29782 = explain env d s  in
+                       let uu____29806 = explain env d s  in
                        FStar_All.pipe_left FStar_Util.print_string
-                         uu____29782
+                         uu____29806
                      else ());
                     (let result = err (d, s)  in
                      FStar_Syntax_Unionfind.rollback tx; result)))))
@@ -11481,14 +11500,14 @@ let (simplify_guard :
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          ((let uu____29808 =
+          ((let uu____29832 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                 (FStar_Options.Other "Simplification")
                in
-            if uu____29808
+            if uu____29832
             then
-              let uu____29813 = FStar_Syntax_Print.term_to_string f  in
-              FStar_Util.print1 "Simplifying guard %s\n" uu____29813
+              let uu____29837 = FStar_Syntax_Print.term_to_string f  in
+              FStar_Util.print1 "Simplifying guard %s\n" uu____29837
             else ());
            (let f1 =
               norm_with_steps "FStar.TypeChecker.Rel.norm_with_steps.6"
@@ -11498,34 +11517,34 @@ let (simplify_guard :
                 FStar_TypeChecker_Env.Primops;
                 FStar_TypeChecker_Env.NoFullNorm] env f
                in
-            (let uu____29821 =
+            (let uu____29845 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "Simplification")
                 in
-             if uu____29821
+             if uu____29845
              then
-               let uu____29826 = FStar_Syntax_Print.term_to_string f1  in
-               FStar_Util.print1 "Simplified guard to %s\n" uu____29826
+               let uu____29850 = FStar_Syntax_Print.term_to_string f1  in
+               FStar_Util.print1 "Simplified guard to %s\n" uu____29850
              else ());
             (let f2 =
-               let uu____29832 =
-                 let uu____29833 = FStar_Syntax_Util.unmeta f1  in
-                 uu____29833.FStar_Syntax_Syntax.n  in
-               match uu____29832 with
+               let uu____29856 =
+                 let uu____29857 = FStar_Syntax_Util.unmeta f1  in
+                 uu____29857.FStar_Syntax_Syntax.n  in
+               match uu____29856 with
                | FStar_Syntax_Syntax.Tm_fvar fv when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.true_lid
                    -> FStar_TypeChecker_Common.Trivial
-               | uu____29837 -> FStar_TypeChecker_Common.NonTrivial f1  in
-             let uu___3926_29838 = g  in
+               | uu____29861 -> FStar_TypeChecker_Common.NonTrivial f1  in
+             let uu___3926_29862 = g  in
              {
                FStar_TypeChecker_Common.guard_f = f2;
                FStar_TypeChecker_Common.deferred =
-                 (uu___3926_29838.FStar_TypeChecker_Common.deferred);
+                 (uu___3926_29862.FStar_TypeChecker_Common.deferred);
                FStar_TypeChecker_Common.univ_ineqs =
-                 (uu___3926_29838.FStar_TypeChecker_Common.univ_ineqs);
+                 (uu___3926_29862.FStar_TypeChecker_Common.univ_ineqs);
                FStar_TypeChecker_Common.implicits =
-                 (uu___3926_29838.FStar_TypeChecker_Common.implicits)
+                 (uu___3926_29862.FStar_TypeChecker_Common.implicits)
              })))
   
 let (with_guard :
@@ -11541,27 +11560,27 @@ let (with_guard :
         match dopt with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (deferred,implicits) ->
-            let uu____29881 =
-              let uu____29882 =
-                let uu____29883 =
+            let uu____29905 =
+              let uu____29906 =
+                let uu____29907 =
                   FStar_All.pipe_right (p_guard prob)
-                    (fun uu____29884  ->
-                       FStar_TypeChecker_Common.NonTrivial uu____29884)
+                    (fun uu____29908  ->
+                       FStar_TypeChecker_Common.NonTrivial uu____29908)
                    in
                 {
-                  FStar_TypeChecker_Common.guard_f = uu____29883;
+                  FStar_TypeChecker_Common.guard_f = uu____29907;
                   FStar_TypeChecker_Common.deferred = deferred;
                   FStar_TypeChecker_Common.univ_ineqs = ([], []);
                   FStar_TypeChecker_Common.implicits = implicits
                 }  in
-              simplify_guard env uu____29882  in
+              simplify_guard env uu____29906  in
             FStar_All.pipe_left
-              (fun uu____29891  -> FStar_Pervasives_Native.Some uu____29891)
-              uu____29881
+              (fun uu____29915  -> FStar_Pervasives_Native.Some uu____29915)
+              uu____29905
   
 let with_guard_no_simp :
-  'uuuuuu29901 .
-    'uuuuuu29901 ->
+  'uuuuuu29925 .
+    'uuuuuu29925 ->
       FStar_TypeChecker_Common.prob ->
         (FStar_TypeChecker_Common.deferred *
           FStar_TypeChecker_Common.implicits) FStar_Pervasives_Native.option
@@ -11573,19 +11592,19 @@ let with_guard_no_simp :
         match dopt with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (deferred,implicits) ->
-            let uu____29941 =
-              let uu____29942 =
+            let uu____29965 =
+              let uu____29966 =
                 FStar_All.pipe_right (p_guard prob)
-                  (fun uu____29943  ->
-                     FStar_TypeChecker_Common.NonTrivial uu____29943)
+                  (fun uu____29967  ->
+                     FStar_TypeChecker_Common.NonTrivial uu____29967)
                  in
               {
-                FStar_TypeChecker_Common.guard_f = uu____29942;
+                FStar_TypeChecker_Common.guard_f = uu____29966;
                 FStar_TypeChecker_Common.deferred = deferred;
                 FStar_TypeChecker_Common.univ_ineqs = ([], []);
                 FStar_TypeChecker_Common.implicits = implicits
               }  in
-            FStar_Pervasives_Native.Some uu____29941
+            FStar_Pervasives_Native.Some uu____29965
   
 let (try_teq :
   Prims.bool ->
@@ -11598,41 +11617,41 @@ let (try_teq :
     fun env  ->
       fun t1  ->
         fun t2  ->
-          (let uu____29976 =
+          (let uu____30000 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Rel")
               in
-           if uu____29976
+           if uu____30000
            then
-             let uu____29981 = FStar_Syntax_Print.term_to_string t1  in
-             let uu____29983 = FStar_Syntax_Print.term_to_string t2  in
-             FStar_Util.print2 "try_teq of %s and %s {\n" uu____29981
-               uu____29983
+             let uu____30005 = FStar_Syntax_Print.term_to_string t1  in
+             let uu____30007 = FStar_Syntax_Print.term_to_string t2  in
+             FStar_Util.print2 "try_teq of %s and %s {\n" uu____30005
+               uu____30007
            else ());
-          (let uu____29988 =
-             let uu____29993 = FStar_TypeChecker_Env.get_range env  in
+          (let uu____30012 =
+             let uu____30017 = FStar_TypeChecker_Env.get_range env  in
              new_t_problem (empty_worklist env) env t1
                FStar_TypeChecker_Common.EQ t2 FStar_Pervasives_Native.None
-               uu____29993
+               uu____30017
               in
-           match uu____29988 with
+           match uu____30012 with
            | (prob,wl) ->
                let g =
-                 let uu____30001 =
+                 let uu____30025 =
                    solve_and_commit env (singleton wl prob smt_ok)
-                     (fun uu____30009  -> FStar_Pervasives_Native.None)
+                     (fun uu____30033  -> FStar_Pervasives_Native.None)
                     in
-                 FStar_All.pipe_left (with_guard env prob) uu____30001  in
-               ((let uu____30027 =
+                 FStar_All.pipe_left (with_guard env prob) uu____30025  in
+               ((let uu____30051 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                      (FStar_Options.Other "Rel")
                     in
-                 if uu____30027
+                 if uu____30051
                  then
-                   let uu____30032 =
+                   let uu____30056 =
                      FStar_Common.string_of_option (guard_to_string env) g
                       in
-                   FStar_Util.print1 "} res = %s\n" uu____30032
+                   FStar_Util.print1 "} res = %s\n" uu____30056
                  else ());
                 g))
   
@@ -11644,29 +11663,29 @@ let (teq :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____30053 = try_teq true env t1 t2  in
-        match uu____30053 with
+        let uu____30077 = try_teq true env t1 t2  in
+        match uu____30077 with
         | FStar_Pervasives_Native.None  ->
-            ((let uu____30058 = FStar_TypeChecker_Env.get_range env  in
-              let uu____30059 =
+            ((let uu____30082 = FStar_TypeChecker_Env.get_range env  in
+              let uu____30083 =
                 FStar_TypeChecker_Err.basic_type_error env
                   FStar_Pervasives_Native.None t2 t1
                  in
-              FStar_Errors.log_issue uu____30058 uu____30059);
+              FStar_Errors.log_issue uu____30082 uu____30083);
              FStar_TypeChecker_Common.trivial_guard)
         | FStar_Pervasives_Native.Some g ->
-            ((let uu____30067 =
+            ((let uu____30091 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                   (FStar_Options.Other "Rel")
                  in
-              if uu____30067
+              if uu____30091
               then
-                let uu____30072 = FStar_Syntax_Print.term_to_string t1  in
-                let uu____30074 = FStar_Syntax_Print.term_to_string t2  in
-                let uu____30076 = guard_to_string env g  in
+                let uu____30096 = FStar_Syntax_Print.term_to_string t1  in
+                let uu____30098 = FStar_Syntax_Print.term_to_string t2  in
+                let uu____30100 = guard_to_string env g  in
                 FStar_Util.print3
-                  "teq of %s and %s succeeded with guard %s\n" uu____30072
-                  uu____30074 uu____30076
+                  "teq of %s and %s succeeded with guard %s\n" uu____30096
+                  uu____30098 uu____30100
               else ());
              g)
   
@@ -11679,47 +11698,47 @@ let (get_teq_predicate :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        (let uu____30100 =
+        (let uu____30124 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel")
             in
-         if uu____30100
+         if uu____30124
          then
-           let uu____30105 = FStar_Syntax_Print.term_to_string t1  in
-           let uu____30107 = FStar_Syntax_Print.term_to_string t2  in
-           FStar_Util.print2 "get_teq_predicate of %s and %s {\n" uu____30105
-             uu____30107
+           let uu____30129 = FStar_Syntax_Print.term_to_string t1  in
+           let uu____30131 = FStar_Syntax_Print.term_to_string t2  in
+           FStar_Util.print2 "get_teq_predicate of %s and %s {\n" uu____30129
+             uu____30131
          else ());
-        (let uu____30112 =
+        (let uu____30136 =
            new_t_prob (empty_worklist env) env t1 FStar_TypeChecker_Common.EQ
              t2
             in
-         match uu____30112 with
+         match uu____30136 with
          | (prob,x,wl) ->
              let g =
-               let uu____30127 =
+               let uu____30151 =
                  solve_and_commit env (singleton wl prob true)
-                   (fun uu____30136  -> FStar_Pervasives_Native.None)
+                   (fun uu____30160  -> FStar_Pervasives_Native.None)
                   in
-               FStar_All.pipe_left (with_guard env prob) uu____30127  in
-             ((let uu____30154 =
+               FStar_All.pipe_left (with_guard env prob) uu____30151  in
+             ((let uu____30178 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Rel")
                   in
-               if uu____30154
+               if uu____30178
                then
-                 let uu____30159 =
+                 let uu____30183 =
                    FStar_Common.string_of_option (guard_to_string env) g  in
-                 FStar_Util.print1 "} res teq predicate = %s\n" uu____30159
+                 FStar_Util.print1 "} res teq predicate = %s\n" uu____30183
                else ());
               (match g with
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some g1 ->
-                   let uu____30167 =
-                     let uu____30168 = FStar_Syntax_Syntax.mk_binder x  in
-                     FStar_TypeChecker_Env.abstract_guard uu____30168 g1  in
-                   FStar_Pervasives_Native.Some uu____30167)))
+                   let uu____30191 =
+                     let uu____30192 = FStar_Syntax_Syntax.mk_binder x  in
+                     FStar_TypeChecker_Env.abstract_guard uu____30192 g1  in
+                   FStar_Pervasives_Native.Some uu____30191)))
   
 let (subtype_fail :
   FStar_TypeChecker_Env.env ->
@@ -11730,12 +11749,12 @@ let (subtype_fail :
     fun e  ->
       fun t1  ->
         fun t2  ->
-          let uu____30190 = FStar_TypeChecker_Env.get_range env  in
-          let uu____30191 =
+          let uu____30214 = FStar_TypeChecker_Env.get_range env  in
+          let uu____30215 =
             FStar_TypeChecker_Err.basic_type_error env
               (FStar_Pervasives_Native.Some e) t2 t1
              in
-          FStar_Errors.log_issue uu____30190 uu____30191
+          FStar_Errors.log_issue uu____30214 uu____30215
   
 let (sub_comp :
   FStar_TypeChecker_Env.env ->
@@ -11750,55 +11769,55 @@ let (sub_comp :
           if env.FStar_TypeChecker_Env.use_eq
           then FStar_TypeChecker_Common.EQ
           else FStar_TypeChecker_Common.SUB  in
-        (let uu____30220 =
+        (let uu____30244 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel")
             in
-         if uu____30220
+         if uu____30244
          then
-           let uu____30225 = FStar_Syntax_Print.comp_to_string c1  in
-           let uu____30227 = FStar_Syntax_Print.comp_to_string c2  in
+           let uu____30249 = FStar_Syntax_Print.comp_to_string c1  in
+           let uu____30251 = FStar_Syntax_Print.comp_to_string c2  in
            FStar_Util.print3 "sub_comp of %s --and-- %s --with-- %s\n"
-             uu____30225 uu____30227
+             uu____30249 uu____30251
              (if rel = FStar_TypeChecker_Common.EQ then "EQ" else "SUB")
          else ());
-        (let uu____30238 =
-           let uu____30245 = FStar_TypeChecker_Env.get_range env  in
+        (let uu____30262 =
+           let uu____30269 = FStar_TypeChecker_Env.get_range env  in
            new_problem (empty_worklist env) env c1 rel c2
-             FStar_Pervasives_Native.None uu____30245 "sub_comp"
+             FStar_Pervasives_Native.None uu____30269 "sub_comp"
             in
-         match uu____30238 with
+         match uu____30262 with
          | (prob,wl) ->
              let prob1 = FStar_TypeChecker_Common.CProb prob  in
              (def_check_prob "sub_comp" prob1;
-              (let uu____30258 =
+              (let uu____30282 =
                  FStar_Util.record_time
-                   (fun uu____30270  ->
-                      let uu____30271 =
+                   (fun uu____30294  ->
+                      let uu____30295 =
                         solve_and_commit env (singleton wl prob1 true)
-                          (fun uu____30280  -> FStar_Pervasives_Native.None)
+                          (fun uu____30304  -> FStar_Pervasives_Native.None)
                          in
-                      FStar_All.pipe_left (with_guard env prob1) uu____30271)
+                      FStar_All.pipe_left (with_guard env prob1) uu____30295)
                   in
-               match uu____30258 with
+               match uu____30282 with
                | (r,ms) ->
-                   ((let uu____30308 =
+                   ((let uu____30332 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "RelBench")
                         in
-                     if uu____30308
+                     if uu____30332
                      then
-                       let uu____30313 = FStar_Syntax_Print.comp_to_string c1
+                       let uu____30337 = FStar_Syntax_Print.comp_to_string c1
                           in
-                       let uu____30315 = FStar_Syntax_Print.comp_to_string c2
+                       let uu____30339 = FStar_Syntax_Print.comp_to_string c2
                           in
-                       let uu____30317 = FStar_Util.string_of_int ms  in
+                       let uu____30341 = FStar_Util.string_of_int ms  in
                        FStar_Util.print4
                          "sub_comp of %s --and-- %s --with-- %s --- solved in %s ms\n"
-                         uu____30313 uu____30315
+                         uu____30337 uu____30339
                          (if rel = FStar_TypeChecker_Common.EQ
                           then "EQ"
-                          else "SUB") uu____30317
+                          else "SUB") uu____30341
                      else ());
                     r))))
   
@@ -11811,53 +11830,53 @@ let (solve_universe_inequalities' :
   =
   fun tx  ->
     fun env  ->
-      fun uu____30355  ->
-        match uu____30355 with
+      fun uu____30379  ->
+        match uu____30379 with
         | (variables,ineqs) ->
             let fail u1 u2 =
               FStar_Syntax_Unionfind.rollback tx;
-              (let uu____30398 =
-                 let uu____30404 =
-                   let uu____30406 = FStar_Syntax_Print.univ_to_string u1  in
-                   let uu____30408 = FStar_Syntax_Print.univ_to_string u2  in
+              (let uu____30422 =
+                 let uu____30428 =
+                   let uu____30430 = FStar_Syntax_Print.univ_to_string u1  in
+                   let uu____30432 = FStar_Syntax_Print.univ_to_string u2  in
                    FStar_Util.format2 "Universe %s and %s are incompatible"
-                     uu____30406 uu____30408
+                     uu____30430 uu____30432
                     in
-                 (FStar_Errors.Fatal_IncompatibleUniverse, uu____30404)  in
-               let uu____30412 = FStar_TypeChecker_Env.get_range env  in
-               FStar_Errors.raise_error uu____30398 uu____30412)
+                 (FStar_Errors.Fatal_IncompatibleUniverse, uu____30428)  in
+               let uu____30436 = FStar_TypeChecker_Env.get_range env  in
+               FStar_Errors.raise_error uu____30422 uu____30436)
                in
             let equiv v v' =
-              let uu____30425 =
-                let uu____30430 = FStar_Syntax_Subst.compress_univ v  in
-                let uu____30431 = FStar_Syntax_Subst.compress_univ v'  in
-                (uu____30430, uu____30431)  in
-              match uu____30425 with
+              let uu____30449 =
+                let uu____30454 = FStar_Syntax_Subst.compress_univ v  in
+                let uu____30455 = FStar_Syntax_Subst.compress_univ v'  in
+                (uu____30454, uu____30455)  in
+              match uu____30449 with
               | (FStar_Syntax_Syntax.U_unif v0,FStar_Syntax_Syntax.U_unif
                  v0') -> FStar_Syntax_Unionfind.univ_equiv v0 v0'
-              | uu____30451 -> false  in
+              | uu____30475 -> false  in
             let sols =
               FStar_All.pipe_right variables
                 (FStar_List.collect
                    (fun v  ->
-                      let uu____30482 = FStar_Syntax_Subst.compress_univ v
+                      let uu____30506 = FStar_Syntax_Subst.compress_univ v
                          in
-                      match uu____30482 with
-                      | FStar_Syntax_Syntax.U_unif uu____30489 ->
+                      match uu____30506 with
+                      | FStar_Syntax_Syntax.U_unif uu____30513 ->
                           let lower_bounds_of_v =
                             FStar_All.pipe_right ineqs
                               (FStar_List.collect
-                                 (fun uu____30518  ->
-                                    match uu____30518 with
+                                 (fun uu____30542  ->
+                                    match uu____30542 with
                                     | (u,v') ->
-                                        let uu____30527 = equiv v v'  in
-                                        if uu____30527
+                                        let uu____30551 = equiv v v'  in
+                                        if uu____30551
                                         then
-                                          let uu____30532 =
+                                          let uu____30556 =
                                             FStar_All.pipe_right variables
                                               (FStar_Util.for_some (equiv u))
                                              in
-                                          (if uu____30532 then [] else [u])
+                                          (if uu____30556 then [] else [u])
                                         else []))
                              in
                           let lb =
@@ -11866,41 +11885,41 @@ let (solve_universe_inequalities' :
                               (FStar_Syntax_Syntax.U_max lower_bounds_of_v)
                              in
                           [(lb, v)]
-                      | uu____30553 -> []))
+                      | uu____30577 -> []))
                in
-            let uu____30558 =
+            let uu____30582 =
               let wl =
-                let uu___4037_30562 = empty_worklist env  in
+                let uu___4037_30586 = empty_worklist env  in
                 {
-                  attempting = (uu___4037_30562.attempting);
-                  wl_deferred = (uu___4037_30562.wl_deferred);
-                  ctr = (uu___4037_30562.ctr);
+                  attempting = (uu___4037_30586.attempting);
+                  wl_deferred = (uu___4037_30586.wl_deferred);
+                  ctr = (uu___4037_30586.ctr);
                   defer_ok = false;
-                  smt_ok = (uu___4037_30562.smt_ok);
-                  umax_heuristic_ok = (uu___4037_30562.umax_heuristic_ok);
-                  tcenv = (uu___4037_30562.tcenv);
-                  wl_implicits = (uu___4037_30562.wl_implicits)
+                  smt_ok = (uu___4037_30586.smt_ok);
+                  umax_heuristic_ok = (uu___4037_30586.umax_heuristic_ok);
+                  tcenv = (uu___4037_30586.tcenv);
+                  wl_implicits = (uu___4037_30586.wl_implicits)
                 }  in
               FStar_All.pipe_right sols
                 (FStar_List.map
-                   (fun uu____30581  ->
-                      match uu____30581 with
+                   (fun uu____30605  ->
+                      match uu____30605 with
                       | (lb,v) ->
-                          let uu____30588 =
+                          let uu____30612 =
                             solve_universe_eq (~- Prims.int_one) wl lb v  in
-                          (match uu____30588 with
+                          (match uu____30612 with
                            | USolved wl1 -> ()
-                           | uu____30591 -> fail lb v)))
+                           | uu____30615 -> fail lb v)))
                in
-            let rec check_ineq uu____30602 =
-              match uu____30602 with
+            let rec check_ineq uu____30626 =
+              match uu____30626 with
               | (u,v) ->
                   let u1 =
                     FStar_TypeChecker_Normalize.normalize_universe env u  in
                   let v1 =
                     FStar_TypeChecker_Normalize.normalize_universe env v  in
                   (match (u1, v1) with
-                   | (FStar_Syntax_Syntax.U_zero ,uu____30614) -> true
+                   | (FStar_Syntax_Syntax.U_zero ,uu____30638) -> true
                    | (FStar_Syntax_Syntax.U_succ
                       u0,FStar_Syntax_Syntax.U_succ v0) ->
                        check_ineq (u0, v0)
@@ -11911,70 +11930,70 @@ let (solve_universe_inequalities' :
                       u0,FStar_Syntax_Syntax.U_unif v0) ->
                        FStar_Syntax_Unionfind.univ_equiv u0 v0
                    | (FStar_Syntax_Syntax.U_name
-                      uu____30638,FStar_Syntax_Syntax.U_succ v0) ->
+                      uu____30662,FStar_Syntax_Syntax.U_succ v0) ->
                        check_ineq (u1, v0)
                    | (FStar_Syntax_Syntax.U_unif
-                      uu____30640,FStar_Syntax_Syntax.U_succ v0) ->
+                      uu____30664,FStar_Syntax_Syntax.U_succ v0) ->
                        check_ineq (u1, v0)
-                   | (FStar_Syntax_Syntax.U_max us,uu____30651) ->
+                   | (FStar_Syntax_Syntax.U_max us,uu____30675) ->
                        FStar_All.pipe_right us
                          (FStar_Util.for_all (fun u2  -> check_ineq (u2, v1)))
-                   | (uu____30659,FStar_Syntax_Syntax.U_max vs) ->
+                   | (uu____30683,FStar_Syntax_Syntax.U_max vs) ->
                        FStar_All.pipe_right vs
                          (FStar_Util.for_some
                             (fun v2  -> check_ineq (u1, v2)))
-                   | uu____30668 -> false)
+                   | uu____30692 -> false)
                in
-            let uu____30674 =
+            let uu____30698 =
               FStar_All.pipe_right ineqs
                 (FStar_Util.for_all
-                   (fun uu____30691  ->
-                      match uu____30691 with
+                   (fun uu____30715  ->
+                      match uu____30715 with
                       | (u,v) ->
-                          let uu____30699 = check_ineq (u, v)  in
-                          if uu____30699
+                          let uu____30723 = check_ineq (u, v)  in
+                          if uu____30723
                           then true
                           else
-                            ((let uu____30707 =
+                            ((let uu____30731 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   (FStar_Options.Other "GenUniverses")
                                  in
-                              if uu____30707
+                              if uu____30731
                               then
-                                let uu____30712 =
+                                let uu____30736 =
                                   FStar_Syntax_Print.univ_to_string u  in
-                                let uu____30714 =
+                                let uu____30738 =
                                   FStar_Syntax_Print.univ_to_string v  in
-                                FStar_Util.print2 "%s </= %s" uu____30712
-                                  uu____30714
+                                FStar_Util.print2 "%s </= %s" uu____30736
+                                  uu____30738
                               else ());
                              false)))
                in
-            if uu____30674
+            if uu____30698
             then ()
             else
-              ((let uu____30724 =
+              ((let uu____30748 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                     (FStar_Options.Other "GenUniverses")
                    in
-                if uu____30724
+                if uu____30748
                 then
-                  ((let uu____30730 = ineqs_to_string (variables, ineqs)  in
+                  ((let uu____30754 = ineqs_to_string (variables, ineqs)  in
                     FStar_Util.print1
                       "Partially solved inequality constraints are: %s\n"
-                      uu____30730);
+                      uu____30754);
                    FStar_Syntax_Unionfind.rollback tx;
-                   (let uu____30742 = ineqs_to_string (variables, ineqs)  in
+                   (let uu____30766 = ineqs_to_string (variables, ineqs)  in
                     FStar_Util.print1
                       "Original solved inequality constraints are: %s\n"
-                      uu____30742))
+                      uu____30766))
                 else ());
-               (let uu____30755 = FStar_TypeChecker_Env.get_range env  in
+               (let uu____30779 = FStar_TypeChecker_Env.get_range env  in
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_FailToSolveUniverseInEquality,
                     "Failed to solve universe inequalities for inductives")
-                  uu____30755))
+                  uu____30779))
   
 let (solve_universe_inequalities :
   FStar_TypeChecker_Env.env ->
@@ -11995,8 +12014,8 @@ let (try_solve_deferred_constraints :
   fun defer_ok  ->
     fun env  ->
       fun g  ->
-        let fail uu____30828 =
-          match uu____30828 with
+        let fail uu____30852 =
+          match uu____30852 with
           | (d,s) ->
               let msg = explain env d s  in
               FStar_Errors.raise_error
@@ -12004,67 +12023,67 @@ let (try_solve_deferred_constraints :
                 (p_loc d)
            in
         let wl =
-          let uu___4114_30851 =
+          let uu___4114_30875 =
             wl_of_guard env g.FStar_TypeChecker_Common.deferred  in
           {
-            attempting = (uu___4114_30851.attempting);
-            wl_deferred = (uu___4114_30851.wl_deferred);
-            ctr = (uu___4114_30851.ctr);
+            attempting = (uu___4114_30875.attempting);
+            wl_deferred = (uu___4114_30875.wl_deferred);
+            ctr = (uu___4114_30875.ctr);
             defer_ok;
-            smt_ok = (uu___4114_30851.smt_ok);
-            umax_heuristic_ok = (uu___4114_30851.umax_heuristic_ok);
-            tcenv = (uu___4114_30851.tcenv);
-            wl_implicits = (uu___4114_30851.wl_implicits)
+            smt_ok = (uu___4114_30875.smt_ok);
+            umax_heuristic_ok = (uu___4114_30875.umax_heuristic_ok);
+            tcenv = (uu___4114_30875.tcenv);
+            wl_implicits = (uu___4114_30875.wl_implicits)
           }  in
-        (let uu____30854 =
+        (let uu____30878 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel")
             in
-         if uu____30854
+         if uu____30878
          then
-           let uu____30859 = FStar_Util.string_of_bool defer_ok  in
-           let uu____30861 = wl_to_string wl  in
-           let uu____30863 =
+           let uu____30883 = FStar_Util.string_of_bool defer_ok  in
+           let uu____30885 = wl_to_string wl  in
+           let uu____30887 =
              FStar_Util.string_of_int
                (FStar_List.length g.FStar_TypeChecker_Common.implicits)
               in
            FStar_Util.print3
              "Trying to solve carried problems (defer_ok=%s): begin\n\t%s\nend\n and %s implicits\n"
-             uu____30859 uu____30861 uu____30863
+             uu____30883 uu____30885 uu____30887
          else ());
         (let g1 =
-           let uu____30869 = solve_and_commit env wl fail  in
-           match uu____30869 with
+           let uu____30893 = solve_and_commit env wl fail  in
+           match uu____30893 with
            | FStar_Pervasives_Native.Some
-               (uu____30876::uu____30877,uu____30878) when
+               (uu____30900::uu____30901,uu____30902) when
                Prims.op_Negation defer_ok ->
                failwith "Impossible: Unexpected deferred constraints remain"
            | FStar_Pervasives_Native.Some (deferred,imps) ->
-               let uu___4129_30907 = g  in
+               let uu___4129_30931 = g  in
                {
                  FStar_TypeChecker_Common.guard_f =
-                   (uu___4129_30907.FStar_TypeChecker_Common.guard_f);
+                   (uu___4129_30931.FStar_TypeChecker_Common.guard_f);
                  FStar_TypeChecker_Common.deferred = deferred;
                  FStar_TypeChecker_Common.univ_ineqs =
-                   (uu___4129_30907.FStar_TypeChecker_Common.univ_ineqs);
+                   (uu___4129_30931.FStar_TypeChecker_Common.univ_ineqs);
                  FStar_TypeChecker_Common.implicits =
                    (FStar_List.append g.FStar_TypeChecker_Common.implicits
                       imps)
                }
-           | uu____30908 ->
+           | uu____30932 ->
                failwith "Impossible: should have raised a failure already"
             in
          solve_universe_inequalities env
            g1.FStar_TypeChecker_Common.univ_ineqs;
-         (let uu___4134_30917 = g1  in
+         (let uu___4134_30941 = g1  in
           {
             FStar_TypeChecker_Common.guard_f =
-              (uu___4134_30917.FStar_TypeChecker_Common.guard_f);
+              (uu___4134_30941.FStar_TypeChecker_Common.guard_f);
             FStar_TypeChecker_Common.deferred =
-              (uu___4134_30917.FStar_TypeChecker_Common.deferred);
+              (uu___4134_30941.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs = ([], []);
             FStar_TypeChecker_Common.implicits =
-              (uu___4134_30917.FStar_TypeChecker_Common.implicits)
+              (uu___4134_30941.FStar_TypeChecker_Common.implicits)
           }))
   
 let (solve_deferred_constraints :
@@ -12098,21 +12117,21 @@ let (discharge_guard' :
              in
           let g1 = solve_deferred_constraints env g  in
           let ret_g =
-            let uu___4146_30994 = g1  in
+            let uu___4146_31018 = g1  in
             {
               FStar_TypeChecker_Common.guard_f =
                 FStar_TypeChecker_Common.Trivial;
               FStar_TypeChecker_Common.deferred =
-                (uu___4146_30994.FStar_TypeChecker_Common.deferred);
+                (uu___4146_31018.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___4146_30994.FStar_TypeChecker_Common.univ_ineqs);
+                (uu___4146_31018.FStar_TypeChecker_Common.univ_ineqs);
               FStar_TypeChecker_Common.implicits =
-                (uu___4146_30994.FStar_TypeChecker_Common.implicits)
+                (uu___4146_31018.FStar_TypeChecker_Common.implicits)
             }  in
-          let uu____30995 =
-            let uu____30997 = FStar_TypeChecker_Env.should_verify env  in
-            Prims.op_Negation uu____30997  in
-          if uu____30995
+          let uu____31019 =
+            let uu____31021 = FStar_TypeChecker_Env.should_verify env  in
+            Prims.op_Negation uu____31021  in
+          if uu____31019
           then FStar_Pervasives_Native.Some ret_g
           else
             (match g1.FStar_TypeChecker_Common.guard_f with
@@ -12121,49 +12140,49 @@ let (discharge_guard' :
              | FStar_TypeChecker_Common.NonTrivial vc ->
                  (if debug
                   then
-                    (let uu____31009 = FStar_TypeChecker_Env.get_range env
+                    (let uu____31033 = FStar_TypeChecker_Env.get_range env
                         in
-                     let uu____31010 =
-                       let uu____31012 = FStar_Syntax_Print.term_to_string vc
+                     let uu____31034 =
+                       let uu____31036 = FStar_Syntax_Print.term_to_string vc
                           in
                        FStar_Util.format1 "Before normalization VC=\n%s\n"
-                         uu____31012
+                         uu____31036
                         in
-                     FStar_Errors.diag uu____31009 uu____31010)
+                     FStar_Errors.diag uu____31033 uu____31034)
                   else ();
                   (let vc1 =
-                     let uu____31018 =
-                       let uu____31022 =
-                         let uu____31024 =
+                     let uu____31042 =
+                       let uu____31046 =
+                         let uu____31048 =
                            FStar_TypeChecker_Env.current_module env  in
-                         FStar_Ident.string_of_lid uu____31024  in
-                       FStar_Pervasives_Native.Some uu____31022  in
+                         FStar_Ident.string_of_lid uu____31048  in
+                       FStar_Pervasives_Native.Some uu____31046  in
                      FStar_Profiling.profile
-                       (fun uu____31027  ->
+                       (fun uu____31051  ->
                           FStar_TypeChecker_Normalize.normalize
                             [FStar_TypeChecker_Env.Eager_unfolding;
                             FStar_TypeChecker_Env.Simplify;
                             FStar_TypeChecker_Env.Primops] env vc)
-                       uu____31018 "FStar.TypeChecker.Rel.vc_normalization"
+                       uu____31042 "FStar.TypeChecker.Rel.vc_normalization"
                       in
                    if debug
                    then
-                     (let uu____31031 = FStar_TypeChecker_Env.get_range env
+                     (let uu____31055 = FStar_TypeChecker_Env.get_range env
                          in
-                      let uu____31032 =
-                        let uu____31034 =
+                      let uu____31056 =
+                        let uu____31058 =
                           FStar_Syntax_Print.term_to_string vc1  in
                         FStar_Util.format1 "After normalization VC=\n%s\n"
-                          uu____31034
+                          uu____31058
                          in
-                      FStar_Errors.diag uu____31031 uu____31032)
+                      FStar_Errors.diag uu____31055 uu____31056)
                    else ();
-                   (let uu____31040 = FStar_TypeChecker_Env.get_range env  in
-                    FStar_TypeChecker_Env.def_check_closed_in_env uu____31040
+                   (let uu____31064 = FStar_TypeChecker_Env.get_range env  in
+                    FStar_TypeChecker_Env.def_check_closed_in_env uu____31064
                       "discharge_guard'" env vc1);
-                   (let uu____31042 =
+                   (let uu____31066 =
                       FStar_TypeChecker_Common.check_trivial vc1  in
-                    match uu____31042 with
+                    match uu____31066 with
                     | FStar_TypeChecker_Common.Trivial  ->
                         FStar_Pervasives_Native.Some ret_g
                     | FStar_TypeChecker_Common.NonTrivial vc2 ->
@@ -12171,78 +12190,78 @@ let (discharge_guard' :
                         then
                           (if debug
                            then
-                             (let uu____31051 =
+                             (let uu____31075 =
                                 FStar_TypeChecker_Env.get_range env  in
-                              let uu____31052 =
-                                let uu____31054 =
+                              let uu____31076 =
+                                let uu____31078 =
                                   FStar_Syntax_Print.term_to_string vc2  in
                                 FStar_Util.format1
                                   "Cannot solve without SMT : %s\n"
-                                  uu____31054
+                                  uu____31078
                                  in
-                              FStar_Errors.diag uu____31051 uu____31052)
+                              FStar_Errors.diag uu____31075 uu____31076)
                            else ();
                            FStar_Pervasives_Native.None)
                         else
                           (if debug
                            then
-                             (let uu____31064 =
+                             (let uu____31088 =
                                 FStar_TypeChecker_Env.get_range env  in
-                              let uu____31065 =
-                                let uu____31067 =
+                              let uu____31089 =
+                                let uu____31091 =
                                   FStar_Syntax_Print.term_to_string vc2  in
                                 FStar_Util.format1 "Checking VC=\n%s\n"
-                                  uu____31067
+                                  uu____31091
                                  in
-                              FStar_Errors.diag uu____31064 uu____31065)
+                              FStar_Errors.diag uu____31088 uu____31089)
                            else ();
                            (let vcs =
-                              let uu____31081 = FStar_Options.use_tactics ()
+                              let uu____31105 = FStar_Options.use_tactics ()
                                  in
-                              if uu____31081
+                              if uu____31105
                               then
                                 FStar_Options.with_saved_options
-                                  (fun uu____31103  ->
-                                     (let uu____31105 =
+                                  (fun uu____31127  ->
+                                     (let uu____31129 =
                                         FStar_Options.set_options
                                           "--no_tactics"
                                          in
                                       FStar_All.pipe_left
-                                        (fun uu____31107  -> ()) uu____31105);
+                                        (fun uu____31131  -> ()) uu____31129);
                                      (let vcs =
                                         (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.preprocess
                                           env vc2
                                          in
                                       FStar_All.pipe_right vcs
                                         (FStar_List.map
-                                           (fun uu____31150  ->
-                                              match uu____31150 with
+                                           (fun uu____31174  ->
+                                              match uu____31174 with
                                               | (env1,goal,opts) ->
-                                                  let uu____31166 =
+                                                  let uu____31190 =
                                                     norm_with_steps
                                                       "FStar.TypeChecker.Rel.norm_with_steps.7"
                                                       [FStar_TypeChecker_Env.Simplify;
                                                       FStar_TypeChecker_Env.Primops]
                                                       env1 goal
                                                      in
-                                                  (env1, uu____31166, opts)))))
+                                                  (env1, uu____31190, opts)))))
                               else
-                                (let uu____31170 =
-                                   let uu____31177 = FStar_Options.peek ()
+                                (let uu____31194 =
+                                   let uu____31201 = FStar_Options.peek ()
                                       in
-                                   (env, vc2, uu____31177)  in
-                                 [uu____31170])
+                                   (env, vc2, uu____31201)  in
+                                 [uu____31194])
                                in
                             FStar_All.pipe_right vcs
                               (FStar_List.iter
-                                 (fun uu____31210  ->
-                                    match uu____31210 with
+                                 (fun uu____31234  ->
+                                    match uu____31234 with
                                     | (env1,goal,opts) ->
-                                        let uu____31220 =
+                                        let uu____31244 =
                                           FStar_TypeChecker_Common.check_trivial
                                             goal
                                            in
-                                        (match uu____31220 with
+                                        (match uu____31244 with
                                          | FStar_TypeChecker_Common.Trivial 
                                              ->
                                              if debug
@@ -12256,43 +12275,43 @@ let (discharge_guard' :
                                               FStar_Options.set opts;
                                               if debug
                                               then
-                                                (let uu____31231 =
+                                                (let uu____31255 =
                                                    FStar_TypeChecker_Env.get_range
                                                      env1
                                                     in
-                                                 let uu____31232 =
-                                                   let uu____31234 =
+                                                 let uu____31256 =
+                                                   let uu____31258 =
                                                      FStar_Syntax_Print.term_to_string
                                                        goal1
                                                       in
-                                                   let uu____31236 =
+                                                   let uu____31260 =
                                                      FStar_TypeChecker_Env.string_of_proof_ns
                                                        env1
                                                       in
                                                    FStar_Util.format2
                                                      "Trying to solve:\n> %s\nWith proof_ns:\n %s\n"
-                                                     uu____31234 uu____31236
+                                                     uu____31258 uu____31260
                                                     in
                                                  FStar_Errors.diag
-                                                   uu____31231 uu____31232)
+                                                   uu____31255 uu____31256)
                                               else ();
                                               if debug
                                               then
-                                                (let uu____31243 =
+                                                (let uu____31267 =
                                                    FStar_TypeChecker_Env.get_range
                                                      env1
                                                     in
-                                                 let uu____31244 =
-                                                   let uu____31246 =
+                                                 let uu____31268 =
+                                                   let uu____31270 =
                                                      FStar_Syntax_Print.term_to_string
                                                        goal1
                                                       in
                                                    FStar_Util.format1
                                                      "Before calling solver VC=\n%s\n"
-                                                     uu____31246
+                                                     uu____31270
                                                     in
                                                  FStar_Errors.diag
-                                                   uu____31243 uu____31244)
+                                                   uu____31267 uu____31268)
                                               else ();
                                               (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.solve
                                                 use_env_range_msg env1 goal1;
@@ -12305,15 +12324,15 @@ let (discharge_guard_no_smt :
   =
   fun env  ->
     fun g  ->
-      let uu____31264 =
+      let uu____31288 =
         discharge_guard' FStar_Pervasives_Native.None env g false  in
-      match uu____31264 with
+      match uu____31288 with
       | FStar_Pervasives_Native.Some g1 -> g1
       | FStar_Pervasives_Native.None  ->
-          let uu____31273 = FStar_TypeChecker_Env.get_range env  in
+          let uu____31297 = FStar_TypeChecker_Env.get_range env  in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_ExpectTrivialPreCondition,
-              "Expected a trivial pre-condition") uu____31273
+              "Expected a trivial pre-condition") uu____31297
   
 let (discharge_guard :
   FStar_TypeChecker_Env.env ->
@@ -12321,9 +12340,9 @@ let (discharge_guard :
   =
   fun env  ->
     fun g  ->
-      let uu____31287 =
+      let uu____31311 =
         discharge_guard' FStar_Pervasives_Native.None env g true  in
-      match uu____31287 with
+      match uu____31311 with
       | FStar_Pervasives_Native.Some g1 -> g1
       | FStar_Pervasives_Native.None  ->
           failwith
@@ -12338,8 +12357,8 @@ let (teq_nosmt :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____31317 = try_teq false env t1 t2  in
-        match uu____31317 with
+        let uu____31341 = try_teq false env t1 t2  in
+        match uu____31341 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some g ->
             discharge_guard' FStar_Pervasives_Native.None env g false
@@ -12355,26 +12374,26 @@ let (resolve_implicits' :
       fun forcelax  ->
         fun g  ->
           let rec unresolved ctx_u =
-            let uu____31361 =
+            let uu____31385 =
               FStar_Syntax_Unionfind.find
                 ctx_u.FStar_Syntax_Syntax.ctx_uvar_head
                in
-            match uu____31361 with
+            match uu____31385 with
             | FStar_Pervasives_Native.Some r ->
                 (match ctx_u.FStar_Syntax_Syntax.ctx_uvar_meta with
                  | FStar_Pervasives_Native.None  -> false
-                 | FStar_Pervasives_Native.Some uu____31374 ->
-                     let uu____31387 =
-                       let uu____31388 = FStar_Syntax_Subst.compress r  in
-                       uu____31388.FStar_Syntax_Syntax.n  in
-                     (match uu____31387 with
-                      | FStar_Syntax_Syntax.Tm_uvar (ctx_u',uu____31393) ->
+                 | FStar_Pervasives_Native.Some uu____31398 ->
+                     let uu____31411 =
+                       let uu____31412 = FStar_Syntax_Subst.compress r  in
+                       uu____31412.FStar_Syntax_Syntax.n  in
+                     (match uu____31411 with
+                      | FStar_Syntax_Syntax.Tm_uvar (ctx_u',uu____31417) ->
                           unresolved ctx_u'
-                      | uu____31410 -> false))
+                      | uu____31434 -> false))
             | FStar_Pervasives_Native.None  -> true  in
           let rec until_fixpoint acc implicits =
-            let uu____31434 = acc  in
-            match uu____31434 with
+            let uu____31458 = acc  in
+            match uu____31458 with
             | (out,changed) ->
                 (match implicits with
                  | [] ->
@@ -12382,8 +12401,8 @@ let (resolve_implicits' :
                      then out
                      else until_fixpoint ([], false) out
                  | hd::tl ->
-                     let uu____31453 = hd  in
-                     (match uu____31453 with
+                     let uu____31477 = hd  in
+                     (match uu____31477 with
                       | { FStar_TypeChecker_Common.imp_reason = reason;
                           FStar_TypeChecker_Common.imp_uvar = ctx_u;
                           FStar_TypeChecker_Common.imp_tm = tm;
@@ -12393,8 +12412,8 @@ let (resolve_implicits' :
                               FStar_Syntax_Syntax.Allow_unresolved
                           then until_fixpoint (out, true) tl
                           else
-                            (let uu____31464 = unresolved ctx_u  in
-                             if uu____31464
+                            (let uu____31488 = unresolved ctx_u  in
+                             if uu____31488
                              then
                                match ctx_u.FStar_Syntax_Syntax.ctx_uvar_meta
                                with
@@ -12403,19 +12422,19 @@ let (resolve_implicits' :
                                | FStar_Pervasives_Native.Some (env_dyn,tau)
                                    ->
                                    let env1 = FStar_Dyn.undyn env_dyn  in
-                                   ((let uu____31488 =
+                                   ((let uu____31512 =
                                        FStar_TypeChecker_Env.debug env1
                                          (FStar_Options.Other "Tac")
                                         in
-                                     if uu____31488
+                                     if uu____31512
                                      then
-                                       let uu____31492 =
+                                       let uu____31516 =
                                          FStar_Syntax_Print.ctx_uvar_to_string
                                            ctx_u
                                           in
                                        FStar_Util.print1
                                          "Running tactic for meta-arg %s\n"
-                                         uu____31492
+                                         uu____31516
                                      else ());
                                     (let t =
                                        env1.FStar_TypeChecker_Env.synth_hook
@@ -12424,9 +12443,9 @@ let (resolve_implicits' :
                                          tau
                                         in
                                      let extra =
-                                       let uu____31501 = teq_nosmt env1 t tm
+                                       let uu____31525 = teq_nosmt env1 t tm
                                           in
-                                       match uu____31501 with
+                                       match uu____31525 with
                                        | FStar_Pervasives_Native.None  ->
                                            failwith
                                              "resolve_implicits: unifying with an unresolved uvar failed?"
@@ -12434,40 +12453,40 @@ let (resolve_implicits' :
                                            g1.FStar_TypeChecker_Common.implicits
                                         in
                                      let ctx_u1 =
-                                       let uu___4259_31511 = ctx_u  in
+                                       let uu___4259_31535 = ctx_u  in
                                        {
                                          FStar_Syntax_Syntax.ctx_uvar_head =
-                                           (uu___4259_31511.FStar_Syntax_Syntax.ctx_uvar_head);
+                                           (uu___4259_31535.FStar_Syntax_Syntax.ctx_uvar_head);
                                          FStar_Syntax_Syntax.ctx_uvar_gamma =
-                                           (uu___4259_31511.FStar_Syntax_Syntax.ctx_uvar_gamma);
+                                           (uu___4259_31535.FStar_Syntax_Syntax.ctx_uvar_gamma);
                                          FStar_Syntax_Syntax.ctx_uvar_binders
                                            =
-                                           (uu___4259_31511.FStar_Syntax_Syntax.ctx_uvar_binders);
+                                           (uu___4259_31535.FStar_Syntax_Syntax.ctx_uvar_binders);
                                          FStar_Syntax_Syntax.ctx_uvar_typ =
-                                           (uu___4259_31511.FStar_Syntax_Syntax.ctx_uvar_typ);
+                                           (uu___4259_31535.FStar_Syntax_Syntax.ctx_uvar_typ);
                                          FStar_Syntax_Syntax.ctx_uvar_reason
                                            =
-                                           (uu___4259_31511.FStar_Syntax_Syntax.ctx_uvar_reason);
+                                           (uu___4259_31535.FStar_Syntax_Syntax.ctx_uvar_reason);
                                          FStar_Syntax_Syntax.ctx_uvar_should_check
                                            =
-                                           (uu___4259_31511.FStar_Syntax_Syntax.ctx_uvar_should_check);
+                                           (uu___4259_31535.FStar_Syntax_Syntax.ctx_uvar_should_check);
                                          FStar_Syntax_Syntax.ctx_uvar_range =
-                                           (uu___4259_31511.FStar_Syntax_Syntax.ctx_uvar_range);
+                                           (uu___4259_31535.FStar_Syntax_Syntax.ctx_uvar_range);
                                          FStar_Syntax_Syntax.ctx_uvar_meta =
                                            FStar_Pervasives_Native.None
                                        }  in
                                      let hd1 =
-                                       let uu___4262_31519 = hd  in
+                                       let uu___4262_31543 = hd  in
                                        {
                                          FStar_TypeChecker_Common.imp_reason
                                            =
-                                           (uu___4262_31519.FStar_TypeChecker_Common.imp_reason);
+                                           (uu___4262_31543.FStar_TypeChecker_Common.imp_reason);
                                          FStar_TypeChecker_Common.imp_uvar =
                                            ctx_u1;
                                          FStar_TypeChecker_Common.imp_tm =
-                                           (uu___4262_31519.FStar_TypeChecker_Common.imp_tm);
+                                           (uu___4262_31543.FStar_TypeChecker_Common.imp_tm);
                                          FStar_TypeChecker_Common.imp_range =
-                                           (uu___4262_31519.FStar_TypeChecker_Common.imp_range)
+                                           (uu___4262_31543.FStar_TypeChecker_Common.imp_range)
                                        }  in
                                      until_fixpoint (out, true)
                                        (FStar_List.append extra tl)))
@@ -12478,107 +12497,107 @@ let (resolve_implicits' :
                                then until_fixpoint (out, true) tl
                                else
                                  (let env1 =
-                                    let uu___4266_31530 = env  in
+                                    let uu___4266_31554 = env  in
                                     {
                                       FStar_TypeChecker_Env.solver =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.solver);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.solver);
                                       FStar_TypeChecker_Env.range =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.range);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.range);
                                       FStar_TypeChecker_Env.curmodule =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.curmodule);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.curmodule);
                                       FStar_TypeChecker_Env.gamma =
                                         (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
                                       FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.gamma_sig);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.gamma_sig);
                                       FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.gamma_cache);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.gamma_cache);
                                       FStar_TypeChecker_Env.modules =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.modules);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.modules);
                                       FStar_TypeChecker_Env.expected_typ =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.expected_typ);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.expected_typ);
                                       FStar_TypeChecker_Env.sigtab =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.sigtab);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.sigtab);
                                       FStar_TypeChecker_Env.attrtab =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.attrtab);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.attrtab);
                                       FStar_TypeChecker_Env.instantiate_imp =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.instantiate_imp);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.instantiate_imp);
                                       FStar_TypeChecker_Env.effects =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.effects);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.effects);
                                       FStar_TypeChecker_Env.generalize =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.generalize);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.generalize);
                                       FStar_TypeChecker_Env.letrecs =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.letrecs);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.letrecs);
                                       FStar_TypeChecker_Env.top_level =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.top_level);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.top_level);
                                       FStar_TypeChecker_Env.check_uvars =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.check_uvars);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.check_uvars);
                                       FStar_TypeChecker_Env.use_eq =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.use_eq);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.use_eq);
                                       FStar_TypeChecker_Env.use_eq_strict =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.use_eq_strict);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.use_eq_strict);
                                       FStar_TypeChecker_Env.is_iface =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.is_iface);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.is_iface);
                                       FStar_TypeChecker_Env.admit =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.admit);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.admit);
                                       FStar_TypeChecker_Env.lax =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.lax);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.lax);
                                       FStar_TypeChecker_Env.lax_universes =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.lax_universes);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.phase1);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.phase1);
                                       FStar_TypeChecker_Env.failhard =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.failhard);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.failhard);
                                       FStar_TypeChecker_Env.nosynth =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.nosynth);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.nosynth);
                                       FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.uvar_subtyping);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.tc_term =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.tc_term);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.type_of =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.type_of);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.type_of);
                                       FStar_TypeChecker_Env.universe_of =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.universe_of);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.universe_of);
                                       FStar_TypeChecker_Env.check_type_of =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.check_type_of);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.check_type_of);
                                       FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.use_bv_sorts);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.use_bv_sorts);
                                       FStar_TypeChecker_Env.qtbl_name_and_index
                                         =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.qtbl_name_and_index);
                                       FStar_TypeChecker_Env.normalized_eff_names
                                         =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.normalized_eff_names);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.normalized_eff_names);
                                       FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.fv_delta_depths);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.fv_delta_depths);
                                       FStar_TypeChecker_Env.proof_ns =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.proof_ns);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.proof_ns);
                                       FStar_TypeChecker_Env.synth_hook =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.synth_hook);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.synth_hook);
                                       FStar_TypeChecker_Env.try_solve_implicits_hook
                                         =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                       FStar_TypeChecker_Env.splice =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.splice);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.splice);
                                       FStar_TypeChecker_Env.mpreprocess =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.mpreprocess);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.mpreprocess);
                                       FStar_TypeChecker_Env.postprocess =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.postprocess);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.postprocess);
                                       FStar_TypeChecker_Env.is_native_tactic
                                         =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.is_native_tactic);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.is_native_tactic);
                                       FStar_TypeChecker_Env.identifier_info =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.identifier_info);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.identifier_info);
                                       FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.tc_hooks);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.tc_hooks);
                                       FStar_TypeChecker_Env.dsenv =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.dsenv);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.nbe =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.nbe);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.strict_args_tab);
+                                        (uu___4266_31554.FStar_TypeChecker_Env.strict_args_tab);
                                       FStar_TypeChecker_Env.erasable_types_tab
                                         =
-                                        (uu___4266_31530.FStar_TypeChecker_Env.erasable_types_tab)
+                                        (uu___4266_31554.FStar_TypeChecker_Env.erasable_types_tab)
                                     }  in
                                   let tm1 =
                                     norm_with_steps
@@ -12588,141 +12607,141 @@ let (resolve_implicits' :
                                   let env2 =
                                     if forcelax
                                     then
-                                      let uu___4271_31535 = env1  in
+                                      let uu___4271_31559 = env1  in
                                       {
                                         FStar_TypeChecker_Env.solver =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.solver);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.solver);
                                         FStar_TypeChecker_Env.range =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.range);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.range);
                                         FStar_TypeChecker_Env.curmodule =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.curmodule);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.curmodule);
                                         FStar_TypeChecker_Env.gamma =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.gamma);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.gamma);
                                         FStar_TypeChecker_Env.gamma_sig =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.gamma_sig);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.gamma_sig);
                                         FStar_TypeChecker_Env.gamma_cache =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.gamma_cache);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.gamma_cache);
                                         FStar_TypeChecker_Env.modules =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.modules);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.modules);
                                         FStar_TypeChecker_Env.expected_typ =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.expected_typ);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.expected_typ);
                                         FStar_TypeChecker_Env.sigtab =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.sigtab);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.sigtab);
                                         FStar_TypeChecker_Env.attrtab =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.attrtab);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.attrtab);
                                         FStar_TypeChecker_Env.instantiate_imp
                                           =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.instantiate_imp);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.instantiate_imp);
                                         FStar_TypeChecker_Env.effects =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.effects);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.effects);
                                         FStar_TypeChecker_Env.generalize =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.generalize);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.generalize);
                                         FStar_TypeChecker_Env.letrecs =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.letrecs);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.letrecs);
                                         FStar_TypeChecker_Env.top_level =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.top_level);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.top_level);
                                         FStar_TypeChecker_Env.check_uvars =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.check_uvars);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.check_uvars);
                                         FStar_TypeChecker_Env.use_eq =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.use_eq);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.use_eq);
                                         FStar_TypeChecker_Env.use_eq_strict =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.use_eq_strict);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.use_eq_strict);
                                         FStar_TypeChecker_Env.is_iface =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.is_iface);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.is_iface);
                                         FStar_TypeChecker_Env.admit =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.admit);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.admit);
                                         FStar_TypeChecker_Env.lax = true;
                                         FStar_TypeChecker_Env.lax_universes =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.lax_universes);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.lax_universes);
                                         FStar_TypeChecker_Env.phase1 =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.phase1);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.phase1);
                                         FStar_TypeChecker_Env.failhard =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.failhard);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.failhard);
                                         FStar_TypeChecker_Env.nosynth =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.nosynth);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.nosynth);
                                         FStar_TypeChecker_Env.uvar_subtyping
                                           =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.uvar_subtyping);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.uvar_subtyping);
                                         FStar_TypeChecker_Env.tc_term =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.tc_term);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.tc_term);
                                         FStar_TypeChecker_Env.type_of =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.type_of);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.type_of);
                                         FStar_TypeChecker_Env.universe_of =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.universe_of);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.universe_of);
                                         FStar_TypeChecker_Env.check_type_of =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.check_type_of);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.check_type_of);
                                         FStar_TypeChecker_Env.use_bv_sorts =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.use_bv_sorts);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.use_bv_sorts);
                                         FStar_TypeChecker_Env.qtbl_name_and_index
                                           =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.qtbl_name_and_index);
                                         FStar_TypeChecker_Env.normalized_eff_names
                                           =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.normalized_eff_names);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.normalized_eff_names);
                                         FStar_TypeChecker_Env.fv_delta_depths
                                           =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.fv_delta_depths);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.fv_delta_depths);
                                         FStar_TypeChecker_Env.proof_ns =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.proof_ns);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.proof_ns);
                                         FStar_TypeChecker_Env.synth_hook =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.synth_hook);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.synth_hook);
                                         FStar_TypeChecker_Env.try_solve_implicits_hook
                                           =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                         FStar_TypeChecker_Env.splice =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.splice);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.splice);
                                         FStar_TypeChecker_Env.mpreprocess =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.mpreprocess);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.mpreprocess);
                                         FStar_TypeChecker_Env.postprocess =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.postprocess);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.postprocess);
                                         FStar_TypeChecker_Env.is_native_tactic
                                           =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.is_native_tactic);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.is_native_tactic);
                                         FStar_TypeChecker_Env.identifier_info
                                           =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.identifier_info);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.identifier_info);
                                         FStar_TypeChecker_Env.tc_hooks =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.tc_hooks);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.tc_hooks);
                                         FStar_TypeChecker_Env.dsenv =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.dsenv);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.dsenv);
                                         FStar_TypeChecker_Env.nbe =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.nbe);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.nbe);
                                         FStar_TypeChecker_Env.strict_args_tab
                                           =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.strict_args_tab);
+                                          (uu___4271_31559.FStar_TypeChecker_Env.strict_args_tab);
                                         FStar_TypeChecker_Env.erasable_types_tab
                                           =
-                                          (uu___4271_31535.FStar_TypeChecker_Env.erasable_types_tab)
+                                          (uu___4271_31559.FStar_TypeChecker_Env.erasable_types_tab)
                                       }
                                     else env1  in
-                                  (let uu____31540 =
+                                  (let uu____31564 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env2)
                                        (FStar_Options.Other "Rel")
                                       in
-                                   if uu____31540
+                                   if uu____31564
                                    then
-                                     let uu____31545 =
+                                     let uu____31569 =
                                        FStar_Syntax_Print.uvar_to_string
                                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_head
                                         in
-                                     let uu____31547 =
+                                     let uu____31571 =
                                        FStar_Syntax_Print.term_to_string tm1
                                         in
-                                     let uu____31549 =
+                                     let uu____31573 =
                                        FStar_Syntax_Print.term_to_string
                                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ
                                         in
-                                     let uu____31551 =
+                                     let uu____31575 =
                                        FStar_Range.string_of_range r  in
                                      FStar_Util.print5
                                        "Checking uvar %s resolved to %s at type %s, introduce for %s at %s\n"
-                                       uu____31545 uu____31547 uu____31549
-                                       reason uu____31551
+                                       uu____31569 uu____31571 uu____31573
+                                       reason uu____31575
                                    else ());
                                   (let g1 =
                                      try
-                                       (fun uu___4277_31558  ->
+                                       (fun uu___4277_31582  ->
                                           match () with
                                           | () ->
                                               env2.FStar_TypeChecker_Env.check_type_of
@@ -12731,59 +12750,59 @@ let (resolve_implicits' :
                                          ()
                                      with
                                      | e when FStar_Errors.handleable e ->
-                                         ((let uu____31565 =
-                                             let uu____31575 =
-                                               let uu____31583 =
-                                                 let uu____31585 =
+                                         ((let uu____31589 =
+                                             let uu____31599 =
+                                               let uu____31607 =
+                                                 let uu____31609 =
                                                    FStar_Syntax_Print.uvar_to_string
                                                      ctx_u.FStar_Syntax_Syntax.ctx_uvar_head
                                                     in
-                                                 let uu____31587 =
+                                                 let uu____31611 =
                                                    FStar_TypeChecker_Normalize.term_to_string
                                                      env2 tm1
                                                     in
-                                                 let uu____31589 =
+                                                 let uu____31613 =
                                                    FStar_TypeChecker_Normalize.term_to_string
                                                      env2
                                                      ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ
                                                     in
                                                  FStar_Util.format3
                                                    "Failed while checking implicit %s set to %s of expected type %s"
-                                                   uu____31585 uu____31587
-                                                   uu____31589
+                                                   uu____31609 uu____31611
+                                                   uu____31613
                                                   in
                                                (FStar_Errors.Error_BadImplicit,
-                                                 uu____31583, r)
+                                                 uu____31607, r)
                                                 in
-                                             [uu____31575]  in
+                                             [uu____31599]  in
                                            FStar_Errors.add_errors
-                                             uu____31565);
+                                             uu____31589);
                                           FStar_Exn.raise e)
                                       in
                                    let g' =
-                                     let uu____31608 =
+                                     let uu____31632 =
                                        discharge_guard'
                                          (FStar_Pervasives_Native.Some
-                                            (fun uu____31619  ->
-                                               let uu____31620 =
+                                            (fun uu____31643  ->
+                                               let uu____31644 =
                                                  FStar_Syntax_Print.term_to_string
                                                    tm1
                                                   in
-                                               let uu____31622 =
+                                               let uu____31646 =
                                                  FStar_Range.string_of_range
                                                    r
                                                   in
-                                               let uu____31624 =
+                                               let uu____31648 =
                                                  FStar_Range.string_of_range
                                                    tm1.FStar_Syntax_Syntax.pos
                                                   in
                                                FStar_Util.format4
                                                  "%s (Introduced at %s for %s resolved at %s)"
-                                                 uu____31620 uu____31622
-                                                 reason uu____31624)) env2 g1
+                                                 uu____31644 uu____31646
+                                                 reason uu____31648)) env2 g1
                                          true
                                         in
-                                     match uu____31608 with
+                                     match uu____31632 with
                                      | FStar_Pervasives_Native.Some g2 -> g2
                                      | FStar_Pervasives_Native.None  ->
                                          failwith
@@ -12794,18 +12813,18 @@ let (resolve_implicits' :
                                          g'.FStar_TypeChecker_Common.implicits
                                          out), true) tl)))))
              in
-          let uu___4289_31632 = g  in
-          let uu____31633 =
+          let uu___4289_31656 = g  in
+          let uu____31657 =
             until_fixpoint ([], false) g.FStar_TypeChecker_Common.implicits
              in
           {
             FStar_TypeChecker_Common.guard_f =
-              (uu___4289_31632.FStar_TypeChecker_Common.guard_f);
+              (uu___4289_31656.FStar_TypeChecker_Common.guard_f);
             FStar_TypeChecker_Common.deferred =
-              (uu___4289_31632.FStar_TypeChecker_Common.deferred);
+              (uu___4289_31656.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___4289_31632.FStar_TypeChecker_Common.univ_ineqs);
-            FStar_TypeChecker_Common.implicits = uu____31633
+              (uu___4289_31656.FStar_TypeChecker_Common.univ_ineqs);
+            FStar_TypeChecker_Common.implicits = uu____31657
           }
   
 let (resolve_implicits :
@@ -12827,31 +12846,31 @@ let (force_trivial_guard :
   fun env  ->
     fun g  ->
       let g1 =
-        let uu____31673 = solve_deferred_constraints env g  in
-        FStar_All.pipe_right uu____31673 (resolve_implicits env)  in
+        let uu____31697 = solve_deferred_constraints env g  in
+        FStar_All.pipe_right uu____31697 (resolve_implicits env)  in
       match g1.FStar_TypeChecker_Common.implicits with
       | [] ->
-          let uu____31674 = discharge_guard env g1  in
-          FStar_All.pipe_left (fun uu____31675  -> ()) uu____31674
-      | imp::uu____31677 ->
-          let uu____31680 =
-            let uu____31686 =
-              let uu____31688 =
+          let uu____31698 = discharge_guard env g1  in
+          FStar_All.pipe_left (fun uu____31699  -> ()) uu____31698
+      | imp::uu____31701 ->
+          let uu____31704 =
+            let uu____31710 =
+              let uu____31712 =
                 FStar_Syntax_Print.uvar_to_string
                   (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head
                  in
-              let uu____31690 =
+              let uu____31714 =
                 FStar_TypeChecker_Normalize.term_to_string env
                   (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_typ
                  in
               FStar_Util.format3
                 "Failed to resolve implicit argument %s of type %s introduced for %s"
-                uu____31688 uu____31690
+                uu____31712 uu____31714
                 imp.FStar_TypeChecker_Common.imp_reason
                in
-            (FStar_Errors.Fatal_FailToResolveImplicitArgument, uu____31686)
+            (FStar_Errors.Fatal_FailToResolveImplicitArgument, uu____31710)
              in
-          FStar_Errors.raise_error uu____31680
+          FStar_Errors.raise_error uu____31704
             imp.FStar_TypeChecker_Common.imp_range
   
 let (teq_force :
@@ -12861,8 +12880,8 @@ let (teq_force :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____31710 = teq env t1 t2  in
-        force_trivial_guard env uu____31710
+        let uu____31734 = teq env t1 t2  in
+        force_trivial_guard env uu____31734
   
 let (teq_nosmt_force :
   FStar_TypeChecker_Env.env ->
@@ -12871,8 +12890,8 @@ let (teq_nosmt_force :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____31729 = teq_nosmt env t1 t2  in
-        match uu____31729 with
+        let uu____31753 = teq_nosmt env t1 t2  in
+        match uu____31753 with
         | FStar_Pervasives_Native.None  -> false
         | FStar_Pervasives_Native.Some g -> (force_trivial_guard env g; true)
   
@@ -12882,15 +12901,15 @@ let (universe_inequality :
   =
   fun u1  ->
     fun u2  ->
-      let uu___4314_31748 = FStar_TypeChecker_Common.trivial_guard  in
+      let uu___4314_31772 = FStar_TypeChecker_Common.trivial_guard  in
       {
         FStar_TypeChecker_Common.guard_f =
-          (uu___4314_31748.FStar_TypeChecker_Common.guard_f);
+          (uu___4314_31772.FStar_TypeChecker_Common.guard_f);
         FStar_TypeChecker_Common.deferred =
-          (uu___4314_31748.FStar_TypeChecker_Common.deferred);
+          (uu___4314_31772.FStar_TypeChecker_Common.deferred);
         FStar_TypeChecker_Common.univ_ineqs = ([], [(u1, u2)]);
         FStar_TypeChecker_Common.implicits =
-          (uu___4314_31748.FStar_TypeChecker_Common.implicits)
+          (uu___4314_31772.FStar_TypeChecker_Common.implicits)
       }
   
 let (check_subtyping :
@@ -12903,48 +12922,48 @@ let (check_subtyping :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        (let uu____31784 =
+        (let uu____31808 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel")
             in
-         if uu____31784
+         if uu____31808
          then
-           let uu____31789 =
+           let uu____31813 =
              FStar_TypeChecker_Normalize.term_to_string env t1  in
-           let uu____31791 =
+           let uu____31815 =
              FStar_TypeChecker_Normalize.term_to_string env t2  in
-           FStar_Util.print2 "check_subtyping of %s and %s\n" uu____31789
-             uu____31791
+           FStar_Util.print2 "check_subtyping of %s and %s\n" uu____31813
+             uu____31815
          else ());
-        (let uu____31796 =
+        (let uu____31820 =
            new_t_prob (empty_worklist env) env t1
              FStar_TypeChecker_Common.SUB t2
             in
-         match uu____31796 with
+         match uu____31820 with
          | (prob,x,wl) ->
              let g =
-               let uu____31815 =
+               let uu____31839 =
                  solve_and_commit env (singleton wl prob true)
-                   (fun uu____31824  -> FStar_Pervasives_Native.None)
+                   (fun uu____31848  -> FStar_Pervasives_Native.None)
                   in
-               FStar_All.pipe_left (with_guard env prob) uu____31815  in
-             ((let uu____31842 =
+               FStar_All.pipe_left (with_guard env prob) uu____31839  in
+             ((let uu____31866 =
                  (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                     (FStar_Options.Other "Rel"))
                    && (FStar_Util.is_some g)
                   in
-               if uu____31842
+               if uu____31866
                then
-                 let uu____31847 =
+                 let uu____31871 =
                    FStar_TypeChecker_Normalize.term_to_string env t1  in
-                 let uu____31849 =
+                 let uu____31873 =
                    FStar_TypeChecker_Normalize.term_to_string env t2  in
-                 let uu____31851 =
-                   let uu____31853 = FStar_Util.must g  in
-                   guard_to_string env uu____31853  in
+                 let uu____31875 =
+                   let uu____31877 = FStar_Util.must g  in
+                   guard_to_string env uu____31877  in
                  FStar_Util.print3
                    "check_subtyping succeeded: %s <: %s\n\tguard is %s\n"
-                   uu____31847 uu____31849 uu____31851
+                   uu____31871 uu____31873 uu____31875
                else ());
               (match g with
                | FStar_Pervasives_Native.None  ->
@@ -12961,14 +12980,14 @@ let (get_subtyping_predicate :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____31890 = check_subtyping env t1 t2  in
-        match uu____31890 with
+        let uu____31914 = check_subtyping env t1 t2  in
+        match uu____31914 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (x,g) ->
-            let uu____31909 =
-              let uu____31910 = FStar_Syntax_Syntax.mk_binder x  in
-              FStar_TypeChecker_Env.abstract_guard uu____31910 g  in
-            FStar_Pervasives_Native.Some uu____31909
+            let uu____31933 =
+              let uu____31934 = FStar_Syntax_Syntax.mk_binder x  in
+              FStar_TypeChecker_Env.abstract_guard uu____31934 g  in
+            FStar_Pervasives_Native.Some uu____31933
   
 let (get_subtyping_prop :
   FStar_TypeChecker_Env.env ->
@@ -12979,16 +12998,16 @@ let (get_subtyping_prop :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____31929 = check_subtyping env t1 t2  in
-        match uu____31929 with
+        let uu____31953 = check_subtyping env t1 t2  in
+        match uu____31953 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (x,g) ->
-            let uu____31948 =
-              let uu____31949 =
-                let uu____31950 = FStar_Syntax_Syntax.mk_binder x  in
-                [uu____31950]  in
-              FStar_TypeChecker_Env.close_guard env uu____31949 g  in
-            FStar_Pervasives_Native.Some uu____31948
+            let uu____31972 =
+              let uu____31973 =
+                let uu____31974 = FStar_Syntax_Syntax.mk_binder x  in
+                [uu____31974]  in
+              FStar_TypeChecker_Env.close_guard env uu____31973 g  in
+            FStar_Pervasives_Native.Some uu____31972
   
 let (subtype_nosmt :
   FStar_TypeChecker_Env.env ->
@@ -12999,39 +13018,39 @@ let (subtype_nosmt :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        (let uu____31988 =
+        (let uu____32012 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel")
             in
-         if uu____31988
+         if uu____32012
          then
-           let uu____31993 =
+           let uu____32017 =
              FStar_TypeChecker_Normalize.term_to_string env t1  in
-           let uu____31995 =
+           let uu____32019 =
              FStar_TypeChecker_Normalize.term_to_string env t2  in
-           FStar_Util.print2 "try_subtype_no_smt of %s and %s\n" uu____31993
-             uu____31995
+           FStar_Util.print2 "try_subtype_no_smt of %s and %s\n" uu____32017
+             uu____32019
          else ());
-        (let uu____32000 =
+        (let uu____32024 =
            new_t_prob (empty_worklist env) env t1
              FStar_TypeChecker_Common.SUB t2
             in
-         match uu____32000 with
+         match uu____32024 with
          | (prob,x,wl) ->
              let g =
-               let uu____32015 =
+               let uu____32039 =
                  solve_and_commit env (singleton wl prob false)
-                   (fun uu____32024  -> FStar_Pervasives_Native.None)
+                   (fun uu____32048  -> FStar_Pervasives_Native.None)
                   in
-               FStar_All.pipe_left (with_guard env prob) uu____32015  in
+               FStar_All.pipe_left (with_guard env prob) uu____32039  in
              (match g with
               | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some g1 ->
                   let g2 =
-                    let uu____32045 =
-                      let uu____32046 = FStar_Syntax_Syntax.mk_binder x  in
-                      [uu____32046]  in
-                    FStar_TypeChecker_Env.close_guard env uu____32045 g1  in
+                    let uu____32069 =
+                      let uu____32070 = FStar_Syntax_Syntax.mk_binder x  in
+                      [uu____32070]  in
+                    FStar_TypeChecker_Env.close_guard env uu____32069 g1  in
                   discharge_guard' FStar_Pervasives_Native.None env g2 false))
   
 let (subtype_nosmt_force :
@@ -13041,8 +13060,8 @@ let (subtype_nosmt_force :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____32087 = subtype_nosmt env t1 t2  in
-        match uu____32087 with
+        let uu____32111 = subtype_nosmt env t1 t2  in
+        match uu____32111 with
         | FStar_Pervasives_Native.None  -> false
         | FStar_Pervasives_Native.Some g -> (force_trivial_guard env g; true)
   

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -10,245 +10,247 @@ let (set_hint_correlator :
           FStar_Pervasives_Native.fst
          in
       let get_n lid =
-        let n_opt = FStar_Util.smap_try_find tbl lid.FStar_Ident.str  in
+        let n_opt =
+          let uu____52 = FStar_Ident.string_of_lid lid  in
+          FStar_Util.smap_try_find tbl uu____52  in
         if FStar_Util.is_some n_opt
         then FStar_All.pipe_right n_opt FStar_Util.must
         else Prims.int_zero  in
-      let uu____64 = FStar_Options.reuse_hint_for ()  in
-      match uu____64 with
+      let uu____66 = FStar_Options.reuse_hint_for ()  in
+      match uu____66 with
       | FStar_Pervasives_Native.Some l ->
           let lid =
-            let uu____72 = FStar_TypeChecker_Env.current_module env  in
-            FStar_Ident.lid_add_suffix uu____72 l  in
-          let uu___15_73 = env  in
-          let uu____74 =
-            let uu____89 =
-              let uu____97 = let uu____103 = get_n lid  in (lid, uu____103)
+            let uu____74 = FStar_TypeChecker_Env.current_module env  in
+            FStar_Ident.lid_add_suffix uu____74 l  in
+          let uu___15_75 = env  in
+          let uu____76 =
+            let uu____91 =
+              let uu____99 = let uu____105 = get_n lid  in (lid, uu____105)
                  in
-              FStar_Pervasives_Native.Some uu____97  in
-            (tbl, uu____89)  in
+              FStar_Pervasives_Native.Some uu____99  in
+            (tbl, uu____91)  in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___15_73.FStar_TypeChecker_Env.solver);
+              (uu___15_75.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___15_73.FStar_TypeChecker_Env.range);
+              (uu___15_75.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___15_73.FStar_TypeChecker_Env.curmodule);
+              (uu___15_75.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___15_73.FStar_TypeChecker_Env.gamma);
+              (uu___15_75.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___15_73.FStar_TypeChecker_Env.gamma_sig);
+              (uu___15_75.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___15_73.FStar_TypeChecker_Env.gamma_cache);
+              (uu___15_75.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___15_73.FStar_TypeChecker_Env.modules);
+              (uu___15_75.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___15_73.FStar_TypeChecker_Env.expected_typ);
+              (uu___15_75.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___15_73.FStar_TypeChecker_Env.sigtab);
+              (uu___15_75.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___15_73.FStar_TypeChecker_Env.attrtab);
+              (uu___15_75.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___15_73.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___15_75.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___15_73.FStar_TypeChecker_Env.effects);
+              (uu___15_75.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___15_73.FStar_TypeChecker_Env.generalize);
+              (uu___15_75.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___15_73.FStar_TypeChecker_Env.letrecs);
+              (uu___15_75.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___15_73.FStar_TypeChecker_Env.top_level);
+              (uu___15_75.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___15_73.FStar_TypeChecker_Env.check_uvars);
+              (uu___15_75.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___15_73.FStar_TypeChecker_Env.use_eq);
+              (uu___15_75.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___15_73.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___15_75.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___15_73.FStar_TypeChecker_Env.is_iface);
+              (uu___15_75.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___15_73.FStar_TypeChecker_Env.admit);
+              (uu___15_75.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax =
-              (uu___15_73.FStar_TypeChecker_Env.lax);
+              (uu___15_75.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___15_73.FStar_TypeChecker_Env.lax_universes);
+              (uu___15_75.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___15_73.FStar_TypeChecker_Env.phase1);
+              (uu___15_75.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___15_73.FStar_TypeChecker_Env.failhard);
+              (uu___15_75.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___15_73.FStar_TypeChecker_Env.nosynth);
+              (uu___15_75.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___15_73.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___15_75.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___15_73.FStar_TypeChecker_Env.tc_term);
+              (uu___15_75.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___15_73.FStar_TypeChecker_Env.type_of);
+              (uu___15_75.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___15_73.FStar_TypeChecker_Env.universe_of);
+              (uu___15_75.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___15_73.FStar_TypeChecker_Env.check_type_of);
+              (uu___15_75.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___15_73.FStar_TypeChecker_Env.use_bv_sorts);
-            FStar_TypeChecker_Env.qtbl_name_and_index = uu____74;
+              (uu___15_75.FStar_TypeChecker_Env.use_bv_sorts);
+            FStar_TypeChecker_Env.qtbl_name_and_index = uu____76;
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___15_73.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___15_75.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___15_73.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___15_75.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___15_73.FStar_TypeChecker_Env.proof_ns);
+              (uu___15_75.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___15_73.FStar_TypeChecker_Env.synth_hook);
+              (uu___15_75.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___15_73.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___15_75.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___15_73.FStar_TypeChecker_Env.splice);
+              (uu___15_75.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___15_73.FStar_TypeChecker_Env.mpreprocess);
+              (uu___15_75.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___15_73.FStar_TypeChecker_Env.postprocess);
+              (uu___15_75.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.is_native_tactic =
-              (uu___15_73.FStar_TypeChecker_Env.is_native_tactic);
+              (uu___15_75.FStar_TypeChecker_Env.is_native_tactic);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___15_73.FStar_TypeChecker_Env.identifier_info);
+              (uu___15_75.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___15_73.FStar_TypeChecker_Env.tc_hooks);
+              (uu___15_75.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___15_73.FStar_TypeChecker_Env.dsenv);
+              (uu___15_75.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___15_73.FStar_TypeChecker_Env.nbe);
+              (uu___15_75.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___15_73.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___15_75.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___15_73.FStar_TypeChecker_Env.erasable_types_tab)
+              (uu___15_75.FStar_TypeChecker_Env.erasable_types_tab)
           }
       | FStar_Pervasives_Native.None  ->
           let lids = FStar_Syntax_Util.lids_of_sigelt se  in
           let lid =
             match lids with
             | [] ->
-                let uu____126 = FStar_TypeChecker_Env.current_module env  in
-                let uu____127 =
-                  let uu____129 = FStar_Ident.next_id ()  in
-                  FStar_All.pipe_right uu____129 FStar_Util.string_of_int  in
-                FStar_Ident.lid_add_suffix uu____126 uu____127
-            | l::uu____134 -> l  in
-          let uu___24_137 = env  in
-          let uu____138 =
-            let uu____153 =
-              let uu____161 = let uu____167 = get_n lid  in (lid, uu____167)
+                let uu____128 = FStar_TypeChecker_Env.current_module env  in
+                let uu____129 =
+                  let uu____131 = FStar_Ident.next_id ()  in
+                  FStar_All.pipe_right uu____131 FStar_Util.string_of_int  in
+                FStar_Ident.lid_add_suffix uu____128 uu____129
+            | l::uu____136 -> l  in
+          let uu___24_139 = env  in
+          let uu____140 =
+            let uu____155 =
+              let uu____163 = let uu____169 = get_n lid  in (lid, uu____169)
                  in
-              FStar_Pervasives_Native.Some uu____161  in
-            (tbl, uu____153)  in
+              FStar_Pervasives_Native.Some uu____163  in
+            (tbl, uu____155)  in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___24_137.FStar_TypeChecker_Env.solver);
+              (uu___24_139.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___24_137.FStar_TypeChecker_Env.range);
+              (uu___24_139.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___24_137.FStar_TypeChecker_Env.curmodule);
+              (uu___24_139.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___24_137.FStar_TypeChecker_Env.gamma);
+              (uu___24_139.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___24_137.FStar_TypeChecker_Env.gamma_sig);
+              (uu___24_139.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___24_137.FStar_TypeChecker_Env.gamma_cache);
+              (uu___24_139.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___24_137.FStar_TypeChecker_Env.modules);
+              (uu___24_139.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___24_137.FStar_TypeChecker_Env.expected_typ);
+              (uu___24_139.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___24_137.FStar_TypeChecker_Env.sigtab);
+              (uu___24_139.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___24_137.FStar_TypeChecker_Env.attrtab);
+              (uu___24_139.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___24_137.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___24_139.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___24_137.FStar_TypeChecker_Env.effects);
+              (uu___24_139.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___24_137.FStar_TypeChecker_Env.generalize);
+              (uu___24_139.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___24_137.FStar_TypeChecker_Env.letrecs);
+              (uu___24_139.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___24_137.FStar_TypeChecker_Env.top_level);
+              (uu___24_139.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___24_137.FStar_TypeChecker_Env.check_uvars);
+              (uu___24_139.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___24_137.FStar_TypeChecker_Env.use_eq);
+              (uu___24_139.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___24_137.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___24_139.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___24_137.FStar_TypeChecker_Env.is_iface);
+              (uu___24_139.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___24_137.FStar_TypeChecker_Env.admit);
+              (uu___24_139.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax =
-              (uu___24_137.FStar_TypeChecker_Env.lax);
+              (uu___24_139.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___24_137.FStar_TypeChecker_Env.lax_universes);
+              (uu___24_139.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___24_137.FStar_TypeChecker_Env.phase1);
+              (uu___24_139.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___24_137.FStar_TypeChecker_Env.failhard);
+              (uu___24_139.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___24_137.FStar_TypeChecker_Env.nosynth);
+              (uu___24_139.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___24_137.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___24_139.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___24_137.FStar_TypeChecker_Env.tc_term);
+              (uu___24_139.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___24_137.FStar_TypeChecker_Env.type_of);
+              (uu___24_139.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___24_137.FStar_TypeChecker_Env.universe_of);
+              (uu___24_139.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___24_137.FStar_TypeChecker_Env.check_type_of);
+              (uu___24_139.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___24_137.FStar_TypeChecker_Env.use_bv_sorts);
-            FStar_TypeChecker_Env.qtbl_name_and_index = uu____138;
+              (uu___24_139.FStar_TypeChecker_Env.use_bv_sorts);
+            FStar_TypeChecker_Env.qtbl_name_and_index = uu____140;
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___24_137.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___24_139.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___24_137.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___24_139.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___24_137.FStar_TypeChecker_Env.proof_ns);
+              (uu___24_139.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___24_137.FStar_TypeChecker_Env.synth_hook);
+              (uu___24_139.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___24_137.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___24_139.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___24_137.FStar_TypeChecker_Env.splice);
+              (uu___24_139.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___24_137.FStar_TypeChecker_Env.mpreprocess);
+              (uu___24_139.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___24_137.FStar_TypeChecker_Env.postprocess);
+              (uu___24_139.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.is_native_tactic =
-              (uu___24_137.FStar_TypeChecker_Env.is_native_tactic);
+              (uu___24_139.FStar_TypeChecker_Env.is_native_tactic);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___24_137.FStar_TypeChecker_Env.identifier_info);
+              (uu___24_139.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___24_137.FStar_TypeChecker_Env.tc_hooks);
+              (uu___24_139.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___24_137.FStar_TypeChecker_Env.dsenv);
+              (uu___24_139.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___24_137.FStar_TypeChecker_Env.nbe);
+              (uu___24_139.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___24_137.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___24_139.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___24_137.FStar_TypeChecker_Env.erasable_types_tab)
+              (uu___24_139.FStar_TypeChecker_Env.erasable_types_tab)
           }
   
 let (log : FStar_TypeChecker_Env.env -> Prims.bool) =
   fun env  ->
     (FStar_Options.log_types ()) &&
-      (let uu____193 =
-         let uu____195 = FStar_TypeChecker_Env.current_module env  in
-         FStar_Ident.lid_equals FStar_Parser_Const.prims_lid uu____195  in
-       Prims.op_Negation uu____193)
+      (let uu____195 =
+         let uu____197 = FStar_TypeChecker_Env.current_module env  in
+         FStar_Ident.lid_equals FStar_Parser_Const.prims_lid uu____197  in
+       Prims.op_Negation uu____195)
   
 let tc_lex_t :
-  'uuuuuu207 .
+  'uuuuuu209 .
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.sigelt Prims.list ->
-        'uuuuuu207 Prims.list ->
+        'uuuuuu209 Prims.list ->
           FStar_Ident.lident Prims.list -> FStar_Syntax_Syntax.sigelt
   =
   fun env  ->
@@ -256,8 +258,8 @@ let tc_lex_t :
       fun quals  ->
         fun lids  ->
           let err_range =
-            let uu____242 = FStar_List.hd ses  in
-            uu____242.FStar_Syntax_Syntax.sigrng  in
+            let uu____244 = FStar_List.hd ses  in
+            uu____244.FStar_Syntax_Syntax.sigrng  in
           (match lids with
            | lex_t::lex_top::lex_cons::[] when
                ((FStar_Ident.lid_equals lex_t FStar_Parser_Const.lex_t_lid)
@@ -268,7 +270,7 @@ let tc_lex_t :
                  (FStar_Ident.lid_equals lex_cons
                     FStar_Parser_Const.lexcons_lid)
                -> ()
-           | uu____247 ->
+           | uu____249 ->
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_InvalidRedefinitionOfLexT,
                    "Invalid (partial) redefinition of lex_t") err_range);
@@ -276,36 +278,36 @@ let tc_lex_t :
            | {
                FStar_Syntax_Syntax.sigel =
                  FStar_Syntax_Syntax.Sig_inductive_typ
-                 (lex_t,uu____253,[],t,uu____255,uu____256);
+                 (lex_t,uu____255,[],t,uu____257,uu____258);
                FStar_Syntax_Syntax.sigrng = r;
                FStar_Syntax_Syntax.sigquals = [];
-               FStar_Syntax_Syntax.sigmeta = uu____258;
-               FStar_Syntax_Syntax.sigattrs = uu____259;
-               FStar_Syntax_Syntax.sigopts = uu____260;_}::{
+               FStar_Syntax_Syntax.sigmeta = uu____260;
+               FStar_Syntax_Syntax.sigattrs = uu____261;
+               FStar_Syntax_Syntax.sigopts = uu____262;_}::{
                                                              FStar_Syntax_Syntax.sigel
                                                                =
                                                                FStar_Syntax_Syntax.Sig_datacon
-                                                               (lex_top,uu____262,_t_top,_lex_t_top,uu____300,uu____265);
+                                                               (lex_top,uu____264,_t_top,_lex_t_top,uu____302,uu____267);
                                                              FStar_Syntax_Syntax.sigrng
                                                                = r1;
                                                              FStar_Syntax_Syntax.sigquals
                                                                = [];
                                                              FStar_Syntax_Syntax.sigmeta
-                                                               = uu____267;
+                                                               = uu____269;
                                                              FStar_Syntax_Syntax.sigattrs
-                                                               = uu____268;
+                                                               = uu____270;
                                                              FStar_Syntax_Syntax.sigopts
-                                                               = uu____269;_}::
+                                                               = uu____271;_}::
                {
                  FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                   (lex_cons,uu____271,_t_cons,_lex_t_cons,uu____310,uu____274);
+                   (lex_cons,uu____273,_t_cons,_lex_t_cons,uu____312,uu____276);
                  FStar_Syntax_Syntax.sigrng = r2;
                  FStar_Syntax_Syntax.sigquals = [];
-                 FStar_Syntax_Syntax.sigmeta = uu____276;
-                 FStar_Syntax_Syntax.sigattrs = uu____277;
-                 FStar_Syntax_Syntax.sigopts = uu____278;_}::[]
+                 FStar_Syntax_Syntax.sigmeta = uu____278;
+                 FStar_Syntax_Syntax.sigattrs = uu____279;
+                 FStar_Syntax_Syntax.sigopts = uu____280;_}::[]
                when
-               ((uu____300 = Prims.int_zero) && (uu____310 = Prims.int_zero))
+               ((uu____302 = Prims.int_zero) && (uu____312 = Prims.int_zero))
                  &&
                  (((FStar_Ident.lid_equals lex_t FStar_Parser_Const.lex_t_lid)
                      &&
@@ -345,22 +347,22 @@ let tc_lex_t :
                    (FStar_Pervasives_Native.Some r1)
                   in
                let lex_top_t =
-                 let uu____337 =
-                   let uu____344 =
-                     let uu____345 =
-                       let uu____352 =
-                         let uu____355 =
+                 let uu____339 =
+                   let uu____346 =
+                     let uu____347 =
+                       let uu____354 =
+                         let uu____357 =
                            FStar_Ident.set_lid_range
                              FStar_Parser_Const.lex_t_lid r1
                             in
-                         FStar_Syntax_Syntax.fvar uu____355
+                         FStar_Syntax_Syntax.fvar uu____357
                            FStar_Syntax_Syntax.delta_constant
                            FStar_Pervasives_Native.None
                           in
-                       (uu____352, [FStar_Syntax_Syntax.U_name utop])  in
-                     FStar_Syntax_Syntax.Tm_uinst uu____345  in
-                   FStar_Syntax_Syntax.mk uu____344  in
-                 uu____337 FStar_Pervasives_Native.None r1  in
+                       (uu____354, [FStar_Syntax_Syntax.U_name utop])  in
+                     FStar_Syntax_Syntax.Tm_uinst uu____347  in
+                   FStar_Syntax_Syntax.mk uu____346  in
+                 uu____339 FStar_Pervasives_Native.None r1  in
                let lex_top_t1 =
                  FStar_Syntax_Subst.close_univ_vars [utop] lex_top_t  in
                let dc_lextop =
@@ -386,70 +388,70 @@ let tc_lex_t :
                   in
                let lex_cons_t =
                  let a =
-                   let uu____370 =
+                   let uu____372 =
                      FStar_Syntax_Syntax.mk
                        (FStar_Syntax_Syntax.Tm_type
                           (FStar_Syntax_Syntax.U_name ucons1))
                        FStar_Pervasives_Native.None r2
                       in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____370
-                    in
-                 let hd =
-                   let uu____372 = FStar_Syntax_Syntax.bv_to_name a  in
-                   FStar_Syntax_Syntax.new_bv
                      (FStar_Pervasives_Native.Some r2) uu____372
                     in
-                 let tl =
-                   let uu____374 =
-                     let uu____375 =
-                       let uu____382 =
-                         let uu____383 =
-                           let uu____390 =
-                             let uu____393 =
-                               FStar_Ident.set_lid_range
-                                 FStar_Parser_Const.lex_t_lid r2
-                                in
-                             FStar_Syntax_Syntax.fvar uu____393
-                               FStar_Syntax_Syntax.delta_constant
-                               FStar_Pervasives_Native.None
-                              in
-                           (uu____390, [FStar_Syntax_Syntax.U_name ucons2])
-                            in
-                         FStar_Syntax_Syntax.Tm_uinst uu____383  in
-                       FStar_Syntax_Syntax.mk uu____382  in
-                     uu____375 FStar_Pervasives_Native.None r2  in
+                 let hd =
+                   let uu____374 = FStar_Syntax_Syntax.bv_to_name a  in
                    FStar_Syntax_Syntax.new_bv
                      (FStar_Pervasives_Native.Some r2) uu____374
                     in
+                 let tl =
+                   let uu____376 =
+                     let uu____377 =
+                       let uu____384 =
+                         let uu____385 =
+                           let uu____392 =
+                             let uu____395 =
+                               FStar_Ident.set_lid_range
+                                 FStar_Parser_Const.lex_t_lid r2
+                                in
+                             FStar_Syntax_Syntax.fvar uu____395
+                               FStar_Syntax_Syntax.delta_constant
+                               FStar_Pervasives_Native.None
+                              in
+                           (uu____392, [FStar_Syntax_Syntax.U_name ucons2])
+                            in
+                         FStar_Syntax_Syntax.Tm_uinst uu____385  in
+                       FStar_Syntax_Syntax.mk uu____384  in
+                     uu____377 FStar_Pervasives_Native.None r2  in
+                   FStar_Syntax_Syntax.new_bv
+                     (FStar_Pervasives_Native.Some r2) uu____376
+                    in
                  let res =
-                   let uu____399 =
-                     let uu____406 =
-                       let uu____407 =
-                         let uu____414 =
-                           let uu____417 =
+                   let uu____401 =
+                     let uu____408 =
+                       let uu____409 =
+                         let uu____416 =
+                           let uu____419 =
                              FStar_Ident.set_lid_range
                                FStar_Parser_Const.lex_t_lid r2
                               in
-                           FStar_Syntax_Syntax.fvar uu____417
+                           FStar_Syntax_Syntax.fvar uu____419
                              FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None
                             in
-                         (uu____414,
+                         (uu____416,
                            [FStar_Syntax_Syntax.U_max
                               [FStar_Syntax_Syntax.U_name ucons1;
                               FStar_Syntax_Syntax.U_name ucons2]])
                           in
-                       FStar_Syntax_Syntax.Tm_uinst uu____407  in
-                     FStar_Syntax_Syntax.mk uu____406  in
-                   uu____399 FStar_Pervasives_Native.None r2  in
-                 let uu____420 = FStar_Syntax_Syntax.mk_Total res  in
+                       FStar_Syntax_Syntax.Tm_uinst uu____409  in
+                     FStar_Syntax_Syntax.mk uu____408  in
+                   uu____401 FStar_Pervasives_Native.None r2  in
+                 let uu____422 = FStar_Syntax_Syntax.mk_Total res  in
                  FStar_Syntax_Util.arrow
                    [(a,
                       (FStar_Pervasives_Native.Some
                          FStar_Syntax_Syntax.imp_tag));
                    (hd, FStar_Pervasives_Native.None);
-                   (tl, FStar_Pervasives_Native.None)] uu____420
+                   (tl, FStar_Pervasives_Native.None)] uu____422
                   in
                let lex_cons_t1 =
                  FStar_Syntax_Subst.close_univ_vars [ucons1; ucons2]
@@ -468,28 +470,28 @@ let tc_lex_t :
                    FStar_Syntax_Syntax.sigattrs = [];
                    FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                  }  in
-               let uu____459 = FStar_TypeChecker_Env.get_range env  in
+               let uu____461 = FStar_TypeChecker_Env.get_range env  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_bundle
                       ([tc; dc_lextop; dc_lexcons], lids));
-                 FStar_Syntax_Syntax.sigrng = uu____459;
+                 FStar_Syntax_Syntax.sigrng = uu____461;
                  FStar_Syntax_Syntax.sigquals = [];
                  FStar_Syntax_Syntax.sigmeta =
                    FStar_Syntax_Syntax.default_sigmeta;
                  FStar_Syntax_Syntax.sigattrs = [];
                  FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                }
-           | uu____464 ->
+           | uu____466 ->
                let err_msg =
-                 let uu____469 =
-                   let uu____471 =
+                 let uu____471 =
+                   let uu____473 =
                      FStar_Syntax_Syntax.mk_sigelt
                        (FStar_Syntax_Syntax.Sig_bundle (ses, lids))
                       in
-                   FStar_Syntax_Print.sigelt_to_string uu____471  in
+                   FStar_Syntax_Print.sigelt_to_string uu____473  in
                  FStar_Util.format1 "Invalid (re)definition of lex_t: %s\n"
-                   uu____469
+                   uu____471
                   in
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_InvalidRedefinitionOfLexT, err_msg)
@@ -502,13 +504,13 @@ let (tc_type_common :
         FStar_Range.range -> FStar_Syntax_Syntax.tscheme)
   =
   fun env  ->
-    fun uu____496  ->
+    fun uu____498  ->
       fun expected_typ  ->
         fun r  ->
-          match uu____496 with
+          match uu____498 with
           | (uvs,t) ->
-              let uu____509 = FStar_Syntax_Subst.open_univ_vars uvs t  in
-              (match uu____509 with
+              let uu____511 = FStar_Syntax_Subst.open_univ_vars uvs t  in
+              (match uu____511 with
                | (uvs1,t1) ->
                    let env1 = FStar_TypeChecker_Env.push_univ_vars env uvs1
                       in
@@ -518,24 +520,24 @@ let (tc_type_common :
                       in
                    if uvs1 = []
                    then
-                     let uu____521 =
+                     let uu____523 =
                        FStar_TypeChecker_Util.generalize_universes env1 t2
                         in
-                     (match uu____521 with
+                     (match uu____523 with
                       | (uvs2,t3) ->
                           (FStar_TypeChecker_Util.check_uvars r t3;
                            (uvs2, t3)))
                    else
-                     (let uu____539 =
-                        let uu____542 =
+                     (let uu____541 =
+                        let uu____544 =
                           FStar_All.pipe_right t2
                             (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                env1)
                            in
-                        FStar_All.pipe_right uu____542
+                        FStar_All.pipe_right uu____544
                           (FStar_Syntax_Subst.close_univ_vars uvs1)
                          in
-                      (uvs1, uu____539)))
+                      (uvs1, uu____541)))
   
 let (tc_declare_typ :
   FStar_TypeChecker_Env.env ->
@@ -545,10 +547,10 @@ let (tc_declare_typ :
   fun env  ->
     fun ts  ->
       fun r  ->
-        let uu____565 =
-          let uu____566 = FStar_Syntax_Util.type_u ()  in
-          FStar_All.pipe_right uu____566 FStar_Pervasives_Native.fst  in
-        tc_type_common env ts uu____565 r
+        let uu____567 =
+          let uu____568 = FStar_Syntax_Util.type_u ()  in
+          FStar_All.pipe_right uu____568 FStar_Pervasives_Native.fst  in
+        tc_type_common env ts uu____567 r
   
 let (tc_assume :
   FStar_TypeChecker_Env.env ->
@@ -558,10 +560,10 @@ let (tc_assume :
   fun env  ->
     fun ts  ->
       fun r  ->
-        let uu____591 =
-          let uu____592 = FStar_Syntax_Util.type_u ()  in
-          FStar_All.pipe_right uu____592 FStar_Pervasives_Native.fst  in
-        tc_type_common env ts uu____591 r
+        let uu____593 =
+          let uu____594 = FStar_Syntax_Util.type_u ()  in
+          FStar_All.pipe_right uu____594 FStar_Pervasives_Native.fst  in
+        tc_type_common env ts uu____593 r
   
 let (tc_inductive' :
   FStar_TypeChecker_Env.env ->
@@ -577,40 +579,40 @@ let (tc_inductive' :
       fun quals  ->
         fun attrs  ->
           fun lids  ->
-            (let uu____650 =
+            (let uu____652 =
                FStar_TypeChecker_Env.debug env FStar_Options.Low  in
-             if uu____650
+             if uu____652
              then
-               let uu____653 =
+               let uu____655 =
                  FStar_Common.string_of_list
                    FStar_Syntax_Print.sigelt_to_string ses
                   in
-               FStar_Util.print1 ">>>>>>>>>>>>>>tc_inductive %s\n" uu____653
+               FStar_Util.print1 ">>>>>>>>>>>>>>tc_inductive %s\n" uu____655
              else ());
-            (let uu____658 =
+            (let uu____660 =
                FStar_TypeChecker_TcInductive.check_inductive_well_typedness
                  env ses quals lids
                 in
-             match uu____658 with
+             match uu____660 with
              | (sig_bndle,tcs,datas) ->
                  let attrs' =
                    FStar_Syntax_Util.remove_attr
                      FStar_Parser_Const.erasable_attr attrs
                     in
                  let data_ops_ses =
-                   let uu____692 =
+                   let uu____694 =
                      FStar_List.map
                        (FStar_TypeChecker_TcInductive.mk_data_operations
                           quals attrs' env tcs) datas
                       in
-                   FStar_All.pipe_right uu____692 FStar_List.flatten  in
-                 ((let uu____706 =
+                   FStar_All.pipe_right uu____694 FStar_List.flatten  in
+                 ((let uu____708 =
                      (FStar_Options.no_positivity ()) ||
-                       (let uu____709 =
+                       (let uu____711 =
                           FStar_TypeChecker_Env.should_verify env  in
-                        Prims.op_Negation uu____709)
+                        Prims.op_Negation uu____711)
                       in
-                   if uu____706
+                   if uu____708
                    then ()
                    else
                      (let env1 =
@@ -623,73 +625,94 @@ let (tc_inductive' :
                               in
                            if Prims.op_Negation b
                            then
-                             let uu____725 =
+                             let uu____728 =
                                match ty.FStar_Syntax_Syntax.sigel with
                                | FStar_Syntax_Syntax.Sig_inductive_typ
-                                   (lid,uu____735,uu____736,uu____737,uu____738,uu____739)
+                                   (lid,uu____738,uu____739,uu____740,uu____741,uu____742)
                                    -> (lid, (ty.FStar_Syntax_Syntax.sigrng))
-                               | uu____748 -> failwith "Impossible!"  in
-                             match uu____725 with
+                               | uu____751 -> failwith "Impossible!"  in
+                             match uu____728 with
                              | (lid,r) ->
-                                 FStar_Errors.log_issue r
+                                 let uu____759 =
+                                   let uu____765 =
+                                     let uu____767 =
+                                       let uu____769 =
+                                         FStar_Ident.string_of_lid lid  in
+                                       Prims.op_Hat uu____769
+                                         " does not satisfy the positivity condition"
+                                        in
+                                     Prims.op_Hat "Inductive type " uu____767
+                                      in
                                    (FStar_Errors.Error_InductiveTypeNotSatisfyPositivityCondition,
-                                     (Prims.op_Hat "Inductive type "
-                                        (Prims.op_Hat lid.FStar_Ident.str
-                                           " does not satisfy the positivity condition")))
+                                     uu____765)
+                                    in
+                                 FStar_Errors.log_issue r uu____759
                            else ()) tcs;
                       FStar_List.iter
                         (fun d  ->
-                           let uu____767 =
+                           let uu____783 =
                              match d.FStar_Syntax_Syntax.sigel with
                              | FStar_Syntax_Syntax.Sig_datacon
-                                 (data_lid,uu____777,uu____778,ty_lid,uu____780,uu____781)
+                                 (data_lid,uu____793,uu____794,ty_lid,uu____796,uu____797)
                                  -> (data_lid, ty_lid)
-                             | uu____788 -> failwith "Impossible"  in
-                           match uu____767 with
+                             | uu____804 -> failwith "Impossible"  in
+                           match uu____783 with
                            | (data_lid,ty_lid) ->
-                               let uu____796 =
+                               let uu____812 =
                                  (FStar_Ident.lid_equals ty_lid
                                     FStar_Parser_Const.exn_lid)
                                    &&
-                                   (let uu____799 =
+                                   (let uu____815 =
                                       FStar_TypeChecker_TcInductive.check_exn_positivity
                                         data_lid env1
                                        in
-                                    Prims.op_Negation uu____799)
+                                    Prims.op_Negation uu____815)
                                   in
-                               if uu____796
+                               if uu____812
                                then
-                                 FStar_Errors.log_issue
-                                   d.FStar_Syntax_Syntax.sigrng
+                                 let uu____818 =
+                                   let uu____824 =
+                                     let uu____826 =
+                                       let uu____828 =
+                                         FStar_Ident.string_of_lid data_lid
+                                          in
+                                       Prims.op_Hat uu____828
+                                         " does not satisfy the positivity condition"
+                                        in
+                                     Prims.op_Hat "Exception " uu____826  in
                                    (FStar_Errors.Error_InductiveTypeNotSatisfyPositivityCondition,
-                                     (Prims.op_Hat "Exception "
-                                        (Prims.op_Hat
-                                           data_lid.FStar_Ident.str
-                                           " does not satisfy the positivity condition")))
+                                     uu____824)
+                                    in
+                                 FStar_Errors.log_issue
+                                   d.FStar_Syntax_Syntax.sigrng uu____818
                                else ()) datas));
                   (let skip_haseq =
-                     let skip_prims_type uu____815 =
+                     let skip_prims_type uu____843 =
                        let lid =
                          let ty = FStar_List.hd tcs  in
                          match ty.FStar_Syntax_Syntax.sigel with
                          | FStar_Syntax_Syntax.Sig_inductive_typ
-                             (lid,uu____820,uu____821,uu____822,uu____823,uu____824)
+                             (lid,uu____848,uu____849,uu____850,uu____851,uu____852)
                              -> lid
-                         | uu____833 -> failwith "Impossible"  in
+                         | uu____861 -> failwith "Impossible"  in
                        FStar_List.existsb
                          (fun s  ->
-                            s = (lid.FStar_Ident.ident).FStar_Ident.idText)
+                            let uu____868 =
+                              let uu____870 = FStar_Ident.ident_of_lid lid
+                                 in
+                              FStar_Ident.text_of_id uu____870  in
+                            s = uu____868)
                          FStar_TypeChecker_TcInductive.early_prims_inductives
                         in
                      let is_noeq =
                        FStar_List.existsb
                          (fun q  -> q = FStar_Syntax_Syntax.Noeq) quals
                         in
-                     let is_erasable uu____850 =
-                       let uu____851 =
-                         let uu____854 = FStar_List.hd tcs  in
-                         uu____854.FStar_Syntax_Syntax.sigattrs  in
-                       FStar_Syntax_Util.has_attribute uu____851
+                     let is_erasable uu____882 =
+                       let uu____883 =
+                         let uu____886 = FStar_List.hd tcs  in
+                         uu____886.FStar_Syntax_Syntax.sigattrs  in
+                       FStar_Syntax_Util.has_attribute uu____883
                          FStar_Parser_Const.erasable_attr
                         in
                      ((((FStar_List.length tcs) = Prims.int_zero) ||
@@ -736,18 +759,18 @@ let (tc_inductive :
         fun attrs  ->
           fun lids  ->
             let env1 = FStar_TypeChecker_Env.push env "tc_inductive"  in
-            let pop uu____944 =
-              let uu____945 = FStar_TypeChecker_Env.pop env1 "tc_inductive"
+            let pop uu____976 =
+              let uu____977 = FStar_TypeChecker_Env.pop env1 "tc_inductive"
                  in
               ()  in
             try
-              (fun uu___203_955  ->
+              (fun uu___203_987  ->
                  match () with
                  | () ->
-                     let uu____962 = tc_inductive' env1 ses quals attrs lids
+                     let uu____994 = tc_inductive' env1 ses quals attrs lids
                         in
-                     FStar_All.pipe_right uu____962 (fun r  -> pop (); r)) ()
-            with | uu___202_993 -> (pop (); FStar_Exn.raise uu___202_993)
+                     FStar_All.pipe_right uu____994 (fun r  -> pop (); r)) ()
+            with | uu___202_1025 -> (pop (); FStar_Exn.raise uu___202_1025)
   
 let (check_must_erase_attribute :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> unit) =
@@ -755,16 +778,16 @@ let (check_must_erase_attribute :
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_let (lbs,l) ->
-          let uu____1024 =
-            let uu____1026 = FStar_Options.ide ()  in
-            Prims.op_Negation uu____1026  in
-          if uu____1024
+          let uu____1056 =
+            let uu____1058 = FStar_Options.ide ()  in
+            Prims.op_Negation uu____1058  in
+          if uu____1056
           then
-            let uu____1029 =
-              let uu____1034 = FStar_TypeChecker_Env.dsenv env  in
-              let uu____1035 = FStar_TypeChecker_Env.current_module env  in
-              FStar_Syntax_DsEnv.iface_decls uu____1034 uu____1035  in
-            (match uu____1029 with
+            let uu____1061 =
+              let uu____1066 = FStar_TypeChecker_Env.dsenv env  in
+              let uu____1067 = FStar_TypeChecker_Env.current_module env  in
+              FStar_Syntax_DsEnv.iface_decls uu____1066 uu____1067  in
+            (match uu____1061 with
              | FStar_Pervasives_Native.None  -> ()
              | FStar_Pervasives_Native.Some iface_decls ->
                  FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
@@ -773,11 +796,15 @@ let (check_must_erase_attribute :
                          let lbname =
                            FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
                          let has_iface_val =
-                           FStar_All.pipe_right iface_decls
-                             (FStar_Util.for_some
-                                (FStar_Parser_AST.decl_is_val
-                                   ((lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.ident))
-                            in
+                           let uu____1091 =
+                             let uu____1099 =
+                               let uu____1105 =
+                                 FStar_Ident.ident_of_lid
+                                   (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                                  in
+                               FStar_Parser_AST.decl_is_val uu____1105  in
+                             FStar_Util.for_some uu____1099  in
+                           FStar_All.pipe_right iface_decls uu____1091  in
                          if has_iface_val
                          then
                            let must_erase =
@@ -790,46 +817,46 @@ let (check_must_erase_attribute :
                               in
                            (if must_erase && (Prims.op_Negation has_attr)
                             then
-                              let uu____1068 =
+                              let uu____1115 =
                                 FStar_Syntax_Syntax.range_of_fv lbname  in
-                              let uu____1069 =
-                                let uu____1075 =
-                                  let uu____1077 =
+                              let uu____1116 =
+                                let uu____1122 =
+                                  let uu____1124 =
                                     FStar_Syntax_Print.fv_to_string lbname
                                      in
-                                  let uu____1079 =
+                                  let uu____1126 =
                                     FStar_Syntax_Print.fv_to_string lbname
                                      in
                                   FStar_Util.format2
                                     "Values of type `%s` will be erased during extraction, but its interface hides this fact. Add the `must_erase_for_extraction` attribute to the `val %s` declaration for this symbol in the interface"
-                                    uu____1077 uu____1079
+                                    uu____1124 uu____1126
                                    in
                                 (FStar_Errors.Error_MustEraseMissing,
-                                  uu____1075)
+                                  uu____1122)
                                  in
-                              FStar_Errors.log_issue uu____1068 uu____1069
+                              FStar_Errors.log_issue uu____1115 uu____1116
                             else
                               if has_attr && (Prims.op_Negation must_erase)
                               then
-                                (let uu____1086 =
+                                (let uu____1133 =
                                    FStar_Syntax_Syntax.range_of_fv lbname  in
-                                 let uu____1087 =
-                                   let uu____1093 =
-                                     let uu____1095 =
+                                 let uu____1134 =
+                                   let uu____1140 =
+                                     let uu____1142 =
                                        FStar_Syntax_Print.fv_to_string lbname
                                         in
                                      FStar_Util.format1
                                        "Values of type `%s` cannot be erased during extraction, but the `must_erase_for_extraction` attribute claims that it can. Please remove the attribute."
-                                       uu____1095
+                                       uu____1142
                                       in
                                    (FStar_Errors.Error_MustEraseMissing,
-                                     uu____1093)
+                                     uu____1140)
                                     in
-                                 FStar_Errors.log_issue uu____1086 uu____1087)
+                                 FStar_Errors.log_issue uu____1133 uu____1134)
                               else ())
                          else ())))
           else ()
-      | uu____1105 -> ()
+      | uu____1152 -> ()
   
 let (unembed_optionstate_knot :
   FStar_Options.optionstate FStar_Syntax_Embeddings.embedding
@@ -840,33 +867,33 @@ let (unembed_optionstate :
     FStar_Options.optionstate FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____1135 =
-      let uu____1142 =
-        let uu____1145 = FStar_ST.op_Bang unembed_optionstate_knot  in
-        FStar_Util.must uu____1145  in
-      FStar_Syntax_Embeddings.unembed uu____1142 t  in
-    uu____1135 true FStar_Syntax_Embeddings.id_norm_cb
+    let uu____1182 =
+      let uu____1189 =
+        let uu____1192 = FStar_ST.op_Bang unembed_optionstate_knot  in
+        FStar_Util.must uu____1192  in
+      FStar_Syntax_Embeddings.unembed uu____1189 t  in
+    uu____1182 true FStar_Syntax_Embeddings.id_norm_cb
   
 let proc_check_with :
   'a . FStar_Syntax_Syntax.attribute Prims.list -> (unit -> 'a) -> 'a =
   fun attrs  ->
     fun kont  ->
-      let uu____1207 =
+      let uu____1254 =
         FStar_Syntax_Util.get_attribute FStar_Parser_Const.check_with_lid
           attrs
          in
-      match uu____1207 with
+      match uu____1254 with
       | FStar_Pervasives_Native.None  -> kont ()
       | FStar_Pervasives_Native.Some ((a1,FStar_Pervasives_Native.None )::[])
           ->
           FStar_Options.with_saved_options
-            (fun uu____1235  ->
-               (let uu____1237 =
-                  let uu____1238 = unembed_optionstate a1  in
-                  FStar_All.pipe_right uu____1238 FStar_Util.must  in
-                FStar_Options.set uu____1237);
+            (fun uu____1282  ->
+               (let uu____1284 =
+                  let uu____1285 = unembed_optionstate a1  in
+                  FStar_All.pipe_right uu____1285 FStar_Util.must  in
+                FStar_Options.set uu____1284);
                kont ())
-      | uu____1243 -> failwith "huh?"
+      | uu____1290 -> failwith "huh?"
   
 let (tc_decls_knot :
   (FStar_TypeChecker_Env.env ->
@@ -886,180 +913,180 @@ let (tc_decl' :
       let env = env0  in
       FStar_TypeChecker_Util.check_sigelt_quals env se;
       proc_check_with se.FStar_Syntax_Syntax.sigattrs
-        (fun uu____1355  ->
+        (fun uu____1402  ->
            let r = se.FStar_Syntax_Syntax.sigrng  in
            let se1 =
-             let uu____1358 = FStar_Options.record_options ()  in
-             if uu____1358
+             let uu____1405 = FStar_Options.record_options ()  in
+             if uu____1405
              then
-               let uu___250_1361 = se  in
-               let uu____1362 =
-                 let uu____1365 = FStar_Options.peek ()  in
-                 FStar_Pervasives_Native.Some uu____1365  in
+               let uu___250_1408 = se  in
+               let uu____1409 =
+                 let uu____1412 = FStar_Options.peek ()  in
+                 FStar_Pervasives_Native.Some uu____1412  in
                {
                  FStar_Syntax_Syntax.sigel =
-                   (uu___250_1361.FStar_Syntax_Syntax.sigel);
+                   (uu___250_1408.FStar_Syntax_Syntax.sigel);
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___250_1361.FStar_Syntax_Syntax.sigrng);
+                   (uu___250_1408.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___250_1361.FStar_Syntax_Syntax.sigquals);
+                   (uu___250_1408.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___250_1361.FStar_Syntax_Syntax.sigmeta);
+                   (uu___250_1408.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___250_1361.FStar_Syntax_Syntax.sigattrs);
-                 FStar_Syntax_Syntax.sigopts = uu____1362
+                   (uu___250_1408.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopts = uu____1409
                }
              else se  in
            match se1.FStar_Syntax_Syntax.sigel with
-           | FStar_Syntax_Syntax.Sig_inductive_typ uu____1378 ->
+           | FStar_Syntax_Syntax.Sig_inductive_typ uu____1425 ->
                failwith "Impossible bare data-constructor"
-           | FStar_Syntax_Syntax.Sig_datacon uu____1406 ->
+           | FStar_Syntax_Syntax.Sig_datacon uu____1453 ->
                failwith "Impossible bare data-constructor"
-           | FStar_Syntax_Syntax.Sig_fail (uu____1433,false ,uu____1434) when
-               (let uu____1449 = FStar_TypeChecker_Env.should_verify env  in
-                Prims.op_Negation uu____1449) ||
+           | FStar_Syntax_Syntax.Sig_fail (uu____1480,false ,uu____1481) when
+               (let uu____1496 = FStar_TypeChecker_Env.should_verify env  in
+                Prims.op_Negation uu____1496) ||
                  (FStar_Options.admit_smt_queries ())
                -> ([], [], env)
            | FStar_Syntax_Syntax.Sig_fail (expected_errors,lax,ses) ->
                let env' =
                  if lax
                  then
-                   let uu___268_1472 = env  in
+                   let uu___268_1519 = env  in
                    {
                      FStar_TypeChecker_Env.solver =
-                       (uu___268_1472.FStar_TypeChecker_Env.solver);
+                       (uu___268_1519.FStar_TypeChecker_Env.solver);
                      FStar_TypeChecker_Env.range =
-                       (uu___268_1472.FStar_TypeChecker_Env.range);
+                       (uu___268_1519.FStar_TypeChecker_Env.range);
                      FStar_TypeChecker_Env.curmodule =
-                       (uu___268_1472.FStar_TypeChecker_Env.curmodule);
+                       (uu___268_1519.FStar_TypeChecker_Env.curmodule);
                      FStar_TypeChecker_Env.gamma =
-                       (uu___268_1472.FStar_TypeChecker_Env.gamma);
+                       (uu___268_1519.FStar_TypeChecker_Env.gamma);
                      FStar_TypeChecker_Env.gamma_sig =
-                       (uu___268_1472.FStar_TypeChecker_Env.gamma_sig);
+                       (uu___268_1519.FStar_TypeChecker_Env.gamma_sig);
                      FStar_TypeChecker_Env.gamma_cache =
-                       (uu___268_1472.FStar_TypeChecker_Env.gamma_cache);
+                       (uu___268_1519.FStar_TypeChecker_Env.gamma_cache);
                      FStar_TypeChecker_Env.modules =
-                       (uu___268_1472.FStar_TypeChecker_Env.modules);
+                       (uu___268_1519.FStar_TypeChecker_Env.modules);
                      FStar_TypeChecker_Env.expected_typ =
-                       (uu___268_1472.FStar_TypeChecker_Env.expected_typ);
+                       (uu___268_1519.FStar_TypeChecker_Env.expected_typ);
                      FStar_TypeChecker_Env.sigtab =
-                       (uu___268_1472.FStar_TypeChecker_Env.sigtab);
+                       (uu___268_1519.FStar_TypeChecker_Env.sigtab);
                      FStar_TypeChecker_Env.attrtab =
-                       (uu___268_1472.FStar_TypeChecker_Env.attrtab);
+                       (uu___268_1519.FStar_TypeChecker_Env.attrtab);
                      FStar_TypeChecker_Env.instantiate_imp =
-                       (uu___268_1472.FStar_TypeChecker_Env.instantiate_imp);
+                       (uu___268_1519.FStar_TypeChecker_Env.instantiate_imp);
                      FStar_TypeChecker_Env.effects =
-                       (uu___268_1472.FStar_TypeChecker_Env.effects);
+                       (uu___268_1519.FStar_TypeChecker_Env.effects);
                      FStar_TypeChecker_Env.generalize =
-                       (uu___268_1472.FStar_TypeChecker_Env.generalize);
+                       (uu___268_1519.FStar_TypeChecker_Env.generalize);
                      FStar_TypeChecker_Env.letrecs =
-                       (uu___268_1472.FStar_TypeChecker_Env.letrecs);
+                       (uu___268_1519.FStar_TypeChecker_Env.letrecs);
                      FStar_TypeChecker_Env.top_level =
-                       (uu___268_1472.FStar_TypeChecker_Env.top_level);
+                       (uu___268_1519.FStar_TypeChecker_Env.top_level);
                      FStar_TypeChecker_Env.check_uvars =
-                       (uu___268_1472.FStar_TypeChecker_Env.check_uvars);
+                       (uu___268_1519.FStar_TypeChecker_Env.check_uvars);
                      FStar_TypeChecker_Env.use_eq =
-                       (uu___268_1472.FStar_TypeChecker_Env.use_eq);
+                       (uu___268_1519.FStar_TypeChecker_Env.use_eq);
                      FStar_TypeChecker_Env.use_eq_strict =
-                       (uu___268_1472.FStar_TypeChecker_Env.use_eq_strict);
+                       (uu___268_1519.FStar_TypeChecker_Env.use_eq_strict);
                      FStar_TypeChecker_Env.is_iface =
-                       (uu___268_1472.FStar_TypeChecker_Env.is_iface);
+                       (uu___268_1519.FStar_TypeChecker_Env.is_iface);
                      FStar_TypeChecker_Env.admit =
-                       (uu___268_1472.FStar_TypeChecker_Env.admit);
+                       (uu___268_1519.FStar_TypeChecker_Env.admit);
                      FStar_TypeChecker_Env.lax = true;
                      FStar_TypeChecker_Env.lax_universes =
-                       (uu___268_1472.FStar_TypeChecker_Env.lax_universes);
+                       (uu___268_1519.FStar_TypeChecker_Env.lax_universes);
                      FStar_TypeChecker_Env.phase1 =
-                       (uu___268_1472.FStar_TypeChecker_Env.phase1);
+                       (uu___268_1519.FStar_TypeChecker_Env.phase1);
                      FStar_TypeChecker_Env.failhard =
-                       (uu___268_1472.FStar_TypeChecker_Env.failhard);
+                       (uu___268_1519.FStar_TypeChecker_Env.failhard);
                      FStar_TypeChecker_Env.nosynth =
-                       (uu___268_1472.FStar_TypeChecker_Env.nosynth);
+                       (uu___268_1519.FStar_TypeChecker_Env.nosynth);
                      FStar_TypeChecker_Env.uvar_subtyping =
-                       (uu___268_1472.FStar_TypeChecker_Env.uvar_subtyping);
+                       (uu___268_1519.FStar_TypeChecker_Env.uvar_subtyping);
                      FStar_TypeChecker_Env.tc_term =
-                       (uu___268_1472.FStar_TypeChecker_Env.tc_term);
+                       (uu___268_1519.FStar_TypeChecker_Env.tc_term);
                      FStar_TypeChecker_Env.type_of =
-                       (uu___268_1472.FStar_TypeChecker_Env.type_of);
+                       (uu___268_1519.FStar_TypeChecker_Env.type_of);
                      FStar_TypeChecker_Env.universe_of =
-                       (uu___268_1472.FStar_TypeChecker_Env.universe_of);
+                       (uu___268_1519.FStar_TypeChecker_Env.universe_of);
                      FStar_TypeChecker_Env.check_type_of =
-                       (uu___268_1472.FStar_TypeChecker_Env.check_type_of);
+                       (uu___268_1519.FStar_TypeChecker_Env.check_type_of);
                      FStar_TypeChecker_Env.use_bv_sorts =
-                       (uu___268_1472.FStar_TypeChecker_Env.use_bv_sorts);
+                       (uu___268_1519.FStar_TypeChecker_Env.use_bv_sorts);
                      FStar_TypeChecker_Env.qtbl_name_and_index =
-                       (uu___268_1472.FStar_TypeChecker_Env.qtbl_name_and_index);
+                       (uu___268_1519.FStar_TypeChecker_Env.qtbl_name_and_index);
                      FStar_TypeChecker_Env.normalized_eff_names =
-                       (uu___268_1472.FStar_TypeChecker_Env.normalized_eff_names);
+                       (uu___268_1519.FStar_TypeChecker_Env.normalized_eff_names);
                      FStar_TypeChecker_Env.fv_delta_depths =
-                       (uu___268_1472.FStar_TypeChecker_Env.fv_delta_depths);
+                       (uu___268_1519.FStar_TypeChecker_Env.fv_delta_depths);
                      FStar_TypeChecker_Env.proof_ns =
-                       (uu___268_1472.FStar_TypeChecker_Env.proof_ns);
+                       (uu___268_1519.FStar_TypeChecker_Env.proof_ns);
                      FStar_TypeChecker_Env.synth_hook =
-                       (uu___268_1472.FStar_TypeChecker_Env.synth_hook);
+                       (uu___268_1519.FStar_TypeChecker_Env.synth_hook);
                      FStar_TypeChecker_Env.try_solve_implicits_hook =
-                       (uu___268_1472.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                       (uu___268_1519.FStar_TypeChecker_Env.try_solve_implicits_hook);
                      FStar_TypeChecker_Env.splice =
-                       (uu___268_1472.FStar_TypeChecker_Env.splice);
+                       (uu___268_1519.FStar_TypeChecker_Env.splice);
                      FStar_TypeChecker_Env.mpreprocess =
-                       (uu___268_1472.FStar_TypeChecker_Env.mpreprocess);
+                       (uu___268_1519.FStar_TypeChecker_Env.mpreprocess);
                      FStar_TypeChecker_Env.postprocess =
-                       (uu___268_1472.FStar_TypeChecker_Env.postprocess);
+                       (uu___268_1519.FStar_TypeChecker_Env.postprocess);
                      FStar_TypeChecker_Env.is_native_tactic =
-                       (uu___268_1472.FStar_TypeChecker_Env.is_native_tactic);
+                       (uu___268_1519.FStar_TypeChecker_Env.is_native_tactic);
                      FStar_TypeChecker_Env.identifier_info =
-                       (uu___268_1472.FStar_TypeChecker_Env.identifier_info);
+                       (uu___268_1519.FStar_TypeChecker_Env.identifier_info);
                      FStar_TypeChecker_Env.tc_hooks =
-                       (uu___268_1472.FStar_TypeChecker_Env.tc_hooks);
+                       (uu___268_1519.FStar_TypeChecker_Env.tc_hooks);
                      FStar_TypeChecker_Env.dsenv =
-                       (uu___268_1472.FStar_TypeChecker_Env.dsenv);
+                       (uu___268_1519.FStar_TypeChecker_Env.dsenv);
                      FStar_TypeChecker_Env.nbe =
-                       (uu___268_1472.FStar_TypeChecker_Env.nbe);
+                       (uu___268_1519.FStar_TypeChecker_Env.nbe);
                      FStar_TypeChecker_Env.strict_args_tab =
-                       (uu___268_1472.FStar_TypeChecker_Env.strict_args_tab);
+                       (uu___268_1519.FStar_TypeChecker_Env.strict_args_tab);
                      FStar_TypeChecker_Env.erasable_types_tab =
-                       (uu___268_1472.FStar_TypeChecker_Env.erasable_types_tab)
+                       (uu___268_1519.FStar_TypeChecker_Env.erasable_types_tab)
                    }
                  else env  in
                let env'1 = FStar_TypeChecker_Env.push env' "expect_failure"
                   in
-               ((let uu____1479 =
+               ((let uu____1526 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Low  in
-                 if uu____1479
+                 if uu____1526
                  then
-                   let uu____1482 =
-                     let uu____1484 =
+                   let uu____1529 =
+                     let uu____1531 =
                        FStar_List.map FStar_Util.string_of_int
                          expected_errors
                         in
                      FStar_All.pipe_left (FStar_String.concat "; ")
-                       uu____1484
+                       uu____1531
                       in
-                   FStar_Util.print1 ">> Expecting errors: [%s]\n" uu____1482
+                   FStar_Util.print1 ">> Expecting errors: [%s]\n" uu____1529
                  else ());
-                (let uu____1498 =
+                (let uu____1545 =
                    FStar_Errors.catch_errors
-                     (fun uu____1528  ->
+                     (fun uu____1575  ->
                         FStar_Options.with_saved_options
-                          (fun uu____1541  ->
-                             let uu____1542 =
-                               let uu____1563 =
+                          (fun uu____1588  ->
+                             let uu____1589 =
+                               let uu____1610 =
                                  FStar_ST.op_Bang tc_decls_knot  in
-                               FStar_Util.must uu____1563  in
-                             uu____1542 env'1 ses))
+                               FStar_Util.must uu____1610  in
+                             uu____1589 env'1 ses))
                     in
-                 match uu____1498 with
-                 | (errs,uu____1672) ->
-                     ((let uu____1702 =
+                 match uu____1545 with
+                 | (errs,uu____1719) ->
+                     ((let uu____1749 =
                          FStar_TypeChecker_Env.debug env FStar_Options.Low
                           in
-                       if uu____1702
+                       if uu____1749
                        then
                          (FStar_Util.print_string ">> Got issues: [\n";
                           FStar_List.iter FStar_Errors.print_issue errs;
                           FStar_Util.print_string ">>]\n")
                        else ());
-                      (let uu____1711 =
+                      (let uu____1758 =
                          FStar_TypeChecker_Env.pop env'1 "expect_failure"  in
                        let actual_errors =
                          FStar_List.concatMap
@@ -1074,47 +1101,47 @@ let (tc_decl' :
                                se1.FStar_Syntax_Syntax.sigrng
                                (FStar_Errors.Error_DidNotFail,
                                  "This top-level definition was expected to fail, but it succeeded"))
-                        | uu____1725 ->
+                        | uu____1772 ->
                             if expected_errors <> []
                             then
-                              let uu____1733 =
+                              let uu____1780 =
                                 FStar_Errors.find_multiset_discrepancy
                                   expected_errors actual_errors
                                  in
-                              (match uu____1733 with
+                              (match uu____1780 with
                                | FStar_Pervasives_Native.None  -> ()
                                | FStar_Pervasives_Native.Some (e,n1,n2) ->
                                    (FStar_List.iter FStar_Errors.print_issue
                                       errs;
-                                    (let uu____1773 =
-                                       let uu____1779 =
-                                         let uu____1781 =
+                                    (let uu____1820 =
+                                       let uu____1826 =
+                                         let uu____1828 =
                                            FStar_Common.string_of_list
                                              FStar_Util.string_of_int
                                              expected_errors
                                             in
-                                         let uu____1784 =
+                                         let uu____1831 =
                                            FStar_Common.string_of_list
                                              FStar_Util.string_of_int
                                              actual_errors
                                             in
-                                         let uu____1787 =
+                                         let uu____1834 =
                                            FStar_Util.string_of_int e  in
-                                         let uu____1789 =
+                                         let uu____1836 =
                                            FStar_Util.string_of_int n2  in
-                                         let uu____1791 =
+                                         let uu____1838 =
                                            FStar_Util.string_of_int n1  in
                                          FStar_Util.format5
                                            "This top-level definition was expected to raise error codes %s, but it raised %s. Error #%s was raised %s times, instead of %s."
-                                           uu____1781 uu____1784 uu____1787
-                                           uu____1789 uu____1791
+                                           uu____1828 uu____1831 uu____1834
+                                           uu____1836 uu____1838
                                           in
                                        (FStar_Errors.Error_DidNotFail,
-                                         uu____1779)
+                                         uu____1826)
                                         in
                                      FStar_Errors.log_issue
                                        se1.FStar_Syntax_Syntax.sigrng
-                                       uu____1773)))
+                                       uu____1820)))
                             else ());
                        ([], [], env)))))
            | FStar_Syntax_Syntax.Sig_bundle (ses,lids) when
@@ -1129,174 +1156,174 @@ let (tc_decl' :
            | FStar_Syntax_Syntax.Sig_bundle (ses,lids) ->
                let env1 = FStar_TypeChecker_Env.set_range env r  in
                let ses1 =
-                 let uu____1834 =
+                 let uu____1881 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env1)
                     in
-                 if uu____1834
+                 if uu____1881
                  then
                    let ses1 =
-                     let uu____1842 =
-                       let uu____1843 =
-                         let uu____1844 =
+                     let uu____1889 =
+                       let uu____1890 =
+                         let uu____1891 =
                            tc_inductive
-                             (let uu___310_1853 = env1  in
+                             (let uu___310_1900 = env1  in
                               {
                                 FStar_TypeChecker_Env.solver =
-                                  (uu___310_1853.FStar_TypeChecker_Env.solver);
+                                  (uu___310_1900.FStar_TypeChecker_Env.solver);
                                 FStar_TypeChecker_Env.range =
-                                  (uu___310_1853.FStar_TypeChecker_Env.range);
+                                  (uu___310_1900.FStar_TypeChecker_Env.range);
                                 FStar_TypeChecker_Env.curmodule =
-                                  (uu___310_1853.FStar_TypeChecker_Env.curmodule);
+                                  (uu___310_1900.FStar_TypeChecker_Env.curmodule);
                                 FStar_TypeChecker_Env.gamma =
-                                  (uu___310_1853.FStar_TypeChecker_Env.gamma);
+                                  (uu___310_1900.FStar_TypeChecker_Env.gamma);
                                 FStar_TypeChecker_Env.gamma_sig =
-                                  (uu___310_1853.FStar_TypeChecker_Env.gamma_sig);
+                                  (uu___310_1900.FStar_TypeChecker_Env.gamma_sig);
                                 FStar_TypeChecker_Env.gamma_cache =
-                                  (uu___310_1853.FStar_TypeChecker_Env.gamma_cache);
+                                  (uu___310_1900.FStar_TypeChecker_Env.gamma_cache);
                                 FStar_TypeChecker_Env.modules =
-                                  (uu___310_1853.FStar_TypeChecker_Env.modules);
+                                  (uu___310_1900.FStar_TypeChecker_Env.modules);
                                 FStar_TypeChecker_Env.expected_typ =
-                                  (uu___310_1853.FStar_TypeChecker_Env.expected_typ);
+                                  (uu___310_1900.FStar_TypeChecker_Env.expected_typ);
                                 FStar_TypeChecker_Env.sigtab =
-                                  (uu___310_1853.FStar_TypeChecker_Env.sigtab);
+                                  (uu___310_1900.FStar_TypeChecker_Env.sigtab);
                                 FStar_TypeChecker_Env.attrtab =
-                                  (uu___310_1853.FStar_TypeChecker_Env.attrtab);
+                                  (uu___310_1900.FStar_TypeChecker_Env.attrtab);
                                 FStar_TypeChecker_Env.instantiate_imp =
-                                  (uu___310_1853.FStar_TypeChecker_Env.instantiate_imp);
+                                  (uu___310_1900.FStar_TypeChecker_Env.instantiate_imp);
                                 FStar_TypeChecker_Env.effects =
-                                  (uu___310_1853.FStar_TypeChecker_Env.effects);
+                                  (uu___310_1900.FStar_TypeChecker_Env.effects);
                                 FStar_TypeChecker_Env.generalize =
-                                  (uu___310_1853.FStar_TypeChecker_Env.generalize);
+                                  (uu___310_1900.FStar_TypeChecker_Env.generalize);
                                 FStar_TypeChecker_Env.letrecs =
-                                  (uu___310_1853.FStar_TypeChecker_Env.letrecs);
+                                  (uu___310_1900.FStar_TypeChecker_Env.letrecs);
                                 FStar_TypeChecker_Env.top_level =
-                                  (uu___310_1853.FStar_TypeChecker_Env.top_level);
+                                  (uu___310_1900.FStar_TypeChecker_Env.top_level);
                                 FStar_TypeChecker_Env.check_uvars =
-                                  (uu___310_1853.FStar_TypeChecker_Env.check_uvars);
+                                  (uu___310_1900.FStar_TypeChecker_Env.check_uvars);
                                 FStar_TypeChecker_Env.use_eq =
-                                  (uu___310_1853.FStar_TypeChecker_Env.use_eq);
+                                  (uu___310_1900.FStar_TypeChecker_Env.use_eq);
                                 FStar_TypeChecker_Env.use_eq_strict =
-                                  (uu___310_1853.FStar_TypeChecker_Env.use_eq_strict);
+                                  (uu___310_1900.FStar_TypeChecker_Env.use_eq_strict);
                                 FStar_TypeChecker_Env.is_iface =
-                                  (uu___310_1853.FStar_TypeChecker_Env.is_iface);
+                                  (uu___310_1900.FStar_TypeChecker_Env.is_iface);
                                 FStar_TypeChecker_Env.admit =
-                                  (uu___310_1853.FStar_TypeChecker_Env.admit);
+                                  (uu___310_1900.FStar_TypeChecker_Env.admit);
                                 FStar_TypeChecker_Env.lax = true;
                                 FStar_TypeChecker_Env.lax_universes =
-                                  (uu___310_1853.FStar_TypeChecker_Env.lax_universes);
+                                  (uu___310_1900.FStar_TypeChecker_Env.lax_universes);
                                 FStar_TypeChecker_Env.phase1 = true;
                                 FStar_TypeChecker_Env.failhard =
-                                  (uu___310_1853.FStar_TypeChecker_Env.failhard);
+                                  (uu___310_1900.FStar_TypeChecker_Env.failhard);
                                 FStar_TypeChecker_Env.nosynth =
-                                  (uu___310_1853.FStar_TypeChecker_Env.nosynth);
+                                  (uu___310_1900.FStar_TypeChecker_Env.nosynth);
                                 FStar_TypeChecker_Env.uvar_subtyping =
-                                  (uu___310_1853.FStar_TypeChecker_Env.uvar_subtyping);
+                                  (uu___310_1900.FStar_TypeChecker_Env.uvar_subtyping);
                                 FStar_TypeChecker_Env.tc_term =
-                                  (uu___310_1853.FStar_TypeChecker_Env.tc_term);
+                                  (uu___310_1900.FStar_TypeChecker_Env.tc_term);
                                 FStar_TypeChecker_Env.type_of =
-                                  (uu___310_1853.FStar_TypeChecker_Env.type_of);
+                                  (uu___310_1900.FStar_TypeChecker_Env.type_of);
                                 FStar_TypeChecker_Env.universe_of =
-                                  (uu___310_1853.FStar_TypeChecker_Env.universe_of);
+                                  (uu___310_1900.FStar_TypeChecker_Env.universe_of);
                                 FStar_TypeChecker_Env.check_type_of =
-                                  (uu___310_1853.FStar_TypeChecker_Env.check_type_of);
+                                  (uu___310_1900.FStar_TypeChecker_Env.check_type_of);
                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                  (uu___310_1853.FStar_TypeChecker_Env.use_bv_sorts);
+                                  (uu___310_1900.FStar_TypeChecker_Env.use_bv_sorts);
                                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                                  (uu___310_1853.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                  (uu___310_1900.FStar_TypeChecker_Env.qtbl_name_and_index);
                                 FStar_TypeChecker_Env.normalized_eff_names =
-                                  (uu___310_1853.FStar_TypeChecker_Env.normalized_eff_names);
+                                  (uu___310_1900.FStar_TypeChecker_Env.normalized_eff_names);
                                 FStar_TypeChecker_Env.fv_delta_depths =
-                                  (uu___310_1853.FStar_TypeChecker_Env.fv_delta_depths);
+                                  (uu___310_1900.FStar_TypeChecker_Env.fv_delta_depths);
                                 FStar_TypeChecker_Env.proof_ns =
-                                  (uu___310_1853.FStar_TypeChecker_Env.proof_ns);
+                                  (uu___310_1900.FStar_TypeChecker_Env.proof_ns);
                                 FStar_TypeChecker_Env.synth_hook =
-                                  (uu___310_1853.FStar_TypeChecker_Env.synth_hook);
+                                  (uu___310_1900.FStar_TypeChecker_Env.synth_hook);
                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                   =
-                                  (uu___310_1853.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                  (uu___310_1900.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                 FStar_TypeChecker_Env.splice =
-                                  (uu___310_1853.FStar_TypeChecker_Env.splice);
+                                  (uu___310_1900.FStar_TypeChecker_Env.splice);
                                 FStar_TypeChecker_Env.mpreprocess =
-                                  (uu___310_1853.FStar_TypeChecker_Env.mpreprocess);
+                                  (uu___310_1900.FStar_TypeChecker_Env.mpreprocess);
                                 FStar_TypeChecker_Env.postprocess =
-                                  (uu___310_1853.FStar_TypeChecker_Env.postprocess);
+                                  (uu___310_1900.FStar_TypeChecker_Env.postprocess);
                                 FStar_TypeChecker_Env.is_native_tactic =
-                                  (uu___310_1853.FStar_TypeChecker_Env.is_native_tactic);
+                                  (uu___310_1900.FStar_TypeChecker_Env.is_native_tactic);
                                 FStar_TypeChecker_Env.identifier_info =
-                                  (uu___310_1853.FStar_TypeChecker_Env.identifier_info);
+                                  (uu___310_1900.FStar_TypeChecker_Env.identifier_info);
                                 FStar_TypeChecker_Env.tc_hooks =
-                                  (uu___310_1853.FStar_TypeChecker_Env.tc_hooks);
+                                  (uu___310_1900.FStar_TypeChecker_Env.tc_hooks);
                                 FStar_TypeChecker_Env.dsenv =
-                                  (uu___310_1853.FStar_TypeChecker_Env.dsenv);
+                                  (uu___310_1900.FStar_TypeChecker_Env.dsenv);
                                 FStar_TypeChecker_Env.nbe =
-                                  (uu___310_1853.FStar_TypeChecker_Env.nbe);
+                                  (uu___310_1900.FStar_TypeChecker_Env.nbe);
                                 FStar_TypeChecker_Env.strict_args_tab =
-                                  (uu___310_1853.FStar_TypeChecker_Env.strict_args_tab);
+                                  (uu___310_1900.FStar_TypeChecker_Env.strict_args_tab);
                                 FStar_TypeChecker_Env.erasable_types_tab =
-                                  (uu___310_1853.FStar_TypeChecker_Env.erasable_types_tab)
+                                  (uu___310_1900.FStar_TypeChecker_Env.erasable_types_tab)
                               }) ses se1.FStar_Syntax_Syntax.sigquals
                              se1.FStar_Syntax_Syntax.sigattrs lids
                             in
-                         FStar_All.pipe_right uu____1844
+                         FStar_All.pipe_right uu____1891
                            FStar_Pervasives_Native.fst
                           in
-                       FStar_All.pipe_right uu____1843
+                       FStar_All.pipe_right uu____1890
                          (FStar_TypeChecker_Normalize.elim_uvars env1)
                         in
-                     FStar_All.pipe_right uu____1842
+                     FStar_All.pipe_right uu____1889
                        FStar_Syntax_Util.ses_of_sigbundle
                       in
-                   ((let uu____1867 =
+                   ((let uu____1914 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                          (FStar_Options.Other "TwoPhases")
                         in
-                     if uu____1867
+                     if uu____1914
                      then
-                       let uu____1872 =
+                       let uu____1919 =
                          FStar_Syntax_Print.sigelt_to_string
-                           (let uu___314_1876 = se1  in
+                           (let uu___314_1923 = se1  in
                             {
                               FStar_Syntax_Syntax.sigel =
                                 (FStar_Syntax_Syntax.Sig_bundle (ses1, lids));
                               FStar_Syntax_Syntax.sigrng =
-                                (uu___314_1876.FStar_Syntax_Syntax.sigrng);
+                                (uu___314_1923.FStar_Syntax_Syntax.sigrng);
                               FStar_Syntax_Syntax.sigquals =
-                                (uu___314_1876.FStar_Syntax_Syntax.sigquals);
+                                (uu___314_1923.FStar_Syntax_Syntax.sigquals);
                               FStar_Syntax_Syntax.sigmeta =
-                                (uu___314_1876.FStar_Syntax_Syntax.sigmeta);
+                                (uu___314_1923.FStar_Syntax_Syntax.sigmeta);
                               FStar_Syntax_Syntax.sigattrs =
-                                (uu___314_1876.FStar_Syntax_Syntax.sigattrs);
+                                (uu___314_1923.FStar_Syntax_Syntax.sigattrs);
                               FStar_Syntax_Syntax.sigopts =
-                                (uu___314_1876.FStar_Syntax_Syntax.sigopts)
+                                (uu___314_1923.FStar_Syntax_Syntax.sigopts)
                             })
                           in
                        FStar_Util.print1 "Inductive after phase 1: %s\n"
-                         uu____1872
+                         uu____1919
                      else ());
                     ses1)
                  else ses  in
-               let uu____1886 =
+               let uu____1933 =
                  tc_inductive env1 ses1 se1.FStar_Syntax_Syntax.sigquals
                    se1.FStar_Syntax_Syntax.sigattrs lids
                   in
-               (match uu____1886 with
+               (match uu____1933 with
                 | (sigbndle,projectors_ses) ->
                     let sigbndle1 =
-                      let uu___321_1910 = sigbndle  in
+                      let uu___321_1957 = sigbndle  in
                       {
                         FStar_Syntax_Syntax.sigel =
-                          (uu___321_1910.FStar_Syntax_Syntax.sigel);
+                          (uu___321_1957.FStar_Syntax_Syntax.sigel);
                         FStar_Syntax_Syntax.sigrng =
-                          (uu___321_1910.FStar_Syntax_Syntax.sigrng);
+                          (uu___321_1957.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (uu___321_1910.FStar_Syntax_Syntax.sigquals);
+                          (uu___321_1957.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (uu___321_1910.FStar_Syntax_Syntax.sigmeta);
+                          (uu___321_1957.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
                           (se1.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
-                          (uu___321_1910.FStar_Syntax_Syntax.sigopts)
+                          (uu___321_1957.FStar_Syntax_Syntax.sigopts)
                       }  in
                     ([sigbndle1], projectors_ses, env0))
            | FStar_Syntax_Syntax.Sig_pragma p ->
@@ -1305,230 +1332,230 @@ let (tc_decl' :
                let is_unelaborated_dm4f =
                  match ne.FStar_Syntax_Syntax.combinators with
                  | FStar_Syntax_Syntax.DM4F_eff combs ->
-                     let uu____1926 =
-                       let uu____1929 =
+                     let uu____1973 =
+                       let uu____1976 =
                          FStar_All.pipe_right
                            combs.FStar_Syntax_Syntax.ret_wp
                            FStar_Pervasives_Native.snd
                           in
-                       FStar_All.pipe_right uu____1929
+                       FStar_All.pipe_right uu____1976
                          FStar_Syntax_Subst.compress
                         in
-                     (match uu____1926 with
+                     (match uu____1973 with
                       | {
                           FStar_Syntax_Syntax.n =
                             FStar_Syntax_Syntax.Tm_unknown ;
-                          FStar_Syntax_Syntax.pos = uu____1945;
-                          FStar_Syntax_Syntax.vars = uu____1946;_} -> true
-                      | uu____1950 -> false)
-                 | uu____1954 -> false  in
+                          FStar_Syntax_Syntax.pos = uu____1992;
+                          FStar_Syntax_Syntax.vars = uu____1993;_} -> true
+                      | uu____1997 -> false)
+                 | uu____2001 -> false  in
                if is_unelaborated_dm4f
                then
-                 let uu____1967 =
+                 let uu____2014 =
                    FStar_TypeChecker_TcEffect.dmff_cps_and_elaborate env ne
                     in
-                 (match uu____1967 with
+                 (match uu____2014 with
                   | (ses,ne1,lift_from_pure_opt) ->
                       let effect_and_lift_ses =
                         match lift_from_pure_opt with
                         | FStar_Pervasives_Native.Some lift ->
-                            [(let uu___345_2006 = se1  in
+                            [(let uu___345_2053 = se1  in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                 FStar_Syntax_Syntax.sigrng =
-                                  (uu___345_2006.FStar_Syntax_Syntax.sigrng);
+                                  (uu___345_2053.FStar_Syntax_Syntax.sigrng);
                                 FStar_Syntax_Syntax.sigquals =
-                                  (uu___345_2006.FStar_Syntax_Syntax.sigquals);
+                                  (uu___345_2053.FStar_Syntax_Syntax.sigquals);
                                 FStar_Syntax_Syntax.sigmeta =
-                                  (uu___345_2006.FStar_Syntax_Syntax.sigmeta);
+                                  (uu___345_2053.FStar_Syntax_Syntax.sigmeta);
                                 FStar_Syntax_Syntax.sigattrs =
-                                  (uu___345_2006.FStar_Syntax_Syntax.sigattrs);
+                                  (uu___345_2053.FStar_Syntax_Syntax.sigattrs);
                                 FStar_Syntax_Syntax.sigopts =
-                                  (uu___345_2006.FStar_Syntax_Syntax.sigopts)
+                                  (uu___345_2053.FStar_Syntax_Syntax.sigopts)
                               });
                             lift]
                         | FStar_Pervasives_Native.None  ->
-                            [(let uu___348_2008 = se1  in
+                            [(let uu___348_2055 = se1  in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                 FStar_Syntax_Syntax.sigrng =
-                                  (uu___348_2008.FStar_Syntax_Syntax.sigrng);
+                                  (uu___348_2055.FStar_Syntax_Syntax.sigrng);
                                 FStar_Syntax_Syntax.sigquals =
-                                  (uu___348_2008.FStar_Syntax_Syntax.sigquals);
+                                  (uu___348_2055.FStar_Syntax_Syntax.sigquals);
                                 FStar_Syntax_Syntax.sigmeta =
-                                  (uu___348_2008.FStar_Syntax_Syntax.sigmeta);
+                                  (uu___348_2055.FStar_Syntax_Syntax.sigmeta);
                                 FStar_Syntax_Syntax.sigattrs =
-                                  (uu___348_2008.FStar_Syntax_Syntax.sigattrs);
+                                  (uu___348_2055.FStar_Syntax_Syntax.sigattrs);
                                 FStar_Syntax_Syntax.sigopts =
-                                  (uu___348_2008.FStar_Syntax_Syntax.sigopts)
+                                  (uu___348_2055.FStar_Syntax_Syntax.sigopts)
                               })]
                          in
                       ([], (FStar_List.append ses effect_and_lift_ses), env0))
                else
                  (let ne1 =
-                    let uu____2016 =
+                    let uu____2063 =
                       (FStar_Options.use_two_phase_tc ()) &&
                         (FStar_TypeChecker_Env.should_verify env)
                        in
-                    if uu____2016
+                    if uu____2063
                     then
                       let ne1 =
-                        let uu____2020 =
-                          let uu____2021 =
-                            let uu____2022 =
+                        let uu____2067 =
+                          let uu____2068 =
+                            let uu____2069 =
                               FStar_TypeChecker_TcEffect.tc_eff_decl
-                                (let uu___352_2025 = env  in
+                                (let uu___352_2072 = env  in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___352_2025.FStar_TypeChecker_Env.solver);
+                                     (uu___352_2072.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___352_2025.FStar_TypeChecker_Env.range);
+                                     (uu___352_2072.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___352_2025.FStar_TypeChecker_Env.curmodule);
+                                     (uu___352_2072.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___352_2025.FStar_TypeChecker_Env.gamma);
+                                     (uu___352_2072.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___352_2025.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___352_2072.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___352_2025.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___352_2072.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___352_2025.FStar_TypeChecker_Env.modules);
+                                     (uu___352_2072.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
-                                     (uu___352_2025.FStar_TypeChecker_Env.expected_typ);
+                                     (uu___352_2072.FStar_TypeChecker_Env.expected_typ);
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___352_2025.FStar_TypeChecker_Env.sigtab);
+                                     (uu___352_2072.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___352_2025.FStar_TypeChecker_Env.attrtab);
+                                     (uu___352_2072.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___352_2025.FStar_TypeChecker_Env.instantiate_imp);
+                                     (uu___352_2072.FStar_TypeChecker_Env.instantiate_imp);
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___352_2025.FStar_TypeChecker_Env.effects);
+                                     (uu___352_2072.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___352_2025.FStar_TypeChecker_Env.generalize);
+                                     (uu___352_2072.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___352_2025.FStar_TypeChecker_Env.letrecs);
+                                     (uu___352_2072.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level =
-                                     (uu___352_2025.FStar_TypeChecker_Env.top_level);
+                                     (uu___352_2072.FStar_TypeChecker_Env.top_level);
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___352_2025.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___352_2072.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq =
-                                     (uu___352_2025.FStar_TypeChecker_Env.use_eq);
+                                     (uu___352_2072.FStar_TypeChecker_Env.use_eq);
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___352_2025.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___352_2072.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___352_2025.FStar_TypeChecker_Env.is_iface);
+                                     (uu___352_2072.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___352_2025.FStar_TypeChecker_Env.admit);
+                                     (uu___352_2072.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax = true;
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___352_2025.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___352_2072.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 = true;
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___352_2025.FStar_TypeChecker_Env.failhard);
+                                     (uu___352_2072.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___352_2025.FStar_TypeChecker_Env.nosynth);
+                                     (uu___352_2072.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___352_2025.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___352_2072.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___352_2025.FStar_TypeChecker_Env.tc_term);
+                                     (uu___352_2072.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___352_2025.FStar_TypeChecker_Env.type_of);
+                                     (uu___352_2072.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___352_2025.FStar_TypeChecker_Env.universe_of);
+                                     (uu___352_2072.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___352_2025.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___352_2072.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts =
-                                     (uu___352_2025.FStar_TypeChecker_Env.use_bv_sorts);
+                                     (uu___352_2072.FStar_TypeChecker_Env.use_bv_sorts);
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___352_2025.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___352_2072.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___352_2025.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___352_2072.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___352_2025.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___352_2072.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___352_2025.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___352_2072.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___352_2025.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___352_2072.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___352_2025.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___352_2072.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___352_2025.FStar_TypeChecker_Env.splice);
+                                     (uu___352_2072.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___352_2025.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___352_2072.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___352_2025.FStar_TypeChecker_Env.postprocess);
+                                     (uu___352_2072.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.is_native_tactic =
-                                     (uu___352_2025.FStar_TypeChecker_Env.is_native_tactic);
+                                     (uu___352_2072.FStar_TypeChecker_Env.is_native_tactic);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___352_2025.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___352_2072.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___352_2025.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___352_2072.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___352_2025.FStar_TypeChecker_Env.dsenv);
+                                     (uu___352_2072.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___352_2025.FStar_TypeChecker_Env.nbe);
+                                     (uu___352_2072.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___352_2025.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___352_2072.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___352_2025.FStar_TypeChecker_Env.erasable_types_tab)
+                                     (uu___352_2072.FStar_TypeChecker_Env.erasable_types_tab)
                                  }) ne se1.FStar_Syntax_Syntax.sigquals
                                in
-                            FStar_All.pipe_right uu____2022
+                            FStar_All.pipe_right uu____2069
                               (fun ne1  ->
-                                 let uu___355_2031 = se1  in
+                                 let uu___355_2078 = se1  in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                    FStar_Syntax_Syntax.sigrng =
-                                     (uu___355_2031.FStar_Syntax_Syntax.sigrng);
+                                     (uu___355_2078.FStar_Syntax_Syntax.sigrng);
                                    FStar_Syntax_Syntax.sigquals =
-                                     (uu___355_2031.FStar_Syntax_Syntax.sigquals);
+                                     (uu___355_2078.FStar_Syntax_Syntax.sigquals);
                                    FStar_Syntax_Syntax.sigmeta =
-                                     (uu___355_2031.FStar_Syntax_Syntax.sigmeta);
+                                     (uu___355_2078.FStar_Syntax_Syntax.sigmeta);
                                    FStar_Syntax_Syntax.sigattrs =
-                                     (uu___355_2031.FStar_Syntax_Syntax.sigattrs);
+                                     (uu___355_2078.FStar_Syntax_Syntax.sigattrs);
                                    FStar_Syntax_Syntax.sigopts =
-                                     (uu___355_2031.FStar_Syntax_Syntax.sigopts)
+                                     (uu___355_2078.FStar_Syntax_Syntax.sigopts)
                                  })
                              in
-                          FStar_All.pipe_right uu____2021
+                          FStar_All.pipe_right uu____2068
                             (FStar_TypeChecker_Normalize.elim_uvars env)
                            in
-                        FStar_All.pipe_right uu____2020
+                        FStar_All.pipe_right uu____2067
                           FStar_Syntax_Util.eff_decl_of_new_effect
                          in
-                      ((let uu____2033 =
+                      ((let uu____2080 =
                           FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "TwoPhases")
                            in
-                        if uu____2033
+                        if uu____2080
                         then
-                          let uu____2038 =
+                          let uu____2085 =
                             FStar_Syntax_Print.sigelt_to_string
-                              (let uu___359_2042 = se1  in
+                              (let uu___359_2089 = se1  in
                                {
                                  FStar_Syntax_Syntax.sigel =
                                    (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                  FStar_Syntax_Syntax.sigrng =
-                                   (uu___359_2042.FStar_Syntax_Syntax.sigrng);
+                                   (uu___359_2089.FStar_Syntax_Syntax.sigrng);
                                  FStar_Syntax_Syntax.sigquals =
-                                   (uu___359_2042.FStar_Syntax_Syntax.sigquals);
+                                   (uu___359_2089.FStar_Syntax_Syntax.sigquals);
                                  FStar_Syntax_Syntax.sigmeta =
-                                   (uu___359_2042.FStar_Syntax_Syntax.sigmeta);
+                                   (uu___359_2089.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
-                                   (uu___359_2042.FStar_Syntax_Syntax.sigattrs);
+                                   (uu___359_2089.FStar_Syntax_Syntax.sigattrs);
                                  FStar_Syntax_Syntax.sigopts =
-                                   (uu___359_2042.FStar_Syntax_Syntax.sigopts)
+                                   (uu___359_2089.FStar_Syntax_Syntax.sigopts)
                                })
                              in
                           FStar_Util.print1 "Effect decl after phase 1: %s\n"
-                            uu____2038
+                            uu____2085
                         else ());
                        ne1)
                     else ne  in
@@ -1537,543 +1564,543 @@ let (tc_decl' :
                       se1.FStar_Syntax_Syntax.sigquals
                      in
                   let se2 =
-                    let uu___364_2050 = se1  in
+                    let uu___364_2097 = se1  in
                     {
                       FStar_Syntax_Syntax.sigel =
                         (FStar_Syntax_Syntax.Sig_new_effect ne2);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___364_2050.FStar_Syntax_Syntax.sigrng);
+                        (uu___364_2097.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
-                        (uu___364_2050.FStar_Syntax_Syntax.sigquals);
+                        (uu___364_2097.FStar_Syntax_Syntax.sigquals);
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___364_2050.FStar_Syntax_Syntax.sigmeta);
+                        (uu___364_2097.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___364_2050.FStar_Syntax_Syntax.sigattrs);
+                        (uu___364_2097.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___364_2050.FStar_Syntax_Syntax.sigopts)
+                        (uu___364_2097.FStar_Syntax_Syntax.sigopts)
                     }  in
                   ([se2], [], env0))
            | FStar_Syntax_Syntax.Sig_sub_effect sub ->
                let sub1 = FStar_TypeChecker_TcEffect.tc_lift env sub r  in
                let se2 =
-                 let uu___370_2058 = se1  in
+                 let uu___370_2105 = se1  in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_sub_effect sub1);
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___370_2058.FStar_Syntax_Syntax.sigrng);
+                     (uu___370_2105.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
-                     (uu___370_2058.FStar_Syntax_Syntax.sigquals);
+                     (uu___370_2105.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___370_2058.FStar_Syntax_Syntax.sigmeta);
+                     (uu___370_2105.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs =
-                     (uu___370_2058.FStar_Syntax_Syntax.sigattrs);
+                     (uu___370_2105.FStar_Syntax_Syntax.sigattrs);
                    FStar_Syntax_Syntax.sigopts =
-                     (uu___370_2058.FStar_Syntax_Syntax.sigopts)
+                     (uu___370_2105.FStar_Syntax_Syntax.sigopts)
                  }  in
                ([se2], [], env)
            | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,uvs,tps,c,flags) ->
-               let uu____2072 =
-                 let uu____2081 =
+               let uu____2119 =
+                 let uu____2128 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env)
                     in
-                 if uu____2081
+                 if uu____2128
                  then
-                   let uu____2092 =
-                     let uu____2093 =
-                       let uu____2094 =
+                   let uu____2139 =
+                     let uu____2140 =
+                       let uu____2141 =
                          FStar_TypeChecker_TcEffect.tc_effect_abbrev
-                           (let uu___381_2105 = env  in
+                           (let uu___381_2152 = env  in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___381_2105.FStar_TypeChecker_Env.solver);
+                                (uu___381_2152.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___381_2105.FStar_TypeChecker_Env.range);
+                                (uu___381_2152.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___381_2105.FStar_TypeChecker_Env.curmodule);
+                                (uu___381_2152.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___381_2105.FStar_TypeChecker_Env.gamma);
+                                (uu___381_2152.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___381_2105.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___381_2152.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___381_2105.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___381_2152.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___381_2105.FStar_TypeChecker_Env.modules);
+                                (uu___381_2152.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
-                                (uu___381_2105.FStar_TypeChecker_Env.expected_typ);
+                                (uu___381_2152.FStar_TypeChecker_Env.expected_typ);
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___381_2105.FStar_TypeChecker_Env.sigtab);
+                                (uu___381_2152.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___381_2105.FStar_TypeChecker_Env.attrtab);
+                                (uu___381_2152.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___381_2105.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___381_2152.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___381_2105.FStar_TypeChecker_Env.effects);
+                                (uu___381_2152.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___381_2105.FStar_TypeChecker_Env.generalize);
+                                (uu___381_2152.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___381_2105.FStar_TypeChecker_Env.letrecs);
+                                (uu___381_2152.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___381_2105.FStar_TypeChecker_Env.top_level);
+                                (uu___381_2152.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___381_2105.FStar_TypeChecker_Env.check_uvars);
+                                (uu___381_2152.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___381_2105.FStar_TypeChecker_Env.use_eq);
+                                (uu___381_2152.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___381_2105.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___381_2152.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___381_2105.FStar_TypeChecker_Env.is_iface);
+                                (uu___381_2152.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___381_2105.FStar_TypeChecker_Env.admit);
+                                (uu___381_2152.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___381_2105.FStar_TypeChecker_Env.lax_universes);
+                                (uu___381_2152.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 = true;
                               FStar_TypeChecker_Env.failhard =
-                                (uu___381_2105.FStar_TypeChecker_Env.failhard);
+                                (uu___381_2152.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___381_2105.FStar_TypeChecker_Env.nosynth);
+                                (uu___381_2152.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___381_2105.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___381_2152.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___381_2105.FStar_TypeChecker_Env.tc_term);
+                                (uu___381_2152.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___381_2105.FStar_TypeChecker_Env.type_of);
+                                (uu___381_2152.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___381_2105.FStar_TypeChecker_Env.universe_of);
+                                (uu___381_2152.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___381_2105.FStar_TypeChecker_Env.check_type_of);
+                                (uu___381_2152.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts =
-                                (uu___381_2105.FStar_TypeChecker_Env.use_bv_sorts);
+                                (uu___381_2152.FStar_TypeChecker_Env.use_bv_sorts);
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___381_2105.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___381_2152.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___381_2105.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___381_2152.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___381_2105.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___381_2152.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___381_2105.FStar_TypeChecker_Env.proof_ns);
+                                (uu___381_2152.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___381_2105.FStar_TypeChecker_Env.synth_hook);
+                                (uu___381_2152.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___381_2105.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___381_2152.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___381_2105.FStar_TypeChecker_Env.splice);
+                                (uu___381_2152.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___381_2105.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___381_2152.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___381_2105.FStar_TypeChecker_Env.postprocess);
+                                (uu___381_2152.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.is_native_tactic =
-                                (uu___381_2105.FStar_TypeChecker_Env.is_native_tactic);
+                                (uu___381_2152.FStar_TypeChecker_Env.is_native_tactic);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___381_2105.FStar_TypeChecker_Env.identifier_info);
+                                (uu___381_2152.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___381_2105.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___381_2152.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___381_2105.FStar_TypeChecker_Env.dsenv);
+                                (uu___381_2152.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___381_2105.FStar_TypeChecker_Env.nbe);
+                                (uu___381_2152.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___381_2105.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___381_2152.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___381_2105.FStar_TypeChecker_Env.erasable_types_tab)
+                                (uu___381_2152.FStar_TypeChecker_Env.erasable_types_tab)
                             }) (lid, uvs, tps, c) r
                           in
-                       FStar_All.pipe_right uu____2094
-                         (fun uu____2122  ->
-                            match uu____2122 with
+                       FStar_All.pipe_right uu____2141
+                         (fun uu____2169  ->
+                            match uu____2169 with
                             | (lid1,uvs1,tps1,c1) ->
-                                let uu___388_2135 = se1  in
+                                let uu___388_2182 = se1  in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_effect_abbrev
                                        (lid1, uvs1, tps1, c1, flags));
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___388_2135.FStar_Syntax_Syntax.sigrng);
+                                    (uu___388_2182.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___388_2135.FStar_Syntax_Syntax.sigquals);
+                                    (uu___388_2182.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___388_2135.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___388_2182.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
-                                    (uu___388_2135.FStar_Syntax_Syntax.sigattrs);
+                                    (uu___388_2182.FStar_Syntax_Syntax.sigattrs);
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___388_2135.FStar_Syntax_Syntax.sigopts)
+                                    (uu___388_2182.FStar_Syntax_Syntax.sigopts)
                                 })
                         in
-                     FStar_All.pipe_right uu____2093
+                     FStar_All.pipe_right uu____2140
                        (FStar_TypeChecker_Normalize.elim_uvars env)
                       in
-                   FStar_All.pipe_right uu____2092
+                   FStar_All.pipe_right uu____2139
                      (fun se2  ->
                         match se2.FStar_Syntax_Syntax.sigel with
                         | FStar_Syntax_Syntax.Sig_effect_abbrev
-                            (lid1,uvs1,tps1,c1,uu____2165) ->
+                            (lid1,uvs1,tps1,c1,uu____2212) ->
                             (lid1, uvs1, tps1, c1)
-                        | uu____2170 ->
+                        | uu____2217 ->
                             failwith
                               "Did not expect Sig_effect_abbrev to not be one after phase 1")
                  else (lid, uvs, tps, c)  in
-               (match uu____2072 with
+               (match uu____2119 with
                 | (lid1,uvs1,tps1,c1) ->
-                    let uu____2196 =
+                    let uu____2243 =
                       FStar_TypeChecker_TcEffect.tc_effect_abbrev env
                         (lid1, uvs1, tps1, c1) r
                        in
-                    (match uu____2196 with
+                    (match uu____2243 with
                      | (lid2,uvs2,tps2,c2) ->
                          let se2 =
-                           let uu___409_2220 = se1  in
+                           let uu___409_2267 = se1  in
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_effect_abbrev
                                   (lid2, uvs2, tps2, c2, flags));
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___409_2220.FStar_Syntax_Syntax.sigrng);
+                               (uu___409_2267.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
-                               (uu___409_2220.FStar_Syntax_Syntax.sigquals);
+                               (uu___409_2267.FStar_Syntax_Syntax.sigquals);
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___409_2220.FStar_Syntax_Syntax.sigmeta);
+                               (uu___409_2267.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___409_2220.FStar_Syntax_Syntax.sigattrs);
+                               (uu___409_2267.FStar_Syntax_Syntax.sigattrs);
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___409_2220.FStar_Syntax_Syntax.sigopts)
+                               (uu___409_2267.FStar_Syntax_Syntax.sigopts)
                            }  in
                          ([se2], [], env0)))
            | FStar_Syntax_Syntax.Sig_declare_typ
-               (uu____2227,uu____2228,uu____2229) when
+               (uu____2274,uu____2275,uu____2276) when
                FStar_All.pipe_right se1.FStar_Syntax_Syntax.sigquals
                  (FStar_Util.for_some
-                    (fun uu___0_2234  ->
-                       match uu___0_2234 with
+                    (fun uu___0_2281  ->
+                       match uu___0_2281 with
                        | FStar_Syntax_Syntax.OnlyName  -> true
-                       | uu____2237 -> false))
+                       | uu____2284 -> false))
                -> ([], [], env0)
-           | FStar_Syntax_Syntax.Sig_let (uu____2243,uu____2244) when
+           | FStar_Syntax_Syntax.Sig_let (uu____2290,uu____2291) when
                FStar_All.pipe_right se1.FStar_Syntax_Syntax.sigquals
                  (FStar_Util.for_some
-                    (fun uu___0_2253  ->
-                       match uu___0_2253 with
+                    (fun uu___0_2300  ->
+                       match uu___0_2300 with
                        | FStar_Syntax_Syntax.OnlyName  -> true
-                       | uu____2256 -> false))
+                       | uu____2303 -> false))
                -> ([], [], env0)
            | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
                let env1 = FStar_TypeChecker_Env.set_range env r  in
-               ((let uu____2267 = FStar_TypeChecker_Env.lid_exists env1 lid
+               ((let uu____2314 = FStar_TypeChecker_Env.lid_exists env1 lid
                     in
-                 if uu____2267
+                 if uu____2314
                  then
-                   let uu____2270 =
-                     let uu____2276 =
-                       let uu____2278 = FStar_Ident.text_of_lid lid  in
+                   let uu____2317 =
+                     let uu____2323 =
+                       let uu____2325 = FStar_Ident.string_of_lid lid  in
                        FStar_Util.format1
                          "Top-level declaration %s for a name that is already used in this module; top-level declarations must be unique in their module"
-                         uu____2278
+                         uu____2325
                         in
                      (FStar_Errors.Fatal_AlreadyDefinedTopLevelDeclaration,
-                       uu____2276)
+                       uu____2323)
                       in
-                   FStar_Errors.raise_error uu____2270 r
+                   FStar_Errors.raise_error uu____2317 r
                  else ());
-                (let uu____2284 =
-                   let uu____2293 =
+                (let uu____2331 =
+                   let uu____2340 =
                      (FStar_Options.use_two_phase_tc ()) &&
                        (FStar_TypeChecker_Env.should_verify env1)
                       in
-                   if uu____2293
+                   if uu____2340
                    then
-                     let uu____2304 =
+                     let uu____2351 =
                        tc_declare_typ
-                         (let uu___433_2307 = env1  in
+                         (let uu___433_2354 = env1  in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___433_2307.FStar_TypeChecker_Env.solver);
+                              (uu___433_2354.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___433_2307.FStar_TypeChecker_Env.range);
+                              (uu___433_2354.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___433_2307.FStar_TypeChecker_Env.curmodule);
+                              (uu___433_2354.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___433_2307.FStar_TypeChecker_Env.gamma);
+                              (uu___433_2354.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___433_2307.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___433_2354.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___433_2307.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___433_2354.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___433_2307.FStar_TypeChecker_Env.modules);
+                              (uu___433_2354.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___433_2307.FStar_TypeChecker_Env.expected_typ);
+                              (uu___433_2354.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___433_2307.FStar_TypeChecker_Env.sigtab);
+                              (uu___433_2354.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___433_2307.FStar_TypeChecker_Env.attrtab);
+                              (uu___433_2354.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___433_2307.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___433_2354.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___433_2307.FStar_TypeChecker_Env.effects);
+                              (uu___433_2354.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___433_2307.FStar_TypeChecker_Env.generalize);
+                              (uu___433_2354.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___433_2307.FStar_TypeChecker_Env.letrecs);
+                              (uu___433_2354.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___433_2307.FStar_TypeChecker_Env.top_level);
+                              (uu___433_2354.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___433_2307.FStar_TypeChecker_Env.check_uvars);
+                              (uu___433_2354.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___433_2307.FStar_TypeChecker_Env.use_eq);
+                              (uu___433_2354.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___433_2307.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___433_2354.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___433_2307.FStar_TypeChecker_Env.is_iface);
+                              (uu___433_2354.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___433_2307.FStar_TypeChecker_Env.admit);
+                              (uu___433_2354.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___433_2307.FStar_TypeChecker_Env.lax_universes);
+                              (uu___433_2354.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 = true;
                             FStar_TypeChecker_Env.failhard =
-                              (uu___433_2307.FStar_TypeChecker_Env.failhard);
+                              (uu___433_2354.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___433_2307.FStar_TypeChecker_Env.nosynth);
+                              (uu___433_2354.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___433_2307.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___433_2354.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___433_2307.FStar_TypeChecker_Env.tc_term);
+                              (uu___433_2354.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___433_2307.FStar_TypeChecker_Env.type_of);
+                              (uu___433_2354.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___433_2307.FStar_TypeChecker_Env.universe_of);
+                              (uu___433_2354.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___433_2307.FStar_TypeChecker_Env.check_type_of);
+                              (uu___433_2354.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___433_2307.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___433_2354.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___433_2307.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___433_2354.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___433_2307.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___433_2354.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___433_2307.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___433_2354.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___433_2307.FStar_TypeChecker_Env.proof_ns);
+                              (uu___433_2354.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___433_2307.FStar_TypeChecker_Env.synth_hook);
+                              (uu___433_2354.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___433_2307.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___433_2354.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___433_2307.FStar_TypeChecker_Env.splice);
+                              (uu___433_2354.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___433_2307.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___433_2354.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___433_2307.FStar_TypeChecker_Env.postprocess);
+                              (uu___433_2354.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.is_native_tactic =
-                              (uu___433_2307.FStar_TypeChecker_Env.is_native_tactic);
+                              (uu___433_2354.FStar_TypeChecker_Env.is_native_tactic);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___433_2307.FStar_TypeChecker_Env.identifier_info);
+                              (uu___433_2354.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___433_2307.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___433_2354.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___433_2307.FStar_TypeChecker_Env.dsenv);
+                              (uu___433_2354.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___433_2307.FStar_TypeChecker_Env.nbe);
+                              (uu___433_2354.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___433_2307.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___433_2354.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___433_2307.FStar_TypeChecker_Env.erasable_types_tab)
+                              (uu___433_2354.FStar_TypeChecker_Env.erasable_types_tab)
                           }) (uvs, t) se1.FStar_Syntax_Syntax.sigrng
                         in
-                     match uu____2304 with
+                     match uu____2351 with
                      | (uvs1,t1) ->
-                         ((let uu____2333 =
+                         ((let uu____2380 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "TwoPhases")
                               in
-                           if uu____2333
+                           if uu____2380
                            then
-                             let uu____2338 =
+                             let uu____2385 =
                                FStar_Syntax_Print.term_to_string t1  in
-                             let uu____2340 =
+                             let uu____2387 =
                                FStar_Syntax_Print.univ_names_to_string uvs1
                                 in
                              FStar_Util.print2
                                "Val declaration after phase 1: %s and uvs: %s\n"
-                               uu____2338 uu____2340
+                               uu____2385 uu____2387
                            else ());
                           (uvs1, t1))
                    else (uvs, t)  in
-                 match uu____2284 with
+                 match uu____2331 with
                  | (uvs1,t1) ->
-                     let uu____2375 =
+                     let uu____2422 =
                        tc_declare_typ env1 (uvs1, t1)
                          se1.FStar_Syntax_Syntax.sigrng
                         in
-                     (match uu____2375 with
+                     (match uu____2422 with
                       | (uvs2,t2) ->
-                          ([(let uu___446_2405 = se1  in
+                          ([(let uu___446_2452 = se1  in
                              {
                                FStar_Syntax_Syntax.sigel =
                                  (FStar_Syntax_Syntax.Sig_declare_typ
                                     (lid, uvs2, t2));
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___446_2405.FStar_Syntax_Syntax.sigrng);
+                                 (uu___446_2452.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___446_2405.FStar_Syntax_Syntax.sigquals);
+                                 (uu___446_2452.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___446_2405.FStar_Syntax_Syntax.sigmeta);
+                                 (uu___446_2452.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
-                                 (uu___446_2405.FStar_Syntax_Syntax.sigattrs);
+                                 (uu___446_2452.FStar_Syntax_Syntax.sigattrs);
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___446_2405.FStar_Syntax_Syntax.sigopts)
+                                 (uu___446_2452.FStar_Syntax_Syntax.sigopts)
                              })], [], env0))))
            | FStar_Syntax_Syntax.Sig_assume (lid,uvs,t) ->
                let env1 = FStar_TypeChecker_Env.set_range env r  in
-               let uu____2410 =
-                 let uu____2419 =
+               let uu____2457 =
+                 let uu____2466 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env1)
                     in
-                 if uu____2419
+                 if uu____2466
                  then
-                   let uu____2430 =
+                   let uu____2477 =
                      tc_assume
-                       (let uu___455_2433 = env1  in
+                       (let uu___455_2480 = env1  in
                         {
                           FStar_TypeChecker_Env.solver =
-                            (uu___455_2433.FStar_TypeChecker_Env.solver);
+                            (uu___455_2480.FStar_TypeChecker_Env.solver);
                           FStar_TypeChecker_Env.range =
-                            (uu___455_2433.FStar_TypeChecker_Env.range);
+                            (uu___455_2480.FStar_TypeChecker_Env.range);
                           FStar_TypeChecker_Env.curmodule =
-                            (uu___455_2433.FStar_TypeChecker_Env.curmodule);
+                            (uu___455_2480.FStar_TypeChecker_Env.curmodule);
                           FStar_TypeChecker_Env.gamma =
-                            (uu___455_2433.FStar_TypeChecker_Env.gamma);
+                            (uu___455_2480.FStar_TypeChecker_Env.gamma);
                           FStar_TypeChecker_Env.gamma_sig =
-                            (uu___455_2433.FStar_TypeChecker_Env.gamma_sig);
+                            (uu___455_2480.FStar_TypeChecker_Env.gamma_sig);
                           FStar_TypeChecker_Env.gamma_cache =
-                            (uu___455_2433.FStar_TypeChecker_Env.gamma_cache);
+                            (uu___455_2480.FStar_TypeChecker_Env.gamma_cache);
                           FStar_TypeChecker_Env.modules =
-                            (uu___455_2433.FStar_TypeChecker_Env.modules);
+                            (uu___455_2480.FStar_TypeChecker_Env.modules);
                           FStar_TypeChecker_Env.expected_typ =
-                            (uu___455_2433.FStar_TypeChecker_Env.expected_typ);
+                            (uu___455_2480.FStar_TypeChecker_Env.expected_typ);
                           FStar_TypeChecker_Env.sigtab =
-                            (uu___455_2433.FStar_TypeChecker_Env.sigtab);
+                            (uu___455_2480.FStar_TypeChecker_Env.sigtab);
                           FStar_TypeChecker_Env.attrtab =
-                            (uu___455_2433.FStar_TypeChecker_Env.attrtab);
+                            (uu___455_2480.FStar_TypeChecker_Env.attrtab);
                           FStar_TypeChecker_Env.instantiate_imp =
-                            (uu___455_2433.FStar_TypeChecker_Env.instantiate_imp);
+                            (uu___455_2480.FStar_TypeChecker_Env.instantiate_imp);
                           FStar_TypeChecker_Env.effects =
-                            (uu___455_2433.FStar_TypeChecker_Env.effects);
+                            (uu___455_2480.FStar_TypeChecker_Env.effects);
                           FStar_TypeChecker_Env.generalize =
-                            (uu___455_2433.FStar_TypeChecker_Env.generalize);
+                            (uu___455_2480.FStar_TypeChecker_Env.generalize);
                           FStar_TypeChecker_Env.letrecs =
-                            (uu___455_2433.FStar_TypeChecker_Env.letrecs);
+                            (uu___455_2480.FStar_TypeChecker_Env.letrecs);
                           FStar_TypeChecker_Env.top_level =
-                            (uu___455_2433.FStar_TypeChecker_Env.top_level);
+                            (uu___455_2480.FStar_TypeChecker_Env.top_level);
                           FStar_TypeChecker_Env.check_uvars =
-                            (uu___455_2433.FStar_TypeChecker_Env.check_uvars);
+                            (uu___455_2480.FStar_TypeChecker_Env.check_uvars);
                           FStar_TypeChecker_Env.use_eq =
-                            (uu___455_2433.FStar_TypeChecker_Env.use_eq);
+                            (uu___455_2480.FStar_TypeChecker_Env.use_eq);
                           FStar_TypeChecker_Env.use_eq_strict =
-                            (uu___455_2433.FStar_TypeChecker_Env.use_eq_strict);
+                            (uu___455_2480.FStar_TypeChecker_Env.use_eq_strict);
                           FStar_TypeChecker_Env.is_iface =
-                            (uu___455_2433.FStar_TypeChecker_Env.is_iface);
+                            (uu___455_2480.FStar_TypeChecker_Env.is_iface);
                           FStar_TypeChecker_Env.admit =
-                            (uu___455_2433.FStar_TypeChecker_Env.admit);
+                            (uu___455_2480.FStar_TypeChecker_Env.admit);
                           FStar_TypeChecker_Env.lax = true;
                           FStar_TypeChecker_Env.lax_universes =
-                            (uu___455_2433.FStar_TypeChecker_Env.lax_universes);
+                            (uu___455_2480.FStar_TypeChecker_Env.lax_universes);
                           FStar_TypeChecker_Env.phase1 = true;
                           FStar_TypeChecker_Env.failhard =
-                            (uu___455_2433.FStar_TypeChecker_Env.failhard);
+                            (uu___455_2480.FStar_TypeChecker_Env.failhard);
                           FStar_TypeChecker_Env.nosynth =
-                            (uu___455_2433.FStar_TypeChecker_Env.nosynth);
+                            (uu___455_2480.FStar_TypeChecker_Env.nosynth);
                           FStar_TypeChecker_Env.uvar_subtyping =
-                            (uu___455_2433.FStar_TypeChecker_Env.uvar_subtyping);
+                            (uu___455_2480.FStar_TypeChecker_Env.uvar_subtyping);
                           FStar_TypeChecker_Env.tc_term =
-                            (uu___455_2433.FStar_TypeChecker_Env.tc_term);
+                            (uu___455_2480.FStar_TypeChecker_Env.tc_term);
                           FStar_TypeChecker_Env.type_of =
-                            (uu___455_2433.FStar_TypeChecker_Env.type_of);
+                            (uu___455_2480.FStar_TypeChecker_Env.type_of);
                           FStar_TypeChecker_Env.universe_of =
-                            (uu___455_2433.FStar_TypeChecker_Env.universe_of);
+                            (uu___455_2480.FStar_TypeChecker_Env.universe_of);
                           FStar_TypeChecker_Env.check_type_of =
-                            (uu___455_2433.FStar_TypeChecker_Env.check_type_of);
+                            (uu___455_2480.FStar_TypeChecker_Env.check_type_of);
                           FStar_TypeChecker_Env.use_bv_sorts =
-                            (uu___455_2433.FStar_TypeChecker_Env.use_bv_sorts);
+                            (uu___455_2480.FStar_TypeChecker_Env.use_bv_sorts);
                           FStar_TypeChecker_Env.qtbl_name_and_index =
-                            (uu___455_2433.FStar_TypeChecker_Env.qtbl_name_and_index);
+                            (uu___455_2480.FStar_TypeChecker_Env.qtbl_name_and_index);
                           FStar_TypeChecker_Env.normalized_eff_names =
-                            (uu___455_2433.FStar_TypeChecker_Env.normalized_eff_names);
+                            (uu___455_2480.FStar_TypeChecker_Env.normalized_eff_names);
                           FStar_TypeChecker_Env.fv_delta_depths =
-                            (uu___455_2433.FStar_TypeChecker_Env.fv_delta_depths);
+                            (uu___455_2480.FStar_TypeChecker_Env.fv_delta_depths);
                           FStar_TypeChecker_Env.proof_ns =
-                            (uu___455_2433.FStar_TypeChecker_Env.proof_ns);
+                            (uu___455_2480.FStar_TypeChecker_Env.proof_ns);
                           FStar_TypeChecker_Env.synth_hook =
-                            (uu___455_2433.FStar_TypeChecker_Env.synth_hook);
+                            (uu___455_2480.FStar_TypeChecker_Env.synth_hook);
                           FStar_TypeChecker_Env.try_solve_implicits_hook =
-                            (uu___455_2433.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                            (uu___455_2480.FStar_TypeChecker_Env.try_solve_implicits_hook);
                           FStar_TypeChecker_Env.splice =
-                            (uu___455_2433.FStar_TypeChecker_Env.splice);
+                            (uu___455_2480.FStar_TypeChecker_Env.splice);
                           FStar_TypeChecker_Env.mpreprocess =
-                            (uu___455_2433.FStar_TypeChecker_Env.mpreprocess);
+                            (uu___455_2480.FStar_TypeChecker_Env.mpreprocess);
                           FStar_TypeChecker_Env.postprocess =
-                            (uu___455_2433.FStar_TypeChecker_Env.postprocess);
+                            (uu___455_2480.FStar_TypeChecker_Env.postprocess);
                           FStar_TypeChecker_Env.is_native_tactic =
-                            (uu___455_2433.FStar_TypeChecker_Env.is_native_tactic);
+                            (uu___455_2480.FStar_TypeChecker_Env.is_native_tactic);
                           FStar_TypeChecker_Env.identifier_info =
-                            (uu___455_2433.FStar_TypeChecker_Env.identifier_info);
+                            (uu___455_2480.FStar_TypeChecker_Env.identifier_info);
                           FStar_TypeChecker_Env.tc_hooks =
-                            (uu___455_2433.FStar_TypeChecker_Env.tc_hooks);
+                            (uu___455_2480.FStar_TypeChecker_Env.tc_hooks);
                           FStar_TypeChecker_Env.dsenv =
-                            (uu___455_2433.FStar_TypeChecker_Env.dsenv);
+                            (uu___455_2480.FStar_TypeChecker_Env.dsenv);
                           FStar_TypeChecker_Env.nbe =
-                            (uu___455_2433.FStar_TypeChecker_Env.nbe);
+                            (uu___455_2480.FStar_TypeChecker_Env.nbe);
                           FStar_TypeChecker_Env.strict_args_tab =
-                            (uu___455_2433.FStar_TypeChecker_Env.strict_args_tab);
+                            (uu___455_2480.FStar_TypeChecker_Env.strict_args_tab);
                           FStar_TypeChecker_Env.erasable_types_tab =
-                            (uu___455_2433.FStar_TypeChecker_Env.erasable_types_tab)
+                            (uu___455_2480.FStar_TypeChecker_Env.erasable_types_tab)
                         }) (uvs, t) se1.FStar_Syntax_Syntax.sigrng
                       in
-                   match uu____2430 with
+                   match uu____2477 with
                    | (uvs1,t1) ->
-                       ((let uu____2459 =
+                       ((let uu____2506 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env1)
                              (FStar_Options.Other "TwoPhases")
                             in
-                         if uu____2459
+                         if uu____2506
                          then
-                           let uu____2464 =
+                           let uu____2511 =
                              FStar_Syntax_Print.term_to_string t1  in
-                           let uu____2466 =
+                           let uu____2513 =
                              FStar_Syntax_Print.univ_names_to_string uvs1  in
                            FStar_Util.print2
                              "Assume after phase 1: %s and uvs: %s\n"
-                             uu____2464 uu____2466
+                             uu____2511 uu____2513
                          else ());
                         (uvs1, t1))
                  else (uvs, t)  in
-               (match uu____2410 with
+               (match uu____2457 with
                 | (uvs1,t1) ->
-                    let uu____2501 =
+                    let uu____2548 =
                       tc_assume env1 (uvs1, t1)
                         se1.FStar_Syntax_Syntax.sigrng
                        in
-                    (match uu____2501 with
+                    (match uu____2548 with
                      | (uvs2,t2) ->
-                         ([(let uu___468_2531 = se1  in
+                         ([(let uu___468_2578 = se1  in
                             {
                               FStar_Syntax_Syntax.sigel =
                                 (FStar_Syntax_Syntax.Sig_assume
                                    (lid, uvs2, t2));
                               FStar_Syntax_Syntax.sigrng =
-                                (uu___468_2531.FStar_Syntax_Syntax.sigrng);
+                                (uu___468_2578.FStar_Syntax_Syntax.sigrng);
                               FStar_Syntax_Syntax.sigquals =
-                                (uu___468_2531.FStar_Syntax_Syntax.sigquals);
+                                (uu___468_2578.FStar_Syntax_Syntax.sigquals);
                               FStar_Syntax_Syntax.sigmeta =
-                                (uu___468_2531.FStar_Syntax_Syntax.sigmeta);
+                                (uu___468_2578.FStar_Syntax_Syntax.sigmeta);
                               FStar_Syntax_Syntax.sigattrs =
-                                (uu___468_2531.FStar_Syntax_Syntax.sigattrs);
+                                (uu___468_2578.FStar_Syntax_Syntax.sigattrs);
                               FStar_Syntax_Syntax.sigopts =
-                                (uu___468_2531.FStar_Syntax_Syntax.sigopts)
+                                (uu___468_2578.FStar_Syntax_Syntax.sigopts)
                             })], [], env0)))
            | FStar_Syntax_Syntax.Sig_main e ->
                let env1 = FStar_TypeChecker_Env.set_range env r  in
@@ -2081,72 +2108,72 @@ let (tc_decl' :
                  FStar_TypeChecker_Env.set_expected_typ env1
                    FStar_Syntax_Syntax.t_unit
                   in
-               let uu____2535 = FStar_TypeChecker_TcTerm.tc_term env2 e  in
-               (match uu____2535 with
+               let uu____2582 = FStar_TypeChecker_TcTerm.tc_term env2 e  in
+               (match uu____2582 with
                 | (e1,c,g1) ->
-                    let uu____2555 =
-                      let uu____2562 = FStar_TypeChecker_Common.lcomp_comp c
+                    let uu____2602 =
+                      let uu____2609 = FStar_TypeChecker_Common.lcomp_comp c
                          in
-                      match uu____2562 with
+                      match uu____2609 with
                       | (c1,g_lc) ->
-                          let uu____2575 =
-                            let uu____2582 =
-                              let uu____2585 =
+                          let uu____2622 =
+                            let uu____2629 =
+                              let uu____2632 =
                                 FStar_Syntax_Util.ml_comp
                                   FStar_Syntax_Syntax.t_unit r
                                  in
-                              FStar_Pervasives_Native.Some uu____2585  in
+                              FStar_Pervasives_Native.Some uu____2632  in
                             FStar_TypeChecker_TcTerm.check_expected_effect
-                              env2 uu____2582 (e1, c1)
+                              env2 uu____2629 (e1, c1)
                              in
-                          (match uu____2575 with
+                          (match uu____2622 with
                            | (e2,_x,g) ->
-                               let uu____2595 =
+                               let uu____2642 =
                                  FStar_TypeChecker_Env.conj_guard g_lc g  in
-                               (e2, _x, uu____2595))
+                               (e2, _x, uu____2642))
                        in
-                    (match uu____2555 with
-                     | (e2,uu____2607,g) ->
-                         ((let uu____2610 =
+                    (match uu____2602 with
+                     | (e2,uu____2654,g) ->
+                         ((let uu____2657 =
                              FStar_TypeChecker_Env.conj_guard g1 g  in
                            FStar_TypeChecker_Rel.force_trivial_guard env2
-                             uu____2610);
+                             uu____2657);
                           (let se2 =
-                             let uu___490_2612 = se1  in
+                             let uu___490_2659 = se1  in
                              {
                                FStar_Syntax_Syntax.sigel =
                                  (FStar_Syntax_Syntax.Sig_main e2);
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___490_2612.FStar_Syntax_Syntax.sigrng);
+                                 (uu___490_2659.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___490_2612.FStar_Syntax_Syntax.sigquals);
+                                 (uu___490_2659.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___490_2612.FStar_Syntax_Syntax.sigmeta);
+                                 (uu___490_2659.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
-                                 (uu___490_2612.FStar_Syntax_Syntax.sigattrs);
+                                 (uu___490_2659.FStar_Syntax_Syntax.sigattrs);
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___490_2612.FStar_Syntax_Syntax.sigopts)
+                                 (uu___490_2659.FStar_Syntax_Syntax.sigopts)
                              }  in
                            ([se2], [], env0)))))
            | FStar_Syntax_Syntax.Sig_splice (lids,t) ->
-               ((let uu____2624 = FStar_Options.debug_any ()  in
-                 if uu____2624
+               ((let uu____2671 = FStar_Options.debug_any ()  in
+                 if uu____2671
                  then
-                   let uu____2627 =
+                   let uu____2674 =
                      FStar_Ident.string_of_lid
                        env.FStar_TypeChecker_Env.curmodule
                       in
-                   let uu____2629 = FStar_Syntax_Print.term_to_string t  in
-                   FStar_Util.print2 "%s: Found splice of (%s)\n" uu____2627
-                     uu____2629
+                   let uu____2676 = FStar_Syntax_Print.term_to_string t  in
+                   FStar_Util.print2 "%s: Found splice of (%s)\n" uu____2674
+                     uu____2676
                  else ());
-                (let uu____2634 =
+                (let uu____2681 =
                    FStar_TypeChecker_TcTerm.tc_tactic
                      FStar_Syntax_Syntax.t_unit FStar_Syntax_Syntax.t_decls
                      env t
                     in
-                 match uu____2634 with
-                 | (t1,uu____2652,g) ->
+                 match uu____2681 with
+                 | (t1,uu____2699,g) ->
                      (FStar_TypeChecker_Rel.force_trivial_guard env g;
                       (let ses = env.FStar_TypeChecker_Env.splice env t1  in
                        let lids' =
@@ -2155,137 +2182,137 @@ let (tc_decl' :
                           in
                        FStar_List.iter
                          (fun lid  ->
-                            let uu____2666 =
+                            let uu____2713 =
                               FStar_List.tryFind (FStar_Ident.lid_equals lid)
                                 lids'
                                in
-                            match uu____2666 with
+                            match uu____2713 with
                             | FStar_Pervasives_Native.None  when
                                 Prims.op_Negation
                                   env.FStar_TypeChecker_Env.nosynth
                                 ->
-                                let uu____2669 =
-                                  let uu____2675 =
-                                    let uu____2677 =
+                                let uu____2716 =
+                                  let uu____2722 =
+                                    let uu____2724 =
                                       FStar_Ident.string_of_lid lid  in
-                                    let uu____2679 =
-                                      let uu____2681 =
+                                    let uu____2726 =
+                                      let uu____2728 =
                                         FStar_List.map
                                           FStar_Ident.string_of_lid lids'
                                          in
                                       FStar_All.pipe_left
-                                        (FStar_String.concat ", ") uu____2681
+                                        (FStar_String.concat ", ") uu____2728
                                        in
                                     FStar_Util.format2
                                       "Splice declared the name %s but it was not defined.\nThose defined were: %s"
-                                      uu____2677 uu____2679
+                                      uu____2724 uu____2726
                                      in
                                   (FStar_Errors.Fatal_SplicedUndef,
-                                    uu____2675)
+                                    uu____2722)
                                    in
-                                FStar_Errors.raise_error uu____2669 r
-                            | uu____2693 -> ()) lids;
+                                FStar_Errors.raise_error uu____2716 r
+                            | uu____2740 -> ()) lids;
                        (let dsenv =
                           FStar_List.fold_left
                             FStar_Syntax_DsEnv.push_sigelt_force
                             env.FStar_TypeChecker_Env.dsenv ses
                            in
                         let env1 =
-                          let uu___511_2698 = env  in
+                          let uu___511_2745 = env  in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___511_2698.FStar_TypeChecker_Env.solver);
+                              (uu___511_2745.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___511_2698.FStar_TypeChecker_Env.range);
+                              (uu___511_2745.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___511_2698.FStar_TypeChecker_Env.curmodule);
+                              (uu___511_2745.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___511_2698.FStar_TypeChecker_Env.gamma);
+                              (uu___511_2745.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___511_2698.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___511_2745.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___511_2698.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___511_2745.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___511_2698.FStar_TypeChecker_Env.modules);
+                              (uu___511_2745.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___511_2698.FStar_TypeChecker_Env.expected_typ);
+                              (uu___511_2745.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___511_2698.FStar_TypeChecker_Env.sigtab);
+                              (uu___511_2745.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___511_2698.FStar_TypeChecker_Env.attrtab);
+                              (uu___511_2745.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___511_2698.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___511_2745.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___511_2698.FStar_TypeChecker_Env.effects);
+                              (uu___511_2745.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___511_2698.FStar_TypeChecker_Env.generalize);
+                              (uu___511_2745.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___511_2698.FStar_TypeChecker_Env.letrecs);
+                              (uu___511_2745.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___511_2698.FStar_TypeChecker_Env.top_level);
+                              (uu___511_2745.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___511_2698.FStar_TypeChecker_Env.check_uvars);
+                              (uu___511_2745.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___511_2698.FStar_TypeChecker_Env.use_eq);
+                              (uu___511_2745.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___511_2698.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___511_2745.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___511_2698.FStar_TypeChecker_Env.is_iface);
+                              (uu___511_2745.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___511_2698.FStar_TypeChecker_Env.admit);
+                              (uu___511_2745.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax =
-                              (uu___511_2698.FStar_TypeChecker_Env.lax);
+                              (uu___511_2745.FStar_TypeChecker_Env.lax);
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___511_2698.FStar_TypeChecker_Env.lax_universes);
+                              (uu___511_2745.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 =
-                              (uu___511_2698.FStar_TypeChecker_Env.phase1);
+                              (uu___511_2745.FStar_TypeChecker_Env.phase1);
                             FStar_TypeChecker_Env.failhard =
-                              (uu___511_2698.FStar_TypeChecker_Env.failhard);
+                              (uu___511_2745.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___511_2698.FStar_TypeChecker_Env.nosynth);
+                              (uu___511_2745.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___511_2698.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___511_2745.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___511_2698.FStar_TypeChecker_Env.tc_term);
+                              (uu___511_2745.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___511_2698.FStar_TypeChecker_Env.type_of);
+                              (uu___511_2745.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___511_2698.FStar_TypeChecker_Env.universe_of);
+                              (uu___511_2745.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___511_2698.FStar_TypeChecker_Env.check_type_of);
+                              (uu___511_2745.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___511_2698.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___511_2745.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___511_2698.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___511_2745.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___511_2698.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___511_2745.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___511_2698.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___511_2745.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___511_2698.FStar_TypeChecker_Env.proof_ns);
+                              (uu___511_2745.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___511_2698.FStar_TypeChecker_Env.synth_hook);
+                              (uu___511_2745.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___511_2698.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___511_2745.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___511_2698.FStar_TypeChecker_Env.splice);
+                              (uu___511_2745.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___511_2698.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___511_2745.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___511_2698.FStar_TypeChecker_Env.postprocess);
+                              (uu___511_2745.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.is_native_tactic =
-                              (uu___511_2698.FStar_TypeChecker_Env.is_native_tactic);
+                              (uu___511_2745.FStar_TypeChecker_Env.is_native_tactic);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___511_2698.FStar_TypeChecker_Env.identifier_info);
+                              (uu___511_2745.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___511_2698.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___511_2745.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv = dsenv;
                             FStar_TypeChecker_Env.nbe =
-                              (uu___511_2698.FStar_TypeChecker_Env.nbe);
+                              (uu___511_2745.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___511_2698.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___511_2745.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___511_2698.FStar_TypeChecker_Env.erasable_types_tab)
+                              (uu___511_2745.FStar_TypeChecker_Env.erasable_types_tab)
                           }  in
                         ([], ses, env1))))))
            | FStar_Syntax_Syntax.Sig_let (lbs,lids) ->
@@ -2300,12 +2327,12 @@ let (tc_decl' :
                          (fun x  ->
                             Prims.op_Negation (x = FStar_Syntax_Syntax.Logic))
                         in
-                     let uu____2766 =
-                       let uu____2768 =
-                         let uu____2777 = drop_logic val_q  in
-                         let uu____2780 = drop_logic q'  in
-                         (uu____2777, uu____2780)  in
-                       match uu____2768 with
+                     let uu____2813 =
+                       let uu____2815 =
+                         let uu____2824 = drop_logic val_q  in
+                         let uu____2827 = drop_logic q'  in
+                         (uu____2824, uu____2827)  in
+                       match uu____2815 with
                        | (val_q1,q'1) ->
                            ((FStar_List.length val_q1) =
                               (FStar_List.length q'1))
@@ -2313,127 +2340,139 @@ let (tc_decl' :
                              (FStar_List.forall2
                                 FStar_Syntax_Util.qualifier_equal val_q1 q'1)
                         in
-                     if uu____2766
+                     if uu____2813
                      then FStar_Pervasives_Native.Some q'
                      else
-                       (let uu____2807 =
-                          let uu____2813 =
-                            let uu____2815 =
+                       (let uu____2854 =
+                          let uu____2860 =
+                            let uu____2862 =
                               FStar_Syntax_Print.lid_to_string l  in
-                            let uu____2817 =
+                            let uu____2864 =
                               FStar_Syntax_Print.quals_to_string val_q  in
-                            let uu____2819 =
+                            let uu____2866 =
                               FStar_Syntax_Print.quals_to_string q'  in
                             FStar_Util.format3
                               "Inconsistent qualifier annotations on %s; Expected {%s}, got {%s}"
-                              uu____2815 uu____2817 uu____2819
+                              uu____2862 uu____2864 uu____2866
                              in
                           (FStar_Errors.Fatal_InconsistentQualifierAnnotation,
-                            uu____2813)
+                            uu____2860)
                            in
-                        FStar_Errors.raise_error uu____2807 r)
+                        FStar_Errors.raise_error uu____2854 r)
                   in
                let rename_parameters lb =
                  let rename_in_typ def typ =
                    let typ1 = FStar_Syntax_Subst.compress typ  in
                    let def_bs =
-                     let uu____2856 =
-                       let uu____2857 = FStar_Syntax_Subst.compress def  in
-                       uu____2857.FStar_Syntax_Syntax.n  in
-                     match uu____2856 with
+                     let uu____2903 =
+                       let uu____2904 = FStar_Syntax_Subst.compress def  in
+                       uu____2904.FStar_Syntax_Syntax.n  in
+                     match uu____2903 with
                      | FStar_Syntax_Syntax.Tm_abs
-                         (binders,uu____2869,uu____2870) -> binders
-                     | uu____2895 -> []  in
+                         (binders,uu____2916,uu____2917) -> binders
+                     | uu____2942 -> []  in
                    match typ1 with
                    | {
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_arrow
                          (val_bs,c);
                        FStar_Syntax_Syntax.pos = r1;
-                       FStar_Syntax_Syntax.vars = uu____2907;_} ->
+                       FStar_Syntax_Syntax.vars = uu____2954;_} ->
                        let has_auto_name bv =
-                         FStar_Util.starts_with
-                           (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                         let uu____2984 =
+                           FStar_Ident.text_of_id
+                             bv.FStar_Syntax_Syntax.ppname
+                            in
+                         FStar_Util.starts_with uu____2984
                            FStar_Ident.reserved_prefix
                           in
                        let rec rename_binders def_bs1 val_bs1 =
                          match (def_bs1, val_bs1) with
-                         | ([],uu____3012) -> val_bs1
-                         | (uu____3043,[]) -> val_bs1
-                         | ((body_bv,uu____3075)::bt,(val_bv,aqual)::vt) ->
-                             let uu____3132 = rename_binders bt vt  in
-                             ((match ((has_auto_name body_bv),
-                                       (has_auto_name val_bv))
-                               with
-                               | (true ,uu____3156) -> (val_bv, aqual)
+                         | ([],uu____3061) -> val_bs1
+                         | (uu____3092,[]) -> val_bs1
+                         | ((body_bv,uu____3124)::bt,(val_bv,aqual)::vt) ->
+                             let uu____3181 =
+                               let uu____3188 =
+                                 let uu____3195 = has_auto_name body_bv  in
+                                 let uu____3197 = has_auto_name val_bv  in
+                                 (uu____3195, uu____3197)  in
+                               match uu____3188 with
+                               | (true ,uu____3207) -> (val_bv, aqual)
                                | (false ,true ) ->
-                                   ((let uu___580_3170 = val_bv  in
+                                   let uu____3218 =
+                                     let uu___580_3219 = val_bv  in
+                                     let uu____3220 =
+                                       let uu____3221 =
+                                         let uu____3227 =
+                                           FStar_Ident.text_of_id
+                                             body_bv.FStar_Syntax_Syntax.ppname
+                                            in
+                                         let uu____3229 =
+                                           FStar_Ident.range_of_id
+                                             val_bv.FStar_Syntax_Syntax.ppname
+                                            in
+                                         (uu____3227, uu____3229)  in
+                                       FStar_Ident.mk_ident uu____3221  in
                                      {
                                        FStar_Syntax_Syntax.ppname =
-                                         (let uu___582_3173 =
-                                            val_bv.FStar_Syntax_Syntax.ppname
-                                             in
-                                          {
-                                            FStar_Ident.idText =
-                                              ((body_bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText);
-                                            FStar_Ident.idRange =
-                                              (uu___582_3173.FStar_Ident.idRange)
-                                          });
+                                         uu____3220;
                                        FStar_Syntax_Syntax.index =
-                                         (uu___580_3170.FStar_Syntax_Syntax.index);
+                                         (uu___580_3219.FStar_Syntax_Syntax.index);
                                        FStar_Syntax_Syntax.sort =
-                                         (uu___580_3170.FStar_Syntax_Syntax.sort)
-                                     }), aqual)
-                               | (false ,false ) -> (val_bv, aqual))) ::
-                               uu____3132
+                                         (uu___580_3219.FStar_Syntax_Syntax.sort)
+                                     }  in
+                                   (uu____3218, aqual)
+                               | (false ,false ) -> (val_bv, aqual)  in
+                             let uu____3239 = rename_binders bt vt  in
+                             uu____3181 :: uu____3239
                           in
-                       let uu____3180 =
-                         let uu____3187 =
-                           let uu____3188 =
-                             let uu____3203 = rename_binders def_bs val_bs
+                       let uu____3254 =
+                         let uu____3261 =
+                           let uu____3262 =
+                             let uu____3277 = rename_binders def_bs val_bs
                                 in
-                             (uu____3203, c)  in
-                           FStar_Syntax_Syntax.Tm_arrow uu____3188  in
-                         FStar_Syntax_Syntax.mk uu____3187  in
-                       uu____3180 FStar_Pervasives_Native.None r1
-                   | uu____3222 -> typ1  in
-                 let uu___588_3223 = lb  in
-                 let uu____3224 =
+                             (uu____3277, c)  in
+                           FStar_Syntax_Syntax.Tm_arrow uu____3262  in
+                         FStar_Syntax_Syntax.mk uu____3261  in
+                       uu____3254 FStar_Pervasives_Native.None r1
+                   | uu____3296 -> typ1  in
+                 let uu___586_3297 = lb  in
+                 let uu____3298 =
                    rename_in_typ lb.FStar_Syntax_Syntax.lbdef
                      lb.FStar_Syntax_Syntax.lbtyp
                     in
                  {
                    FStar_Syntax_Syntax.lbname =
-                     (uu___588_3223.FStar_Syntax_Syntax.lbname);
+                     (uu___586_3297.FStar_Syntax_Syntax.lbname);
                    FStar_Syntax_Syntax.lbunivs =
-                     (uu___588_3223.FStar_Syntax_Syntax.lbunivs);
-                   FStar_Syntax_Syntax.lbtyp = uu____3224;
+                     (uu___586_3297.FStar_Syntax_Syntax.lbunivs);
+                   FStar_Syntax_Syntax.lbtyp = uu____3298;
                    FStar_Syntax_Syntax.lbeff =
-                     (uu___588_3223.FStar_Syntax_Syntax.lbeff);
+                     (uu___586_3297.FStar_Syntax_Syntax.lbeff);
                    FStar_Syntax_Syntax.lbdef =
-                     (uu___588_3223.FStar_Syntax_Syntax.lbdef);
+                     (uu___586_3297.FStar_Syntax_Syntax.lbdef);
                    FStar_Syntax_Syntax.lbattrs =
-                     (uu___588_3223.FStar_Syntax_Syntax.lbattrs);
+                     (uu___586_3297.FStar_Syntax_Syntax.lbattrs);
                    FStar_Syntax_Syntax.lbpos =
-                     (uu___588_3223.FStar_Syntax_Syntax.lbpos)
+                     (uu___586_3297.FStar_Syntax_Syntax.lbpos)
                  }  in
-               let uu____3227 =
+               let uu____3301 =
                  FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                    (FStar_List.fold_left
-                      (fun uu____3282  ->
+                      (fun uu____3356  ->
                          fun lb  ->
-                           match uu____3282 with
+                           match uu____3356 with
                            | (gen,lbs1,quals_opt) ->
                                let lbname =
                                  FStar_Util.right
                                    lb.FStar_Syntax_Syntax.lbname
                                   in
-                               let uu____3328 =
-                                 let uu____3340 =
+                               let uu____3402 =
+                                 let uu____3414 =
                                    FStar_TypeChecker_Env.try_lookup_val_decl
                                      env1
                                      (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                     in
-                                 match uu____3340 with
+                                 match uu____3414 with
                                  | FStar_Pervasives_Native.None  ->
                                      if lb.FStar_Syntax_Syntax.lbunivs <> []
                                      then (false, lb, quals_opt)
@@ -2450,7 +2489,7 @@ let (tc_decl' :
                                        with
                                        | FStar_Syntax_Syntax.Tm_unknown  ->
                                            lb.FStar_Syntax_Syntax.lbdef
-                                       | uu____3420 ->
+                                       | uu____3494 ->
                                            FStar_Syntax_Syntax.mk
                                              (FStar_Syntax_Syntax.Tm_ascribed
                                                 ((lb.FStar_Syntax_Syntax.lbdef),
@@ -2473,16 +2512,16 @@ let (tc_decl' :
                                             "Inline universes are incoherent with annotation from val declaration")
                                           r
                                       else ();
-                                      (let uu____3467 =
+                                      (let uu____3541 =
                                          FStar_Syntax_Syntax.mk_lb
                                            ((FStar_Util.Inr lbname), uvs,
                                              FStar_Parser_Const.effect_ALL_lid,
                                              tval, def, [],
                                              (lb.FStar_Syntax_Syntax.lbpos))
                                           in
-                                       (false, uu____3467, quals_opt1)))
+                                       (false, uu____3541, quals_opt1)))
                                   in
-                               (match uu____3328 with
+                               (match uu____3402 with
                                 | (gen1,lb1,quals_opt1) ->
                                     (gen1, (lb1 :: lbs1), quals_opt1)))
                       (true, [],
@@ -2492,38 +2531,38 @@ let (tc_decl' :
                            FStar_Pervasives_Native.Some
                              (se1.FStar_Syntax_Syntax.sigquals))))
                   in
-               (match uu____3227 with
+               (match uu____3301 with
                 | (should_generalize,lbs',quals_opt) ->
                     let quals =
                       match quals_opt with
                       | FStar_Pervasives_Native.None  ->
                           [FStar_Syntax_Syntax.Visible_default]
                       | FStar_Pervasives_Native.Some q ->
-                          let uu____3571 =
+                          let uu____3645 =
                             FStar_All.pipe_right q
                               (FStar_Util.for_some
-                                 (fun uu___1_3577  ->
-                                    match uu___1_3577 with
+                                 (fun uu___1_3651  ->
+                                    match uu___1_3651 with
                                     | FStar_Syntax_Syntax.Irreducible  ->
                                         true
                                     | FStar_Syntax_Syntax.Visible_default  ->
                                         true
                                     | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
                                          -> true
-                                    | uu____3582 -> false))
+                                    | uu____3656 -> false))
                              in
-                          if uu____3571
+                          if uu____3645
                           then q
                           else FStar_Syntax_Syntax.Visible_default :: q
                        in
                     let lbs'1 = FStar_List.rev lbs'  in
-                    let uu____3592 =
-                      let uu____3601 =
+                    let uu____3666 =
+                      let uu____3675 =
                         FStar_Syntax_Util.extract_attr'
                           FStar_Parser_Const.preprocess_with
                           se1.FStar_Syntax_Syntax.sigattrs
                          in
-                      match uu____3601 with
+                      match uu____3675 with
                       | FStar_Pervasives_Native.None  ->
                           ((se1.FStar_Syntax_Syntax.sigattrs),
                             FStar_Pervasives_Native.None)
@@ -2537,55 +2576,55 @@ let (tc_decl' :
                            ((se1.FStar_Syntax_Syntax.sigattrs),
                              FStar_Pervasives_Native.None))
                        in
-                    (match uu____3592 with
+                    (match uu____3666 with
                      | (attrs,pre_tau) ->
                          let se2 =
-                           let uu___646_3706 = se1  in
+                           let uu___644_3780 = se1  in
                            {
                              FStar_Syntax_Syntax.sigel =
-                               (uu___646_3706.FStar_Syntax_Syntax.sigel);
+                               (uu___644_3780.FStar_Syntax_Syntax.sigel);
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___646_3706.FStar_Syntax_Syntax.sigrng);
+                               (uu___644_3780.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
-                               (uu___646_3706.FStar_Syntax_Syntax.sigquals);
+                               (uu___644_3780.FStar_Syntax_Syntax.sigquals);
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___646_3706.FStar_Syntax_Syntax.sigmeta);
+                               (uu___644_3780.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs = attrs;
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___646_3706.FStar_Syntax_Syntax.sigopts)
+                               (uu___644_3780.FStar_Syntax_Syntax.sigopts)
                            }  in
                          let preprocess_lb tau lb =
                            let lbdef =
                              FStar_TypeChecker_Env.preprocess env1 tau
                                lb.FStar_Syntax_Syntax.lbdef
                               in
-                           (let uu____3720 =
+                           (let uu____3794 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env1)
                                 (FStar_Options.Other "TwoPhases")
                                in
-                            if uu____3720
+                            if uu____3794
                             then
-                              let uu____3725 =
+                              let uu____3799 =
                                 FStar_Syntax_Print.term_to_string lbdef  in
                               FStar_Util.print1 "lb preprocessed into: %s\n"
-                                uu____3725
+                                uu____3799
                             else ());
-                           (let uu___655_3730 = lb  in
+                           (let uu___653_3804 = lb  in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___655_3730.FStar_Syntax_Syntax.lbname);
+                                (uu___653_3804.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___655_3730.FStar_Syntax_Syntax.lbunivs);
+                                (uu___653_3804.FStar_Syntax_Syntax.lbunivs);
                               FStar_Syntax_Syntax.lbtyp =
-                                (uu___655_3730.FStar_Syntax_Syntax.lbtyp);
+                                (uu___653_3804.FStar_Syntax_Syntax.lbtyp);
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___655_3730.FStar_Syntax_Syntax.lbeff);
+                                (uu___653_3804.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef = lbdef;
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___655_3730.FStar_Syntax_Syntax.lbattrs);
+                                (uu___653_3804.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___655_3730.FStar_Syntax_Syntax.lbpos)
+                                (uu___653_3804.FStar_Syntax_Syntax.lbpos)
                             })
                             in
                          let lbs'2 =
@@ -2594,386 +2633,386 @@ let (tc_decl' :
                                FStar_List.map (preprocess_lb tau) lbs'1
                            | FStar_Pervasives_Native.None  -> lbs'1  in
                          let e =
-                           let uu____3740 =
-                             let uu____3747 =
-                               let uu____3748 =
-                                 let uu____3762 =
+                           let uu____3814 =
+                             let uu____3821 =
+                               let uu____3822 =
+                                 let uu____3836 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_constant
                                         FStar_Const.Const_unit)
                                      FStar_Pervasives_Native.None r
                                     in
                                  (((FStar_Pervasives_Native.fst lbs), lbs'2),
-                                   uu____3762)
+                                   uu____3836)
                                   in
-                               FStar_Syntax_Syntax.Tm_let uu____3748  in
-                             FStar_Syntax_Syntax.mk uu____3747  in
-                           uu____3740 FStar_Pervasives_Native.None r  in
+                               FStar_Syntax_Syntax.Tm_let uu____3822  in
+                             FStar_Syntax_Syntax.mk uu____3821  in
+                           uu____3814 FStar_Pervasives_Native.None r  in
                          let env' =
-                           let uu___662_3781 = env1  in
+                           let uu___660_3855 = env1  in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___662_3781.FStar_TypeChecker_Env.solver);
+                               (uu___660_3855.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___662_3781.FStar_TypeChecker_Env.range);
+                               (uu___660_3855.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___662_3781.FStar_TypeChecker_Env.curmodule);
+                               (uu___660_3855.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___662_3781.FStar_TypeChecker_Env.gamma);
+                               (uu___660_3855.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___662_3781.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___660_3855.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___662_3781.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___660_3855.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___662_3781.FStar_TypeChecker_Env.modules);
+                               (uu___660_3855.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___662_3781.FStar_TypeChecker_Env.expected_typ);
+                               (uu___660_3855.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___662_3781.FStar_TypeChecker_Env.sigtab);
+                               (uu___660_3855.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___662_3781.FStar_TypeChecker_Env.attrtab);
+                               (uu___660_3855.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___662_3781.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___660_3855.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___662_3781.FStar_TypeChecker_Env.effects);
+                               (uu___660_3855.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
                                should_generalize;
                              FStar_TypeChecker_Env.letrecs =
-                               (uu___662_3781.FStar_TypeChecker_Env.letrecs);
+                               (uu___660_3855.FStar_TypeChecker_Env.letrecs);
                              FStar_TypeChecker_Env.top_level = true;
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___662_3781.FStar_TypeChecker_Env.check_uvars);
+                               (uu___660_3855.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___662_3781.FStar_TypeChecker_Env.use_eq);
+                               (uu___660_3855.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___662_3781.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___660_3855.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___662_3781.FStar_TypeChecker_Env.is_iface);
+                               (uu___660_3855.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___662_3781.FStar_TypeChecker_Env.admit);
+                               (uu___660_3855.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax =
-                               (uu___662_3781.FStar_TypeChecker_Env.lax);
+                               (uu___660_3855.FStar_TypeChecker_Env.lax);
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___662_3781.FStar_TypeChecker_Env.lax_universes);
+                               (uu___660_3855.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___662_3781.FStar_TypeChecker_Env.phase1);
+                               (uu___660_3855.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___662_3781.FStar_TypeChecker_Env.failhard);
+                               (uu___660_3855.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___662_3781.FStar_TypeChecker_Env.nosynth);
+                               (uu___660_3855.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___662_3781.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___660_3855.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___662_3781.FStar_TypeChecker_Env.tc_term);
+                               (uu___660_3855.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___662_3781.FStar_TypeChecker_Env.type_of);
+                               (uu___660_3855.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___662_3781.FStar_TypeChecker_Env.universe_of);
+                               (uu___660_3855.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___662_3781.FStar_TypeChecker_Env.check_type_of);
+                               (uu___660_3855.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___662_3781.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___660_3855.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___662_3781.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___660_3855.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___662_3781.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___660_3855.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___662_3781.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___660_3855.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___662_3781.FStar_TypeChecker_Env.proof_ns);
+                               (uu___660_3855.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___662_3781.FStar_TypeChecker_Env.synth_hook);
+                               (uu___660_3855.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___662_3781.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___660_3855.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___662_3781.FStar_TypeChecker_Env.splice);
+                               (uu___660_3855.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___662_3781.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___660_3855.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___662_3781.FStar_TypeChecker_Env.postprocess);
+                               (uu___660_3855.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.is_native_tactic =
-                               (uu___662_3781.FStar_TypeChecker_Env.is_native_tactic);
+                               (uu___660_3855.FStar_TypeChecker_Env.is_native_tactic);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___662_3781.FStar_TypeChecker_Env.identifier_info);
+                               (uu___660_3855.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___662_3781.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___660_3855.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___662_3781.FStar_TypeChecker_Env.dsenv);
+                               (uu___660_3855.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___662_3781.FStar_TypeChecker_Env.nbe);
+                               (uu___660_3855.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___662_3781.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___660_3855.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___662_3781.FStar_TypeChecker_Env.erasable_types_tab)
+                               (uu___660_3855.FStar_TypeChecker_Env.erasable_types_tab)
                            }  in
                          let e1 =
-                           let uu____3784 =
+                           let uu____3858 =
                              (FStar_Options.use_two_phase_tc ()) &&
                                (FStar_TypeChecker_Env.should_verify env')
                               in
-                           if uu____3784
+                           if uu____3858
                            then
                              let drop_lbtyp e_lax =
-                               let uu____3793 =
-                                 let uu____3794 =
+                               let uu____3867 =
+                                 let uu____3868 =
                                    FStar_Syntax_Subst.compress e_lax  in
-                                 uu____3794.FStar_Syntax_Syntax.n  in
-                               match uu____3793 with
+                                 uu____3868.FStar_Syntax_Syntax.n  in
+                               match uu____3867 with
                                | FStar_Syntax_Syntax.Tm_let
                                    ((false ,lb::[]),e2) ->
                                    let lb_unannotated =
-                                     let uu____3816 =
-                                       let uu____3817 =
+                                     let uu____3890 =
+                                       let uu____3891 =
                                          FStar_Syntax_Subst.compress e  in
-                                       uu____3817.FStar_Syntax_Syntax.n  in
-                                     match uu____3816 with
+                                       uu____3891.FStar_Syntax_Syntax.n  in
+                                     match uu____3890 with
                                      | FStar_Syntax_Syntax.Tm_let
-                                         ((uu____3821,lb1::[]),uu____3823) ->
-                                         let uu____3839 =
-                                           let uu____3840 =
+                                         ((uu____3895,lb1::[]),uu____3897) ->
+                                         let uu____3913 =
+                                           let uu____3914 =
                                              FStar_Syntax_Subst.compress
                                                lb1.FStar_Syntax_Syntax.lbtyp
                                               in
-                                           uu____3840.FStar_Syntax_Syntax.n
+                                           uu____3914.FStar_Syntax_Syntax.n
                                             in
-                                         (match uu____3839 with
+                                         (match uu____3913 with
                                           | FStar_Syntax_Syntax.Tm_unknown 
                                               -> true
-                                          | uu____3845 -> false)
-                                     | uu____3847 ->
+                                          | uu____3919 -> false)
+                                     | uu____3921 ->
                                          failwith
                                            "Impossible: first phase lb and second phase lb differ in structure!"
                                       in
                                    if lb_unannotated
                                    then
-                                     let uu___687_3851 = e_lax  in
+                                     let uu___685_3925 = e_lax  in
                                      {
                                        FStar_Syntax_Syntax.n =
                                          (FStar_Syntax_Syntax.Tm_let
                                             ((false,
-                                               [(let uu___689_3866 = lb  in
+                                               [(let uu___687_3940 = lb  in
                                                  {
                                                    FStar_Syntax_Syntax.lbname
                                                      =
-                                                     (uu___689_3866.FStar_Syntax_Syntax.lbname);
+                                                     (uu___687_3940.FStar_Syntax_Syntax.lbname);
                                                    FStar_Syntax_Syntax.lbunivs
                                                      =
-                                                     (uu___689_3866.FStar_Syntax_Syntax.lbunivs);
+                                                     (uu___687_3940.FStar_Syntax_Syntax.lbunivs);
                                                    FStar_Syntax_Syntax.lbtyp
                                                      =
                                                      FStar_Syntax_Syntax.tun;
                                                    FStar_Syntax_Syntax.lbeff
                                                      =
-                                                     (uu___689_3866.FStar_Syntax_Syntax.lbeff);
+                                                     (uu___687_3940.FStar_Syntax_Syntax.lbeff);
                                                    FStar_Syntax_Syntax.lbdef
                                                      =
-                                                     (uu___689_3866.FStar_Syntax_Syntax.lbdef);
+                                                     (uu___687_3940.FStar_Syntax_Syntax.lbdef);
                                                    FStar_Syntax_Syntax.lbattrs
                                                      =
-                                                     (uu___689_3866.FStar_Syntax_Syntax.lbattrs);
+                                                     (uu___687_3940.FStar_Syntax_Syntax.lbattrs);
                                                    FStar_Syntax_Syntax.lbpos
                                                      =
-                                                     (uu___689_3866.FStar_Syntax_Syntax.lbpos)
+                                                     (uu___687_3940.FStar_Syntax_Syntax.lbpos)
                                                  })]), e2));
                                        FStar_Syntax_Syntax.pos =
-                                         (uu___687_3851.FStar_Syntax_Syntax.pos);
+                                         (uu___685_3925.FStar_Syntax_Syntax.pos);
                                        FStar_Syntax_Syntax.vars =
-                                         (uu___687_3851.FStar_Syntax_Syntax.vars)
+                                         (uu___685_3925.FStar_Syntax_Syntax.vars)
                                      }
                                    else e_lax
-                               | uu____3869 -> e_lax  in
-                             let uu____3870 =
+                               | uu____3943 -> e_lax  in
+                             let uu____3944 =
                                FStar_Util.record_time
-                                 (fun uu____3878  ->
-                                    let uu____3879 =
-                                      let uu____3880 =
-                                        let uu____3881 =
+                                 (fun uu____3952  ->
+                                    let uu____3953 =
+                                      let uu____3954 =
+                                        let uu____3955 =
                                           FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
-                                            (let uu___693_3890 = env'  in
+                                            (let uu___691_3964 = env'  in
                                              {
                                                FStar_TypeChecker_Env.solver =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.solver);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.solver);
                                                FStar_TypeChecker_Env.range =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.range);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.range);
                                                FStar_TypeChecker_Env.curmodule
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.curmodule);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.curmodule);
                                                FStar_TypeChecker_Env.gamma =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.gamma);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.gamma);
                                                FStar_TypeChecker_Env.gamma_sig
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.gamma_sig);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.gamma_sig);
                                                FStar_TypeChecker_Env.gamma_cache
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.gamma_cache);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.gamma_cache);
                                                FStar_TypeChecker_Env.modules
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.modules);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.modules);
                                                FStar_TypeChecker_Env.expected_typ
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.expected_typ);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.expected_typ);
                                                FStar_TypeChecker_Env.sigtab =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.sigtab);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.sigtab);
                                                FStar_TypeChecker_Env.attrtab
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.attrtab);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.attrtab);
                                                FStar_TypeChecker_Env.instantiate_imp
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.instantiate_imp);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.instantiate_imp);
                                                FStar_TypeChecker_Env.effects
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.effects);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.effects);
                                                FStar_TypeChecker_Env.generalize
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.generalize);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.generalize);
                                                FStar_TypeChecker_Env.letrecs
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.letrecs);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.letrecs);
                                                FStar_TypeChecker_Env.top_level
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.top_level);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.top_level);
                                                FStar_TypeChecker_Env.check_uvars
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.check_uvars);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.check_uvars);
                                                FStar_TypeChecker_Env.use_eq =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.use_eq);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.use_eq);
                                                FStar_TypeChecker_Env.use_eq_strict
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.use_eq_strict);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.use_eq_strict);
                                                FStar_TypeChecker_Env.is_iface
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.is_iface);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.is_iface);
                                                FStar_TypeChecker_Env.admit =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.admit);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.admit);
                                                FStar_TypeChecker_Env.lax =
                                                  true;
                                                FStar_TypeChecker_Env.lax_universes
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.lax_universes);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.lax_universes);
                                                FStar_TypeChecker_Env.phase1 =
                                                  true;
                                                FStar_TypeChecker_Env.failhard
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.failhard);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.failhard);
                                                FStar_TypeChecker_Env.nosynth
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.nosynth);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.nosynth);
                                                FStar_TypeChecker_Env.uvar_subtyping
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.uvar_subtyping);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.uvar_subtyping);
                                                FStar_TypeChecker_Env.tc_term
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.tc_term);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.tc_term);
                                                FStar_TypeChecker_Env.type_of
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.type_of);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.type_of);
                                                FStar_TypeChecker_Env.universe_of
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.universe_of);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.universe_of);
                                                FStar_TypeChecker_Env.check_type_of
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.check_type_of);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.check_type_of);
                                                FStar_TypeChecker_Env.use_bv_sorts
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.use_bv_sorts);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.use_bv_sorts);
                                                FStar_TypeChecker_Env.qtbl_name_and_index
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                FStar_TypeChecker_Env.normalized_eff_names
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.normalized_eff_names);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.normalized_eff_names);
                                                FStar_TypeChecker_Env.fv_delta_depths
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.fv_delta_depths);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.fv_delta_depths);
                                                FStar_TypeChecker_Env.proof_ns
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.proof_ns);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.proof_ns);
                                                FStar_TypeChecker_Env.synth_hook
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.synth_hook);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.synth_hook);
                                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                FStar_TypeChecker_Env.splice =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.splice);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.splice);
                                                FStar_TypeChecker_Env.mpreprocess
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.mpreprocess);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.mpreprocess);
                                                FStar_TypeChecker_Env.postprocess
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.postprocess);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.postprocess);
                                                FStar_TypeChecker_Env.is_native_tactic
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.is_native_tactic);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.is_native_tactic);
                                                FStar_TypeChecker_Env.identifier_info
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.identifier_info);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.identifier_info);
                                                FStar_TypeChecker_Env.tc_hooks
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.tc_hooks);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.tc_hooks);
                                                FStar_TypeChecker_Env.dsenv =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.dsenv);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.dsenv);
                                                FStar_TypeChecker_Env.nbe =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.nbe);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.nbe);
                                                FStar_TypeChecker_Env.strict_args_tab
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.strict_args_tab);
+                                                 (uu___691_3964.FStar_TypeChecker_Env.strict_args_tab);
                                                FStar_TypeChecker_Env.erasable_types_tab
                                                  =
-                                                 (uu___693_3890.FStar_TypeChecker_Env.erasable_types_tab)
+                                                 (uu___691_3964.FStar_TypeChecker_Env.erasable_types_tab)
                                              }) e
                                            in
-                                        FStar_All.pipe_right uu____3881
-                                          (fun uu____3903  ->
-                                             match uu____3903 with
-                                             | (e1,uu____3911,uu____3912) ->
+                                        FStar_All.pipe_right uu____3955
+                                          (fun uu____3977  ->
+                                             match uu____3977 with
+                                             | (e1,uu____3985,uu____3986) ->
                                                  e1)
                                          in
-                                      FStar_All.pipe_right uu____3880
+                                      FStar_All.pipe_right uu____3954
                                         (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                            env')
                                        in
-                                    FStar_All.pipe_right uu____3879
+                                    FStar_All.pipe_right uu____3953
                                       drop_lbtyp)
                                 in
-                             match uu____3870 with
+                             match uu____3944 with
                              | (e1,ms) ->
-                                 ((let uu____3918 =
+                                 ((let uu____3992 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env1)
                                        (FStar_Options.Other "TwoPhases")
                                       in
-                                   if uu____3918
+                                   if uu____3992
                                    then
-                                     let uu____3923 =
+                                     let uu____3997 =
                                        FStar_Syntax_Print.term_to_string e1
                                         in
                                      FStar_Util.print1
                                        "Let binding after phase 1: %s\n"
-                                       uu____3923
+                                       uu____3997
                                    else ());
-                                  (let uu____3929 =
+                                  (let uu____4003 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env1)
                                        (FStar_Options.Other "TCDeclTime")
                                       in
-                                   if uu____3929
+                                   if uu____4003
                                    then
-                                     let uu____3934 =
+                                     let uu____4008 =
                                        FStar_Util.string_of_int ms  in
                                      FStar_Util.print1
                                        "Let binding elaborated (phase 1) in %s milliseconds\n"
-                                       uu____3934
+                                       uu____4008
                                    else ());
                                   e1)
                            else e  in
-                         let uu____3941 =
-                           let uu____3950 =
+                         let uu____4015 =
+                           let uu____4024 =
                              FStar_Syntax_Util.extract_attr'
                                FStar_Parser_Const.postprocess_with
                                se2.FStar_Syntax_Syntax.sigattrs
                               in
-                           match uu____3950 with
+                           match uu____4024 with
                            | FStar_Pervasives_Native.None  ->
                                ((se2.FStar_Syntax_Syntax.sigattrs),
                                  FStar_Pervasives_Native.None)
@@ -2987,22 +3026,22 @@ let (tc_decl' :
                                 ((se2.FStar_Syntax_Syntax.sigattrs),
                                   FStar_Pervasives_Native.None))
                             in
-                         (match uu____3941 with
+                         (match uu____4015 with
                           | (attrs1,post_tau) ->
                               let se3 =
-                                let uu___723_4055 = se2  in
+                                let uu___721_4129 = se2  in
                                 {
                                   FStar_Syntax_Syntax.sigel =
-                                    (uu___723_4055.FStar_Syntax_Syntax.sigel);
+                                    (uu___721_4129.FStar_Syntax_Syntax.sigel);
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___723_4055.FStar_Syntax_Syntax.sigrng);
+                                    (uu___721_4129.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___723_4055.FStar_Syntax_Syntax.sigquals);
+                                    (uu___721_4129.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___723_4055.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___721_4129.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs = attrs1;
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___723_4055.FStar_Syntax_Syntax.sigopts)
+                                    (uu___721_4129.FStar_Syntax_Syntax.sigopts)
                                 }  in
                               let postprocess_lb tau lb =
                                 let lbdef =
@@ -3010,58 +3049,58 @@ let (tc_decl' :
                                     lb.FStar_Syntax_Syntax.lbtyp
                                     lb.FStar_Syntax_Syntax.lbdef
                                    in
-                                let uu___730_4068 = lb  in
+                                let uu___728_4142 = lb  in
                                 {
                                   FStar_Syntax_Syntax.lbname =
-                                    (uu___730_4068.FStar_Syntax_Syntax.lbname);
+                                    (uu___728_4142.FStar_Syntax_Syntax.lbname);
                                   FStar_Syntax_Syntax.lbunivs =
-                                    (uu___730_4068.FStar_Syntax_Syntax.lbunivs);
+                                    (uu___728_4142.FStar_Syntax_Syntax.lbunivs);
                                   FStar_Syntax_Syntax.lbtyp =
-                                    (uu___730_4068.FStar_Syntax_Syntax.lbtyp);
+                                    (uu___728_4142.FStar_Syntax_Syntax.lbtyp);
                                   FStar_Syntax_Syntax.lbeff =
-                                    (uu___730_4068.FStar_Syntax_Syntax.lbeff);
+                                    (uu___728_4142.FStar_Syntax_Syntax.lbeff);
                                   FStar_Syntax_Syntax.lbdef = lbdef;
                                   FStar_Syntax_Syntax.lbattrs =
-                                    (uu___730_4068.FStar_Syntax_Syntax.lbattrs);
+                                    (uu___728_4142.FStar_Syntax_Syntax.lbattrs);
                                   FStar_Syntax_Syntax.lbpos =
-                                    (uu___730_4068.FStar_Syntax_Syntax.lbpos)
+                                    (uu___728_4142.FStar_Syntax_Syntax.lbpos)
                                 }  in
-                              let uu____4069 =
+                              let uu____4143 =
                                 FStar_Util.record_time
-                                  (fun uu____4088  ->
+                                  (fun uu____4162  ->
                                      FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
                                        env' e1)
                                  in
-                              (match uu____4069 with
+                              (match uu____4143 with
                                | (r1,ms) ->
-                                   ((let uu____4116 =
+                                   ((let uu____4190 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env1)
                                          (FStar_Options.Other "TCDeclTime")
                                         in
-                                     if uu____4116
+                                     if uu____4190
                                      then
-                                       let uu____4121 =
+                                       let uu____4195 =
                                          FStar_Util.string_of_int ms  in
                                        FStar_Util.print1
                                          "Let binding typechecked in phase 2 in %s milliseconds\n"
-                                         uu____4121
+                                         uu____4195
                                      else ());
-                                    (let uu____4126 =
+                                    (let uu____4200 =
                                        match r1 with
                                        | ({
                                             FStar_Syntax_Syntax.n =
                                               FStar_Syntax_Syntax.Tm_let
                                               (lbs1,e2);
                                             FStar_Syntax_Syntax.pos =
-                                              uu____4151;
+                                              uu____4225;
                                             FStar_Syntax_Syntax.vars =
-                                              uu____4152;_},uu____4153,g)
+                                              uu____4226;_},uu____4227,g)
                                            when
                                            FStar_TypeChecker_Env.is_trivial g
                                            ->
                                            let lbs2 =
-                                             let uu____4183 =
+                                             let uu____4257 =
                                                FStar_All.pipe_right
                                                  (FStar_Pervasives_Native.snd
                                                     lbs1)
@@ -3069,10 +3108,10 @@ let (tc_decl' :
                                                     rename_parameters)
                                                 in
                                              ((FStar_Pervasives_Native.fst
-                                                 lbs1), uu____4183)
+                                                 lbs1), uu____4257)
                                               in
                                            let lbs3 =
-                                             let uu____4207 =
+                                             let uu____4281 =
                                                match post_tau with
                                                | FStar_Pervasives_Native.Some
                                                    tau ->
@@ -3086,40 +3125,40 @@ let (tc_decl' :
                                                      lbs2
                                                 in
                                              ((FStar_Pervasives_Native.fst
-                                                 lbs2), uu____4207)
+                                                 lbs2), uu____4281)
                                               in
                                            let quals1 =
                                              match e2.FStar_Syntax_Syntax.n
                                              with
                                              | FStar_Syntax_Syntax.Tm_meta
-                                                 (uu____4230,FStar_Syntax_Syntax.Meta_desugared
+                                                 (uu____4304,FStar_Syntax_Syntax.Meta_desugared
                                                   (FStar_Syntax_Syntax.Masked_effect
                                                   ))
                                                  ->
                                                  FStar_Syntax_Syntax.HasMaskedEffect
                                                  :: quals
-                                             | uu____4235 -> quals  in
-                                           ((let uu___760_4244 = se3  in
+                                             | uu____4309 -> quals  in
+                                           ((let uu___758_4318 = se3  in
                                              {
                                                FStar_Syntax_Syntax.sigel =
                                                  (FStar_Syntax_Syntax.Sig_let
                                                     (lbs3, lids));
                                                FStar_Syntax_Syntax.sigrng =
-                                                 (uu___760_4244.FStar_Syntax_Syntax.sigrng);
+                                                 (uu___758_4318.FStar_Syntax_Syntax.sigrng);
                                                FStar_Syntax_Syntax.sigquals =
                                                  quals1;
                                                FStar_Syntax_Syntax.sigmeta =
-                                                 (uu___760_4244.FStar_Syntax_Syntax.sigmeta);
+                                                 (uu___758_4318.FStar_Syntax_Syntax.sigmeta);
                                                FStar_Syntax_Syntax.sigattrs =
-                                                 (uu___760_4244.FStar_Syntax_Syntax.sigattrs);
+                                                 (uu___758_4318.FStar_Syntax_Syntax.sigattrs);
                                                FStar_Syntax_Syntax.sigopts =
-                                                 (uu___760_4244.FStar_Syntax_Syntax.sigopts)
+                                                 (uu___758_4318.FStar_Syntax_Syntax.sigopts)
                                              }), lbs3)
-                                       | uu____4247 ->
+                                       | uu____4321 ->
                                            failwith
                                              "impossible (typechecking should preserve Tm_let)"
                                         in
-                                     match uu____4126 with
+                                     match uu____4200 with
                                      | (se4,lbs1) ->
                                          (FStar_All.pipe_right
                                             (FStar_Pervasives_Native.snd lbs1)
@@ -3132,265 +3171,265 @@ let (tc_decl' :
                                                   FStar_TypeChecker_Env.insert_fv_info
                                                     env1 fv
                                                     lb.FStar_Syntax_Syntax.lbtyp));
-                                          (let uu____4303 = log env1  in
-                                           if uu____4303
+                                          (let uu____4377 = log env1  in
+                                           if uu____4377
                                            then
-                                             let uu____4306 =
-                                               let uu____4308 =
+                                             let uu____4380 =
+                                               let uu____4382 =
                                                  FStar_All.pipe_right
                                                    (FStar_Pervasives_Native.snd
                                                       lbs1)
                                                    (FStar_List.map
                                                       (fun lb  ->
                                                          let should_log =
-                                                           let uu____4328 =
-                                                             let uu____4337 =
-                                                               let uu____4338
+                                                           let uu____4402 =
+                                                             let uu____4411 =
+                                                               let uu____4412
                                                                  =
-                                                                 let uu____4341
+                                                                 let uu____4415
                                                                    =
                                                                    FStar_Util.right
                                                                     lb.FStar_Syntax_Syntax.lbname
                                                                     in
-                                                                 uu____4341.FStar_Syntax_Syntax.fv_name
+                                                                 uu____4415.FStar_Syntax_Syntax.fv_name
                                                                   in
-                                                               uu____4338.FStar_Syntax_Syntax.v
+                                                               uu____4412.FStar_Syntax_Syntax.v
                                                                 in
                                                              FStar_TypeChecker_Env.try_lookup_val_decl
                                                                env1
-                                                               uu____4337
+                                                               uu____4411
                                                               in
-                                                           match uu____4328
+                                                           match uu____4402
                                                            with
                                                            | FStar_Pervasives_Native.None
                                                                 -> true
-                                                           | uu____4350 ->
+                                                           | uu____4424 ->
                                                                false
                                                             in
                                                          if should_log
                                                          then
-                                                           let uu____4362 =
+                                                           let uu____4436 =
                                                              FStar_Syntax_Print.lbname_to_string
                                                                lb.FStar_Syntax_Syntax.lbname
                                                               in
-                                                           let uu____4364 =
+                                                           let uu____4438 =
                                                              FStar_Syntax_Print.term_to_string
                                                                lb.FStar_Syntax_Syntax.lbtyp
                                                               in
                                                            FStar_Util.format2
                                                              "let %s : %s"
-                                                             uu____4362
-                                                             uu____4364
+                                                             uu____4436
+                                                             uu____4438
                                                          else ""))
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____4308
+                                                 uu____4382
                                                  (FStar_String.concat "\n")
                                                 in
                                              FStar_Util.print1 "%s\n"
-                                               uu____4306
+                                               uu____4380
                                            else ());
                                           check_must_erase_attribute env0 se4;
                                           ([se4], [], env0))))))))
-           | FStar_Syntax_Syntax.Sig_polymonadic_bind (m,n,p,t,uu____4387) ->
+           | FStar_Syntax_Syntax.Sig_polymonadic_bind (m,n,p,t,uu____4461) ->
                let t1 =
-                 let uu____4389 =
+                 let uu____4463 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env)
                     in
-                 if uu____4389
+                 if uu____4463
                  then
-                   let uu____4392 =
-                     let uu____4397 =
-                       let uu____4398 =
-                         let uu____4399 =
+                   let uu____4466 =
+                     let uu____4471 =
+                       let uu____4472 =
+                         let uu____4473 =
                            FStar_TypeChecker_TcEffect.tc_polymonadic_bind
-                             (let uu___785_4406 = env  in
+                             (let uu___783_4480 = env  in
                               {
                                 FStar_TypeChecker_Env.solver =
-                                  (uu___785_4406.FStar_TypeChecker_Env.solver);
+                                  (uu___783_4480.FStar_TypeChecker_Env.solver);
                                 FStar_TypeChecker_Env.range =
-                                  (uu___785_4406.FStar_TypeChecker_Env.range);
+                                  (uu___783_4480.FStar_TypeChecker_Env.range);
                                 FStar_TypeChecker_Env.curmodule =
-                                  (uu___785_4406.FStar_TypeChecker_Env.curmodule);
+                                  (uu___783_4480.FStar_TypeChecker_Env.curmodule);
                                 FStar_TypeChecker_Env.gamma =
-                                  (uu___785_4406.FStar_TypeChecker_Env.gamma);
+                                  (uu___783_4480.FStar_TypeChecker_Env.gamma);
                                 FStar_TypeChecker_Env.gamma_sig =
-                                  (uu___785_4406.FStar_TypeChecker_Env.gamma_sig);
+                                  (uu___783_4480.FStar_TypeChecker_Env.gamma_sig);
                                 FStar_TypeChecker_Env.gamma_cache =
-                                  (uu___785_4406.FStar_TypeChecker_Env.gamma_cache);
+                                  (uu___783_4480.FStar_TypeChecker_Env.gamma_cache);
                                 FStar_TypeChecker_Env.modules =
-                                  (uu___785_4406.FStar_TypeChecker_Env.modules);
+                                  (uu___783_4480.FStar_TypeChecker_Env.modules);
                                 FStar_TypeChecker_Env.expected_typ =
-                                  (uu___785_4406.FStar_TypeChecker_Env.expected_typ);
+                                  (uu___783_4480.FStar_TypeChecker_Env.expected_typ);
                                 FStar_TypeChecker_Env.sigtab =
-                                  (uu___785_4406.FStar_TypeChecker_Env.sigtab);
+                                  (uu___783_4480.FStar_TypeChecker_Env.sigtab);
                                 FStar_TypeChecker_Env.attrtab =
-                                  (uu___785_4406.FStar_TypeChecker_Env.attrtab);
+                                  (uu___783_4480.FStar_TypeChecker_Env.attrtab);
                                 FStar_TypeChecker_Env.instantiate_imp =
-                                  (uu___785_4406.FStar_TypeChecker_Env.instantiate_imp);
+                                  (uu___783_4480.FStar_TypeChecker_Env.instantiate_imp);
                                 FStar_TypeChecker_Env.effects =
-                                  (uu___785_4406.FStar_TypeChecker_Env.effects);
+                                  (uu___783_4480.FStar_TypeChecker_Env.effects);
                                 FStar_TypeChecker_Env.generalize =
-                                  (uu___785_4406.FStar_TypeChecker_Env.generalize);
+                                  (uu___783_4480.FStar_TypeChecker_Env.generalize);
                                 FStar_TypeChecker_Env.letrecs =
-                                  (uu___785_4406.FStar_TypeChecker_Env.letrecs);
+                                  (uu___783_4480.FStar_TypeChecker_Env.letrecs);
                                 FStar_TypeChecker_Env.top_level =
-                                  (uu___785_4406.FStar_TypeChecker_Env.top_level);
+                                  (uu___783_4480.FStar_TypeChecker_Env.top_level);
                                 FStar_TypeChecker_Env.check_uvars =
-                                  (uu___785_4406.FStar_TypeChecker_Env.check_uvars);
+                                  (uu___783_4480.FStar_TypeChecker_Env.check_uvars);
                                 FStar_TypeChecker_Env.use_eq =
-                                  (uu___785_4406.FStar_TypeChecker_Env.use_eq);
+                                  (uu___783_4480.FStar_TypeChecker_Env.use_eq);
                                 FStar_TypeChecker_Env.use_eq_strict =
-                                  (uu___785_4406.FStar_TypeChecker_Env.use_eq_strict);
+                                  (uu___783_4480.FStar_TypeChecker_Env.use_eq_strict);
                                 FStar_TypeChecker_Env.is_iface =
-                                  (uu___785_4406.FStar_TypeChecker_Env.is_iface);
+                                  (uu___783_4480.FStar_TypeChecker_Env.is_iface);
                                 FStar_TypeChecker_Env.admit =
-                                  (uu___785_4406.FStar_TypeChecker_Env.admit);
+                                  (uu___783_4480.FStar_TypeChecker_Env.admit);
                                 FStar_TypeChecker_Env.lax = true;
                                 FStar_TypeChecker_Env.lax_universes =
-                                  (uu___785_4406.FStar_TypeChecker_Env.lax_universes);
+                                  (uu___783_4480.FStar_TypeChecker_Env.lax_universes);
                                 FStar_TypeChecker_Env.phase1 = true;
                                 FStar_TypeChecker_Env.failhard =
-                                  (uu___785_4406.FStar_TypeChecker_Env.failhard);
+                                  (uu___783_4480.FStar_TypeChecker_Env.failhard);
                                 FStar_TypeChecker_Env.nosynth =
-                                  (uu___785_4406.FStar_TypeChecker_Env.nosynth);
+                                  (uu___783_4480.FStar_TypeChecker_Env.nosynth);
                                 FStar_TypeChecker_Env.uvar_subtyping =
-                                  (uu___785_4406.FStar_TypeChecker_Env.uvar_subtyping);
+                                  (uu___783_4480.FStar_TypeChecker_Env.uvar_subtyping);
                                 FStar_TypeChecker_Env.tc_term =
-                                  (uu___785_4406.FStar_TypeChecker_Env.tc_term);
+                                  (uu___783_4480.FStar_TypeChecker_Env.tc_term);
                                 FStar_TypeChecker_Env.type_of =
-                                  (uu___785_4406.FStar_TypeChecker_Env.type_of);
+                                  (uu___783_4480.FStar_TypeChecker_Env.type_of);
                                 FStar_TypeChecker_Env.universe_of =
-                                  (uu___785_4406.FStar_TypeChecker_Env.universe_of);
+                                  (uu___783_4480.FStar_TypeChecker_Env.universe_of);
                                 FStar_TypeChecker_Env.check_type_of =
-                                  (uu___785_4406.FStar_TypeChecker_Env.check_type_of);
+                                  (uu___783_4480.FStar_TypeChecker_Env.check_type_of);
                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                  (uu___785_4406.FStar_TypeChecker_Env.use_bv_sorts);
+                                  (uu___783_4480.FStar_TypeChecker_Env.use_bv_sorts);
                                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                                  (uu___785_4406.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                  (uu___783_4480.FStar_TypeChecker_Env.qtbl_name_and_index);
                                 FStar_TypeChecker_Env.normalized_eff_names =
-                                  (uu___785_4406.FStar_TypeChecker_Env.normalized_eff_names);
+                                  (uu___783_4480.FStar_TypeChecker_Env.normalized_eff_names);
                                 FStar_TypeChecker_Env.fv_delta_depths =
-                                  (uu___785_4406.FStar_TypeChecker_Env.fv_delta_depths);
+                                  (uu___783_4480.FStar_TypeChecker_Env.fv_delta_depths);
                                 FStar_TypeChecker_Env.proof_ns =
-                                  (uu___785_4406.FStar_TypeChecker_Env.proof_ns);
+                                  (uu___783_4480.FStar_TypeChecker_Env.proof_ns);
                                 FStar_TypeChecker_Env.synth_hook =
-                                  (uu___785_4406.FStar_TypeChecker_Env.synth_hook);
+                                  (uu___783_4480.FStar_TypeChecker_Env.synth_hook);
                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                   =
-                                  (uu___785_4406.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                  (uu___783_4480.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                 FStar_TypeChecker_Env.splice =
-                                  (uu___785_4406.FStar_TypeChecker_Env.splice);
+                                  (uu___783_4480.FStar_TypeChecker_Env.splice);
                                 FStar_TypeChecker_Env.mpreprocess =
-                                  (uu___785_4406.FStar_TypeChecker_Env.mpreprocess);
+                                  (uu___783_4480.FStar_TypeChecker_Env.mpreprocess);
                                 FStar_TypeChecker_Env.postprocess =
-                                  (uu___785_4406.FStar_TypeChecker_Env.postprocess);
+                                  (uu___783_4480.FStar_TypeChecker_Env.postprocess);
                                 FStar_TypeChecker_Env.is_native_tactic =
-                                  (uu___785_4406.FStar_TypeChecker_Env.is_native_tactic);
+                                  (uu___783_4480.FStar_TypeChecker_Env.is_native_tactic);
                                 FStar_TypeChecker_Env.identifier_info =
-                                  (uu___785_4406.FStar_TypeChecker_Env.identifier_info);
+                                  (uu___783_4480.FStar_TypeChecker_Env.identifier_info);
                                 FStar_TypeChecker_Env.tc_hooks =
-                                  (uu___785_4406.FStar_TypeChecker_Env.tc_hooks);
+                                  (uu___783_4480.FStar_TypeChecker_Env.tc_hooks);
                                 FStar_TypeChecker_Env.dsenv =
-                                  (uu___785_4406.FStar_TypeChecker_Env.dsenv);
+                                  (uu___783_4480.FStar_TypeChecker_Env.dsenv);
                                 FStar_TypeChecker_Env.nbe =
-                                  (uu___785_4406.FStar_TypeChecker_Env.nbe);
+                                  (uu___783_4480.FStar_TypeChecker_Env.nbe);
                                 FStar_TypeChecker_Env.strict_args_tab =
-                                  (uu___785_4406.FStar_TypeChecker_Env.strict_args_tab);
+                                  (uu___783_4480.FStar_TypeChecker_Env.strict_args_tab);
                                 FStar_TypeChecker_Env.erasable_types_tab =
-                                  (uu___785_4406.FStar_TypeChecker_Env.erasable_types_tab)
+                                  (uu___783_4480.FStar_TypeChecker_Env.erasable_types_tab)
                               }) m n p t
                             in
-                         FStar_All.pipe_right uu____4399
-                           (fun uu____4417  ->
-                              match uu____4417 with
+                         FStar_All.pipe_right uu____4473
+                           (fun uu____4491  ->
+                              match uu____4491 with
                               | (t1,ty) ->
-                                  let uu___790_4424 = se1  in
+                                  let uu___788_4498 = se1  in
                                   {
                                     FStar_Syntax_Syntax.sigel =
                                       (FStar_Syntax_Syntax.Sig_polymonadic_bind
                                          (m, n, p, t1, ty));
                                     FStar_Syntax_Syntax.sigrng =
-                                      (uu___790_4424.FStar_Syntax_Syntax.sigrng);
+                                      (uu___788_4498.FStar_Syntax_Syntax.sigrng);
                                     FStar_Syntax_Syntax.sigquals =
-                                      (uu___790_4424.FStar_Syntax_Syntax.sigquals);
+                                      (uu___788_4498.FStar_Syntax_Syntax.sigquals);
                                     FStar_Syntax_Syntax.sigmeta =
-                                      (uu___790_4424.FStar_Syntax_Syntax.sigmeta);
+                                      (uu___788_4498.FStar_Syntax_Syntax.sigmeta);
                                     FStar_Syntax_Syntax.sigattrs =
-                                      (uu___790_4424.FStar_Syntax_Syntax.sigattrs);
+                                      (uu___788_4498.FStar_Syntax_Syntax.sigattrs);
                                     FStar_Syntax_Syntax.sigopts =
-                                      (uu___790_4424.FStar_Syntax_Syntax.sigopts)
+                                      (uu___788_4498.FStar_Syntax_Syntax.sigopts)
                                   })
                           in
-                       FStar_All.pipe_right uu____4398
+                       FStar_All.pipe_right uu____4472
                          (FStar_TypeChecker_Normalize.elim_uvars env)
                         in
-                     FStar_All.pipe_right uu____4397
+                     FStar_All.pipe_right uu____4471
                        (fun se2  ->
                           match se2.FStar_Syntax_Syntax.sigel with
                           | FStar_Syntax_Syntax.Sig_polymonadic_bind
-                              (uu____4440,uu____4441,uu____4442,t1,ty) ->
+                              (uu____4514,uu____4515,uu____4516,t1,ty) ->
                               (t1, ty)
-                          | uu____4445 ->
+                          | uu____4519 ->
                               failwith
                                 "Impossible! tc for Sig_polymonadic_bind must be a Sig_polymonadic_bind")
                       in
-                   match uu____4392 with
+                   match uu____4466 with
                    | (t1,ty) ->
-                       ((let uu____4454 =
+                       ((let uu____4528 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env)
                              (FStar_Options.Other "TwoPhases")
                             in
-                         if uu____4454
+                         if uu____4528
                          then
-                           let uu____4459 =
+                           let uu____4533 =
                              FStar_Syntax_Print.sigelt_to_string
-                               (let uu___805_4463 = se1  in
+                               (let uu___803_4537 = se1  in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_polymonadic_bind
                                        (m, n, p, t1, ty));
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___805_4463.FStar_Syntax_Syntax.sigrng);
+                                    (uu___803_4537.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___805_4463.FStar_Syntax_Syntax.sigquals);
+                                    (uu___803_4537.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___805_4463.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___803_4537.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
-                                    (uu___805_4463.FStar_Syntax_Syntax.sigattrs);
+                                    (uu___803_4537.FStar_Syntax_Syntax.sigattrs);
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___805_4463.FStar_Syntax_Syntax.sigopts)
+                                    (uu___803_4537.FStar_Syntax_Syntax.sigopts)
                                 })
                               in
                            FStar_Util.print1
                              "Polymonadic bind after phase 1: %s\n"
-                             uu____4459
+                             uu____4533
                          else ());
                         t1)
                  else t  in
-               let uu____4469 =
+               let uu____4543 =
                  FStar_TypeChecker_TcEffect.tc_polymonadic_bind env m n p t1
                   in
-               (match uu____4469 with
+               (match uu____4543 with
                 | (t2,ty) ->
                     let se2 =
-                      let uu___812_4487 = se1  in
+                      let uu___810_4561 = se1  in
                       {
                         FStar_Syntax_Syntax.sigel =
                           (FStar_Syntax_Syntax.Sig_polymonadic_bind
                              (m, n, p, t2, ty));
                         FStar_Syntax_Syntax.sigrng =
-                          (uu___812_4487.FStar_Syntax_Syntax.sigrng);
+                          (uu___810_4561.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (uu___812_4487.FStar_Syntax_Syntax.sigquals);
+                          (uu___810_4561.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (uu___812_4487.FStar_Syntax_Syntax.sigmeta);
+                          (uu___810_4561.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
-                          (uu___812_4487.FStar_Syntax_Syntax.sigattrs);
+                          (uu___810_4561.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
-                          (uu___812_4487.FStar_Syntax_Syntax.sigopts)
+                          (uu___810_4561.FStar_Syntax_Syntax.sigopts)
                       }  in
                     ([se2], [], env0)))
   
@@ -3402,38 +3441,39 @@ let (tc_decl :
   =
   fun env  ->
     fun se  ->
-      let uu____4523 =
+      let uu____4597 =
         env.FStar_TypeChecker_Env.nosynth && (FStar_Options.debug_any ())  in
-      if uu____4523
+      if uu____4597
       then ([], [], env)
       else
         (let env1 = set_hint_correlator env se  in
-         (let uu____4544 =
-            FStar_Options.debug_module
-              (env1.FStar_TypeChecker_Env.curmodule).FStar_Ident.str
-             in
-          if uu____4544
+         (let uu____4618 =
+            let uu____4620 =
+              FStar_Ident.string_of_lid env1.FStar_TypeChecker_Env.curmodule
+               in
+            FStar_Options.debug_module uu____4620  in
+          if uu____4618
           then
-            let uu____4547 =
-              let uu____4549 =
+            let uu____4623 =
+              let uu____4625 =
                 FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
-                  (FStar_List.map (fun l  -> l.FStar_Ident.str))
+                  (FStar_List.map FStar_Ident.string_of_lid)
                  in
-              FStar_All.pipe_right uu____4549 (FStar_String.concat ", ")  in
-            FStar_Util.print1 "Processing %s\n" uu____4547
+              FStar_All.pipe_right uu____4625 (FStar_String.concat ", ")  in
+            FStar_Util.print1 "Processing %s\n" uu____4623
           else ());
-         (let uu____4570 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low
+         (let uu____4644 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low
              in
-          if uu____4570
+          if uu____4644
           then
-            let uu____4573 = FStar_Syntax_Print.sigelt_to_string se  in
-            FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu____4573
+            let uu____4647 = FStar_Syntax_Print.sigelt_to_string se  in
+            FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu____4647
           else ());
          tc_decl' env1 se)
   
 let for_export :
-  'uuuuuu4587 .
-    'uuuuuu4587 ->
+  'uuuuuu4661 .
+    'uuuuuu4661 ->
       FStar_Ident.lident Prims.list ->
         FStar_Syntax_Syntax.sigelt ->
           (FStar_Syntax_Syntax.sigelt Prims.list * FStar_Ident.lident
@@ -3445,159 +3485,159 @@ let for_export :
         let is_abstract quals =
           FStar_All.pipe_right quals
             (FStar_Util.for_some
-               (fun uu___2_4630  ->
-                  match uu___2_4630 with
+               (fun uu___2_4704  ->
+                  match uu___2_4704 with
                   | FStar_Syntax_Syntax.Abstract  -> true
-                  | uu____4633 -> false))
+                  | uu____4707 -> false))
            in
         let is_hidden_proj_or_disc q =
           match q with
-          | FStar_Syntax_Syntax.Projector (l,uu____4644) ->
+          | FStar_Syntax_Syntax.Projector (l,uu____4718) ->
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Ident.lid_equals l))
           | FStar_Syntax_Syntax.Discriminator l ->
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Ident.lid_equals l))
-          | uu____4652 -> false  in
+          | uu____4726 -> false  in
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_pragma uu____4662 -> ([], hidden)
-        | FStar_Syntax_Syntax.Sig_fail uu____4667 ->
+        | FStar_Syntax_Syntax.Sig_pragma uu____4736 -> ([], hidden)
+        | FStar_Syntax_Syntax.Sig_fail uu____4741 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_splice uu____4689 ->
+        | FStar_Syntax_Syntax.Sig_splice uu____4763 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_inductive_typ uu____4705 ->
+        | FStar_Syntax_Syntax.Sig_inductive_typ uu____4779 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_datacon uu____4731 ->
+        | FStar_Syntax_Syntax.Sig_datacon uu____4805 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_bundle (ses,uu____4757) ->
-            let uu____4766 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____4766
+        | FStar_Syntax_Syntax.Sig_bundle (ses,uu____4831) ->
+            let uu____4840 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____4840
             then
-              let for_export_bundle se1 uu____4803 =
-                match uu____4803 with
+              let for_export_bundle se1 uu____4877 =
+                match uu____4877 with
                 | (out,hidden1) ->
                     (match se1.FStar_Syntax_Syntax.sigel with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (l,us,bs,t,uu____4842,uu____4843) ->
+                         (l,us,bs,t,uu____4916,uu____4917) ->
                          let dec =
-                           let uu___868_4853 = se1  in
-                           let uu____4854 =
-                             let uu____4855 =
-                               let uu____4862 =
-                                 let uu____4863 =
+                           let uu___865_4927 = se1  in
+                           let uu____4928 =
+                             let uu____4929 =
+                               let uu____4936 =
+                                 let uu____4937 =
                                    FStar_Syntax_Syntax.mk_Total t  in
-                                 FStar_Syntax_Util.arrow bs uu____4863  in
-                               (l, us, uu____4862)  in
-                             FStar_Syntax_Syntax.Sig_declare_typ uu____4855
+                                 FStar_Syntax_Util.arrow bs uu____4937  in
+                               (l, us, uu____4936)  in
+                             FStar_Syntax_Syntax.Sig_declare_typ uu____4929
                               in
                            {
-                             FStar_Syntax_Syntax.sigel = uu____4854;
+                             FStar_Syntax_Syntax.sigel = uu____4928;
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___868_4853.FStar_Syntax_Syntax.sigrng);
+                               (uu___865_4927.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
                                (FStar_Syntax_Syntax.Assumption ::
                                FStar_Syntax_Syntax.New ::
                                (se1.FStar_Syntax_Syntax.sigquals));
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___868_4853.FStar_Syntax_Syntax.sigmeta);
+                               (uu___865_4927.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___868_4853.FStar_Syntax_Syntax.sigattrs);
+                               (uu___865_4927.FStar_Syntax_Syntax.sigattrs);
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___868_4853.FStar_Syntax_Syntax.sigopts)
+                               (uu___865_4927.FStar_Syntax_Syntax.sigopts)
                            }  in
                          ((dec :: out), hidden1)
                      | FStar_Syntax_Syntax.Sig_datacon
-                         (l,us,t,uu____4873,uu____4874,uu____4875) ->
+                         (l,us,t,uu____4947,uu____4948,uu____4949) ->
                          let dec =
-                           let uu___879_4883 = se1  in
+                           let uu___876_4957 = se1  in
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_declare_typ
                                   (l, us, t));
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___879_4883.FStar_Syntax_Syntax.sigrng);
+                               (uu___876_4957.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
                                [FStar_Syntax_Syntax.Assumption];
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___879_4883.FStar_Syntax_Syntax.sigmeta);
+                               (uu___876_4957.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___879_4883.FStar_Syntax_Syntax.sigattrs);
+                               (uu___876_4957.FStar_Syntax_Syntax.sigattrs);
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___879_4883.FStar_Syntax_Syntax.sigopts)
+                               (uu___876_4957.FStar_Syntax_Syntax.sigopts)
                            }  in
                          ((dec :: out), (l :: hidden1))
-                     | uu____4888 -> (out, hidden1))
+                     | uu____4962 -> (out, hidden1))
                  in
               FStar_List.fold_right for_export_bundle ses ([], hidden)
             else ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_assume (uu____4911,uu____4912,uu____4913)
+        | FStar_Syntax_Syntax.Sig_assume (uu____4985,uu____4986,uu____4987)
             ->
-            let uu____4914 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____4914 then ([], hidden) else ([se], hidden)
+            let uu____4988 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____4988 then ([], hidden) else ([se], hidden)
         | FStar_Syntax_Syntax.Sig_declare_typ (l,us,t) ->
-            let uu____4938 =
+            let uu____5012 =
               FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                 (FStar_Util.for_some is_hidden_proj_or_disc)
                in
-            if uu____4938
+            if uu____5012
             then
-              ([(let uu___895_4957 = se  in
+              ([(let uu___892_5031 = se  in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_declare_typ (l, us, t));
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___895_4957.FStar_Syntax_Syntax.sigrng);
+                     (uu___892_5031.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
                      [FStar_Syntax_Syntax.Assumption];
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___895_4957.FStar_Syntax_Syntax.sigmeta);
+                     (uu___892_5031.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs =
-                     (uu___895_4957.FStar_Syntax_Syntax.sigattrs);
+                     (uu___892_5031.FStar_Syntax_Syntax.sigattrs);
                    FStar_Syntax_Syntax.sigopts =
-                     (uu___895_4957.FStar_Syntax_Syntax.sigopts)
+                     (uu___892_5031.FStar_Syntax_Syntax.sigopts)
                  })], (l :: hidden))
             else
-              (let uu____4960 =
+              (let uu____5034 =
                  FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                    (FStar_Util.for_some
-                      (fun uu___3_4966  ->
-                         match uu___3_4966 with
+                      (fun uu___3_5040  ->
+                         match uu___3_5040 with
                          | FStar_Syntax_Syntax.Assumption  -> true
-                         | FStar_Syntax_Syntax.Projector uu____4969 -> true
-                         | FStar_Syntax_Syntax.Discriminator uu____4975 ->
+                         | FStar_Syntax_Syntax.Projector uu____5043 -> true
+                         | FStar_Syntax_Syntax.Discriminator uu____5049 ->
                              true
-                         | uu____4977 -> false))
+                         | uu____5051 -> false))
                   in
-               if uu____4960 then ([se], hidden) else ([], hidden))
-        | FStar_Syntax_Syntax.Sig_main uu____4998 -> ([], hidden)
-        | FStar_Syntax_Syntax.Sig_new_effect uu____5003 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_sub_effect uu____5008 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_effect_abbrev uu____5013 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____5030 ->
+               if uu____5034 then ([se], hidden) else ([], hidden))
+        | FStar_Syntax_Syntax.Sig_main uu____5072 -> ([], hidden)
+        | FStar_Syntax_Syntax.Sig_new_effect uu____5077 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_sub_effect uu____5082 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_effect_abbrev uu____5087 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____5104 ->
             ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5046) when
+        | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5120) when
             FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
               (FStar_Util.for_some is_hidden_proj_or_disc)
             ->
             let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
             let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                in
-            let uu____5060 =
+            let uu____5134 =
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv))
                in
-            if uu____5060
+            if uu____5134
             then ([], hidden)
             else
               (let dec =
-                 let uu____5081 = FStar_Ident.range_of_lid lid  in
+                 let uu____5155 = FStar_Ident.range_of_lid lid  in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_declare_typ
                         (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v),
                           (lb.FStar_Syntax_Syntax.lbunivs),
                           (lb.FStar_Syntax_Syntax.lbtyp)));
-                   FStar_Syntax_Syntax.sigrng = uu____5081;
+                   FStar_Syntax_Syntax.sigrng = uu____5155;
                    FStar_Syntax_Syntax.sigquals =
                      [FStar_Syntax_Syntax.Assumption];
                    FStar_Syntax_Syntax.sigmeta =
@@ -3607,44 +3647,44 @@ let for_export :
                  }  in
                ([dec], (lid :: hidden)))
         | FStar_Syntax_Syntax.Sig_let (lbs,l) ->
-            let uu____5092 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____5092
+            let uu____5166 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____5166
             then
-              let uu____5103 =
+              let uu____5177 =
                 FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                   (FStar_List.map
                      (fun lb  ->
-                        let uu___932_5117 = se  in
-                        let uu____5118 =
-                          let uu____5119 =
-                            let uu____5126 =
-                              let uu____5127 =
-                                let uu____5130 =
+                        let uu___929_5191 = se  in
+                        let uu____5192 =
+                          let uu____5193 =
+                            let uu____5200 =
+                              let uu____5201 =
+                                let uu____5204 =
                                   FStar_Util.right
                                     lb.FStar_Syntax_Syntax.lbname
                                    in
-                                uu____5130.FStar_Syntax_Syntax.fv_name  in
-                              uu____5127.FStar_Syntax_Syntax.v  in
-                            (uu____5126, (lb.FStar_Syntax_Syntax.lbunivs),
+                                uu____5204.FStar_Syntax_Syntax.fv_name  in
+                              uu____5201.FStar_Syntax_Syntax.v  in
+                            (uu____5200, (lb.FStar_Syntax_Syntax.lbunivs),
                               (lb.FStar_Syntax_Syntax.lbtyp))
                              in
-                          FStar_Syntax_Syntax.Sig_declare_typ uu____5119  in
+                          FStar_Syntax_Syntax.Sig_declare_typ uu____5193  in
                         {
-                          FStar_Syntax_Syntax.sigel = uu____5118;
+                          FStar_Syntax_Syntax.sigel = uu____5192;
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___932_5117.FStar_Syntax_Syntax.sigrng);
+                            (uu___929_5191.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
                             (FStar_Syntax_Syntax.Assumption ::
                             (se.FStar_Syntax_Syntax.sigquals));
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___932_5117.FStar_Syntax_Syntax.sigmeta);
+                            (uu___929_5191.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___932_5117.FStar_Syntax_Syntax.sigattrs);
+                            (uu___929_5191.FStar_Syntax_Syntax.sigattrs);
                           FStar_Syntax_Syntax.sigopts =
-                            (uu___932_5117.FStar_Syntax_Syntax.sigopts)
+                            (uu___929_5191.FStar_Syntax_Syntax.sigopts)
                         }))
                  in
-              (uu____5103, hidden)
+              (uu____5177, hidden)
             else ([se], hidden)
   
 let (add_sigelt_to_env :
@@ -3654,466 +3694,466 @@ let (add_sigelt_to_env :
   fun env  ->
     fun se  ->
       fun from_cache  ->
-        (let uu____5160 = FStar_TypeChecker_Env.debug env FStar_Options.Low
+        (let uu____5234 = FStar_TypeChecker_Env.debug env FStar_Options.Low
             in
-         if uu____5160
+         if uu____5234
          then
-           let uu____5163 = FStar_Syntax_Print.sigelt_to_string se  in
-           let uu____5165 = FStar_Util.string_of_bool from_cache  in
+           let uu____5237 = FStar_Syntax_Print.sigelt_to_string se  in
+           let uu____5239 = FStar_Util.string_of_bool from_cache  in
            FStar_Util.print2
              ">>>>>>>>>>>>>>Adding top-level decl to environment: %s (from_cache:%s)\n"
-             uu____5163 uu____5165
+             uu____5237 uu____5239
          else ());
         (match se.FStar_Syntax_Syntax.sigel with
-         | FStar_Syntax_Syntax.Sig_inductive_typ uu____5170 ->
-             let uu____5187 =
-               let uu____5193 =
-                 let uu____5195 = FStar_Syntax_Print.sigelt_to_string se  in
+         | FStar_Syntax_Syntax.Sig_inductive_typ uu____5244 ->
+             let uu____5261 =
+               let uu____5267 =
+                 let uu____5269 = FStar_Syntax_Print.sigelt_to_string se  in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____5195
+                   uu____5269
                   in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____5193)  in
-             FStar_Errors.raise_error uu____5187
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____5267)  in
+             FStar_Errors.raise_error uu____5261
                se.FStar_Syntax_Syntax.sigrng
-         | FStar_Syntax_Syntax.Sig_datacon uu____5199 ->
-             let uu____5215 =
-               let uu____5221 =
-                 let uu____5223 = FStar_Syntax_Print.sigelt_to_string se  in
+         | FStar_Syntax_Syntax.Sig_datacon uu____5273 ->
+             let uu____5289 =
+               let uu____5295 =
+                 let uu____5297 = FStar_Syntax_Print.sigelt_to_string se  in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____5223
+                   uu____5297
                   in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____5221)  in
-             FStar_Errors.raise_error uu____5215
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____5295)  in
+             FStar_Errors.raise_error uu____5289
                se.FStar_Syntax_Syntax.sigrng
          | FStar_Syntax_Syntax.Sig_declare_typ
-             (uu____5227,uu____5228,uu____5229) when
+             (uu____5301,uu____5302,uu____5303) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___4_5234  ->
-                     match uu___4_5234 with
+                  (fun uu___4_5308  ->
+                     match uu___4_5308 with
                      | FStar_Syntax_Syntax.OnlyName  -> true
-                     | uu____5237 -> false))
+                     | uu____5311 -> false))
              -> env
-         | FStar_Syntax_Syntax.Sig_let (uu____5239,uu____5240) when
+         | FStar_Syntax_Syntax.Sig_let (uu____5313,uu____5314) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___4_5249  ->
-                     match uu___4_5249 with
+                  (fun uu___4_5323  ->
+                     match uu___4_5323 with
                      | FStar_Syntax_Syntax.OnlyName  -> true
-                     | uu____5252 -> false))
+                     | uu____5326 -> false))
              -> env
-         | uu____5254 ->
+         | uu____5328 ->
              let env1 = FStar_TypeChecker_Env.push_sigelt env se  in
              (match se.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.PushOptions uu____5256) ->
+                  (FStar_Syntax_Syntax.PushOptions uu____5330) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___969_5263 = env1  in
-                     let uu____5264 = FStar_Options.using_facts_from ()  in
+                    (let uu___966_5337 = env1  in
+                     let uu____5338 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___969_5263.FStar_TypeChecker_Env.solver);
+                         (uu___966_5337.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___969_5263.FStar_TypeChecker_Env.range);
+                         (uu___966_5337.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___969_5263.FStar_TypeChecker_Env.curmodule);
+                         (uu___966_5337.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___969_5263.FStar_TypeChecker_Env.gamma);
+                         (uu___966_5337.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___969_5263.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___966_5337.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___969_5263.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___966_5337.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___969_5263.FStar_TypeChecker_Env.modules);
+                         (uu___966_5337.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___969_5263.FStar_TypeChecker_Env.expected_typ);
+                         (uu___966_5337.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___969_5263.FStar_TypeChecker_Env.sigtab);
+                         (uu___966_5337.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___969_5263.FStar_TypeChecker_Env.attrtab);
+                         (uu___966_5337.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___969_5263.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___966_5337.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___969_5263.FStar_TypeChecker_Env.effects);
+                         (uu___966_5337.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___969_5263.FStar_TypeChecker_Env.generalize);
+                         (uu___966_5337.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___969_5263.FStar_TypeChecker_Env.letrecs);
+                         (uu___966_5337.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___969_5263.FStar_TypeChecker_Env.top_level);
+                         (uu___966_5337.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___969_5263.FStar_TypeChecker_Env.check_uvars);
+                         (uu___966_5337.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___969_5263.FStar_TypeChecker_Env.use_eq);
+                         (uu___966_5337.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___969_5263.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___966_5337.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___969_5263.FStar_TypeChecker_Env.is_iface);
+                         (uu___966_5337.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___969_5263.FStar_TypeChecker_Env.admit);
+                         (uu___966_5337.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___969_5263.FStar_TypeChecker_Env.lax);
+                         (uu___966_5337.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___969_5263.FStar_TypeChecker_Env.lax_universes);
+                         (uu___966_5337.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___969_5263.FStar_TypeChecker_Env.phase1);
+                         (uu___966_5337.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___969_5263.FStar_TypeChecker_Env.failhard);
+                         (uu___966_5337.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___969_5263.FStar_TypeChecker_Env.nosynth);
+                         (uu___966_5337.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___969_5263.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___966_5337.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___969_5263.FStar_TypeChecker_Env.tc_term);
+                         (uu___966_5337.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___969_5263.FStar_TypeChecker_Env.type_of);
+                         (uu___966_5337.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___969_5263.FStar_TypeChecker_Env.universe_of);
+                         (uu___966_5337.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___969_5263.FStar_TypeChecker_Env.check_type_of);
+                         (uu___966_5337.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___969_5263.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___966_5337.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___969_5263.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___966_5337.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___969_5263.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___966_5337.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___969_5263.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____5264;
+                         (uu___966_5337.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____5338;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___969_5263.FStar_TypeChecker_Env.synth_hook);
+                         (uu___966_5337.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___969_5263.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___966_5337.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___969_5263.FStar_TypeChecker_Env.splice);
+                         (uu___966_5337.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___969_5263.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___966_5337.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___969_5263.FStar_TypeChecker_Env.postprocess);
+                         (uu___966_5337.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___969_5263.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___966_5337.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___969_5263.FStar_TypeChecker_Env.identifier_info);
+                         (uu___966_5337.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___969_5263.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___966_5337.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___969_5263.FStar_TypeChecker_Env.dsenv);
+                         (uu___966_5337.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___969_5263.FStar_TypeChecker_Env.nbe);
+                         (uu___966_5337.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___969_5263.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___966_5337.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___969_5263.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___966_5337.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.PopOptions ) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___969_5268 = env1  in
-                     let uu____5269 = FStar_Options.using_facts_from ()  in
+                    (let uu___966_5342 = env1  in
+                     let uu____5343 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___969_5268.FStar_TypeChecker_Env.solver);
+                         (uu___966_5342.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___969_5268.FStar_TypeChecker_Env.range);
+                         (uu___966_5342.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___969_5268.FStar_TypeChecker_Env.curmodule);
+                         (uu___966_5342.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___969_5268.FStar_TypeChecker_Env.gamma);
+                         (uu___966_5342.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___969_5268.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___966_5342.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___969_5268.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___966_5342.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___969_5268.FStar_TypeChecker_Env.modules);
+                         (uu___966_5342.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___969_5268.FStar_TypeChecker_Env.expected_typ);
+                         (uu___966_5342.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___969_5268.FStar_TypeChecker_Env.sigtab);
+                         (uu___966_5342.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___969_5268.FStar_TypeChecker_Env.attrtab);
+                         (uu___966_5342.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___969_5268.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___966_5342.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___969_5268.FStar_TypeChecker_Env.effects);
+                         (uu___966_5342.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___969_5268.FStar_TypeChecker_Env.generalize);
+                         (uu___966_5342.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___969_5268.FStar_TypeChecker_Env.letrecs);
+                         (uu___966_5342.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___969_5268.FStar_TypeChecker_Env.top_level);
+                         (uu___966_5342.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___969_5268.FStar_TypeChecker_Env.check_uvars);
+                         (uu___966_5342.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___969_5268.FStar_TypeChecker_Env.use_eq);
+                         (uu___966_5342.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___969_5268.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___966_5342.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___969_5268.FStar_TypeChecker_Env.is_iface);
+                         (uu___966_5342.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___969_5268.FStar_TypeChecker_Env.admit);
+                         (uu___966_5342.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___969_5268.FStar_TypeChecker_Env.lax);
+                         (uu___966_5342.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___969_5268.FStar_TypeChecker_Env.lax_universes);
+                         (uu___966_5342.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___969_5268.FStar_TypeChecker_Env.phase1);
+                         (uu___966_5342.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___969_5268.FStar_TypeChecker_Env.failhard);
+                         (uu___966_5342.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___969_5268.FStar_TypeChecker_Env.nosynth);
+                         (uu___966_5342.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___969_5268.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___966_5342.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___969_5268.FStar_TypeChecker_Env.tc_term);
+                         (uu___966_5342.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___969_5268.FStar_TypeChecker_Env.type_of);
+                         (uu___966_5342.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___969_5268.FStar_TypeChecker_Env.universe_of);
+                         (uu___966_5342.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___969_5268.FStar_TypeChecker_Env.check_type_of);
+                         (uu___966_5342.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___969_5268.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___966_5342.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___969_5268.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___966_5342.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___969_5268.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___966_5342.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___969_5268.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____5269;
+                         (uu___966_5342.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____5343;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___969_5268.FStar_TypeChecker_Env.synth_hook);
+                         (uu___966_5342.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___969_5268.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___966_5342.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___969_5268.FStar_TypeChecker_Env.splice);
+                         (uu___966_5342.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___969_5268.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___966_5342.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___969_5268.FStar_TypeChecker_Env.postprocess);
+                         (uu___966_5342.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___969_5268.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___966_5342.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___969_5268.FStar_TypeChecker_Env.identifier_info);
+                         (uu___966_5342.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___969_5268.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___966_5342.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___969_5268.FStar_TypeChecker_Env.dsenv);
+                         (uu___966_5342.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___969_5268.FStar_TypeChecker_Env.nbe);
+                         (uu___966_5342.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___969_5268.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___966_5342.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___969_5268.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___966_5342.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.SetOptions uu____5270) ->
+                  (FStar_Syntax_Syntax.SetOptions uu____5344) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___969_5275 = env1  in
-                     let uu____5276 = FStar_Options.using_facts_from ()  in
+                    (let uu___966_5349 = env1  in
+                     let uu____5350 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___969_5275.FStar_TypeChecker_Env.solver);
+                         (uu___966_5349.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___969_5275.FStar_TypeChecker_Env.range);
+                         (uu___966_5349.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___969_5275.FStar_TypeChecker_Env.curmodule);
+                         (uu___966_5349.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___969_5275.FStar_TypeChecker_Env.gamma);
+                         (uu___966_5349.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___969_5275.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___966_5349.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___969_5275.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___966_5349.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___969_5275.FStar_TypeChecker_Env.modules);
+                         (uu___966_5349.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___969_5275.FStar_TypeChecker_Env.expected_typ);
+                         (uu___966_5349.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___969_5275.FStar_TypeChecker_Env.sigtab);
+                         (uu___966_5349.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___969_5275.FStar_TypeChecker_Env.attrtab);
+                         (uu___966_5349.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___969_5275.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___966_5349.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___969_5275.FStar_TypeChecker_Env.effects);
+                         (uu___966_5349.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___969_5275.FStar_TypeChecker_Env.generalize);
+                         (uu___966_5349.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___969_5275.FStar_TypeChecker_Env.letrecs);
+                         (uu___966_5349.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___969_5275.FStar_TypeChecker_Env.top_level);
+                         (uu___966_5349.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___969_5275.FStar_TypeChecker_Env.check_uvars);
+                         (uu___966_5349.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___969_5275.FStar_TypeChecker_Env.use_eq);
+                         (uu___966_5349.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___969_5275.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___966_5349.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___969_5275.FStar_TypeChecker_Env.is_iface);
+                         (uu___966_5349.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___969_5275.FStar_TypeChecker_Env.admit);
+                         (uu___966_5349.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___969_5275.FStar_TypeChecker_Env.lax);
+                         (uu___966_5349.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___969_5275.FStar_TypeChecker_Env.lax_universes);
+                         (uu___966_5349.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___969_5275.FStar_TypeChecker_Env.phase1);
+                         (uu___966_5349.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___969_5275.FStar_TypeChecker_Env.failhard);
+                         (uu___966_5349.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___969_5275.FStar_TypeChecker_Env.nosynth);
+                         (uu___966_5349.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___969_5275.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___966_5349.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___969_5275.FStar_TypeChecker_Env.tc_term);
+                         (uu___966_5349.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___969_5275.FStar_TypeChecker_Env.type_of);
+                         (uu___966_5349.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___969_5275.FStar_TypeChecker_Env.universe_of);
+                         (uu___966_5349.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___969_5275.FStar_TypeChecker_Env.check_type_of);
+                         (uu___966_5349.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___969_5275.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___966_5349.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___969_5275.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___966_5349.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___969_5275.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___966_5349.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___969_5275.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____5276;
+                         (uu___966_5349.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____5350;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___969_5275.FStar_TypeChecker_Env.synth_hook);
+                         (uu___966_5349.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___969_5275.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___966_5349.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___969_5275.FStar_TypeChecker_Env.splice);
+                         (uu___966_5349.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___969_5275.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___966_5349.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___969_5275.FStar_TypeChecker_Env.postprocess);
+                         (uu___966_5349.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___969_5275.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___966_5349.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___969_5275.FStar_TypeChecker_Env.identifier_info);
+                         (uu___966_5349.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___969_5275.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___966_5349.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___969_5275.FStar_TypeChecker_Env.dsenv);
+                         (uu___966_5349.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___969_5275.FStar_TypeChecker_Env.nbe);
+                         (uu___966_5349.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___969_5275.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___966_5349.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___969_5275.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___966_5349.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.ResetOptions uu____5277) ->
+                  (FStar_Syntax_Syntax.ResetOptions uu____5351) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___969_5284 = env1  in
-                     let uu____5285 = FStar_Options.using_facts_from ()  in
+                    (let uu___966_5358 = env1  in
+                     let uu____5359 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___969_5284.FStar_TypeChecker_Env.solver);
+                         (uu___966_5358.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___969_5284.FStar_TypeChecker_Env.range);
+                         (uu___966_5358.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___969_5284.FStar_TypeChecker_Env.curmodule);
+                         (uu___966_5358.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___969_5284.FStar_TypeChecker_Env.gamma);
+                         (uu___966_5358.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___969_5284.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___966_5358.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___969_5284.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___966_5358.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___969_5284.FStar_TypeChecker_Env.modules);
+                         (uu___966_5358.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___969_5284.FStar_TypeChecker_Env.expected_typ);
+                         (uu___966_5358.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___969_5284.FStar_TypeChecker_Env.sigtab);
+                         (uu___966_5358.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___969_5284.FStar_TypeChecker_Env.attrtab);
+                         (uu___966_5358.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___969_5284.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___966_5358.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___969_5284.FStar_TypeChecker_Env.effects);
+                         (uu___966_5358.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___969_5284.FStar_TypeChecker_Env.generalize);
+                         (uu___966_5358.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___969_5284.FStar_TypeChecker_Env.letrecs);
+                         (uu___966_5358.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___969_5284.FStar_TypeChecker_Env.top_level);
+                         (uu___966_5358.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___969_5284.FStar_TypeChecker_Env.check_uvars);
+                         (uu___966_5358.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___969_5284.FStar_TypeChecker_Env.use_eq);
+                         (uu___966_5358.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___969_5284.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___966_5358.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___969_5284.FStar_TypeChecker_Env.is_iface);
+                         (uu___966_5358.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___969_5284.FStar_TypeChecker_Env.admit);
+                         (uu___966_5358.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___969_5284.FStar_TypeChecker_Env.lax);
+                         (uu___966_5358.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___969_5284.FStar_TypeChecker_Env.lax_universes);
+                         (uu___966_5358.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___969_5284.FStar_TypeChecker_Env.phase1);
+                         (uu___966_5358.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___969_5284.FStar_TypeChecker_Env.failhard);
+                         (uu___966_5358.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___969_5284.FStar_TypeChecker_Env.nosynth);
+                         (uu___966_5358.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___969_5284.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___966_5358.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___969_5284.FStar_TypeChecker_Env.tc_term);
+                         (uu___966_5358.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___969_5284.FStar_TypeChecker_Env.type_of);
+                         (uu___966_5358.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___969_5284.FStar_TypeChecker_Env.universe_of);
+                         (uu___966_5358.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___969_5284.FStar_TypeChecker_Env.check_type_of);
+                         (uu___966_5358.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___969_5284.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___966_5358.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___969_5284.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___966_5358.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___969_5284.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___966_5358.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___969_5284.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____5285;
+                         (uu___966_5358.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____5359;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___969_5284.FStar_TypeChecker_Env.synth_hook);
+                         (uu___966_5358.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___969_5284.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___966_5358.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___969_5284.FStar_TypeChecker_Env.splice);
+                         (uu___966_5358.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___969_5284.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___966_5358.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___969_5284.FStar_TypeChecker_Env.postprocess);
+                         (uu___966_5358.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.is_native_tactic =
-                         (uu___969_5284.FStar_TypeChecker_Env.is_native_tactic);
+                         (uu___966_5358.FStar_TypeChecker_Env.is_native_tactic);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___969_5284.FStar_TypeChecker_Env.identifier_info);
+                         (uu___966_5358.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___969_5284.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___966_5358.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___969_5284.FStar_TypeChecker_Env.dsenv);
+                         (uu___966_5358.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___969_5284.FStar_TypeChecker_Env.nbe);
+                         (uu___966_5358.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___969_5284.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___966_5358.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___969_5284.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___966_5358.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.RestartSolver ) ->
@@ -4132,20 +4172,20 @@ let (add_sigelt_to_env :
                     (FStar_List.fold_left
                        (fun env3  ->
                           fun a  ->
-                            let uu____5301 =
+                            let uu____5375 =
                               FStar_Syntax_Util.action_as_lb
                                 ne.FStar_Syntax_Syntax.mname a
                                 (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                in
-                            FStar_TypeChecker_Env.push_sigelt env3 uu____5301)
+                            FStar_TypeChecker_Env.push_sigelt env3 uu____5375)
                        env2)
               | FStar_Syntax_Syntax.Sig_sub_effect sub ->
                   FStar_TypeChecker_Util.update_env_sub_eff env1 sub
               | FStar_Syntax_Syntax.Sig_polymonadic_bind
-                  (m,n,p,uu____5306,ty) ->
+                  (m,n,p,uu____5380,ty) ->
                   FStar_TypeChecker_Util.update_env_polymonadic_bind env1 m n
                     p ty
-              | uu____5308 -> env1))
+              | uu____5382 -> env1))
   
 let (tc_decls :
   FStar_TypeChecker_Env.env ->
@@ -4155,36 +4195,36 @@ let (tc_decls :
   =
   fun env  ->
     fun ses  ->
-      let rec process_one_decl uu____5377 se =
-        match uu____5377 with
+      let rec process_one_decl uu____5451 se =
+        match uu____5451 with
         | (ses1,exports,env1,hidden) ->
-            ((let uu____5430 =
+            ((let uu____5504 =
                 FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
-              if uu____5430
+              if uu____5504
               then
-                let uu____5433 = FStar_Syntax_Print.tag_of_sigelt se  in
-                let uu____5435 = FStar_Syntax_Print.sigelt_to_string se  in
+                let uu____5507 = FStar_Syntax_Print.tag_of_sigelt se  in
+                let uu____5509 = FStar_Syntax_Print.sigelt_to_string se  in
                 FStar_Util.print2
-                  ">>>>>>>>>>>>>>Checking top-level %s decl %s\n" uu____5433
-                  uu____5435
+                  ">>>>>>>>>>>>>>Checking top-level %s decl %s\n" uu____5507
+                  uu____5509
               else ());
-             (let uu____5440 = tc_decl env1 se  in
-              match uu____5440 with
+             (let uu____5514 = tc_decl env1 se  in
+              match uu____5514 with
               | (ses',ses_elaborated,env2) ->
                   let ses'1 =
                     FStar_All.pipe_right ses'
                       (FStar_List.map
                          (fun se1  ->
-                            (let uu____5493 =
+                            (let uu____5567 =
                                FStar_TypeChecker_Env.debug env2
                                  (FStar_Options.Other "UF")
                                 in
-                             if uu____5493
+                             if uu____5567
                              then
-                               let uu____5497 =
+                               let uu____5571 =
                                  FStar_Syntax_Print.sigelt_to_string se1  in
                                FStar_Util.print1
-                                 "About to elim vars from %s\n" uu____5497
+                                 "About to elim vars from %s\n" uu____5571
                              else ());
                             FStar_TypeChecker_Normalize.elim_uvars env2 se1))
                      in
@@ -4192,17 +4232,17 @@ let (tc_decls :
                     FStar_All.pipe_right ses_elaborated
                       (FStar_List.map
                          (fun se1  ->
-                            (let uu____5513 =
+                            (let uu____5587 =
                                FStar_TypeChecker_Env.debug env2
                                  (FStar_Options.Other "UF")
                                 in
-                             if uu____5513
+                             if uu____5587
                              then
-                               let uu____5517 =
+                               let uu____5591 =
                                  FStar_Syntax_Print.sigelt_to_string se1  in
                                FStar_Util.print1
                                  "About to elim vars from (elaborated) %s\n"
-                                 uu____5517
+                                 uu____5591
                              else ());
                             FStar_TypeChecker_Normalize.elim_uvars env2 se1))
                      in
@@ -4227,43 +4267,43 @@ let (tc_decls :
                            env2)
                        in
                     FStar_Syntax_Unionfind.reset ();
-                    (let uu____5535 =
+                    (let uu____5609 =
                        (FStar_Options.log_types ()) ||
                          (FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env3)
                             (FStar_Options.Other "LogTypes"))
                         in
-                     if uu____5535
+                     if uu____5609
                      then
-                       let uu____5540 =
+                       let uu____5614 =
                          FStar_List.fold_left
                            (fun s  ->
                               fun se1  ->
-                                let uu____5549 =
-                                  let uu____5551 =
+                                let uu____5623 =
+                                  let uu____5625 =
                                     FStar_Syntax_Print.sigelt_to_string se1
                                      in
-                                  Prims.op_Hat uu____5551 "\n"  in
-                                Prims.op_Hat s uu____5549) "" ses'1
+                                  Prims.op_Hat uu____5625 "\n"  in
+                                Prims.op_Hat s uu____5623) "" ses'1
                           in
-                       FStar_Util.print1 "Checked: %s\n" uu____5540
+                       FStar_Util.print1 "Checked: %s\n" uu____5614
                      else ());
                     FStar_List.iter
                       (fun se1  ->
                          (env3.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.encode_sig
                            env3 se1) ses'1;
-                    (let uu____5561 =
-                       let uu____5570 =
+                    (let uu____5635 =
+                       let uu____5644 =
                          FStar_Options.use_extracted_interfaces ()  in
-                       if uu____5570
+                       if uu____5644
                        then ((FStar_List.rev_append ses'1 exports), [])
                        else
-                         (let accum_exports_hidden uu____5612 se1 =
-                            match uu____5612 with
+                         (let accum_exports_hidden uu____5686 se1 =
+                            match uu____5686 with
                             | (exports1,hidden1) ->
-                                let uu____5640 = for_export env3 hidden1 se1
+                                let uu____5714 = for_export env3 hidden1 se1
                                    in
-                                (match uu____5640 with
+                                (match uu____5714 with
                                  | (se_exported,hidden2) ->
                                      ((FStar_List.rev_append se_exported
                                          exports1), hidden2))
@@ -4271,33 +4311,33 @@ let (tc_decls :
                           FStar_List.fold_left accum_exports_hidden
                             (exports, hidden) ses'1)
                         in
-                     match uu____5561 with
+                     match uu____5635 with
                      | (exports1,hidden1) ->
                          (((FStar_List.rev_append ses'1 ses1), exports1,
                             env3, hidden1), ses_elaborated1))))))
          in
       let process_one_decl_timed acc se =
-        let uu____5794 = acc  in
-        match uu____5794 with
-        | (uu____5829,uu____5830,env1,uu____5832) ->
+        let uu____5868 = acc  in
+        match uu____5868 with
+        | (uu____5903,uu____5904,env1,uu____5906) ->
             let r =
-              let uu____5866 =
-                let uu____5870 =
-                  let uu____5872 = FStar_TypeChecker_Env.current_module env1
+              let uu____5940 =
+                let uu____5944 =
+                  let uu____5946 = FStar_TypeChecker_Env.current_module env1
                      in
-                  FStar_Ident.string_of_lid uu____5872  in
-                FStar_Pervasives_Native.Some uu____5870  in
+                  FStar_Ident.string_of_lid uu____5946  in
+                FStar_Pervasives_Native.Some uu____5944  in
               FStar_Profiling.profile
-                (fun uu____5895  -> process_one_decl acc se) uu____5866
+                (fun uu____5969  -> process_one_decl acc se) uu____5940
                 "FStar.TypeChecker.Tc.process_one_decl"
                in
-            ((let uu____5898 = FStar_Options.profile_group_by_decls ()  in
-              if uu____5898
+            ((let uu____5972 = FStar_Options.profile_group_by_decls ()  in
+              if uu____5972
               then
                 let tag =
                   match FStar_Syntax_Util.lids_of_sigelt se with
-                  | hd::uu____5905 -> FStar_Ident.string_of_lid hd
-                  | uu____5908 ->
+                  | hd::uu____5979 -> FStar_Ident.string_of_lid hd
+                  | uu____5982 ->
                       FStar_Range.string_of_range
                         (FStar_Syntax_Util.range_of_sigelt se)
                    in
@@ -4305,15 +4345,15 @@ let (tc_decls :
               else ());
              r)
          in
-      let uu____5913 =
+      let uu____5987 =
         FStar_Util.fold_flatten process_one_decl_timed ([], [], env, []) ses
          in
-      match uu____5913 with
-      | (ses1,exports,env1,uu____5961) ->
+      match uu____5987 with
+      | (ses1,exports,env1,uu____6035) ->
           ((FStar_List.rev_append ses1 []),
             (FStar_List.rev_append exports []), env1)
   
-let (uu___1059 : unit) =
+let (uu___1056 : unit) =
   FStar_ST.op_Colon_Equals tc_decls_knot
     (FStar_Pervasives_Native.Some tc_decls)
   
@@ -4326,197 +4366,197 @@ let (check_exports :
     fun modul  ->
       fun exports  ->
         let env1 =
-          let uu___1063_6077 = env  in
+          let uu___1060_6151 = env  in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1063_6077.FStar_TypeChecker_Env.solver);
+              (uu___1060_6151.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1063_6077.FStar_TypeChecker_Env.range);
+              (uu___1060_6151.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1063_6077.FStar_TypeChecker_Env.curmodule);
+              (uu___1060_6151.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1063_6077.FStar_TypeChecker_Env.gamma);
+              (uu___1060_6151.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1063_6077.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1060_6151.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1063_6077.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1060_6151.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1063_6077.FStar_TypeChecker_Env.modules);
+              (uu___1060_6151.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1063_6077.FStar_TypeChecker_Env.expected_typ);
+              (uu___1060_6151.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1063_6077.FStar_TypeChecker_Env.sigtab);
+              (uu___1060_6151.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1063_6077.FStar_TypeChecker_Env.attrtab);
+              (uu___1060_6151.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___1063_6077.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___1060_6151.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___1063_6077.FStar_TypeChecker_Env.effects);
+              (uu___1060_6151.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1063_6077.FStar_TypeChecker_Env.generalize);
+              (uu___1060_6151.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1063_6077.FStar_TypeChecker_Env.letrecs);
+              (uu___1060_6151.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level = true;
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1063_6077.FStar_TypeChecker_Env.check_uvars);
+              (uu___1060_6151.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1063_6077.FStar_TypeChecker_Env.use_eq);
+              (uu___1060_6151.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1063_6077.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1060_6151.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1063_6077.FStar_TypeChecker_Env.is_iface);
+              (uu___1060_6151.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1063_6077.FStar_TypeChecker_Env.admit);
+              (uu___1060_6151.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax = true;
             FStar_TypeChecker_Env.lax_universes = true;
             FStar_TypeChecker_Env.phase1 =
-              (uu___1063_6077.FStar_TypeChecker_Env.phase1);
+              (uu___1060_6151.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___1063_6077.FStar_TypeChecker_Env.failhard);
+              (uu___1060_6151.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___1063_6077.FStar_TypeChecker_Env.nosynth);
+              (uu___1060_6151.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1063_6077.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1060_6151.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1063_6077.FStar_TypeChecker_Env.tc_term);
+              (uu___1060_6151.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1063_6077.FStar_TypeChecker_Env.type_of);
+              (uu___1060_6151.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1063_6077.FStar_TypeChecker_Env.universe_of);
+              (uu___1060_6151.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1063_6077.FStar_TypeChecker_Env.check_type_of);
+              (uu___1060_6151.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1063_6077.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1060_6151.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1063_6077.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1060_6151.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1063_6077.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1060_6151.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1063_6077.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1060_6151.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1063_6077.FStar_TypeChecker_Env.proof_ns);
+              (uu___1060_6151.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1063_6077.FStar_TypeChecker_Env.synth_hook);
+              (uu___1060_6151.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1063_6077.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1060_6151.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1063_6077.FStar_TypeChecker_Env.splice);
+              (uu___1060_6151.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1063_6077.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1060_6151.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1063_6077.FStar_TypeChecker_Env.postprocess);
+              (uu___1060_6151.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.is_native_tactic =
-              (uu___1063_6077.FStar_TypeChecker_Env.is_native_tactic);
+              (uu___1060_6151.FStar_TypeChecker_Env.is_native_tactic);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1063_6077.FStar_TypeChecker_Env.identifier_info);
+              (uu___1060_6151.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1063_6077.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1060_6151.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1063_6077.FStar_TypeChecker_Env.dsenv);
+              (uu___1060_6151.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1063_6077.FStar_TypeChecker_Env.nbe);
+              (uu___1060_6151.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1063_6077.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1060_6151.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1063_6077.FStar_TypeChecker_Env.erasable_types_tab)
+              (uu___1060_6151.FStar_TypeChecker_Env.erasable_types_tab)
           }  in
         let check_term lid univs t =
-          let uu____6097 = FStar_Syntax_Subst.open_univ_vars univs t  in
-          match uu____6097 with
+          let uu____6171 = FStar_Syntax_Subst.open_univ_vars univs t  in
+          match uu____6171 with
           | (univs1,t1) ->
-              ((let uu____6105 =
-                  let uu____6107 =
-                    let uu____6113 =
+              ((let uu____6179 =
+                  let uu____6181 =
+                    let uu____6187 =
                       FStar_TypeChecker_Env.set_current_module env1
                         modul.FStar_Syntax_Syntax.name
                        in
-                    FStar_TypeChecker_Env.debug uu____6113  in
-                  FStar_All.pipe_left uu____6107
+                    FStar_TypeChecker_Env.debug uu____6187  in
+                  FStar_All.pipe_left uu____6181
                     (FStar_Options.Other "Exports")
                    in
-                if uu____6105
+                if uu____6179
                 then
-                  let uu____6117 = FStar_Syntax_Print.lid_to_string lid  in
-                  let uu____6119 =
-                    let uu____6121 =
+                  let uu____6191 = FStar_Syntax_Print.lid_to_string lid  in
+                  let uu____6193 =
+                    let uu____6195 =
                       FStar_All.pipe_right univs1
                         (FStar_List.map
                            (fun x  ->
                               FStar_Syntax_Print.univ_to_string
                                 (FStar_Syntax_Syntax.U_name x)))
                        in
-                    FStar_All.pipe_right uu____6121
+                    FStar_All.pipe_right uu____6195
                       (FStar_String.concat ", ")
                      in
-                  let uu____6138 = FStar_Syntax_Print.term_to_string t1  in
+                  let uu____6212 = FStar_Syntax_Print.term_to_string t1  in
                   FStar_Util.print3 "Checking for export %s <%s> : %s\n"
-                    uu____6117 uu____6119 uu____6138
+                    uu____6191 uu____6193 uu____6212
                 else ());
                (let env2 = FStar_TypeChecker_Env.push_univ_vars env1 univs1
                    in
-                let uu____6144 =
+                let uu____6218 =
                   FStar_TypeChecker_TcTerm.tc_trivial_guard env2 t1  in
-                FStar_All.pipe_right uu____6144 (fun uu____6153  -> ())))
+                FStar_All.pipe_right uu____6218 (fun uu____6227  -> ())))
            in
         let check_term1 lid univs t =
-          (let uu____6171 =
-             let uu____6173 =
+          (let uu____6245 =
+             let uu____6247 =
                FStar_Syntax_Print.lid_to_string
                  modul.FStar_Syntax_Syntax.name
                 in
-             let uu____6175 = FStar_Syntax_Print.lid_to_string lid  in
+             let uu____6249 = FStar_Syntax_Print.lid_to_string lid  in
              FStar_Util.format2
                "Interface of %s violates its abstraction (add a 'private' qualifier to '%s'?)"
-               uu____6173 uu____6175
+               uu____6247 uu____6249
               in
-           FStar_Errors.message_prefix.FStar_Errors.set_prefix uu____6171);
+           FStar_Errors.message_prefix.FStar_Errors.set_prefix uu____6245);
           check_term lid univs t;
           FStar_Errors.message_prefix.FStar_Errors.clear_prefix ()  in
         let rec check_sigelt se =
           match se.FStar_Syntax_Syntax.sigel with
-          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____6186) ->
-              let uu____6195 =
-                let uu____6197 =
+          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____6260) ->
+              let uu____6269 =
+                let uu____6271 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____6197  in
-              if uu____6195
+                Prims.op_Negation uu____6271  in
+              if uu____6269
               then FStar_All.pipe_right ses (FStar_List.iter check_sigelt)
               else ()
           | FStar_Syntax_Syntax.Sig_inductive_typ
-              (l,univs,binders,typ,uu____6211,uu____6212) ->
+              (l,univs,binders,typ,uu____6285,uu____6286) ->
               let t =
-                let uu____6224 =
-                  let uu____6231 =
-                    let uu____6232 =
-                      let uu____6247 = FStar_Syntax_Syntax.mk_Total typ  in
-                      (binders, uu____6247)  in
-                    FStar_Syntax_Syntax.Tm_arrow uu____6232  in
-                  FStar_Syntax_Syntax.mk uu____6231  in
-                uu____6224 FStar_Pervasives_Native.None
+                let uu____6298 =
+                  let uu____6305 =
+                    let uu____6306 =
+                      let uu____6321 = FStar_Syntax_Syntax.mk_Total typ  in
+                      (binders, uu____6321)  in
+                    FStar_Syntax_Syntax.Tm_arrow uu____6306  in
+                  FStar_Syntax_Syntax.mk uu____6305  in
+                uu____6298 FStar_Pervasives_Native.None
                   se.FStar_Syntax_Syntax.sigrng
                  in
               check_term1 l univs t
           | FStar_Syntax_Syntax.Sig_datacon
-              (l,univs,t,uu____6263,uu____6264,uu____6265) ->
+              (l,univs,t,uu____6337,uu____6338,uu____6339) ->
               check_term1 l univs t
           | FStar_Syntax_Syntax.Sig_declare_typ (l,univs,t) ->
-              let uu____6275 =
-                let uu____6277 =
+              let uu____6349 =
+                let uu____6351 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____6277  in
-              if uu____6275 then check_term1 l univs t else ()
-          | FStar_Syntax_Syntax.Sig_let ((uu____6285,lbs),uu____6287) ->
-              let uu____6298 =
-                let uu____6300 =
+                Prims.op_Negation uu____6351  in
+              if uu____6349 then check_term1 l univs t else ()
+          | FStar_Syntax_Syntax.Sig_let ((uu____6359,lbs),uu____6361) ->
+              let uu____6372 =
+                let uu____6374 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____6300  in
-              if uu____6298
+                Prims.op_Negation uu____6374  in
+              if uu____6372
               then
                 FStar_All.pipe_right lbs
                   (FStar_List.iter
@@ -4530,13 +4570,13 @@ let (check_exports :
               else ()
           | FStar_Syntax_Syntax.Sig_effect_abbrev
               (l,univs,binders,comp,flags) ->
-              let uu____6323 =
-                let uu____6325 =
+              let uu____6397 =
+                let uu____6399 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____6325  in
-              if uu____6323
+                Prims.op_Negation uu____6399  in
+              if uu____6397
               then
                 let arrow =
                   FStar_Syntax_Syntax.mk
@@ -4546,22 +4586,22 @@ let (check_exports :
                    in
                 check_term1 l univs arrow
               else ()
-          | FStar_Syntax_Syntax.Sig_main uu____6346 -> ()
-          | FStar_Syntax_Syntax.Sig_assume uu____6347 -> ()
-          | FStar_Syntax_Syntax.Sig_new_effect uu____6354 -> ()
-          | FStar_Syntax_Syntax.Sig_sub_effect uu____6355 -> ()
-          | FStar_Syntax_Syntax.Sig_pragma uu____6356 -> ()
-          | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____6357 -> ()
-          | FStar_Syntax_Syntax.Sig_fail uu____6368 ->
+          | FStar_Syntax_Syntax.Sig_main uu____6420 -> ()
+          | FStar_Syntax_Syntax.Sig_assume uu____6421 -> ()
+          | FStar_Syntax_Syntax.Sig_new_effect uu____6428 -> ()
+          | FStar_Syntax_Syntax.Sig_sub_effect uu____6429 -> ()
+          | FStar_Syntax_Syntax.Sig_pragma uu____6430 -> ()
+          | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____6431 -> ()
+          | FStar_Syntax_Syntax.Sig_fail uu____6442 ->
               failwith "Impossible (Already handled)"
-          | FStar_Syntax_Syntax.Sig_splice uu____6382 ->
+          | FStar_Syntax_Syntax.Sig_splice uu____6456 ->
               failwith "Impossible (Already handled)"
            in
-        let uu____6390 =
+        let uu____6464 =
           FStar_Ident.lid_equals modul.FStar_Syntax_Syntax.name
             FStar_Parser_Const.prims_lid
            in
-        if uu____6390 then () else FStar_List.iter check_sigelt exports
+        if uu____6464 then () else FStar_List.iter check_sigelt exports
   
 let (extract_interface :
   FStar_TypeChecker_Env.env ->
@@ -4609,155 +4649,155 @@ let (extract_interface :
           (fun q  ->
              match q with
              | FStar_Syntax_Syntax.Discriminator l -> true
-             | FStar_Syntax_Syntax.Projector (l,uu____6496) -> true
-             | uu____6498 -> false) quals
+             | FStar_Syntax_Syntax.Projector (l,uu____6570) -> true
+             | uu____6572 -> false) quals
          in
       let vals_of_abstract_inductive s =
         let mk_typ_for_abstract_inductive bs t r =
           match bs with
           | [] -> t
-          | uu____6528 ->
+          | uu____6602 ->
               (match t.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_arrow (bs',c) ->
                    FStar_Syntax_Syntax.mk
                      (FStar_Syntax_Syntax.Tm_arrow
                         ((FStar_List.append bs bs'), c))
                      FStar_Pervasives_Native.None r
-               | uu____6567 ->
-                   let uu____6568 =
-                     let uu____6575 =
-                       let uu____6576 =
-                         let uu____6591 = FStar_Syntax_Syntax.mk_Total t  in
-                         (bs, uu____6591)  in
-                       FStar_Syntax_Syntax.Tm_arrow uu____6576  in
-                     FStar_Syntax_Syntax.mk uu____6575  in
-                   uu____6568 FStar_Pervasives_Native.None r)
+               | uu____6641 ->
+                   let uu____6642 =
+                     let uu____6649 =
+                       let uu____6650 =
+                         let uu____6665 = FStar_Syntax_Syntax.mk_Total t  in
+                         (bs, uu____6665)  in
+                       FStar_Syntax_Syntax.Tm_arrow uu____6650  in
+                     FStar_Syntax_Syntax.mk uu____6649  in
+                   uu____6642 FStar_Pervasives_Native.None r)
            in
         match s.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ
-            (lid,uvs,bs,t,uu____6608,uu____6609) ->
+            (lid,uvs,bs,t,uu____6682,uu____6683) ->
             let s1 =
-              let uu___1191_6619 = s  in
-              let uu____6620 =
-                let uu____6621 =
-                  let uu____6628 =
+              let uu___1188_6693 = s  in
+              let uu____6694 =
+                let uu____6695 =
+                  let uu____6702 =
                     mk_typ_for_abstract_inductive bs t
                       s.FStar_Syntax_Syntax.sigrng
                      in
-                  (lid, uvs, uu____6628)  in
-                FStar_Syntax_Syntax.Sig_declare_typ uu____6621  in
-              let uu____6629 =
-                let uu____6632 =
-                  let uu____6635 =
+                  (lid, uvs, uu____6702)  in
+                FStar_Syntax_Syntax.Sig_declare_typ uu____6695  in
+              let uu____6703 =
+                let uu____6706 =
+                  let uu____6709 =
                     filter_out_abstract_and_noeq
                       s.FStar_Syntax_Syntax.sigquals
                      in
-                  FStar_Syntax_Syntax.New :: uu____6635  in
-                FStar_Syntax_Syntax.Assumption :: uu____6632  in
+                  FStar_Syntax_Syntax.New :: uu____6709  in
+                FStar_Syntax_Syntax.Assumption :: uu____6706  in
               {
-                FStar_Syntax_Syntax.sigel = uu____6620;
+                FStar_Syntax_Syntax.sigel = uu____6694;
                 FStar_Syntax_Syntax.sigrng =
-                  (uu___1191_6619.FStar_Syntax_Syntax.sigrng);
-                FStar_Syntax_Syntax.sigquals = uu____6629;
+                  (uu___1188_6693.FStar_Syntax_Syntax.sigrng);
+                FStar_Syntax_Syntax.sigquals = uu____6703;
                 FStar_Syntax_Syntax.sigmeta =
-                  (uu___1191_6619.FStar_Syntax_Syntax.sigmeta);
+                  (uu___1188_6693.FStar_Syntax_Syntax.sigmeta);
                 FStar_Syntax_Syntax.sigattrs =
-                  (uu___1191_6619.FStar_Syntax_Syntax.sigattrs);
+                  (uu___1188_6693.FStar_Syntax_Syntax.sigattrs);
                 FStar_Syntax_Syntax.sigopts =
-                  (uu___1191_6619.FStar_Syntax_Syntax.sigopts)
+                  (uu___1188_6693.FStar_Syntax_Syntax.sigopts)
               }  in
             [s1]
-        | uu____6638 -> failwith "Impossible!"  in
-      let val_of_lb s lid uu____6663 lbdef =
-        match uu____6663 with
+        | uu____6712 -> failwith "Impossible!"  in
+      let val_of_lb s lid uu____6737 lbdef =
+        match uu____6737 with
         | (uvs,t) ->
             let attrs =
-              let uu____6674 =
+              let uu____6748 =
                 FStar_TypeChecker_Util.must_erase_for_extraction en lbdef  in
-              if uu____6674
+              if uu____6748
               then
-                let uu____6679 =
-                  let uu____6680 =
+                let uu____6753 =
+                  let uu____6754 =
                     FStar_Syntax_Syntax.lid_as_fv
                       FStar_Parser_Const.must_erase_for_extraction_attr
                       FStar_Syntax_Syntax.delta_constant
                       FStar_Pervasives_Native.None
                      in
-                  FStar_All.pipe_right uu____6680
+                  FStar_All.pipe_right uu____6754
                     FStar_Syntax_Syntax.fv_to_tm
                    in
-                uu____6679 :: (s.FStar_Syntax_Syntax.sigattrs)
+                uu____6753 :: (s.FStar_Syntax_Syntax.sigattrs)
               else s.FStar_Syntax_Syntax.sigattrs  in
-            let uu___1204_6683 = s  in
-            let uu____6684 =
-              let uu____6687 =
+            let uu___1201_6757 = s  in
+            let uu____6758 =
+              let uu____6761 =
                 filter_out_abstract_and_inline s.FStar_Syntax_Syntax.sigquals
                  in
-              FStar_Syntax_Syntax.Assumption :: uu____6687  in
+              FStar_Syntax_Syntax.Assumption :: uu____6761  in
             {
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, uvs, t));
               FStar_Syntax_Syntax.sigrng =
-                (uu___1204_6683.FStar_Syntax_Syntax.sigrng);
-              FStar_Syntax_Syntax.sigquals = uu____6684;
+                (uu___1201_6757.FStar_Syntax_Syntax.sigrng);
+              FStar_Syntax_Syntax.sigquals = uu____6758;
               FStar_Syntax_Syntax.sigmeta =
-                (uu___1204_6683.FStar_Syntax_Syntax.sigmeta);
+                (uu___1201_6757.FStar_Syntax_Syntax.sigmeta);
               FStar_Syntax_Syntax.sigattrs = attrs;
               FStar_Syntax_Syntax.sigopts =
-                (uu___1204_6683.FStar_Syntax_Syntax.sigopts)
+                (uu___1201_6757.FStar_Syntax_Syntax.sigopts)
             }
          in
       let should_keep_lbdef t =
         let comp_effect_name c =
           match c.FStar_Syntax_Syntax.n with
           | FStar_Syntax_Syntax.Comp c1 -> c1.FStar_Syntax_Syntax.effect_name
-          | uu____6705 -> failwith "Impossible!"  in
+          | uu____6779 -> failwith "Impossible!"  in
         let c_opt =
-          let uu____6712 = FStar_Syntax_Util.is_unit t  in
-          if uu____6712
+          let uu____6786 = FStar_Syntax_Util.is_unit t  in
+          if uu____6786
           then
-            let uu____6719 = FStar_Syntax_Syntax.mk_Total t  in
-            FStar_Pervasives_Native.Some uu____6719
+            let uu____6793 = FStar_Syntax_Syntax.mk_Total t  in
+            FStar_Pervasives_Native.Some uu____6793
           else
-            (let uu____6726 =
-               let uu____6727 = FStar_Syntax_Subst.compress t  in
-               uu____6727.FStar_Syntax_Syntax.n  in
-             match uu____6726 with
-             | FStar_Syntax_Syntax.Tm_arrow (uu____6734,c) ->
+            (let uu____6800 =
+               let uu____6801 = FStar_Syntax_Subst.compress t  in
+               uu____6801.FStar_Syntax_Syntax.n  in
+             match uu____6800 with
+             | FStar_Syntax_Syntax.Tm_arrow (uu____6808,c) ->
                  FStar_Pervasives_Native.Some c
-             | uu____6758 -> FStar_Pervasives_Native.None)
+             | uu____6832 -> FStar_Pervasives_Native.None)
            in
         match c_opt with
         | FStar_Pervasives_Native.None  -> true
         | FStar_Pervasives_Native.Some c ->
-            let uu____6770 = FStar_Syntax_Util.is_lemma_comp c  in
-            if uu____6770
+            let uu____6844 = FStar_Syntax_Util.is_lemma_comp c  in
+            if uu____6844
             then false
             else
-              (let uu____6777 = FStar_Syntax_Util.is_pure_or_ghost_comp c  in
-               if uu____6777
+              (let uu____6851 = FStar_Syntax_Util.is_pure_or_ghost_comp c  in
+               if uu____6851
                then true
                else
-                 (let uu____6784 = comp_effect_name c  in
-                  FStar_TypeChecker_Env.is_reifiable_effect en uu____6784))
+                 (let uu____6858 = comp_effect_name c  in
+                  FStar_TypeChecker_Env.is_reifiable_effect en uu____6858))
          in
       let extract_sigelt s =
-        (let uu____6796 =
+        (let uu____6870 =
            FStar_TypeChecker_Env.debug en FStar_Options.Extreme  in
-         if uu____6796
+         if uu____6870
          then
-           let uu____6799 = FStar_Syntax_Print.sigelt_to_string s  in
-           FStar_Util.print1 "Extracting interface for %s\n" uu____6799
+           let uu____6873 = FStar_Syntax_Print.sigelt_to_string s  in
+           FStar_Util.print1 "Extracting interface for %s\n" uu____6873
          else ());
         (match s.FStar_Syntax_Syntax.sigel with
-         | FStar_Syntax_Syntax.Sig_inductive_typ uu____6806 ->
+         | FStar_Syntax_Syntax.Sig_inductive_typ uu____6880 ->
              failwith "Impossible! extract_interface: bare data constructor"
-         | FStar_Syntax_Syntax.Sig_datacon uu____6826 ->
+         | FStar_Syntax_Syntax.Sig_datacon uu____6900 ->
              failwith "Impossible! extract_interface: bare data constructor"
-         | FStar_Syntax_Syntax.Sig_splice uu____6845 ->
+         | FStar_Syntax_Syntax.Sig_splice uu____6919 ->
              failwith
                "Impossible! extract_interface: trying to extract splice"
-         | FStar_Syntax_Syntax.Sig_fail uu____6855 ->
+         | FStar_Syntax_Syntax.Sig_fail uu____6929 ->
              failwith
                "Impossible! extract_interface: trying to extract Sig_fail"
          | FStar_Syntax_Syntax.Sig_bundle (sigelts,lidents) ->
@@ -4769,74 +4809,74 @@ let (extract_interface :
                        fun s1  ->
                          match s1.FStar_Syntax_Syntax.sigel with
                          | FStar_Syntax_Syntax.Sig_inductive_typ
-                             (lid,uu____6907,uu____6908,uu____6909,uu____6910,uu____6911)
+                             (lid,uu____6981,uu____6982,uu____6983,uu____6984,uu____6985)
                              ->
-                             ((let uu____6921 =
-                                 let uu____6924 =
+                             ((let uu____6995 =
+                                 let uu____6998 =
                                    FStar_ST.op_Bang abstract_inductive_tycons
                                     in
-                                 lid :: uu____6924  in
+                                 lid :: uu____6998  in
                                FStar_ST.op_Colon_Equals
-                                 abstract_inductive_tycons uu____6921);
-                              (let uu____6973 = vals_of_abstract_inductive s1
+                                 abstract_inductive_tycons uu____6995);
+                              (let uu____7047 = vals_of_abstract_inductive s1
                                   in
-                               FStar_List.append uu____6973 sigelts1))
+                               FStar_List.append uu____7047 sigelts1))
                          | FStar_Syntax_Syntax.Sig_datacon
-                             (lid,uu____6977,uu____6978,uu____6979,uu____6980,uu____6981)
+                             (lid,uu____7051,uu____7052,uu____7053,uu____7054,uu____7055)
                              ->
-                             ((let uu____6989 =
-                                 let uu____6992 =
+                             ((let uu____7063 =
+                                 let uu____7066 =
                                    FStar_ST.op_Bang
                                      abstract_inductive_datacons
                                     in
-                                 lid :: uu____6992  in
+                                 lid :: uu____7066  in
                                FStar_ST.op_Colon_Equals
-                                 abstract_inductive_datacons uu____6989);
+                                 abstract_inductive_datacons uu____7063);
                               sigelts1)
-                         | uu____7041 ->
+                         | uu____7115 ->
                              failwith
                                "Impossible! extract_interface: Sig_bundle can't have anything other than Sig_inductive_typ and Sig_datacon")
                     [])
              else [s]
          | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
-             let uu____7050 =
+             let uu____7124 =
                is_projector_or_discriminator_of_an_abstract_inductive
                  s.FStar_Syntax_Syntax.sigquals
                 in
-             if uu____7050
+             if uu____7124
              then []
              else
                if is_assume s.FStar_Syntax_Syntax.sigquals
                then
-                 (let uu____7060 =
-                    let uu___1270_7061 = s  in
-                    let uu____7062 =
+                 (let uu____7134 =
+                    let uu___1267_7135 = s  in
+                    let uu____7136 =
                       filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___1270_7061.FStar_Syntax_Syntax.sigel);
+                        (uu___1267_7135.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___1270_7061.FStar_Syntax_Syntax.sigrng);
-                      FStar_Syntax_Syntax.sigquals = uu____7062;
+                        (uu___1267_7135.FStar_Syntax_Syntax.sigrng);
+                      FStar_Syntax_Syntax.sigquals = uu____7136;
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___1270_7061.FStar_Syntax_Syntax.sigmeta);
+                        (uu___1267_7135.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___1270_7061.FStar_Syntax_Syntax.sigattrs);
+                        (uu___1267_7135.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___1270_7061.FStar_Syntax_Syntax.sigopts)
+                        (uu___1267_7135.FStar_Syntax_Syntax.sigopts)
                     }  in
-                  [uu____7060])
+                  [uu____7134])
                else []
          | FStar_Syntax_Syntax.Sig_let (lbs,lids) ->
-             let uu____7073 =
+             let uu____7147 =
                is_projector_or_discriminator_of_an_abstract_inductive
                  s.FStar_Syntax_Syntax.sigquals
                 in
-             if uu____7073
+             if uu____7147
              then []
              else
-               (let uu____7080 = lbs  in
-                match uu____7080 with
+               (let uu____7154 = lbs  in
+                match uu____7154 with
                 | (flbs,slbs) ->
                     let typs_and_defs =
                       FStar_All.pipe_right slbs
@@ -4848,17 +4888,17 @@ let (extract_interface :
                        in
                     let is_lemma =
                       FStar_List.existsML
-                        (fun uu____7142  ->
-                           match uu____7142 with
-                           | (uu____7150,t,uu____7152) ->
+                        (fun uu____7216  ->
+                           match uu____7216 with
+                           | (uu____7224,t,uu____7226) ->
                                FStar_All.pipe_right t
                                  FStar_Syntax_Util.is_lemma) typs_and_defs
                        in
                     let vals =
                       FStar_List.map2
                         (fun lid  ->
-                           fun uu____7169  ->
-                             match uu____7169 with
+                           fun uu____7243  ->
+                             match uu____7243 with
                              | (u,t,d) -> val_of_lb s lid (u, t) d) lids
                         typs_and_defs
                        in
@@ -4870,9 +4910,9 @@ let (extract_interface :
                     else
                       (let should_keep_defs =
                          FStar_List.existsML
-                           (fun uu____7196  ->
-                              match uu____7196 with
-                              | (uu____7204,t,uu____7206) ->
+                           (fun uu____7270  ->
+                              match uu____7270 with
+                              | (uu____7278,t,uu____7280) ->
                                   FStar_All.pipe_right t should_keep_lbdef)
                            typs_and_defs
                           in
@@ -4880,79 +4920,79 @@ let (extract_interface :
          | FStar_Syntax_Syntax.Sig_main t ->
              failwith
                "Did not anticipate main would arise when extracting interfaces!"
-         | FStar_Syntax_Syntax.Sig_assume (lid,uu____7218,uu____7219) ->
+         | FStar_Syntax_Syntax.Sig_assume (lid,uu____7292,uu____7293) ->
              let is_haseq = FStar_TypeChecker_TcInductive.is_haseq_lid lid
                 in
              if is_haseq
              then
                let is_haseq_of_abstract_inductive =
-                 let uu____7227 = FStar_ST.op_Bang abstract_inductive_tycons
+                 let uu____7301 = FStar_ST.op_Bang abstract_inductive_tycons
                     in
                  FStar_List.existsML
                    (fun l  ->
-                      let uu____7256 =
+                      let uu____7330 =
                         FStar_TypeChecker_TcInductive.get_haseq_axiom_lid l
                          in
-                      FStar_Ident.lid_equals lid uu____7256) uu____7227
+                      FStar_Ident.lid_equals lid uu____7330) uu____7301
                   in
                (if is_haseq_of_abstract_inductive
                 then
-                  let uu____7260 =
-                    let uu___1312_7261 = s  in
-                    let uu____7262 =
+                  let uu____7334 =
+                    let uu___1309_7335 = s  in
+                    let uu____7336 =
                       filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___1312_7261.FStar_Syntax_Syntax.sigel);
+                        (uu___1309_7335.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___1312_7261.FStar_Syntax_Syntax.sigrng);
-                      FStar_Syntax_Syntax.sigquals = uu____7262;
+                        (uu___1309_7335.FStar_Syntax_Syntax.sigrng);
+                      FStar_Syntax_Syntax.sigquals = uu____7336;
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___1312_7261.FStar_Syntax_Syntax.sigmeta);
+                        (uu___1309_7335.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___1312_7261.FStar_Syntax_Syntax.sigattrs);
+                        (uu___1309_7335.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___1312_7261.FStar_Syntax_Syntax.sigopts)
+                        (uu___1309_7335.FStar_Syntax_Syntax.sigopts)
                     }  in
-                  [uu____7260]
+                  [uu____7334]
                 else [])
              else
-               (let uu____7269 =
-                  let uu___1314_7270 = s  in
-                  let uu____7271 =
+               (let uu____7343 =
+                  let uu___1311_7344 = s  in
+                  let uu____7345 =
                     filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                   {
                     FStar_Syntax_Syntax.sigel =
-                      (uu___1314_7270.FStar_Syntax_Syntax.sigel);
+                      (uu___1311_7344.FStar_Syntax_Syntax.sigel);
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___1314_7270.FStar_Syntax_Syntax.sigrng);
-                    FStar_Syntax_Syntax.sigquals = uu____7271;
+                      (uu___1311_7344.FStar_Syntax_Syntax.sigrng);
+                    FStar_Syntax_Syntax.sigquals = uu____7345;
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___1314_7270.FStar_Syntax_Syntax.sigmeta);
+                      (uu___1311_7344.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___1314_7270.FStar_Syntax_Syntax.sigattrs);
+                      (uu___1311_7344.FStar_Syntax_Syntax.sigattrs);
                     FStar_Syntax_Syntax.sigopts =
-                      (uu___1314_7270.FStar_Syntax_Syntax.sigopts)
+                      (uu___1311_7344.FStar_Syntax_Syntax.sigopts)
                   }  in
-                [uu____7269])
-         | FStar_Syntax_Syntax.Sig_new_effect uu____7274 -> [s]
-         | FStar_Syntax_Syntax.Sig_sub_effect uu____7275 -> [s]
-         | FStar_Syntax_Syntax.Sig_effect_abbrev uu____7276 -> [s]
-         | FStar_Syntax_Syntax.Sig_pragma uu____7289 -> [s]
-         | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____7290 -> [s])
+                [uu____7343])
+         | FStar_Syntax_Syntax.Sig_new_effect uu____7348 -> [s]
+         | FStar_Syntax_Syntax.Sig_sub_effect uu____7349 -> [s]
+         | FStar_Syntax_Syntax.Sig_effect_abbrev uu____7350 -> [s]
+         | FStar_Syntax_Syntax.Sig_pragma uu____7363 -> [s]
+         | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____7364 -> [s])
          in
-      let uu___1326_7301 = m  in
-      let uu____7302 =
-        let uu____7303 =
+      let uu___1323_7375 = m  in
+      let uu____7376 =
+        let uu____7377 =
           FStar_All.pipe_right m.FStar_Syntax_Syntax.declarations
             (FStar_List.map extract_sigelt)
            in
-        FStar_All.pipe_right uu____7303 FStar_List.flatten  in
+        FStar_All.pipe_right uu____7377 FStar_List.flatten  in
       {
-        FStar_Syntax_Syntax.name = (uu___1326_7301.FStar_Syntax_Syntax.name);
-        FStar_Syntax_Syntax.declarations = uu____7302;
+        FStar_Syntax_Syntax.name = (uu___1323_7375.FStar_Syntax_Syntax.name);
+        FStar_Syntax_Syntax.declarations = uu____7376;
         FStar_Syntax_Syntax.exports =
-          (uu___1326_7301.FStar_Syntax_Syntax.exports);
+          (uu___1323_7375.FStar_Syntax_Syntax.exports);
         FStar_Syntax_Syntax.is_interface = true
       }
   
@@ -4965,7 +5005,7 @@ let (snapshot_context :
   fun env  ->
     fun msg  ->
       FStar_Util.atomically
-        (fun uu____7354  -> FStar_TypeChecker_Env.snapshot env msg)
+        (fun uu____7428  -> FStar_TypeChecker_Env.snapshot env msg)
   
 let (rollback_context :
   FStar_TypeChecker_Env.solver_t ->
@@ -4978,7 +5018,7 @@ let (rollback_context :
     fun msg  ->
       fun depth  ->
         FStar_Util.atomically
-          (fun uu____7401  ->
+          (fun uu____7475  ->
              let env = FStar_TypeChecker_Env.rollback solver msg depth  in
              env)
   
@@ -4986,8 +5026,8 @@ let (push_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
   fun env  ->
     fun msg  ->
-      let uu____7416 = snapshot_context env msg  in
-      FStar_Pervasives_Native.snd uu____7416
+      let uu____7490 = snapshot_context env msg  in
+      FStar_Pervasives_Native.snd uu____7490
   
 let (pop_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
@@ -5005,140 +5045,143 @@ let (tc_partial_modul :
   fun env  ->
     fun modul  ->
       let verify =
-        FStar_Options.should_verify
-          (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
-         in
+        let uu____7562 =
+          FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name  in
+        FStar_Options.should_verify uu____7562  in
       let action = if verify then "Verifying" else "Lax-checking"  in
       let label =
         if modul.FStar_Syntax_Syntax.is_interface
         then "interface"
         else "implementation"  in
-      (let uu____7505 = FStar_Options.debug_any ()  in
-       if uu____7505
+      (let uu____7581 = FStar_Options.debug_any ()  in
+       if uu____7581
        then
-         FStar_Util.print3 "%s %s of %s\n" action label
-           (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
+         let uu____7584 =
+           FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name  in
+         FStar_Util.print3 "%s %s of %s\n" action label uu____7584
        else ());
       (let name =
+         let uu____7591 =
+           FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name  in
          FStar_Util.format2 "%s %s"
            (if modul.FStar_Syntax_Syntax.is_interface
             then "interface"
-            else "module") (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
+            else "module") uu____7591
           in
        let env1 =
-         let uu___1351_7521 = env  in
+         let uu___1348_7601 = env  in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___1351_7521.FStar_TypeChecker_Env.solver);
+             (uu___1348_7601.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___1351_7521.FStar_TypeChecker_Env.range);
+             (uu___1348_7601.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___1351_7521.FStar_TypeChecker_Env.curmodule);
+             (uu___1348_7601.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
-             (uu___1351_7521.FStar_TypeChecker_Env.gamma);
+             (uu___1348_7601.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___1351_7521.FStar_TypeChecker_Env.gamma_sig);
+             (uu___1348_7601.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___1351_7521.FStar_TypeChecker_Env.gamma_cache);
+             (uu___1348_7601.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___1351_7521.FStar_TypeChecker_Env.modules);
+             (uu___1348_7601.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___1351_7521.FStar_TypeChecker_Env.expected_typ);
+             (uu___1348_7601.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___1351_7521.FStar_TypeChecker_Env.sigtab);
+             (uu___1348_7601.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___1351_7521.FStar_TypeChecker_Env.attrtab);
+             (uu___1348_7601.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___1351_7521.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___1348_7601.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___1351_7521.FStar_TypeChecker_Env.effects);
+             (uu___1348_7601.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___1351_7521.FStar_TypeChecker_Env.generalize);
+             (uu___1348_7601.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs =
-             (uu___1351_7521.FStar_TypeChecker_Env.letrecs);
+             (uu___1348_7601.FStar_TypeChecker_Env.letrecs);
            FStar_TypeChecker_Env.top_level =
-             (uu___1351_7521.FStar_TypeChecker_Env.top_level);
+             (uu___1348_7601.FStar_TypeChecker_Env.top_level);
            FStar_TypeChecker_Env.check_uvars =
-             (uu___1351_7521.FStar_TypeChecker_Env.check_uvars);
+             (uu___1348_7601.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___1351_7521.FStar_TypeChecker_Env.use_eq);
+             (uu___1348_7601.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___1351_7521.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___1348_7601.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
              (modul.FStar_Syntax_Syntax.is_interface);
            FStar_TypeChecker_Env.admit = (Prims.op_Negation verify);
            FStar_TypeChecker_Env.lax =
-             (uu___1351_7521.FStar_TypeChecker_Env.lax);
+             (uu___1348_7601.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___1351_7521.FStar_TypeChecker_Env.lax_universes);
+             (uu___1348_7601.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___1351_7521.FStar_TypeChecker_Env.phase1);
+             (uu___1348_7601.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___1351_7521.FStar_TypeChecker_Env.failhard);
+             (uu___1348_7601.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___1351_7521.FStar_TypeChecker_Env.nosynth);
+             (uu___1348_7601.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___1351_7521.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___1348_7601.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___1351_7521.FStar_TypeChecker_Env.tc_term);
+             (uu___1348_7601.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___1351_7521.FStar_TypeChecker_Env.type_of);
+             (uu___1348_7601.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___1351_7521.FStar_TypeChecker_Env.universe_of);
+             (uu___1348_7601.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___1351_7521.FStar_TypeChecker_Env.check_type_of);
+             (uu___1348_7601.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___1351_7521.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___1348_7601.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___1351_7521.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___1348_7601.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___1351_7521.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___1348_7601.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___1351_7521.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___1348_7601.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___1351_7521.FStar_TypeChecker_Env.proof_ns);
+             (uu___1348_7601.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___1351_7521.FStar_TypeChecker_Env.synth_hook);
+             (uu___1348_7601.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___1351_7521.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___1348_7601.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___1351_7521.FStar_TypeChecker_Env.splice);
+             (uu___1348_7601.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___1351_7521.FStar_TypeChecker_Env.mpreprocess);
+             (uu___1348_7601.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___1351_7521.FStar_TypeChecker_Env.postprocess);
+             (uu___1348_7601.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.is_native_tactic =
-             (uu___1351_7521.FStar_TypeChecker_Env.is_native_tactic);
+             (uu___1348_7601.FStar_TypeChecker_Env.is_native_tactic);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___1351_7521.FStar_TypeChecker_Env.identifier_info);
+             (uu___1348_7601.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___1351_7521.FStar_TypeChecker_Env.tc_hooks);
+             (uu___1348_7601.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___1351_7521.FStar_TypeChecker_Env.dsenv);
+             (uu___1348_7601.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___1351_7521.FStar_TypeChecker_Env.nbe);
+             (uu___1348_7601.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___1351_7521.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___1348_7601.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___1351_7521.FStar_TypeChecker_Env.erasable_types_tab)
+             (uu___1348_7601.FStar_TypeChecker_Env.erasable_types_tab)
          }  in
        let env2 =
          FStar_TypeChecker_Env.set_current_module env1
            modul.FStar_Syntax_Syntax.name
           in
-       let uu____7523 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations
+       let uu____7603 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations
           in
-       match uu____7523 with
+       match uu____7603 with
        | (ses,exports,env3) ->
-           ((let uu___1359_7556 = modul  in
+           ((let uu___1356_7636 = modul  in
              {
                FStar_Syntax_Syntax.name =
-                 (uu___1359_7556.FStar_Syntax_Syntax.name);
+                 (uu___1356_7636.FStar_Syntax_Syntax.name);
                FStar_Syntax_Syntax.declarations = ses;
                FStar_Syntax_Syntax.exports =
-                 (uu___1359_7556.FStar_Syntax_Syntax.exports);
+                 (uu___1356_7636.FStar_Syntax_Syntax.exports);
                FStar_Syntax_Syntax.is_interface =
-                 (uu___1359_7556.FStar_Syntax_Syntax.is_interface)
+                 (uu___1356_7636.FStar_Syntax_Syntax.is_interface)
              }), exports, env3))
   
 let (tc_more_partial_modul :
@@ -5151,21 +5194,21 @@ let (tc_more_partial_modul :
   fun env  ->
     fun modul  ->
       fun decls  ->
-        let uu____7585 = tc_decls env decls  in
-        match uu____7585 with
+        let uu____7665 = tc_decls env decls  in
+        match uu____7665 with
         | (ses,exports,env1) ->
             let modul1 =
-              let uu___1368_7616 = modul  in
+              let uu___1365_7696 = modul  in
               {
                 FStar_Syntax_Syntax.name =
-                  (uu___1368_7616.FStar_Syntax_Syntax.name);
+                  (uu___1365_7696.FStar_Syntax_Syntax.name);
                 FStar_Syntax_Syntax.declarations =
                   (FStar_List.append modul.FStar_Syntax_Syntax.declarations
                      ses);
                 FStar_Syntax_Syntax.exports =
-                  (uu___1368_7616.FStar_Syntax_Syntax.exports);
+                  (uu___1365_7696.FStar_Syntax_Syntax.exports);
                 FStar_Syntax_Syntax.is_interface =
-                  (uu___1368_7616.FStar_Syntax_Syntax.is_interface)
+                  (uu___1365_7696.FStar_Syntax_Syntax.is_interface)
               }  in
             (modul1, exports, env1)
   
@@ -5178,12 +5221,12 @@ let rec (tc_modul :
     fun m  ->
       fun iface_exists  ->
         let msg =
-          Prims.op_Hat "Internals for "
-            (m.FStar_Syntax_Syntax.name).FStar_Ident.str
-           in
+          let uu____7755 =
+            FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
+          Prims.op_Hat "Internals for " uu____7755  in
         let env01 = push_context env0 msg  in
-        let uu____7677 = tc_partial_modul env01 m  in
-        match uu____7677 with
+        let uu____7759 = tc_partial_modul env01 m  in
+        match uu____7759 with
         | (modul,non_private_decls,env) ->
             finish_partial_modul false iface_exists env modul
               non_private_decls
@@ -5207,322 +5250,331 @@ and (finish_partial_modul :
                   && (FStar_Options.use_extracted_interfaces ()))
                  && (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface))
                 &&
-                (let uu____7714 = FStar_Errors.get_err_count ()  in
-                 uu____7714 = Prims.int_zero)
+                (let uu____7796 = FStar_Errors.get_err_count ()  in
+                 uu____7796 = Prims.int_zero)
                in
             if should_extract_interface
             then
               let modul_iface = extract_interface en m  in
-              ((let uu____7725 =
+              ((let uu____7807 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug en)
                     FStar_Options.Low
                    in
-                if uu____7725
+                if uu____7807
                 then
-                  let uu____7729 =
-                    let uu____7731 =
-                      FStar_Options.should_verify
-                        (m.FStar_Syntax_Syntax.name).FStar_Ident.str
-                       in
-                    if uu____7731 then "" else " (in lax mode) "  in
-                  let uu____7739 =
-                    let uu____7741 =
-                      FStar_Options.dump_module
-                        (m.FStar_Syntax_Syntax.name).FStar_Ident.str
-                       in
-                    if uu____7741
+                  let uu____7811 =
+                    FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
+                  let uu____7813 =
+                    let uu____7815 =
+                      let uu____7817 =
+                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
+                         in
+                      FStar_Options.should_verify uu____7817  in
+                    if uu____7815 then "" else " (in lax mode) "  in
+                  let uu____7825 =
+                    let uu____7827 =
+                      let uu____7829 =
+                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
+                         in
+                      FStar_Options.dump_module uu____7829  in
+                    if uu____7827
                     then
-                      let uu____7745 =
-                        let uu____7747 = FStar_Syntax_Print.modul_to_string m
+                      let uu____7833 =
+                        let uu____7835 = FStar_Syntax_Print.modul_to_string m
                            in
-                        Prims.op_Hat uu____7747 "\n"  in
-                      Prims.op_Hat "\nfrom: " uu____7745
+                        Prims.op_Hat uu____7835 "\n"  in
+                      Prims.op_Hat "\nfrom: " uu____7833
                     else ""  in
-                  let uu____7754 =
-                    let uu____7756 =
-                      FStar_Options.dump_module
-                        (m.FStar_Syntax_Syntax.name).FStar_Ident.str
-                       in
-                    if uu____7756
+                  let uu____7842 =
+                    let uu____7844 =
+                      let uu____7846 =
+                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
+                         in
+                      FStar_Options.dump_module uu____7846  in
+                    if uu____7844
                     then
-                      let uu____7760 =
-                        let uu____7762 =
+                      let uu____7850 =
+                        let uu____7852 =
                           FStar_Syntax_Print.modul_to_string modul_iface  in
-                        Prims.op_Hat uu____7762 "\n"  in
-                      Prims.op_Hat "\nto: " uu____7760
+                        Prims.op_Hat uu____7852 "\n"  in
+                      Prims.op_Hat "\nto: " uu____7850
                     else ""  in
                   FStar_Util.print4
                     "Extracting and type checking module %s interface%s%s%s\n"
-                    (m.FStar_Syntax_Syntax.name).FStar_Ident.str uu____7729
-                    uu____7739 uu____7754
+                    uu____7811 uu____7813 uu____7825 uu____7842
                 else ());
                (let en0 =
                   let en0 =
-                    pop_context en
-                      (Prims.op_Hat "Ending modul "
-                         (m.FStar_Syntax_Syntax.name).FStar_Ident.str)
-                     in
+                    let uu____7864 =
+                      let uu____7866 =
+                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
+                         in
+                      Prims.op_Hat "Ending modul " uu____7866  in
+                    pop_context en uu____7864  in
                   let en01 =
-                    let uu___1394_7776 = en0  in
+                    let uu___1391_7870 = en0  in
                     {
                       FStar_TypeChecker_Env.solver =
-                        (uu___1394_7776.FStar_TypeChecker_Env.solver);
+                        (uu___1391_7870.FStar_TypeChecker_Env.solver);
                       FStar_TypeChecker_Env.range =
-                        (uu___1394_7776.FStar_TypeChecker_Env.range);
+                        (uu___1391_7870.FStar_TypeChecker_Env.range);
                       FStar_TypeChecker_Env.curmodule =
-                        (uu___1394_7776.FStar_TypeChecker_Env.curmodule);
+                        (uu___1391_7870.FStar_TypeChecker_Env.curmodule);
                       FStar_TypeChecker_Env.gamma =
-                        (uu___1394_7776.FStar_TypeChecker_Env.gamma);
+                        (uu___1391_7870.FStar_TypeChecker_Env.gamma);
                       FStar_TypeChecker_Env.gamma_sig =
-                        (uu___1394_7776.FStar_TypeChecker_Env.gamma_sig);
+                        (uu___1391_7870.FStar_TypeChecker_Env.gamma_sig);
                       FStar_TypeChecker_Env.gamma_cache =
-                        (uu___1394_7776.FStar_TypeChecker_Env.gamma_cache);
+                        (uu___1391_7870.FStar_TypeChecker_Env.gamma_cache);
                       FStar_TypeChecker_Env.modules =
-                        (uu___1394_7776.FStar_TypeChecker_Env.modules);
+                        (uu___1391_7870.FStar_TypeChecker_Env.modules);
                       FStar_TypeChecker_Env.expected_typ =
-                        (uu___1394_7776.FStar_TypeChecker_Env.expected_typ);
+                        (uu___1391_7870.FStar_TypeChecker_Env.expected_typ);
                       FStar_TypeChecker_Env.sigtab =
-                        (uu___1394_7776.FStar_TypeChecker_Env.sigtab);
+                        (uu___1391_7870.FStar_TypeChecker_Env.sigtab);
                       FStar_TypeChecker_Env.attrtab =
-                        (uu___1394_7776.FStar_TypeChecker_Env.attrtab);
+                        (uu___1391_7870.FStar_TypeChecker_Env.attrtab);
                       FStar_TypeChecker_Env.instantiate_imp =
-                        (uu___1394_7776.FStar_TypeChecker_Env.instantiate_imp);
+                        (uu___1391_7870.FStar_TypeChecker_Env.instantiate_imp);
                       FStar_TypeChecker_Env.effects =
-                        (uu___1394_7776.FStar_TypeChecker_Env.effects);
+                        (uu___1391_7870.FStar_TypeChecker_Env.effects);
                       FStar_TypeChecker_Env.generalize =
-                        (uu___1394_7776.FStar_TypeChecker_Env.generalize);
+                        (uu___1391_7870.FStar_TypeChecker_Env.generalize);
                       FStar_TypeChecker_Env.letrecs =
-                        (uu___1394_7776.FStar_TypeChecker_Env.letrecs);
+                        (uu___1391_7870.FStar_TypeChecker_Env.letrecs);
                       FStar_TypeChecker_Env.top_level =
-                        (uu___1394_7776.FStar_TypeChecker_Env.top_level);
+                        (uu___1391_7870.FStar_TypeChecker_Env.top_level);
                       FStar_TypeChecker_Env.check_uvars =
-                        (uu___1394_7776.FStar_TypeChecker_Env.check_uvars);
+                        (uu___1391_7870.FStar_TypeChecker_Env.check_uvars);
                       FStar_TypeChecker_Env.use_eq =
-                        (uu___1394_7776.FStar_TypeChecker_Env.use_eq);
+                        (uu___1391_7870.FStar_TypeChecker_Env.use_eq);
                       FStar_TypeChecker_Env.use_eq_strict =
-                        (uu___1394_7776.FStar_TypeChecker_Env.use_eq_strict);
+                        (uu___1391_7870.FStar_TypeChecker_Env.use_eq_strict);
                       FStar_TypeChecker_Env.is_iface =
-                        (uu___1394_7776.FStar_TypeChecker_Env.is_iface);
+                        (uu___1391_7870.FStar_TypeChecker_Env.is_iface);
                       FStar_TypeChecker_Env.admit =
-                        (uu___1394_7776.FStar_TypeChecker_Env.admit);
+                        (uu___1391_7870.FStar_TypeChecker_Env.admit);
                       FStar_TypeChecker_Env.lax =
-                        (uu___1394_7776.FStar_TypeChecker_Env.lax);
+                        (uu___1391_7870.FStar_TypeChecker_Env.lax);
                       FStar_TypeChecker_Env.lax_universes =
-                        (uu___1394_7776.FStar_TypeChecker_Env.lax_universes);
+                        (uu___1391_7870.FStar_TypeChecker_Env.lax_universes);
                       FStar_TypeChecker_Env.phase1 =
-                        (uu___1394_7776.FStar_TypeChecker_Env.phase1);
+                        (uu___1391_7870.FStar_TypeChecker_Env.phase1);
                       FStar_TypeChecker_Env.failhard =
-                        (uu___1394_7776.FStar_TypeChecker_Env.failhard);
+                        (uu___1391_7870.FStar_TypeChecker_Env.failhard);
                       FStar_TypeChecker_Env.nosynth =
-                        (uu___1394_7776.FStar_TypeChecker_Env.nosynth);
+                        (uu___1391_7870.FStar_TypeChecker_Env.nosynth);
                       FStar_TypeChecker_Env.uvar_subtyping =
-                        (uu___1394_7776.FStar_TypeChecker_Env.uvar_subtyping);
+                        (uu___1391_7870.FStar_TypeChecker_Env.uvar_subtyping);
                       FStar_TypeChecker_Env.tc_term =
-                        (uu___1394_7776.FStar_TypeChecker_Env.tc_term);
+                        (uu___1391_7870.FStar_TypeChecker_Env.tc_term);
                       FStar_TypeChecker_Env.type_of =
-                        (uu___1394_7776.FStar_TypeChecker_Env.type_of);
+                        (uu___1391_7870.FStar_TypeChecker_Env.type_of);
                       FStar_TypeChecker_Env.universe_of =
-                        (uu___1394_7776.FStar_TypeChecker_Env.universe_of);
+                        (uu___1391_7870.FStar_TypeChecker_Env.universe_of);
                       FStar_TypeChecker_Env.check_type_of =
-                        (uu___1394_7776.FStar_TypeChecker_Env.check_type_of);
+                        (uu___1391_7870.FStar_TypeChecker_Env.check_type_of);
                       FStar_TypeChecker_Env.use_bv_sorts =
-                        (uu___1394_7776.FStar_TypeChecker_Env.use_bv_sorts);
+                        (uu___1391_7870.FStar_TypeChecker_Env.use_bv_sorts);
                       FStar_TypeChecker_Env.qtbl_name_and_index =
-                        (uu___1394_7776.FStar_TypeChecker_Env.qtbl_name_and_index);
+                        (uu___1391_7870.FStar_TypeChecker_Env.qtbl_name_and_index);
                       FStar_TypeChecker_Env.normalized_eff_names =
-                        (uu___1394_7776.FStar_TypeChecker_Env.normalized_eff_names);
+                        (uu___1391_7870.FStar_TypeChecker_Env.normalized_eff_names);
                       FStar_TypeChecker_Env.fv_delta_depths =
-                        (uu___1394_7776.FStar_TypeChecker_Env.fv_delta_depths);
+                        (uu___1391_7870.FStar_TypeChecker_Env.fv_delta_depths);
                       FStar_TypeChecker_Env.proof_ns =
-                        (uu___1394_7776.FStar_TypeChecker_Env.proof_ns);
+                        (uu___1391_7870.FStar_TypeChecker_Env.proof_ns);
                       FStar_TypeChecker_Env.synth_hook =
-                        (uu___1394_7776.FStar_TypeChecker_Env.synth_hook);
+                        (uu___1391_7870.FStar_TypeChecker_Env.synth_hook);
                       FStar_TypeChecker_Env.try_solve_implicits_hook =
-                        (uu___1394_7776.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                        (uu___1391_7870.FStar_TypeChecker_Env.try_solve_implicits_hook);
                       FStar_TypeChecker_Env.splice =
-                        (uu___1394_7776.FStar_TypeChecker_Env.splice);
+                        (uu___1391_7870.FStar_TypeChecker_Env.splice);
                       FStar_TypeChecker_Env.mpreprocess =
-                        (uu___1394_7776.FStar_TypeChecker_Env.mpreprocess);
+                        (uu___1391_7870.FStar_TypeChecker_Env.mpreprocess);
                       FStar_TypeChecker_Env.postprocess =
-                        (uu___1394_7776.FStar_TypeChecker_Env.postprocess);
+                        (uu___1391_7870.FStar_TypeChecker_Env.postprocess);
                       FStar_TypeChecker_Env.is_native_tactic =
-                        (uu___1394_7776.FStar_TypeChecker_Env.is_native_tactic);
+                        (uu___1391_7870.FStar_TypeChecker_Env.is_native_tactic);
                       FStar_TypeChecker_Env.identifier_info =
-                        (uu___1394_7776.FStar_TypeChecker_Env.identifier_info);
+                        (uu___1391_7870.FStar_TypeChecker_Env.identifier_info);
                       FStar_TypeChecker_Env.tc_hooks =
-                        (uu___1394_7776.FStar_TypeChecker_Env.tc_hooks);
+                        (uu___1391_7870.FStar_TypeChecker_Env.tc_hooks);
                       FStar_TypeChecker_Env.dsenv =
                         (en.FStar_TypeChecker_Env.dsenv);
                       FStar_TypeChecker_Env.nbe =
-                        (uu___1394_7776.FStar_TypeChecker_Env.nbe);
+                        (uu___1391_7870.FStar_TypeChecker_Env.nbe);
                       FStar_TypeChecker_Env.strict_args_tab =
-                        (uu___1394_7776.FStar_TypeChecker_Env.strict_args_tab);
+                        (uu___1391_7870.FStar_TypeChecker_Env.strict_args_tab);
                       FStar_TypeChecker_Env.erasable_types_tab =
-                        (uu___1394_7776.FStar_TypeChecker_Env.erasable_types_tab)
+                        (uu___1391_7870.FStar_TypeChecker_Env.erasable_types_tab)
                     }  in
                   let en02 =
-                    let uu___1397_7778 = en01  in
-                    let uu____7779 =
-                      let uu____7794 =
+                    let uu___1394_7872 = en01  in
+                    let uu____7873 =
+                      let uu____7888 =
                         FStar_All.pipe_right
                           en.FStar_TypeChecker_Env.qtbl_name_and_index
                           FStar_Pervasives_Native.fst
                          in
-                      (uu____7794, FStar_Pervasives_Native.None)  in
+                      (uu____7888, FStar_Pervasives_Native.None)  in
                     {
                       FStar_TypeChecker_Env.solver =
-                        (uu___1397_7778.FStar_TypeChecker_Env.solver);
+                        (uu___1394_7872.FStar_TypeChecker_Env.solver);
                       FStar_TypeChecker_Env.range =
-                        (uu___1397_7778.FStar_TypeChecker_Env.range);
+                        (uu___1394_7872.FStar_TypeChecker_Env.range);
                       FStar_TypeChecker_Env.curmodule =
-                        (uu___1397_7778.FStar_TypeChecker_Env.curmodule);
+                        (uu___1394_7872.FStar_TypeChecker_Env.curmodule);
                       FStar_TypeChecker_Env.gamma =
-                        (uu___1397_7778.FStar_TypeChecker_Env.gamma);
+                        (uu___1394_7872.FStar_TypeChecker_Env.gamma);
                       FStar_TypeChecker_Env.gamma_sig =
-                        (uu___1397_7778.FStar_TypeChecker_Env.gamma_sig);
+                        (uu___1394_7872.FStar_TypeChecker_Env.gamma_sig);
                       FStar_TypeChecker_Env.gamma_cache =
-                        (uu___1397_7778.FStar_TypeChecker_Env.gamma_cache);
+                        (uu___1394_7872.FStar_TypeChecker_Env.gamma_cache);
                       FStar_TypeChecker_Env.modules =
-                        (uu___1397_7778.FStar_TypeChecker_Env.modules);
+                        (uu___1394_7872.FStar_TypeChecker_Env.modules);
                       FStar_TypeChecker_Env.expected_typ =
-                        (uu___1397_7778.FStar_TypeChecker_Env.expected_typ);
+                        (uu___1394_7872.FStar_TypeChecker_Env.expected_typ);
                       FStar_TypeChecker_Env.sigtab =
-                        (uu___1397_7778.FStar_TypeChecker_Env.sigtab);
+                        (uu___1394_7872.FStar_TypeChecker_Env.sigtab);
                       FStar_TypeChecker_Env.attrtab =
-                        (uu___1397_7778.FStar_TypeChecker_Env.attrtab);
+                        (uu___1394_7872.FStar_TypeChecker_Env.attrtab);
                       FStar_TypeChecker_Env.instantiate_imp =
-                        (uu___1397_7778.FStar_TypeChecker_Env.instantiate_imp);
+                        (uu___1394_7872.FStar_TypeChecker_Env.instantiate_imp);
                       FStar_TypeChecker_Env.effects =
-                        (uu___1397_7778.FStar_TypeChecker_Env.effects);
+                        (uu___1394_7872.FStar_TypeChecker_Env.effects);
                       FStar_TypeChecker_Env.generalize =
-                        (uu___1397_7778.FStar_TypeChecker_Env.generalize);
+                        (uu___1394_7872.FStar_TypeChecker_Env.generalize);
                       FStar_TypeChecker_Env.letrecs =
-                        (uu___1397_7778.FStar_TypeChecker_Env.letrecs);
+                        (uu___1394_7872.FStar_TypeChecker_Env.letrecs);
                       FStar_TypeChecker_Env.top_level =
-                        (uu___1397_7778.FStar_TypeChecker_Env.top_level);
+                        (uu___1394_7872.FStar_TypeChecker_Env.top_level);
                       FStar_TypeChecker_Env.check_uvars =
-                        (uu___1397_7778.FStar_TypeChecker_Env.check_uvars);
+                        (uu___1394_7872.FStar_TypeChecker_Env.check_uvars);
                       FStar_TypeChecker_Env.use_eq =
-                        (uu___1397_7778.FStar_TypeChecker_Env.use_eq);
+                        (uu___1394_7872.FStar_TypeChecker_Env.use_eq);
                       FStar_TypeChecker_Env.use_eq_strict =
-                        (uu___1397_7778.FStar_TypeChecker_Env.use_eq_strict);
+                        (uu___1394_7872.FStar_TypeChecker_Env.use_eq_strict);
                       FStar_TypeChecker_Env.is_iface =
-                        (uu___1397_7778.FStar_TypeChecker_Env.is_iface);
+                        (uu___1394_7872.FStar_TypeChecker_Env.is_iface);
                       FStar_TypeChecker_Env.admit =
-                        (uu___1397_7778.FStar_TypeChecker_Env.admit);
+                        (uu___1394_7872.FStar_TypeChecker_Env.admit);
                       FStar_TypeChecker_Env.lax =
-                        (uu___1397_7778.FStar_TypeChecker_Env.lax);
+                        (uu___1394_7872.FStar_TypeChecker_Env.lax);
                       FStar_TypeChecker_Env.lax_universes =
-                        (uu___1397_7778.FStar_TypeChecker_Env.lax_universes);
+                        (uu___1394_7872.FStar_TypeChecker_Env.lax_universes);
                       FStar_TypeChecker_Env.phase1 =
-                        (uu___1397_7778.FStar_TypeChecker_Env.phase1);
+                        (uu___1394_7872.FStar_TypeChecker_Env.phase1);
                       FStar_TypeChecker_Env.failhard =
-                        (uu___1397_7778.FStar_TypeChecker_Env.failhard);
+                        (uu___1394_7872.FStar_TypeChecker_Env.failhard);
                       FStar_TypeChecker_Env.nosynth =
-                        (uu___1397_7778.FStar_TypeChecker_Env.nosynth);
+                        (uu___1394_7872.FStar_TypeChecker_Env.nosynth);
                       FStar_TypeChecker_Env.uvar_subtyping =
-                        (uu___1397_7778.FStar_TypeChecker_Env.uvar_subtyping);
+                        (uu___1394_7872.FStar_TypeChecker_Env.uvar_subtyping);
                       FStar_TypeChecker_Env.tc_term =
-                        (uu___1397_7778.FStar_TypeChecker_Env.tc_term);
+                        (uu___1394_7872.FStar_TypeChecker_Env.tc_term);
                       FStar_TypeChecker_Env.type_of =
-                        (uu___1397_7778.FStar_TypeChecker_Env.type_of);
+                        (uu___1394_7872.FStar_TypeChecker_Env.type_of);
                       FStar_TypeChecker_Env.universe_of =
-                        (uu___1397_7778.FStar_TypeChecker_Env.universe_of);
+                        (uu___1394_7872.FStar_TypeChecker_Env.universe_of);
                       FStar_TypeChecker_Env.check_type_of =
-                        (uu___1397_7778.FStar_TypeChecker_Env.check_type_of);
+                        (uu___1394_7872.FStar_TypeChecker_Env.check_type_of);
                       FStar_TypeChecker_Env.use_bv_sorts =
-                        (uu___1397_7778.FStar_TypeChecker_Env.use_bv_sorts);
-                      FStar_TypeChecker_Env.qtbl_name_and_index = uu____7779;
+                        (uu___1394_7872.FStar_TypeChecker_Env.use_bv_sorts);
+                      FStar_TypeChecker_Env.qtbl_name_and_index = uu____7873;
                       FStar_TypeChecker_Env.normalized_eff_names =
-                        (uu___1397_7778.FStar_TypeChecker_Env.normalized_eff_names);
+                        (uu___1394_7872.FStar_TypeChecker_Env.normalized_eff_names);
                       FStar_TypeChecker_Env.fv_delta_depths =
-                        (uu___1397_7778.FStar_TypeChecker_Env.fv_delta_depths);
+                        (uu___1394_7872.FStar_TypeChecker_Env.fv_delta_depths);
                       FStar_TypeChecker_Env.proof_ns =
-                        (uu___1397_7778.FStar_TypeChecker_Env.proof_ns);
+                        (uu___1394_7872.FStar_TypeChecker_Env.proof_ns);
                       FStar_TypeChecker_Env.synth_hook =
-                        (uu___1397_7778.FStar_TypeChecker_Env.synth_hook);
+                        (uu___1394_7872.FStar_TypeChecker_Env.synth_hook);
                       FStar_TypeChecker_Env.try_solve_implicits_hook =
-                        (uu___1397_7778.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                        (uu___1394_7872.FStar_TypeChecker_Env.try_solve_implicits_hook);
                       FStar_TypeChecker_Env.splice =
-                        (uu___1397_7778.FStar_TypeChecker_Env.splice);
+                        (uu___1394_7872.FStar_TypeChecker_Env.splice);
                       FStar_TypeChecker_Env.mpreprocess =
-                        (uu___1397_7778.FStar_TypeChecker_Env.mpreprocess);
+                        (uu___1394_7872.FStar_TypeChecker_Env.mpreprocess);
                       FStar_TypeChecker_Env.postprocess =
-                        (uu___1397_7778.FStar_TypeChecker_Env.postprocess);
+                        (uu___1394_7872.FStar_TypeChecker_Env.postprocess);
                       FStar_TypeChecker_Env.is_native_tactic =
-                        (uu___1397_7778.FStar_TypeChecker_Env.is_native_tactic);
+                        (uu___1394_7872.FStar_TypeChecker_Env.is_native_tactic);
                       FStar_TypeChecker_Env.identifier_info =
-                        (uu___1397_7778.FStar_TypeChecker_Env.identifier_info);
+                        (uu___1394_7872.FStar_TypeChecker_Env.identifier_info);
                       FStar_TypeChecker_Env.tc_hooks =
-                        (uu___1397_7778.FStar_TypeChecker_Env.tc_hooks);
+                        (uu___1394_7872.FStar_TypeChecker_Env.tc_hooks);
                       FStar_TypeChecker_Env.dsenv =
-                        (uu___1397_7778.FStar_TypeChecker_Env.dsenv);
+                        (uu___1394_7872.FStar_TypeChecker_Env.dsenv);
                       FStar_TypeChecker_Env.nbe =
-                        (uu___1397_7778.FStar_TypeChecker_Env.nbe);
+                        (uu___1394_7872.FStar_TypeChecker_Env.nbe);
                       FStar_TypeChecker_Env.strict_args_tab =
-                        (uu___1397_7778.FStar_TypeChecker_Env.strict_args_tab);
+                        (uu___1394_7872.FStar_TypeChecker_Env.strict_args_tab);
                       FStar_TypeChecker_Env.erasable_types_tab =
-                        (uu___1397_7778.FStar_TypeChecker_Env.erasable_types_tab)
+                        (uu___1394_7872.FStar_TypeChecker_Env.erasable_types_tab)
                     }  in
-                  let uu____7840 =
-                    let uu____7842 = FStar_Options.interactive ()  in
-                    Prims.op_Negation uu____7842  in
-                  if uu____7840
+                  let uu____7934 =
+                    let uu____7936 = FStar_Options.interactive ()  in
+                    Prims.op_Negation uu____7936  in
+                  if uu____7934
                   then
-                    ((let uu____7846 =
+                    ((let uu____7940 =
                         FStar_Options.restore_cmd_line_options true  in
-                      FStar_All.pipe_right uu____7846 (fun uu____7848  -> ()));
+                      FStar_All.pipe_right uu____7940 (fun uu____7942  -> ()));
                      en02)
                   else en02  in
-                let uu____7851 = tc_modul en0 modul_iface true  in
-                match uu____7851 with
+                let uu____7945 = tc_modul en0 modul_iface true  in
+                match uu____7945 with
                 | (modul_iface1,env) ->
-                    ((let uu___1406_7864 = m  in
+                    ((let uu___1403_7958 = m  in
                       {
                         FStar_Syntax_Syntax.name =
-                          (uu___1406_7864.FStar_Syntax_Syntax.name);
+                          (uu___1403_7958.FStar_Syntax_Syntax.name);
                         FStar_Syntax_Syntax.declarations =
-                          (uu___1406_7864.FStar_Syntax_Syntax.declarations);
+                          (uu___1403_7958.FStar_Syntax_Syntax.declarations);
                         FStar_Syntax_Syntax.exports =
                           (modul_iface1.FStar_Syntax_Syntax.exports);
                         FStar_Syntax_Syntax.is_interface =
-                          (uu___1406_7864.FStar_Syntax_Syntax.is_interface)
+                          (uu___1403_7958.FStar_Syntax_Syntax.is_interface)
                       }), env)))
             else
               (let modul =
-                 let uu___1408_7868 = m  in
+                 let uu___1405_7962 = m  in
                  {
                    FStar_Syntax_Syntax.name =
-                     (uu___1408_7868.FStar_Syntax_Syntax.name);
+                     (uu___1405_7962.FStar_Syntax_Syntax.name);
                    FStar_Syntax_Syntax.declarations =
-                     (uu___1408_7868.FStar_Syntax_Syntax.declarations);
+                     (uu___1405_7962.FStar_Syntax_Syntax.declarations);
                    FStar_Syntax_Syntax.exports = exports;
                    FStar_Syntax_Syntax.is_interface =
-                     (uu___1408_7868.FStar_Syntax_Syntax.is_interface)
+                     (uu___1405_7962.FStar_Syntax_Syntax.is_interface)
                  }  in
                let env = FStar_TypeChecker_Env.finish_module en modul  in
-               (let uu____7871 =
+               (let uu____7965 =
                   FStar_All.pipe_right
                     env.FStar_TypeChecker_Env.qtbl_name_and_index
                     FStar_Pervasives_Native.fst
                    in
-                FStar_All.pipe_right uu____7871 FStar_Util.smap_clear);
-               (let uu____7907 =
-                  ((let uu____7911 = FStar_Options.lax ()  in
-                    Prims.op_Negation uu____7911) &&
+                FStar_All.pipe_right uu____7965 FStar_Util.smap_clear);
+               (let uu____8001 =
+                  ((let uu____8005 = FStar_Options.lax ()  in
+                    Prims.op_Negation uu____8005) &&
                      (Prims.op_Negation loading_from_cache))
                     &&
-                    (let uu____7914 =
+                    (let uu____8008 =
                        FStar_Options.use_extracted_interfaces ()  in
-                     Prims.op_Negation uu____7914)
+                     Prims.op_Negation uu____8008)
                    in
-                if uu____7907 then check_exports env modul exports else ());
-               (let uu____7920 =
-                  pop_context env
-                    (Prims.op_Hat "Ending modul "
-                       (modul.FStar_Syntax_Syntax.name).FStar_Ident.str)
-                   in
-                FStar_All.pipe_right uu____7920 (fun uu____7922  -> ()));
+                if uu____8001 then check_exports env modul exports else ());
+               (let uu____8014 =
+                  let uu____8015 =
+                    let uu____8017 =
+                      FStar_Ident.string_of_lid
+                        modul.FStar_Syntax_Syntax.name
+                       in
+                    Prims.op_Hat "Ending modul " uu____8017  in
+                  pop_context env uu____8015  in
+                FStar_All.pipe_right uu____8014 (fun uu____8020  -> ()));
                (modul, env))
 
 let (load_checked_module :
@@ -5536,11 +5588,11 @@ let (load_checked_module :
           m.FStar_Syntax_Syntax.name
          in
       let env1 =
-        let uu____7936 =
-          let uu____7938 =
+        let uu____8034 =
+          let uu____8036 =
             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-          Prims.op_Hat "Internals for " uu____7938  in
-        push_context env uu____7936  in
+          Prims.op_Hat "Internals for " uu____8036  in
+        push_context env uu____8034  in
       let env2 =
         FStar_List.fold_left
           (fun env2  ->
@@ -5550,15 +5602,15 @@ let (load_checked_module :
                FStar_All.pipe_right lids
                  (FStar_List.iter
                     (fun lid  ->
-                       let uu____7960 =
+                       let uu____8058 =
                          FStar_TypeChecker_Env.lookup_sigelt env3 lid  in
                        ()));
                env3) env1 m.FStar_Syntax_Syntax.declarations
          in
-      let uu____7963 =
+      let uu____8061 =
         finish_partial_modul true true env2 m m.FStar_Syntax_Syntax.exports
          in
-      match uu____7963 with | (uu____7970,env3) -> env3
+      match uu____8061 with | (uu____8068,env3) -> env3
   
 let (check_module :
   FStar_TypeChecker_Env.env ->
@@ -5568,150 +5620,152 @@ let (check_module :
   fun env  ->
     fun m  ->
       fun b  ->
-        (let uu____7995 = FStar_Options.debug_any ()  in
-         if uu____7995
+        (let uu____8093 = FStar_Options.debug_any ()  in
+         if uu____8093
          then
-           let uu____7998 =
+           let uu____8096 =
              FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name  in
            FStar_Util.print2 "Checking %s: %s\n"
              (if m.FStar_Syntax_Syntax.is_interface
               then "i'face"
-              else "module") uu____7998
+              else "module") uu____8096
          else ());
-        (let uu____8010 =
-           FStar_Options.dump_module
-             (m.FStar_Syntax_Syntax.name).FStar_Ident.str
-            in
-         if uu____8010
+        (let uu____8108 =
+           let uu____8110 =
+             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
+           FStar_Options.dump_module uu____8110  in
+         if uu____8108
          then
-           let uu____8013 = FStar_Syntax_Print.modul_to_string m  in
-           FStar_Util.print1 "Module before type checking:\n%s\n" uu____8013
+           let uu____8113 = FStar_Syntax_Print.modul_to_string m  in
+           FStar_Util.print1 "Module before type checking:\n%s\n" uu____8113
          else ());
         (let env1 =
-           let uu___1438_8019 = env  in
-           let uu____8020 =
-             let uu____8022 =
-               FStar_Options.should_verify
-                 (m.FStar_Syntax_Syntax.name).FStar_Ident.str
-                in
-             Prims.op_Negation uu____8022  in
+           let uu___1435_8119 = env  in
+           let uu____8120 =
+             let uu____8122 =
+               let uu____8124 =
+                 FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
+               FStar_Options.should_verify uu____8124  in
+             Prims.op_Negation uu____8122  in
            {
              FStar_TypeChecker_Env.solver =
-               (uu___1438_8019.FStar_TypeChecker_Env.solver);
+               (uu___1435_8119.FStar_TypeChecker_Env.solver);
              FStar_TypeChecker_Env.range =
-               (uu___1438_8019.FStar_TypeChecker_Env.range);
+               (uu___1435_8119.FStar_TypeChecker_Env.range);
              FStar_TypeChecker_Env.curmodule =
-               (uu___1438_8019.FStar_TypeChecker_Env.curmodule);
+               (uu___1435_8119.FStar_TypeChecker_Env.curmodule);
              FStar_TypeChecker_Env.gamma =
-               (uu___1438_8019.FStar_TypeChecker_Env.gamma);
+               (uu___1435_8119.FStar_TypeChecker_Env.gamma);
              FStar_TypeChecker_Env.gamma_sig =
-               (uu___1438_8019.FStar_TypeChecker_Env.gamma_sig);
+               (uu___1435_8119.FStar_TypeChecker_Env.gamma_sig);
              FStar_TypeChecker_Env.gamma_cache =
-               (uu___1438_8019.FStar_TypeChecker_Env.gamma_cache);
+               (uu___1435_8119.FStar_TypeChecker_Env.gamma_cache);
              FStar_TypeChecker_Env.modules =
-               (uu___1438_8019.FStar_TypeChecker_Env.modules);
+               (uu___1435_8119.FStar_TypeChecker_Env.modules);
              FStar_TypeChecker_Env.expected_typ =
-               (uu___1438_8019.FStar_TypeChecker_Env.expected_typ);
+               (uu___1435_8119.FStar_TypeChecker_Env.expected_typ);
              FStar_TypeChecker_Env.sigtab =
-               (uu___1438_8019.FStar_TypeChecker_Env.sigtab);
+               (uu___1435_8119.FStar_TypeChecker_Env.sigtab);
              FStar_TypeChecker_Env.attrtab =
-               (uu___1438_8019.FStar_TypeChecker_Env.attrtab);
+               (uu___1435_8119.FStar_TypeChecker_Env.attrtab);
              FStar_TypeChecker_Env.instantiate_imp =
-               (uu___1438_8019.FStar_TypeChecker_Env.instantiate_imp);
+               (uu___1435_8119.FStar_TypeChecker_Env.instantiate_imp);
              FStar_TypeChecker_Env.effects =
-               (uu___1438_8019.FStar_TypeChecker_Env.effects);
+               (uu___1435_8119.FStar_TypeChecker_Env.effects);
              FStar_TypeChecker_Env.generalize =
-               (uu___1438_8019.FStar_TypeChecker_Env.generalize);
+               (uu___1435_8119.FStar_TypeChecker_Env.generalize);
              FStar_TypeChecker_Env.letrecs =
-               (uu___1438_8019.FStar_TypeChecker_Env.letrecs);
+               (uu___1435_8119.FStar_TypeChecker_Env.letrecs);
              FStar_TypeChecker_Env.top_level =
-               (uu___1438_8019.FStar_TypeChecker_Env.top_level);
+               (uu___1435_8119.FStar_TypeChecker_Env.top_level);
              FStar_TypeChecker_Env.check_uvars =
-               (uu___1438_8019.FStar_TypeChecker_Env.check_uvars);
+               (uu___1435_8119.FStar_TypeChecker_Env.check_uvars);
              FStar_TypeChecker_Env.use_eq =
-               (uu___1438_8019.FStar_TypeChecker_Env.use_eq);
+               (uu___1435_8119.FStar_TypeChecker_Env.use_eq);
              FStar_TypeChecker_Env.use_eq_strict =
-               (uu___1438_8019.FStar_TypeChecker_Env.use_eq_strict);
+               (uu___1435_8119.FStar_TypeChecker_Env.use_eq_strict);
              FStar_TypeChecker_Env.is_iface =
-               (uu___1438_8019.FStar_TypeChecker_Env.is_iface);
+               (uu___1435_8119.FStar_TypeChecker_Env.is_iface);
              FStar_TypeChecker_Env.admit =
-               (uu___1438_8019.FStar_TypeChecker_Env.admit);
-             FStar_TypeChecker_Env.lax = uu____8020;
+               (uu___1435_8119.FStar_TypeChecker_Env.admit);
+             FStar_TypeChecker_Env.lax = uu____8120;
              FStar_TypeChecker_Env.lax_universes =
-               (uu___1438_8019.FStar_TypeChecker_Env.lax_universes);
+               (uu___1435_8119.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
-               (uu___1438_8019.FStar_TypeChecker_Env.phase1);
+               (uu___1435_8119.FStar_TypeChecker_Env.phase1);
              FStar_TypeChecker_Env.failhard =
-               (uu___1438_8019.FStar_TypeChecker_Env.failhard);
+               (uu___1435_8119.FStar_TypeChecker_Env.failhard);
              FStar_TypeChecker_Env.nosynth =
-               (uu___1438_8019.FStar_TypeChecker_Env.nosynth);
+               (uu___1435_8119.FStar_TypeChecker_Env.nosynth);
              FStar_TypeChecker_Env.uvar_subtyping =
-               (uu___1438_8019.FStar_TypeChecker_Env.uvar_subtyping);
+               (uu___1435_8119.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.tc_term =
-               (uu___1438_8019.FStar_TypeChecker_Env.tc_term);
+               (uu___1435_8119.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.type_of =
-               (uu___1438_8019.FStar_TypeChecker_Env.type_of);
+               (uu___1435_8119.FStar_TypeChecker_Env.type_of);
              FStar_TypeChecker_Env.universe_of =
-               (uu___1438_8019.FStar_TypeChecker_Env.universe_of);
+               (uu___1435_8119.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.check_type_of =
-               (uu___1438_8019.FStar_TypeChecker_Env.check_type_of);
+               (uu___1435_8119.FStar_TypeChecker_Env.check_type_of);
              FStar_TypeChecker_Env.use_bv_sorts =
-               (uu___1438_8019.FStar_TypeChecker_Env.use_bv_sorts);
+               (uu___1435_8119.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
-               (uu___1438_8019.FStar_TypeChecker_Env.qtbl_name_and_index);
+               (uu___1435_8119.FStar_TypeChecker_Env.qtbl_name_and_index);
              FStar_TypeChecker_Env.normalized_eff_names =
-               (uu___1438_8019.FStar_TypeChecker_Env.normalized_eff_names);
+               (uu___1435_8119.FStar_TypeChecker_Env.normalized_eff_names);
              FStar_TypeChecker_Env.fv_delta_depths =
-               (uu___1438_8019.FStar_TypeChecker_Env.fv_delta_depths);
+               (uu___1435_8119.FStar_TypeChecker_Env.fv_delta_depths);
              FStar_TypeChecker_Env.proof_ns =
-               (uu___1438_8019.FStar_TypeChecker_Env.proof_ns);
+               (uu___1435_8119.FStar_TypeChecker_Env.proof_ns);
              FStar_TypeChecker_Env.synth_hook =
-               (uu___1438_8019.FStar_TypeChecker_Env.synth_hook);
+               (uu___1435_8119.FStar_TypeChecker_Env.synth_hook);
              FStar_TypeChecker_Env.try_solve_implicits_hook =
-               (uu___1438_8019.FStar_TypeChecker_Env.try_solve_implicits_hook);
+               (uu___1435_8119.FStar_TypeChecker_Env.try_solve_implicits_hook);
              FStar_TypeChecker_Env.splice =
-               (uu___1438_8019.FStar_TypeChecker_Env.splice);
+               (uu___1435_8119.FStar_TypeChecker_Env.splice);
              FStar_TypeChecker_Env.mpreprocess =
-               (uu___1438_8019.FStar_TypeChecker_Env.mpreprocess);
+               (uu___1435_8119.FStar_TypeChecker_Env.mpreprocess);
              FStar_TypeChecker_Env.postprocess =
-               (uu___1438_8019.FStar_TypeChecker_Env.postprocess);
+               (uu___1435_8119.FStar_TypeChecker_Env.postprocess);
              FStar_TypeChecker_Env.is_native_tactic =
-               (uu___1438_8019.FStar_TypeChecker_Env.is_native_tactic);
+               (uu___1435_8119.FStar_TypeChecker_Env.is_native_tactic);
              FStar_TypeChecker_Env.identifier_info =
-               (uu___1438_8019.FStar_TypeChecker_Env.identifier_info);
+               (uu___1435_8119.FStar_TypeChecker_Env.identifier_info);
              FStar_TypeChecker_Env.tc_hooks =
-               (uu___1438_8019.FStar_TypeChecker_Env.tc_hooks);
+               (uu___1435_8119.FStar_TypeChecker_Env.tc_hooks);
              FStar_TypeChecker_Env.dsenv =
-               (uu___1438_8019.FStar_TypeChecker_Env.dsenv);
+               (uu___1435_8119.FStar_TypeChecker_Env.dsenv);
              FStar_TypeChecker_Env.nbe =
-               (uu___1438_8019.FStar_TypeChecker_Env.nbe);
+               (uu___1435_8119.FStar_TypeChecker_Env.nbe);
              FStar_TypeChecker_Env.strict_args_tab =
-               (uu___1438_8019.FStar_TypeChecker_Env.strict_args_tab);
+               (uu___1435_8119.FStar_TypeChecker_Env.strict_args_tab);
              FStar_TypeChecker_Env.erasable_types_tab =
-               (uu___1438_8019.FStar_TypeChecker_Env.erasable_types_tab)
+               (uu___1435_8119.FStar_TypeChecker_Env.erasable_types_tab)
            }  in
-         let uu____8024 = tc_modul env1 m b  in
-         match uu____8024 with
+         let uu____8126 = tc_modul env1 m b  in
+         match uu____8126 with
          | (m1,env2) ->
-             ((let uu____8036 =
-                 FStar_Options.dump_module
-                   (m1.FStar_Syntax_Syntax.name).FStar_Ident.str
-                  in
-               if uu____8036
+             ((let uu____8138 =
+                 let uu____8140 =
+                   FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name  in
+                 FStar_Options.dump_module uu____8140  in
+               if uu____8138
                then
-                 let uu____8039 = FStar_Syntax_Print.modul_to_string m1  in
+                 let uu____8143 = FStar_Syntax_Print.modul_to_string m1  in
                  FStar_Util.print1 "Module after type checking:\n%s\n"
-                   uu____8039
+                   uu____8143
                else ());
-              (let uu____8045 =
-                 (FStar_Options.dump_module
-                    (m1.FStar_Syntax_Syntax.name).FStar_Ident.str)
-                   &&
-                   (FStar_Options.debug_at_level
-                      (m1.FStar_Syntax_Syntax.name).FStar_Ident.str
+              (let uu____8149 =
+                 (let uu____8153 =
+                    FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name  in
+                  FStar_Options.dump_module uu____8153) &&
+                   (let uu____8156 =
+                      FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name
+                       in
+                    FStar_Options.debug_at_level uu____8156
                       (FStar_Options.Other "Normalize"))
                   in
-               if uu____8045
+               if uu____8149
                then
                  let normalize_toplevel_lets se =
                    match se.FStar_Syntax_Syntax.sigel with
@@ -5728,76 +5782,76 @@ let (check_module :
                            FStar_TypeChecker_Env.AllowUnboundUniverses]
                           in
                        let update lb =
-                         let uu____8083 =
+                         let uu____8194 =
                            FStar_Syntax_Subst.open_univ_vars
                              lb.FStar_Syntax_Syntax.lbunivs
                              lb.FStar_Syntax_Syntax.lbdef
                             in
-                         match uu____8083 with
+                         match uu____8194 with
                          | (univnames,e) ->
-                             let uu___1460_8090 = lb  in
-                             let uu____8091 =
-                               let uu____8094 =
+                             let uu___1457_8201 = lb  in
+                             let uu____8202 =
+                               let uu____8205 =
                                  FStar_TypeChecker_Env.push_univ_vars env2
                                    univnames
                                   in
-                               n uu____8094 e  in
+                               n uu____8205 e  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___1460_8090.FStar_Syntax_Syntax.lbname);
+                                 (uu___1457_8201.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___1460_8090.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___1457_8201.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___1460_8090.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___1457_8201.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1460_8090.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = uu____8091;
+                                 (uu___1457_8201.FStar_Syntax_Syntax.lbeff);
+                               FStar_Syntax_Syntax.lbdef = uu____8202;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___1460_8090.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___1457_8201.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1460_8090.FStar_Syntax_Syntax.lbpos)
+                                 (uu___1457_8201.FStar_Syntax_Syntax.lbpos)
                              }
                           in
-                       let uu___1462_8095 = se  in
-                       let uu____8096 =
-                         let uu____8097 =
-                           let uu____8104 =
-                             let uu____8105 = FStar_List.map update lbs  in
-                             (b1, uu____8105)  in
-                           (uu____8104, ids)  in
-                         FStar_Syntax_Syntax.Sig_let uu____8097  in
+                       let uu___1459_8206 = se  in
+                       let uu____8207 =
+                         let uu____8208 =
+                           let uu____8215 =
+                             let uu____8216 = FStar_List.map update lbs  in
+                             (b1, uu____8216)  in
+                           (uu____8215, ids)  in
+                         FStar_Syntax_Syntax.Sig_let uu____8208  in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____8096;
+                         FStar_Syntax_Syntax.sigel = uu____8207;
                          FStar_Syntax_Syntax.sigrng =
-                           (uu___1462_8095.FStar_Syntax_Syntax.sigrng);
+                           (uu___1459_8206.FStar_Syntax_Syntax.sigrng);
                          FStar_Syntax_Syntax.sigquals =
-                           (uu___1462_8095.FStar_Syntax_Syntax.sigquals);
+                           (uu___1459_8206.FStar_Syntax_Syntax.sigquals);
                          FStar_Syntax_Syntax.sigmeta =
-                           (uu___1462_8095.FStar_Syntax_Syntax.sigmeta);
+                           (uu___1459_8206.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs =
-                           (uu___1462_8095.FStar_Syntax_Syntax.sigattrs);
+                           (uu___1459_8206.FStar_Syntax_Syntax.sigattrs);
                          FStar_Syntax_Syntax.sigopts =
-                           (uu___1462_8095.FStar_Syntax_Syntax.sigopts)
+                           (uu___1459_8206.FStar_Syntax_Syntax.sigopts)
                        }
-                   | uu____8113 -> se  in
+                   | uu____8224 -> se  in
                  let normalized_module =
-                   let uu___1466_8115 = m1  in
-                   let uu____8116 =
+                   let uu___1463_8226 = m1  in
+                   let uu____8227 =
                      FStar_List.map normalize_toplevel_lets
                        m1.FStar_Syntax_Syntax.declarations
                       in
                    {
                      FStar_Syntax_Syntax.name =
-                       (uu___1466_8115.FStar_Syntax_Syntax.name);
-                     FStar_Syntax_Syntax.declarations = uu____8116;
+                       (uu___1463_8226.FStar_Syntax_Syntax.name);
+                     FStar_Syntax_Syntax.declarations = uu____8227;
                      FStar_Syntax_Syntax.exports =
-                       (uu___1466_8115.FStar_Syntax_Syntax.exports);
+                       (uu___1463_8226.FStar_Syntax_Syntax.exports);
                      FStar_Syntax_Syntax.is_interface =
-                       (uu___1466_8115.FStar_Syntax_Syntax.is_interface)
+                       (uu___1463_8226.FStar_Syntax_Syntax.is_interface)
                    }  in
-                 let uu____8117 =
+                 let uu____8228 =
                    FStar_Syntax_Print.modul_to_string normalized_module  in
-                 FStar_Util.print1 "%s\n" uu____8117
+                 FStar_Util.print1 "%s\n" uu____8228
                else ());
               (m1, env2)))
   

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -310,125 +310,131 @@ let (tc_layered_eff_decl :
                Prims.int_zero)
         then
           (let uu____402 =
+             let uu____408 =
+               let uu____410 =
+                 let uu____412 =
+                   FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname  in
+                 Prims.op_Hat uu____412 ")"  in
+               Prims.op_Hat "Binders are not supported for layered effects ("
+                 uu____410
+                in
+             (FStar_Errors.Fatal_UnexpectedEffect, uu____408)  in
+           let uu____417 =
              FStar_Ident.range_of_lid ed.FStar_Syntax_Syntax.mname  in
-           FStar_Errors.raise_error
-             (FStar_Errors.Fatal_UnexpectedEffect,
-               (Prims.op_Hat
-                  "Binders are not supported for layered effects ("
-                  (Prims.op_Hat
-                     (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str ")")))
-             uu____402)
+           FStar_Errors.raise_error uu____402 uu____417)
         else ();
-        (let log_combinator s uu____431 =
-           match uu____431 with
+        (let log_combinator s uu____443 =
+           match uu____443 with
            | (us,t,ty) ->
-               let uu____460 =
+               let uu____472 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
                    (FStar_Options.Other "LayeredEffects")
                   in
-               if uu____460
+               if uu____472
                then
-                 let uu____465 = FStar_Syntax_Print.tscheme_to_string (us, t)
+                 let uu____477 =
+                   FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname  in
+                 let uu____479 = FStar_Syntax_Print.tscheme_to_string (us, t)
                     in
-                 let uu____471 =
+                 let uu____485 =
                    FStar_Syntax_Print.tscheme_to_string (us, ty)  in
-                 FStar_Util.print4 "Typechecked %s:%s = %s:%s\n"
-                   (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str s uu____465
-                   uu____471
+                 FStar_Util.print4 "Typechecked %s:%s = %s:%s\n" uu____477 s
+                   uu____479 uu____485
                else ()
             in
          let fresh_a_and_u_a a =
-           let uu____496 = FStar_Syntax_Util.type_u ()  in
-           FStar_All.pipe_right uu____496
-             (fun uu____513  ->
-                match uu____513 with
+           let uu____510 = FStar_Syntax_Util.type_u ()  in
+           FStar_All.pipe_right uu____510
+             (fun uu____527  ->
+                match uu____527 with
                 | (t,u) ->
-                    let uu____524 =
-                      let uu____525 =
+                    let uu____538 =
+                      let uu____539 =
                         FStar_Syntax_Syntax.gen_bv a
                           FStar_Pervasives_Native.None t
                          in
-                      FStar_All.pipe_right uu____525
+                      FStar_All.pipe_right uu____539
                         FStar_Syntax_Syntax.mk_binder
                        in
-                    (uu____524, u))
+                    (uu____538, u))
             in
          let fresh_x_a x a =
-           let uu____539 =
-             let uu____540 =
-               let uu____541 =
+           let uu____553 =
+             let uu____554 =
+               let uu____555 =
                  FStar_All.pipe_right a FStar_Pervasives_Native.fst  in
-               FStar_All.pipe_right uu____541 FStar_Syntax_Syntax.bv_to_name
+               FStar_All.pipe_right uu____555 FStar_Syntax_Syntax.bv_to_name
                 in
              FStar_Syntax_Syntax.gen_bv x FStar_Pervasives_Native.None
-               uu____540
+               uu____554
               in
-           FStar_All.pipe_right uu____539 FStar_Syntax_Syntax.mk_binder  in
+           FStar_All.pipe_right uu____553 FStar_Syntax_Syntax.mk_binder  in
          let check_and_gen1 =
-           check_and_gen env0 (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str
-            in
+           let uu____589 =
+             FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname  in
+           check_and_gen env0 uu____589  in
          let signature =
            let r =
              (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.signature).FStar_Syntax_Syntax.pos
               in
-           let uu____593 =
+           let uu____609 =
              check_and_gen1 "signature" Prims.int_one
                ed.FStar_Syntax_Syntax.signature
               in
-           match uu____593 with
+           match uu____609 with
            | (sig_us,sig_t,sig_ty) ->
-               let uu____617 = FStar_Syntax_Subst.open_univ_vars sig_us sig_t
+               let uu____633 = FStar_Syntax_Subst.open_univ_vars sig_us sig_t
                   in
-               (match uu____617 with
+               (match uu____633 with
                 | (us,t) ->
                     let env = FStar_TypeChecker_Env.push_univ_vars env0 us
                        in
-                    let uu____637 = fresh_a_and_u_a "a"  in
-                    (match uu____637 with
+                    let uu____653 = fresh_a_and_u_a "a"  in
+                    (match uu____653 with
                      | (a,u) ->
                          let rest_bs =
-                           let uu____658 =
-                             let uu____659 =
+                           let uu____674 =
+                             let uu____675 =
                                FStar_All.pipe_right a
                                  FStar_Pervasives_Native.fst
                                 in
-                             FStar_All.pipe_right uu____659
+                             FStar_All.pipe_right uu____675
                                FStar_Syntax_Syntax.bv_to_name
                               in
                            FStar_TypeChecker_Util.layered_effect_indices_as_binders
                              env r ed.FStar_Syntax_Syntax.mname
-                             (sig_us, sig_t) u uu____658
+                             (sig_us, sig_t) u uu____674
                             in
                          let bs = a :: rest_bs  in
                          let k =
-                           let uu____690 =
+                           let uu____706 =
                              FStar_Syntax_Syntax.mk_Total
                                FStar_Syntax_Syntax.teff
                               in
-                           FStar_Syntax_Util.arrow bs uu____690  in
+                           FStar_Syntax_Util.arrow bs uu____706  in
                          let g_eq = FStar_TypeChecker_Rel.teq env t k  in
                          (FStar_TypeChecker_Rel.force_trivial_guard env g_eq;
-                          (let uu____695 =
-                             let uu____698 =
+                          (let uu____711 =
+                             let uu____714 =
                                FStar_All.pipe_right k
                                  (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                     env)
                                 in
-                             FStar_Syntax_Subst.close_univ_vars us uu____698
+                             FStar_Syntax_Subst.close_univ_vars us uu____714
                               in
-                           (sig_us, uu____695, sig_ty)))))
+                           (sig_us, uu____711, sig_ty)))))
             in
          log_combinator "signature" signature;
-         (let uu____707 =
+         (let uu____723 =
             let repr_ts =
-              let uu____729 =
+              let uu____745 =
                 FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr  in
-              FStar_All.pipe_right uu____729 FStar_Util.must  in
+              FStar_All.pipe_right uu____745 FStar_Util.must  in
             let r =
               (FStar_Pervasives_Native.snd repr_ts).FStar_Syntax_Syntax.pos
                in
-            let uu____757 = check_and_gen1 "repr" Prims.int_one repr_ts  in
-            match uu____757 with
+            let uu____773 = check_and_gen1 "repr" Prims.int_one repr_ts  in
+            match uu____773 with
             | (repr_us,repr_t,repr_ty) ->
                 let underlying_effect_lid =
                   let repr_t1 =
@@ -439,361 +445,364 @@ let (tc_layered_eff_decl :
                       FStar_TypeChecker_Env.AllowUnboundUniverses] env0
                       repr_t
                      in
-                  let uu____788 =
-                    let uu____789 = FStar_Syntax_Subst.compress repr_t1  in
-                    uu____789.FStar_Syntax_Syntax.n  in
-                  match uu____788 with
-                  | FStar_Syntax_Syntax.Tm_abs (uu____792,t,uu____794) ->
-                      let uu____819 =
-                        let uu____820 = FStar_Syntax_Subst.compress t  in
-                        uu____820.FStar_Syntax_Syntax.n  in
-                      (match uu____819 with
-                       | FStar_Syntax_Syntax.Tm_arrow (uu____823,c) ->
-                           let uu____845 =
+                  let uu____804 =
+                    let uu____805 = FStar_Syntax_Subst.compress repr_t1  in
+                    uu____805.FStar_Syntax_Syntax.n  in
+                  match uu____804 with
+                  | FStar_Syntax_Syntax.Tm_abs (uu____808,t,uu____810) ->
+                      let uu____835 =
+                        let uu____836 = FStar_Syntax_Subst.compress t  in
+                        uu____836.FStar_Syntax_Syntax.n  in
+                      (match uu____835 with
+                       | FStar_Syntax_Syntax.Tm_arrow (uu____839,c) ->
+                           let uu____861 =
                              FStar_All.pipe_right c
                                FStar_Syntax_Util.comp_effect_name
                               in
-                           FStar_All.pipe_right uu____845
+                           FStar_All.pipe_right uu____861
                              (FStar_TypeChecker_Env.norm_eff_name env0)
-                       | uu____848 ->
-                           let uu____849 =
-                             let uu____855 =
-                               let uu____857 =
+                       | uu____864 ->
+                           let uu____865 =
+                             let uu____871 =
+                               let uu____873 =
                                  FStar_All.pipe_right
                                    ed.FStar_Syntax_Syntax.mname
                                    FStar_Ident.string_of_lid
                                   in
-                               let uu____860 =
+                               let uu____876 =
                                  FStar_Syntax_Print.term_to_string t  in
                                FStar_Util.format2
                                  "repr body for %s is not an arrow (%s)"
-                                 uu____857 uu____860
+                                 uu____873 uu____876
                                 in
-                             (FStar_Errors.Fatal_UnexpectedEffect, uu____855)
+                             (FStar_Errors.Fatal_UnexpectedEffect, uu____871)
                               in
-                           FStar_Errors.raise_error uu____849 r)
-                  | uu____864 ->
-                      let uu____865 =
-                        let uu____871 =
-                          let uu____873 =
+                           FStar_Errors.raise_error uu____865 r)
+                  | uu____880 ->
+                      let uu____881 =
+                        let uu____887 =
+                          let uu____889 =
                             FStar_All.pipe_right ed.FStar_Syntax_Syntax.mname
                               FStar_Ident.string_of_lid
                              in
-                          let uu____876 =
+                          let uu____892 =
                             FStar_Syntax_Print.term_to_string repr_t1  in
                           FStar_Util.format2
                             "repr for %s is not an abstraction (%s)"
-                            uu____873 uu____876
+                            uu____889 uu____892
                            in
-                        (FStar_Errors.Fatal_UnexpectedEffect, uu____871)  in
-                      FStar_Errors.raise_error uu____865 r
+                        (FStar_Errors.Fatal_UnexpectedEffect, uu____887)  in
+                      FStar_Errors.raise_error uu____881 r
                    in
-                ((let uu____881 =
+                ((let uu____897 =
                     (FStar_All.pipe_right quals
                        (FStar_List.contains FStar_Syntax_Syntax.TotalEffect))
                       &&
-                      (let uu____887 =
+                      (let uu____903 =
                          FStar_TypeChecker_Env.is_total_effect env0
                            underlying_effect_lid
                           in
-                       Prims.op_Negation uu____887)
+                       Prims.op_Negation uu____903)
                      in
-                  if uu____881
+                  if uu____897
                   then
-                    let uu____890 =
-                      let uu____896 =
-                        let uu____898 =
+                    let uu____906 =
+                      let uu____912 =
+                        let uu____914 =
                           FStar_All.pipe_right ed.FStar_Syntax_Syntax.mname
                             FStar_Ident.string_of_lid
                            in
-                        let uu____901 =
+                        let uu____917 =
                           FStar_All.pipe_right underlying_effect_lid
                             FStar_Ident.string_of_lid
                            in
                         FStar_Util.format2
                           "Effect %s is marked total but its underlying effect %s is not total"
-                          uu____898 uu____901
+                          uu____914 uu____917
                          in
                       (FStar_Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                        uu____896)
+                        uu____912)
                        in
-                    FStar_Errors.raise_error uu____890 r
+                    FStar_Errors.raise_error uu____906 r
                   else ());
-                 (let uu____908 =
+                 (let uu____924 =
                     FStar_Syntax_Subst.open_univ_vars repr_us repr_ty  in
-                  match uu____908 with
+                  match uu____924 with
                   | (us,ty) ->
                       let env = FStar_TypeChecker_Env.push_univ_vars env0 us
                          in
-                      let uu____932 = fresh_a_and_u_a "a"  in
-                      (match uu____932 with
+                      let uu____948 = fresh_a_and_u_a "a"  in
+                      (match uu____948 with
                        | (a,u) ->
                            let rest_bs =
                              let signature_ts =
-                               let uu____958 = signature  in
-                               match uu____958 with
-                               | (us1,t,uu____973) -> (us1, t)  in
-                             let uu____990 =
-                               let uu____991 =
+                               let uu____974 = signature  in
+                               match uu____974 with
+                               | (us1,t,uu____989) -> (us1, t)  in
+                             let uu____1006 =
+                               let uu____1007 =
                                  FStar_All.pipe_right a
                                    FStar_Pervasives_Native.fst
                                   in
-                               FStar_All.pipe_right uu____991
+                               FStar_All.pipe_right uu____1007
                                  FStar_Syntax_Syntax.bv_to_name
                                 in
                              FStar_TypeChecker_Util.layered_effect_indices_as_binders
                                env r ed.FStar_Syntax_Syntax.mname
-                               signature_ts u uu____990
+                               signature_ts u uu____1006
                               in
                            let bs = a :: rest_bs  in
                            let k =
-                             let uu____1018 =
-                               let uu____1021 = FStar_Syntax_Util.type_u ()
+                             let uu____1034 =
+                               let uu____1037 = FStar_Syntax_Util.type_u ()
                                   in
-                               FStar_All.pipe_right uu____1021
-                                 (fun uu____1034  ->
-                                    match uu____1034 with
+                               FStar_All.pipe_right uu____1037
+                                 (fun uu____1050  ->
+                                    match uu____1050 with
                                     | (t,u1) ->
-                                        let uu____1041 =
-                                          let uu____1044 =
+                                        let uu____1057 =
+                                          let uu____1060 =
                                             FStar_TypeChecker_Env.new_u_univ
                                               ()
                                              in
                                           FStar_Pervasives_Native.Some
-                                            uu____1044
+                                            uu____1060
                                            in
                                         FStar_Syntax_Syntax.mk_Total' t
-                                          uu____1041)
+                                          uu____1057)
                                 in
-                             FStar_Syntax_Util.arrow bs uu____1018  in
+                             FStar_Syntax_Util.arrow bs uu____1034  in
                            let g = FStar_TypeChecker_Rel.teq env ty k  in
                            (FStar_TypeChecker_Rel.force_trivial_guard env g;
-                            (let uu____1047 =
-                               let uu____1060 =
-                                 let uu____1063 =
+                            (let uu____1063 =
+                               let uu____1076 =
+                                 let uu____1079 =
                                    FStar_All.pipe_right k
                                      (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                         env)
                                     in
                                  FStar_Syntax_Subst.close_univ_vars us
-                                   uu____1063
+                                   uu____1079
                                   in
-                               (repr_us, repr_t, uu____1060)  in
-                             (uu____1047, underlying_effect_lid))))))
+                               (repr_us, repr_t, uu____1076)  in
+                             (uu____1063, underlying_effect_lid))))))
              in
-          match uu____707 with
+          match uu____723 with
           | (repr,underlying_effect_lid) ->
               (log_combinator "repr" repr;
                (let fresh_repr r env u a_tm =
                   let signature_ts =
-                    let uu____1136 = signature  in
-                    match uu____1136 with | (us,t,uu____1151) -> (us, t)  in
+                    let uu____1152 = signature  in
+                    match uu____1152 with | (us,t,uu____1167) -> (us, t)  in
                   let repr_ts =
-                    let uu____1169 = repr  in
-                    match uu____1169 with | (us,t,uu____1184) -> (us, t)  in
+                    let uu____1185 = repr  in
+                    match uu____1185 with | (us,t,uu____1200) -> (us, t)  in
                   FStar_TypeChecker_Util.fresh_effect_repr env r
                     ed.FStar_Syntax_Syntax.mname signature_ts
                     (FStar_Pervasives_Native.Some repr_ts) u a_tm
                    in
                 let not_an_arrow_error comb n t r =
-                  let uu____1234 =
-                    let uu____1240 =
-                      let uu____1242 = FStar_Util.string_of_int n  in
-                      let uu____1244 = FStar_Syntax_Print.tag_of_term t  in
-                      let uu____1246 = FStar_Syntax_Print.term_to_string t
+                  let uu____1250 =
+                    let uu____1256 =
+                      let uu____1258 =
+                        FStar_Ident.string_of_lid
+                          ed.FStar_Syntax_Syntax.mname
+                         in
+                      let uu____1260 = FStar_Util.string_of_int n  in
+                      let uu____1262 = FStar_Syntax_Print.tag_of_term t  in
+                      let uu____1264 = FStar_Syntax_Print.term_to_string t
                          in
                       FStar_Util.format5
                         "Type of %s:%s is not an arrow with >= %s binders (%s::%s)"
-                        (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str comb
-                        uu____1242 uu____1244 uu____1246
+                        uu____1258 comb uu____1260 uu____1262 uu____1264
                        in
-                    (FStar_Errors.Fatal_UnexpectedEffect, uu____1240)  in
-                  FStar_Errors.raise_error uu____1234 r  in
+                    (FStar_Errors.Fatal_UnexpectedEffect, uu____1256)  in
+                  FStar_Errors.raise_error uu____1250 r  in
                 let return_repr =
                   let return_repr_ts =
-                    let uu____1276 =
+                    let uu____1294 =
                       FStar_All.pipe_right ed
                         FStar_Syntax_Util.get_return_repr
                        in
-                    FStar_All.pipe_right uu____1276 FStar_Util.must  in
+                    FStar_All.pipe_right uu____1294 FStar_Util.must  in
                   let r =
                     (FStar_Pervasives_Native.snd return_repr_ts).FStar_Syntax_Syntax.pos
                      in
-                  let uu____1304 =
+                  let uu____1322 =
                     check_and_gen1 "return_repr" Prims.int_one return_repr_ts
                      in
-                  match uu____1304 with
+                  match uu____1322 with
                   | (ret_us,ret_t,ret_ty) ->
-                      let uu____1328 =
+                      let uu____1346 =
                         FStar_Syntax_Subst.open_univ_vars ret_us ret_ty  in
-                      (match uu____1328 with
+                      (match uu____1346 with
                        | (us,ty) ->
                            let env =
                              FStar_TypeChecker_Env.push_univ_vars env0 us  in
                            (check_no_subtyping_for_layered_combinator env ty
                               FStar_Pervasives_Native.None;
-                            (let uu____1349 = fresh_a_and_u_a "a"  in
-                             match uu____1349 with
+                            (let uu____1367 = fresh_a_and_u_a "a"  in
+                             match uu____1367 with
                              | (a,u_a) ->
                                  let x_a = fresh_x_a "x" a  in
                                  let rest_bs =
-                                   let uu____1380 =
-                                     let uu____1381 =
+                                   let uu____1398 =
+                                     let uu____1399 =
                                        FStar_Syntax_Subst.compress ty  in
-                                     uu____1381.FStar_Syntax_Syntax.n  in
-                                   match uu____1380 with
+                                     uu____1399.FStar_Syntax_Syntax.n  in
+                                   match uu____1398 with
                                    | FStar_Syntax_Syntax.Tm_arrow
-                                       (bs,uu____1393) when
+                                       (bs,uu____1411) when
                                        (FStar_List.length bs) >=
                                          (Prims.of_int (2))
                                        ->
-                                       let uu____1421 =
+                                       let uu____1439 =
                                          FStar_Syntax_Subst.open_binders bs
                                           in
-                                       (match uu____1421 with
-                                        | (a',uu____1431)::(x',uu____1433)::bs1
+                                       (match uu____1439 with
+                                        | (a',uu____1449)::(x',uu____1451)::bs1
                                             ->
-                                            let uu____1463 =
-                                              let uu____1464 =
-                                                let uu____1469 =
-                                                  let uu____1472 =
-                                                    let uu____1473 =
-                                                      let uu____1480 =
+                                            let uu____1481 =
+                                              let uu____1482 =
+                                                let uu____1487 =
+                                                  let uu____1490 =
+                                                    let uu____1491 =
+                                                      let uu____1498 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           (FStar_Pervasives_Native.fst
                                                              a)
                                                          in
-                                                      (a', uu____1480)  in
+                                                      (a', uu____1498)  in
                                                     FStar_Syntax_Syntax.NT
-                                                      uu____1473
+                                                      uu____1491
                                                      in
-                                                  [uu____1472]  in
+                                                  [uu____1490]  in
                                                 FStar_Syntax_Subst.subst_binders
-                                                  uu____1469
+                                                  uu____1487
                                                  in
                                               FStar_All.pipe_right bs1
-                                                uu____1464
+                                                uu____1482
                                                in
-                                            let uu____1487 =
-                                              let uu____1500 =
-                                                let uu____1503 =
-                                                  let uu____1504 =
-                                                    let uu____1511 =
+                                            let uu____1505 =
+                                              let uu____1518 =
+                                                let uu____1521 =
+                                                  let uu____1522 =
+                                                    let uu____1529 =
                                                       FStar_Syntax_Syntax.bv_to_name
                                                         (FStar_Pervasives_Native.fst
                                                            x_a)
                                                        in
-                                                    (x', uu____1511)  in
+                                                    (x', uu____1529)  in
                                                   FStar_Syntax_Syntax.NT
-                                                    uu____1504
+                                                    uu____1522
                                                    in
-                                                [uu____1503]  in
+                                                [uu____1521]  in
                                               FStar_Syntax_Subst.subst_binders
-                                                uu____1500
+                                                uu____1518
                                                in
-                                            FStar_All.pipe_right uu____1463
-                                              uu____1487)
-                                   | uu____1526 ->
+                                            FStar_All.pipe_right uu____1481
+                                              uu____1505)
+                                   | uu____1544 ->
                                        not_an_arrow_error "return"
                                          (Prims.of_int (2)) ty r
                                     in
                                  let bs = a :: x_a :: rest_bs  in
-                                 let uu____1550 =
-                                   let uu____1555 =
+                                 let uu____1568 =
+                                   let uu____1573 =
                                      FStar_TypeChecker_Env.push_binders env
                                        bs
                                       in
-                                   let uu____1556 =
+                                   let uu____1574 =
                                      FStar_All.pipe_right
                                        (FStar_Pervasives_Native.fst a)
                                        FStar_Syntax_Syntax.bv_to_name
                                       in
-                                   fresh_repr r uu____1555 u_a uu____1556  in
-                                 (match uu____1550 with
+                                   fresh_repr r uu____1573 u_a uu____1574  in
+                                 (match uu____1568 with
                                   | (repr1,g) ->
                                       let k =
-                                        let uu____1576 =
+                                        let uu____1594 =
                                           FStar_Syntax_Syntax.mk_Total' repr1
                                             (FStar_Pervasives_Native.Some u_a)
                                            in
-                                        FStar_Syntax_Util.arrow bs uu____1576
+                                        FStar_Syntax_Util.arrow bs uu____1594
                                          in
                                       let g_eq =
                                         FStar_TypeChecker_Rel.teq env ty k
                                          in
-                                      ((let uu____1581 =
+                                      ((let uu____1599 =
                                           FStar_TypeChecker_Env.conj_guard g
                                             g_eq
                                            in
                                         FStar_TypeChecker_Rel.force_trivial_guard
-                                          env uu____1581);
-                                       (let uu____1582 =
-                                          let uu____1585 =
+                                          env uu____1599);
+                                       (let uu____1600 =
+                                          let uu____1603 =
                                             FStar_All.pipe_right k
                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                  env)
                                              in
-                                          FStar_All.pipe_right uu____1585
+                                          FStar_All.pipe_right uu____1603
                                             (FStar_Syntax_Subst.close_univ_vars
                                                us)
                                            in
-                                        (ret_us, ret_t, uu____1582)))))))
+                                        (ret_us, ret_t, uu____1600)))))))
                    in
                 log_combinator "return_repr" return_repr;
                 (let bind_repr =
                    let bind_repr_ts =
-                     let uu____1614 =
+                     let uu____1632 =
                        FStar_All.pipe_right ed
                          FStar_Syntax_Util.get_bind_repr
                         in
-                     FStar_All.pipe_right uu____1614 FStar_Util.must  in
+                     FStar_All.pipe_right uu____1632 FStar_Util.must  in
                    let r =
                      (FStar_Pervasives_Native.snd bind_repr_ts).FStar_Syntax_Syntax.pos
                       in
-                   let uu____1642 =
+                   let uu____1660 =
                      check_and_gen1 "bind_repr" (Prims.of_int (2))
                        bind_repr_ts
                       in
-                   match uu____1642 with
+                   match uu____1660 with
                    | (bind_us,bind_t,bind_ty) ->
-                       let uu____1666 =
+                       let uu____1684 =
                          FStar_Syntax_Subst.open_univ_vars bind_us bind_ty
                           in
-                       (match uu____1666 with
+                       (match uu____1684 with
                         | (us,ty) ->
                             let env =
                               FStar_TypeChecker_Env.push_univ_vars env0 us
                                in
                             (check_no_subtyping_for_layered_combinator env ty
                                FStar_Pervasives_Native.None;
-                             (let uu____1687 = fresh_a_and_u_a "a"  in
-                              match uu____1687 with
+                             (let uu____1705 = fresh_a_and_u_a "a"  in
+                              match uu____1705 with
                               | (a,u_a) ->
-                                  let uu____1707 = fresh_a_and_u_a "b"  in
-                                  (match uu____1707 with
+                                  let uu____1725 = fresh_a_and_u_a "b"  in
+                                  (match uu____1725 with
                                    | (b,u_b) ->
                                        let rest_bs =
-                                         let uu____1736 =
-                                           let uu____1737 =
+                                         let uu____1754 =
+                                           let uu____1755 =
                                              FStar_Syntax_Subst.compress ty
                                               in
-                                           uu____1737.FStar_Syntax_Syntax.n
+                                           uu____1755.FStar_Syntax_Syntax.n
                                             in
-                                         match uu____1736 with
+                                         match uu____1754 with
                                          | FStar_Syntax_Syntax.Tm_arrow
-                                             (bs,uu____1749) when
+                                             (bs,uu____1767) when
                                              (FStar_List.length bs) >=
                                                (Prims.of_int (4))
                                              ->
-                                             let uu____1777 =
+                                             let uu____1795 =
                                                FStar_Syntax_Subst.open_binders
                                                  bs
                                                 in
-                                             (match uu____1777 with
-                                              | (a',uu____1787)::(b',uu____1789)::bs1
+                                             (match uu____1795 with
+                                              | (a',uu____1805)::(b',uu____1807)::bs1
                                                   ->
-                                                  let uu____1819 =
-                                                    let uu____1820 =
+                                                  let uu____1837 =
+                                                    let uu____1838 =
                                                       FStar_All.pipe_right
                                                         bs1
                                                         (FStar_List.splitAt
@@ -803,191 +812,195 @@ let (tc_layered_eff_decl :
                                                               (Prims.of_int (2))))
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____1820
+                                                      uu____1838
                                                       FStar_Pervasives_Native.fst
                                                      in
-                                                  let uu____1886 =
-                                                    let uu____1899 =
-                                                      let uu____1902 =
-                                                        let uu____1903 =
-                                                          let uu____1910 =
+                                                  let uu____1904 =
+                                                    let uu____1917 =
+                                                      let uu____1920 =
+                                                        let uu____1921 =
+                                                          let uu____1928 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               (FStar_Pervasives_Native.fst
                                                                  a)
                                                              in
-                                                          (a', uu____1910)
+                                                          (a', uu____1928)
                                                            in
                                                         FStar_Syntax_Syntax.NT
-                                                          uu____1903
+                                                          uu____1921
                                                          in
-                                                      let uu____1917 =
-                                                        let uu____1920 =
-                                                          let uu____1921 =
-                                                            let uu____1928 =
+                                                      let uu____1935 =
+                                                        let uu____1938 =
+                                                          let uu____1939 =
+                                                            let uu____1946 =
                                                               FStar_Syntax_Syntax.bv_to_name
                                                                 (FStar_Pervasives_Native.fst
                                                                    b)
                                                                in
-                                                            (b', uu____1928)
+                                                            (b', uu____1946)
                                                              in
                                                           FStar_Syntax_Syntax.NT
-                                                            uu____1921
+                                                            uu____1939
                                                            in
-                                                        [uu____1920]  in
-                                                      uu____1902 ::
-                                                        uu____1917
+                                                        [uu____1938]  in
+                                                      uu____1920 ::
+                                                        uu____1935
                                                        in
                                                     FStar_Syntax_Subst.subst_binders
-                                                      uu____1899
+                                                      uu____1917
                                                      in
                                                   FStar_All.pipe_right
-                                                    uu____1819 uu____1886)
-                                         | uu____1943 ->
+                                                    uu____1837 uu____1904)
+                                         | uu____1961 ->
                                              not_an_arrow_error "bind"
                                                (Prims.of_int (4)) ty r
                                           in
                                        let bs = a :: b :: rest_bs  in
-                                       let uu____1967 =
-                                         let uu____1978 =
-                                           let uu____1983 =
+                                       let uu____1985 =
+                                         let uu____1996 =
+                                           let uu____2001 =
                                              FStar_TypeChecker_Env.push_binders
                                                env bs
                                               in
-                                           let uu____1984 =
+                                           let uu____2002 =
                                              FStar_All.pipe_right
                                                (FStar_Pervasives_Native.fst a)
                                                FStar_Syntax_Syntax.bv_to_name
                                               in
-                                           fresh_repr r uu____1983 u_a
-                                             uu____1984
+                                           fresh_repr r uu____2001 u_a
+                                             uu____2002
                                             in
-                                         match uu____1978 with
+                                         match uu____1996 with
                                          | (repr1,g) ->
-                                             let uu____1999 =
-                                               let uu____2006 =
+                                             let uu____2017 =
+                                               let uu____2024 =
                                                  FStar_Syntax_Syntax.gen_bv
                                                    "f"
                                                    FStar_Pervasives_Native.None
                                                    repr1
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____2006
+                                                 uu____2024
                                                  FStar_Syntax_Syntax.mk_binder
                                                 in
-                                             (uu____1999, g)
+                                             (uu____2017, g)
                                           in
-                                       (match uu____1967 with
+                                       (match uu____1985 with
                                         | (f,guard_f) ->
-                                            let uu____2046 =
+                                            let uu____2064 =
                                               let x_a = fresh_x_a "x" a  in
-                                              let uu____2059 =
-                                                let uu____2064 =
+                                              let uu____2077 =
+                                                let uu____2082 =
                                                   FStar_TypeChecker_Env.push_binders
                                                     env
                                                     (FStar_List.append bs
                                                        [x_a])
                                                    in
-                                                let uu____2083 =
+                                                let uu____2101 =
                                                   FStar_All.pipe_right
                                                     (FStar_Pervasives_Native.fst
                                                        b)
                                                     FStar_Syntax_Syntax.bv_to_name
                                                    in
-                                                fresh_repr r uu____2064 u_b
-                                                  uu____2083
+                                                fresh_repr r uu____2082 u_b
+                                                  uu____2101
                                                  in
-                                              match uu____2059 with
+                                              match uu____2077 with
                                               | (repr1,g) ->
-                                                  let uu____2098 =
-                                                    let uu____2105 =
-                                                      let uu____2106 =
-                                                        let uu____2107 =
-                                                          let uu____2110 =
-                                                            let uu____2113 =
+                                                  let uu____2116 =
+                                                    let uu____2123 =
+                                                      let uu____2124 =
+                                                        let uu____2125 =
+                                                          let uu____2128 =
+                                                            let uu____2131 =
                                                               FStar_TypeChecker_Env.new_u_univ
                                                                 ()
                                                                in
                                                             FStar_Pervasives_Native.Some
-                                                              uu____2113
+                                                              uu____2131
                                                              in
                                                           FStar_Syntax_Syntax.mk_Total'
-                                                            repr1 uu____2110
+                                                            repr1 uu____2128
                                                            in
                                                         FStar_Syntax_Util.arrow
-                                                          [x_a] uu____2107
+                                                          [x_a] uu____2125
                                                          in
                                                       FStar_Syntax_Syntax.gen_bv
                                                         "g"
                                                         FStar_Pervasives_Native.None
-                                                        uu____2106
+                                                        uu____2124
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____2105
+                                                      uu____2123
                                                       FStar_Syntax_Syntax.mk_binder
                                                      in
-                                                  (uu____2098, g)
+                                                  (uu____2116, g)
                                                in
-                                            (match uu____2046 with
+                                            (match uu____2064 with
                                              | (g,guard_g) ->
-                                                 let uu____2165 =
-                                                   let uu____2170 =
+                                                 let uu____2183 =
+                                                   let uu____2188 =
                                                      FStar_TypeChecker_Env.push_binders
                                                        env bs
                                                       in
-                                                   let uu____2171 =
+                                                   let uu____2189 =
                                                      FStar_All.pipe_right
                                                        (FStar_Pervasives_Native.fst
                                                           b)
                                                        FStar_Syntax_Syntax.bv_to_name
                                                       in
-                                                   fresh_repr r uu____2170
-                                                     u_b uu____2171
+                                                   fresh_repr r uu____2188
+                                                     u_b uu____2189
                                                     in
-                                                 (match uu____2165 with
+                                                 (match uu____2183 with
                                                   | (repr1,guard_repr) ->
-                                                      let uu____2188 =
-                                                        let uu____2193 =
+                                                      let uu____2206 =
+                                                        let uu____2211 =
                                                           FStar_TypeChecker_Env.push_binders
                                                             env bs
                                                            in
-                                                        let uu____2194 =
+                                                        let uu____2212 =
+                                                          let uu____2214 =
+                                                            FStar_Ident.string_of_lid
+                                                              ed.FStar_Syntax_Syntax.mname
+                                                             in
                                                           FStar_Util.format1
                                                             "implicit for pure_wp in checking bind for %s"
-                                                            (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str
+                                                            uu____2214
                                                            in
                                                         pure_wp_uvar
-                                                          uu____2193 repr1
-                                                          uu____2194 r
+                                                          uu____2211 repr1
+                                                          uu____2212 r
                                                          in
-                                                      (match uu____2188 with
+                                                      (match uu____2206 with
                                                        | (pure_wp_uvar1,g_pure_wp_uvar)
                                                            ->
                                                            let k =
-                                                             let uu____2214 =
-                                                               let uu____2217
+                                                             let uu____2234 =
+                                                               let uu____2237
                                                                  =
-                                                                 let uu____2218
+                                                                 let uu____2238
                                                                    =
-                                                                   let uu____2219
+                                                                   let uu____2239
                                                                     =
                                                                     FStar_TypeChecker_Env.new_u_univ
                                                                     ()  in
-                                                                   [uu____2219]
+                                                                   [uu____2239]
                                                                     in
-                                                                 let uu____2220
+                                                                 let uu____2240
                                                                    =
-                                                                   let uu____2231
+                                                                   let uu____2251
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     pure_wp_uvar1
                                                                     FStar_Syntax_Syntax.as_arg
                                                                      in
-                                                                   [uu____2231]
+                                                                   [uu____2251]
                                                                     in
                                                                  {
                                                                    FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____2218;
+                                                                    uu____2238;
                                                                    FStar_Syntax_Syntax.effect_name
                                                                     =
                                                                     FStar_Parser_Const.effect_PURE_lid;
@@ -995,18 +1008,18 @@ let (tc_layered_eff_decl :
                                                                     = repr1;
                                                                    FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____2220;
+                                                                    uu____2240;
                                                                    FStar_Syntax_Syntax.flags
                                                                     = []
                                                                  }  in
                                                                FStar_Syntax_Syntax.mk_Comp
-                                                                 uu____2217
+                                                                 uu____2237
                                                                 in
                                                              FStar_Syntax_Util.arrow
                                                                (FStar_List.append
                                                                   bs 
                                                                   [f; g])
-                                                               uu____2214
+                                                               uu____2234
                                                               in
                                                            let guard_eq =
                                                              FStar_TypeChecker_Rel.teq
@@ -1020,8 +1033,8 @@ let (tc_layered_eff_decl :
                                                               guard_repr;
                                                               g_pure_wp_uvar;
                                                               guard_eq];
-                                                            (let uu____2290 =
-                                                               let uu____2293
+                                                            (let uu____2310 =
+                                                               let uu____2313
                                                                  =
                                                                  FStar_All.pipe_right
                                                                    k
@@ -1029,83 +1042,83 @@ let (tc_layered_eff_decl :
                                                                     env)
                                                                   in
                                                                FStar_All.pipe_right
-                                                                 uu____2293
+                                                                 uu____2313
                                                                  (FStar_Syntax_Subst.close_univ_vars
                                                                     bind_us)
                                                                 in
                                                              (bind_us,
                                                                bind_t,
-                                                               uu____2290)))))))))))
+                                                               uu____2310)))))))))))
                     in
                  log_combinator "bind_repr" bind_repr;
                  (let stronger_repr =
                     let stronger_repr =
-                      let uu____2322 =
+                      let uu____2342 =
                         FStar_All.pipe_right ed
                           FStar_Syntax_Util.get_stronger_repr
                          in
-                      FStar_All.pipe_right uu____2322 FStar_Util.must  in
+                      FStar_All.pipe_right uu____2342 FStar_Util.must  in
                     let r =
                       (FStar_Pervasives_Native.snd stronger_repr).FStar_Syntax_Syntax.pos
                        in
-                    let uu____2350 =
+                    let uu____2370 =
                       check_and_gen1 "stronger_repr" Prims.int_one
                         stronger_repr
                        in
-                    match uu____2350 with
+                    match uu____2370 with
                     | (stronger_us,stronger_t,stronger_ty) ->
-                        ((let uu____2375 =
+                        ((let uu____2395 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env0)
                               (FStar_Options.Other "LayeredEffects")
                              in
-                          if uu____2375
+                          if uu____2395
                           then
-                            let uu____2380 =
+                            let uu____2400 =
                               FStar_Syntax_Print.tscheme_to_string
                                 (stronger_us, stronger_t)
                                in
-                            let uu____2386 =
+                            let uu____2406 =
                               FStar_Syntax_Print.tscheme_to_string
                                 (stronger_us, stronger_ty)
                                in
                             FStar_Util.print2
                               "stronger combinator typechecked with term: %s and type: %s\n"
-                              uu____2380 uu____2386
+                              uu____2400 uu____2406
                           else ());
-                         (let uu____2395 =
+                         (let uu____2415 =
                             FStar_Syntax_Subst.open_univ_vars stronger_us
                               stronger_ty
                              in
-                          match uu____2395 with
+                          match uu____2415 with
                           | (us,ty) ->
                               let env =
                                 FStar_TypeChecker_Env.push_univ_vars env0 us
                                  in
                               (check_no_subtyping_for_layered_combinator env
                                  ty FStar_Pervasives_Native.None;
-                               (let uu____2416 = fresh_a_and_u_a "a"  in
-                                match uu____2416 with
+                               (let uu____2436 = fresh_a_and_u_a "a"  in
+                                match uu____2436 with
                                 | (a,u) ->
                                     let rest_bs =
-                                      let uu____2445 =
-                                        let uu____2446 =
+                                      let uu____2465 =
+                                        let uu____2466 =
                                           FStar_Syntax_Subst.compress ty  in
-                                        uu____2446.FStar_Syntax_Syntax.n  in
-                                      match uu____2445 with
+                                        uu____2466.FStar_Syntax_Syntax.n  in
+                                      match uu____2465 with
                                       | FStar_Syntax_Syntax.Tm_arrow
-                                          (bs,uu____2458) when
+                                          (bs,uu____2478) when
                                           (FStar_List.length bs) >=
                                             (Prims.of_int (2))
                                           ->
-                                          let uu____2486 =
+                                          let uu____2506 =
                                             FStar_Syntax_Subst.open_binders
                                               bs
                                              in
-                                          (match uu____2486 with
-                                           | (a',uu____2496)::bs1 ->
-                                               let uu____2516 =
-                                                 let uu____2517 =
+                                          (match uu____2506 with
+                                           | (a',uu____2516)::bs1 ->
+                                               let uu____2536 =
+                                                 let uu____2537 =
                                                    FStar_All.pipe_right bs1
                                                      (FStar_List.splitAt
                                                         ((FStar_List.length
@@ -1113,143 +1126,147 @@ let (tc_layered_eff_decl :
                                                            - Prims.int_one))
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____2517
+                                                   uu____2537
                                                    FStar_Pervasives_Native.fst
                                                   in
-                                               let uu____2615 =
-                                                 let uu____2628 =
-                                                   let uu____2631 =
-                                                     let uu____2632 =
-                                                       let uu____2639 =
+                                               let uu____2635 =
+                                                 let uu____2648 =
+                                                   let uu____2651 =
+                                                     let uu____2652 =
+                                                       let uu____2659 =
                                                          FStar_Syntax_Syntax.bv_to_name
                                                            (FStar_Pervasives_Native.fst
                                                               a)
                                                           in
-                                                       (a', uu____2639)  in
+                                                       (a', uu____2659)  in
                                                      FStar_Syntax_Syntax.NT
-                                                       uu____2632
+                                                       uu____2652
                                                       in
-                                                   [uu____2631]  in
+                                                   [uu____2651]  in
                                                  FStar_Syntax_Subst.subst_binders
-                                                   uu____2628
+                                                   uu____2648
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____2516 uu____2615)
-                                      | uu____2654 ->
+                                                 uu____2536 uu____2635)
+                                      | uu____2674 ->
                                           not_an_arrow_error "stronger"
                                             (Prims.of_int (2)) ty r
                                        in
                                     let bs = a :: rest_bs  in
-                                    let uu____2672 =
-                                      let uu____2683 =
-                                        let uu____2688 =
+                                    let uu____2692 =
+                                      let uu____2703 =
+                                        let uu____2708 =
                                           FStar_TypeChecker_Env.push_binders
                                             env bs
                                            in
-                                        let uu____2689 =
+                                        let uu____2709 =
                                           FStar_All.pipe_right
                                             (FStar_Pervasives_Native.fst a)
                                             FStar_Syntax_Syntax.bv_to_name
                                            in
-                                        fresh_repr r uu____2688 u uu____2689
+                                        fresh_repr r uu____2708 u uu____2709
                                          in
-                                      match uu____2683 with
+                                      match uu____2703 with
                                       | (repr1,g) ->
-                                          let uu____2704 =
-                                            let uu____2711 =
+                                          let uu____2724 =
+                                            let uu____2731 =
                                               FStar_Syntax_Syntax.gen_bv "f"
                                                 FStar_Pervasives_Native.None
                                                 repr1
                                                in
-                                            FStar_All.pipe_right uu____2711
+                                            FStar_All.pipe_right uu____2731
                                               FStar_Syntax_Syntax.mk_binder
                                              in
-                                          (uu____2704, g)
+                                          (uu____2724, g)
                                        in
-                                    (match uu____2672 with
+                                    (match uu____2692 with
                                      | (f,guard_f) ->
-                                         let uu____2751 =
-                                           let uu____2756 =
+                                         let uu____2771 =
+                                           let uu____2776 =
                                              FStar_TypeChecker_Env.push_binders
                                                env bs
                                               in
-                                           let uu____2757 =
+                                           let uu____2777 =
                                              FStar_All.pipe_right
                                                (FStar_Pervasives_Native.fst a)
                                                FStar_Syntax_Syntax.bv_to_name
                                               in
-                                           fresh_repr r uu____2756 u
-                                             uu____2757
+                                           fresh_repr r uu____2776 u
+                                             uu____2777
                                             in
-                                         (match uu____2751 with
+                                         (match uu____2771 with
                                           | (ret_t,guard_ret_t) ->
-                                              let uu____2774 =
-                                                let uu____2779 =
+                                              let uu____2794 =
+                                                let uu____2799 =
                                                   FStar_TypeChecker_Env.push_binders
                                                     env bs
                                                    in
-                                                let uu____2780 =
+                                                let uu____2800 =
+                                                  let uu____2802 =
+                                                    FStar_Ident.string_of_lid
+                                                      ed.FStar_Syntax_Syntax.mname
+                                                     in
                                                   FStar_Util.format1
                                                     "implicit for pure_wp in checking stronger for %s"
-                                                    (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str
+                                                    uu____2802
                                                    in
-                                                pure_wp_uvar uu____2779 ret_t
-                                                  uu____2780 r
+                                                pure_wp_uvar uu____2799 ret_t
+                                                  uu____2800 r
                                                  in
-                                              (match uu____2774 with
+                                              (match uu____2794 with
                                                | (pure_wp_uvar1,guard_wp) ->
                                                    let c =
-                                                     let uu____2798 =
-                                                       let uu____2799 =
-                                                         let uu____2800 =
+                                                     let uu____2820 =
+                                                       let uu____2821 =
+                                                         let uu____2822 =
                                                            FStar_TypeChecker_Env.new_u_univ
                                                              ()
                                                             in
-                                                         [uu____2800]  in
-                                                       let uu____2801 =
-                                                         let uu____2812 =
+                                                         [uu____2822]  in
+                                                       let uu____2823 =
+                                                         let uu____2834 =
                                                            FStar_All.pipe_right
                                                              pure_wp_uvar1
                                                              FStar_Syntax_Syntax.as_arg
                                                             in
-                                                         [uu____2812]  in
+                                                         [uu____2834]  in
                                                        {
                                                          FStar_Syntax_Syntax.comp_univs
-                                                           = uu____2799;
+                                                           = uu____2821;
                                                          FStar_Syntax_Syntax.effect_name
                                                            =
                                                            FStar_Parser_Const.effect_PURE_lid;
                                                          FStar_Syntax_Syntax.result_typ
                                                            = ret_t;
                                                          FStar_Syntax_Syntax.effect_args
-                                                           = uu____2801;
+                                                           = uu____2823;
                                                          FStar_Syntax_Syntax.flags
                                                            = []
                                                        }  in
                                                      FStar_Syntax_Syntax.mk_Comp
-                                                       uu____2798
+                                                       uu____2820
                                                       in
                                                    let k =
                                                      FStar_Syntax_Util.arrow
                                                        (FStar_List.append bs
                                                           [f]) c
                                                       in
-                                                   ((let uu____2867 =
+                                                   ((let uu____2889 =
                                                        FStar_All.pipe_left
                                                          (FStar_TypeChecker_Env.debug
                                                             env)
                                                          (FStar_Options.Other
                                                             "LayeredEffects")
                                                         in
-                                                     if uu____2867
+                                                     if uu____2889
                                                      then
-                                                       let uu____2872 =
+                                                       let uu____2894 =
                                                          FStar_Syntax_Print.term_to_string
                                                            k
                                                           in
                                                        FStar_Util.print1
                                                          "Expected type before unification: %s\n"
-                                                         uu____2872
+                                                         uu____2894
                                                      else ());
                                                     (let guard_eq =
                                                        FStar_TypeChecker_Rel.teq
@@ -1262,89 +1279,89 @@ let (tc_layered_eff_decl :
                                                        guard_ret_t;
                                                        guard_wp;
                                                        guard_eq];
-                                                     (let uu____2879 =
-                                                        let uu____2882 =
-                                                          let uu____2883 =
+                                                     (let uu____2901 =
+                                                        let uu____2904 =
+                                                          let uu____2905 =
                                                             FStar_All.pipe_right
                                                               k
                                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                                  env)
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____2883
+                                                            uu____2905
                                                             (FStar_TypeChecker_Normalize.normalize
                                                                [FStar_TypeChecker_Env.Beta;
                                                                FStar_TypeChecker_Env.Eager_unfolding]
                                                                env)
                                                            in
                                                         FStar_All.pipe_right
-                                                          uu____2882
+                                                          uu____2904
                                                           (FStar_Syntax_Subst.close_univ_vars
                                                              stronger_us)
                                                          in
                                                       (stronger_us,
                                                         stronger_t,
-                                                        uu____2879)))))))))))
+                                                        uu____2901)))))))))))
                      in
                   log_combinator "stronger_repr" stronger_repr;
                   (let if_then_else =
                      let if_then_else_ts =
-                       let uu____2914 =
+                       let uu____2936 =
                          FStar_All.pipe_right ed
                            FStar_Syntax_Util.get_layered_if_then_else_combinator
                           in
-                       FStar_All.pipe_right uu____2914 FStar_Util.must  in
+                       FStar_All.pipe_right uu____2936 FStar_Util.must  in
                      let r =
                        (FStar_Pervasives_Native.snd if_then_else_ts).FStar_Syntax_Syntax.pos
                         in
-                     let uu____2954 =
+                     let uu____2976 =
                        check_and_gen1 "if_then_else" Prims.int_one
                          if_then_else_ts
                         in
-                     match uu____2954 with
+                     match uu____2976 with
                      | (if_then_else_us,if_then_else_t,if_then_else_ty) ->
-                         let uu____2978 =
+                         let uu____3000 =
                            FStar_Syntax_Subst.open_univ_vars if_then_else_us
                              if_then_else_t
                             in
-                         (match uu____2978 with
+                         (match uu____3000 with
                           | (us,t) ->
-                              let uu____2997 =
+                              let uu____3019 =
                                 FStar_Syntax_Subst.open_univ_vars
                                   if_then_else_us if_then_else_ty
                                  in
-                              (match uu____2997 with
-                               | (uu____3014,ty) ->
+                              (match uu____3019 with
+                               | (uu____3036,ty) ->
                                    let env =
                                      FStar_TypeChecker_Env.push_univ_vars
                                        env0 us
                                       in
                                    (check_no_subtyping_for_layered_combinator
                                       env t (FStar_Pervasives_Native.Some ty);
-                                    (let uu____3018 = fresh_a_and_u_a "a"  in
-                                     match uu____3018 with
+                                    (let uu____3040 = fresh_a_and_u_a "a"  in
+                                     match uu____3040 with
                                      | (a,u_a) ->
                                          let rest_bs =
-                                           let uu____3047 =
-                                             let uu____3048 =
+                                           let uu____3069 =
+                                             let uu____3070 =
                                                FStar_Syntax_Subst.compress ty
                                                 in
-                                             uu____3048.FStar_Syntax_Syntax.n
+                                             uu____3070.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____3047 with
+                                           match uu____3069 with
                                            | FStar_Syntax_Syntax.Tm_arrow
-                                               (bs,uu____3060) when
+                                               (bs,uu____3082) when
                                                (FStar_List.length bs) >=
                                                  (Prims.of_int (4))
                                                ->
-                                               let uu____3088 =
+                                               let uu____3110 =
                                                  FStar_Syntax_Subst.open_binders
                                                    bs
                                                   in
-                                               (match uu____3088 with
-                                                | (a',uu____3098)::bs1 ->
-                                                    let uu____3118 =
-                                                      let uu____3119 =
+                                               (match uu____3110 with
+                                                | (a',uu____3120)::bs1 ->
+                                                    let uu____3140 =
+                                                      let uu____3141 =
                                                         FStar_All.pipe_right
                                                           bs1
                                                           (FStar_List.splitAt
@@ -1354,143 +1371,143 @@ let (tc_layered_eff_decl :
                                                                 (Prims.of_int (3))))
                                                          in
                                                       FStar_All.pipe_right
-                                                        uu____3119
+                                                        uu____3141
                                                         FStar_Pervasives_Native.fst
                                                        in
-                                                    let uu____3217 =
-                                                      let uu____3230 =
-                                                        let uu____3233 =
-                                                          let uu____3234 =
-                                                            let uu____3241 =
-                                                              let uu____3244
+                                                    let uu____3239 =
+                                                      let uu____3252 =
+                                                        let uu____3255 =
+                                                          let uu____3256 =
+                                                            let uu____3263 =
+                                                              let uu____3266
                                                                 =
                                                                 FStar_All.pipe_right
                                                                   a
                                                                   FStar_Pervasives_Native.fst
                                                                  in
                                                               FStar_All.pipe_right
-                                                                uu____3244
+                                                                uu____3266
                                                                 FStar_Syntax_Syntax.bv_to_name
                                                                in
-                                                            (a', uu____3241)
+                                                            (a', uu____3263)
                                                              in
                                                           FStar_Syntax_Syntax.NT
-                                                            uu____3234
+                                                            uu____3256
                                                            in
-                                                        [uu____3233]  in
+                                                        [uu____3255]  in
                                                       FStar_Syntax_Subst.subst_binders
-                                                        uu____3230
+                                                        uu____3252
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____3118 uu____3217)
-                                           | uu____3265 ->
+                                                      uu____3140 uu____3239)
+                                           | uu____3287 ->
                                                not_an_arrow_error
                                                  "if_then_else"
                                                  (Prims.of_int (4)) ty r
                                             in
                                          let bs = a :: rest_bs  in
-                                         let uu____3283 =
-                                           let uu____3294 =
-                                             let uu____3299 =
+                                         let uu____3305 =
+                                           let uu____3316 =
+                                             let uu____3321 =
                                                FStar_TypeChecker_Env.push_binders
                                                  env bs
                                                 in
-                                             let uu____3300 =
-                                               let uu____3301 =
+                                             let uu____3322 =
+                                               let uu____3323 =
                                                  FStar_All.pipe_right a
                                                    FStar_Pervasives_Native.fst
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____3301
+                                                 uu____3323
                                                  FStar_Syntax_Syntax.bv_to_name
                                                 in
-                                             fresh_repr r uu____3299 u_a
-                                               uu____3300
+                                             fresh_repr r uu____3321 u_a
+                                               uu____3322
                                               in
-                                           match uu____3294 with
+                                           match uu____3316 with
                                            | (repr1,g) ->
-                                               let uu____3322 =
-                                                 let uu____3329 =
+                                               let uu____3344 =
+                                                 let uu____3351 =
                                                    FStar_Syntax_Syntax.gen_bv
                                                      "f"
                                                      FStar_Pervasives_Native.None
                                                      repr1
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____3329
+                                                   uu____3351
                                                    FStar_Syntax_Syntax.mk_binder
                                                   in
-                                               (uu____3322, g)
+                                               (uu____3344, g)
                                             in
-                                         (match uu____3283 with
+                                         (match uu____3305 with
                                           | (f_bs,guard_f) ->
-                                              let uu____3369 =
-                                                let uu____3380 =
-                                                  let uu____3385 =
+                                              let uu____3391 =
+                                                let uu____3402 =
+                                                  let uu____3407 =
                                                     FStar_TypeChecker_Env.push_binders
                                                       env bs
                                                      in
-                                                  let uu____3386 =
-                                                    let uu____3387 =
+                                                  let uu____3408 =
+                                                    let uu____3409 =
                                                       FStar_All.pipe_right a
                                                         FStar_Pervasives_Native.fst
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____3387
+                                                      uu____3409
                                                       FStar_Syntax_Syntax.bv_to_name
                                                      in
-                                                  fresh_repr r uu____3385 u_a
-                                                    uu____3386
+                                                  fresh_repr r uu____3407 u_a
+                                                    uu____3408
                                                    in
-                                                match uu____3380 with
+                                                match uu____3402 with
                                                 | (repr1,g) ->
-                                                    let uu____3408 =
-                                                      let uu____3415 =
+                                                    let uu____3430 =
+                                                      let uu____3437 =
                                                         FStar_Syntax_Syntax.gen_bv
                                                           "g"
                                                           FStar_Pervasives_Native.None
                                                           repr1
                                                          in
                                                       FStar_All.pipe_right
-                                                        uu____3415
+                                                        uu____3437
                                                         FStar_Syntax_Syntax.mk_binder
                                                        in
-                                                    (uu____3408, g)
+                                                    (uu____3430, g)
                                                  in
-                                              (match uu____3369 with
+                                              (match uu____3391 with
                                                | (g_bs,guard_g) ->
                                                    let p_b =
-                                                     let uu____3462 =
+                                                     let uu____3484 =
                                                        FStar_Syntax_Syntax.gen_bv
                                                          "p"
                                                          FStar_Pervasives_Native.None
                                                          FStar_Syntax_Util.ktype0
                                                         in
                                                      FStar_All.pipe_right
-                                                       uu____3462
+                                                       uu____3484
                                                        FStar_Syntax_Syntax.mk_binder
                                                       in
-                                                   let uu____3470 =
-                                                     let uu____3475 =
+                                                   let uu____3492 =
+                                                     let uu____3497 =
                                                        FStar_TypeChecker_Env.push_binders
                                                          env
                                                          (FStar_List.append
                                                             bs [p_b])
                                                         in
-                                                     let uu____3494 =
-                                                       let uu____3495 =
+                                                     let uu____3516 =
+                                                       let uu____3517 =
                                                          FStar_All.pipe_right
                                                            a
                                                            FStar_Pervasives_Native.fst
                                                           in
                                                        FStar_All.pipe_right
-                                                         uu____3495
+                                                         uu____3517
                                                          FStar_Syntax_Syntax.bv_to_name
                                                         in
-                                                     fresh_repr r uu____3475
-                                                       u_a uu____3494
+                                                     fresh_repr r uu____3497
+                                                       u_a uu____3516
                                                       in
-                                                   (match uu____3470 with
+                                                   (match uu____3492 with
                                                     | (t_body,guard_body) ->
                                                         let k =
                                                           FStar_Syntax_Util.abs
@@ -1513,148 +1530,148 @@ let (tc_layered_eff_decl :
                                                            (FStar_List.iter
                                                               (FStar_TypeChecker_Rel.force_trivial_guard
                                                                  env));
-                                                         (let uu____3555 =
-                                                            let uu____3558 =
+                                                         (let uu____3577 =
+                                                            let uu____3580 =
                                                               FStar_All.pipe_right
                                                                 k
                                                                 (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                                    env)
                                                                in
                                                             FStar_All.pipe_right
-                                                              uu____3558
+                                                              uu____3580
                                                               (FStar_Syntax_Subst.close_univ_vars
                                                                  if_then_else_us)
                                                              in
                                                           (if_then_else_us,
-                                                            uu____3555,
+                                                            uu____3577,
                                                             if_then_else_ty))))))))))
                       in
                    log_combinator "if_then_else" if_then_else;
                    (let r =
-                      let uu____3571 =
-                        let uu____3574 =
-                          let uu____3583 =
+                      let uu____3593 =
+                        let uu____3596 =
+                          let uu____3605 =
                             FStar_All.pipe_right ed
                               FStar_Syntax_Util.get_layered_if_then_else_combinator
                              in
-                          FStar_All.pipe_right uu____3583 FStar_Util.must  in
-                        FStar_All.pipe_right uu____3574
+                          FStar_All.pipe_right uu____3605 FStar_Util.must  in
+                        FStar_All.pipe_right uu____3596
                           FStar_Pervasives_Native.snd
                          in
-                      uu____3571.FStar_Syntax_Syntax.pos  in
-                    let uu____3644 = if_then_else  in
-                    match uu____3644 with
-                    | (ite_us,ite_t,uu____3659) ->
-                        let uu____3672 =
+                      uu____3593.FStar_Syntax_Syntax.pos  in
+                    let uu____3666 = if_then_else  in
+                    match uu____3666 with
+                    | (ite_us,ite_t,uu____3681) ->
+                        let uu____3694 =
                           FStar_Syntax_Subst.open_univ_vars ite_us ite_t  in
-                        (match uu____3672 with
+                        (match uu____3694 with
                          | (us,ite_t1) ->
-                             let uu____3679 =
-                               let uu____3694 =
-                                 let uu____3695 =
+                             let uu____3701 =
+                               let uu____3716 =
+                                 let uu____3717 =
                                    FStar_Syntax_Subst.compress ite_t1  in
-                                 uu____3695.FStar_Syntax_Syntax.n  in
-                               match uu____3694 with
+                                 uu____3717.FStar_Syntax_Syntax.n  in
+                               match uu____3716 with
                                | FStar_Syntax_Syntax.Tm_abs
-                                   (bs,uu____3713,uu____3714) ->
+                                   (bs,uu____3735,uu____3736) ->
                                    let bs1 =
                                      FStar_Syntax_Subst.open_binders bs  in
-                                   let uu____3740 =
-                                     let uu____3753 =
-                                       let uu____3758 =
-                                         let uu____3761 =
-                                           let uu____3770 =
+                                   let uu____3762 =
+                                     let uu____3775 =
+                                       let uu____3780 =
+                                         let uu____3783 =
+                                           let uu____3792 =
                                              FStar_All.pipe_right bs1
                                                (FStar_List.splitAt
                                                   ((FStar_List.length bs1) -
                                                      (Prims.of_int (3))))
                                               in
-                                           FStar_All.pipe_right uu____3770
+                                           FStar_All.pipe_right uu____3792
                                              FStar_Pervasives_Native.snd
                                             in
-                                         FStar_All.pipe_right uu____3761
+                                         FStar_All.pipe_right uu____3783
                                            (FStar_List.map
                                               FStar_Pervasives_Native.fst)
                                           in
-                                       FStar_All.pipe_right uu____3758
+                                       FStar_All.pipe_right uu____3780
                                          (FStar_List.map
                                             FStar_Syntax_Syntax.bv_to_name)
                                         in
-                                     FStar_All.pipe_right uu____3753
+                                     FStar_All.pipe_right uu____3775
                                        (fun l  ->
-                                          let uu____3926 = l  in
-                                          match uu____3926 with
+                                          let uu____3948 = l  in
+                                          match uu____3948 with
                                           | f::g::p::[] -> (f, g, p))
                                       in
-                                   (match uu____3740 with
+                                   (match uu____3762 with
                                     | (f,g,p) ->
-                                        let uu____3995 =
-                                          let uu____3996 =
+                                        let uu____4017 =
+                                          let uu____4018 =
                                             FStar_TypeChecker_Env.push_univ_vars
                                               env0 us
                                              in
                                           FStar_TypeChecker_Env.push_binders
-                                            uu____3996 bs1
+                                            uu____4018 bs1
                                            in
-                                        let uu____3997 =
-                                          let uu____3998 =
-                                            let uu____4003 =
-                                              let uu____4004 =
-                                                let uu____4007 =
+                                        let uu____4019 =
+                                          let uu____4020 =
+                                            let uu____4025 =
+                                              let uu____4026 =
+                                                let uu____4029 =
                                                   FStar_All.pipe_right bs1
                                                     (FStar_List.map
                                                        FStar_Pervasives_Native.fst)
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____4007
+                                                  uu____4029
                                                   (FStar_List.map
                                                      FStar_Syntax_Syntax.bv_to_name)
                                                  in
-                                              FStar_All.pipe_right uu____4004
+                                              FStar_All.pipe_right uu____4026
                                                 (FStar_List.map
                                                    FStar_Syntax_Syntax.as_arg)
                                                in
                                             FStar_Syntax_Syntax.mk_Tm_app
-                                              ite_t1 uu____4003
+                                              ite_t1 uu____4025
                                              in
-                                          uu____3998
+                                          uu____4020
                                             FStar_Pervasives_Native.None r
                                            in
-                                        (uu____3995, uu____3997, f, g, p))
-                               | uu____4038 ->
+                                        (uu____4017, uu____4019, f, g, p))
+                               | uu____4060 ->
                                    failwith
                                      "Impossible! ite_t must have been an abstraction with at least 3 binders"
                                 in
-                             (match uu____3679 with
+                             (match uu____3701 with
                               | (env,ite_t_applied,f_t,g_t,p_t) ->
-                                  let uu____4067 =
-                                    let uu____4076 = stronger_repr  in
-                                    match uu____4076 with
-                                    | (uu____4097,subcomp_t,subcomp_ty) ->
-                                        let uu____4112 =
+                                  let uu____4089 =
+                                    let uu____4098 = stronger_repr  in
+                                    match uu____4098 with
+                                    | (uu____4119,subcomp_t,subcomp_ty) ->
+                                        let uu____4134 =
                                           FStar_Syntax_Subst.open_univ_vars
                                             us subcomp_t
                                            in
-                                        (match uu____4112 with
-                                         | (uu____4125,subcomp_t1) ->
-                                             let uu____4127 =
-                                               let uu____4138 =
+                                        (match uu____4134 with
+                                         | (uu____4147,subcomp_t1) ->
+                                             let uu____4149 =
+                                               let uu____4160 =
                                                  FStar_Syntax_Subst.open_univ_vars
                                                    us subcomp_ty
                                                   in
-                                               match uu____4138 with
-                                               | (uu____4153,subcomp_ty1) ->
-                                                   let uu____4155 =
-                                                     let uu____4156 =
+                                               match uu____4160 with
+                                               | (uu____4175,subcomp_ty1) ->
+                                                   let uu____4177 =
+                                                     let uu____4178 =
                                                        FStar_Syntax_Subst.compress
                                                          subcomp_ty1
                                                         in
-                                                     uu____4156.FStar_Syntax_Syntax.n
+                                                     uu____4178.FStar_Syntax_Syntax.n
                                                       in
-                                                   (match uu____4155 with
+                                                   (match uu____4177 with
                                                     | FStar_Syntax_Syntax.Tm_arrow
-                                                        (bs,uu____4170) ->
-                                                        let uu____4191 =
+                                                        (bs,uu____4192) ->
+                                                        let uu____4213 =
                                                           FStar_All.pipe_right
                                                             bs
                                                             (FStar_List.splitAt
@@ -1663,34 +1680,34 @@ let (tc_layered_eff_decl :
                                                                   -
                                                                   Prims.int_one))
                                                            in
-                                                        (match uu____4191
+                                                        (match uu____4213
                                                          with
                                                          | (bs_except_last,last_b)
                                                              ->
-                                                             let uu____4297 =
+                                                             let uu____4319 =
                                                                FStar_All.pipe_right
                                                                  bs_except_last
                                                                  (FStar_List.map
                                                                     FStar_Pervasives_Native.snd)
                                                                 in
-                                                             let uu____4324 =
-                                                               let uu____4327
+                                                             let uu____4346 =
+                                                               let uu____4349
                                                                  =
                                                                  FStar_All.pipe_right
                                                                    last_b
                                                                    FStar_List.hd
                                                                   in
                                                                FStar_All.pipe_right
-                                                                 uu____4327
+                                                                 uu____4349
                                                                  FStar_Pervasives_Native.snd
                                                                 in
-                                                             (uu____4297,
-                                                               uu____4324))
-                                                    | uu____4370 ->
+                                                             (uu____4319,
+                                                               uu____4346))
+                                                    | uu____4392 ->
                                                         failwith
                                                           "Impossible! subcomp_ty must have been an arrow with at lease 1 binder")
                                                 in
-                                             (match uu____4127 with
+                                             (match uu____4149 with
                                               | (aqs_except_last,last_aq) ->
                                                   let aux t =
                                                     let tun_args =
@@ -1709,102 +1726,102 @@ let (tc_layered_eff_decl :
                                                       FStar_Pervasives_Native.None
                                                       r
                                                      in
-                                                  let uu____4483 = aux f_t
+                                                  let uu____4505 = aux f_t
                                                      in
-                                                  let uu____4486 = aux g_t
+                                                  let uu____4508 = aux g_t
                                                      in
-                                                  (uu____4483, uu____4486)))
+                                                  (uu____4505, uu____4508)))
                                      in
-                                  (match uu____4067 with
+                                  (match uu____4089 with
                                    | (subcomp_f,subcomp_g) ->
-                                       let uu____4503 =
+                                       let uu____4525 =
                                          let aux t =
-                                           let uu____4520 =
-                                             let uu____4527 =
-                                               let uu____4528 =
-                                                 let uu____4555 =
-                                                   let uu____4572 =
-                                                     let uu____4581 =
+                                           let uu____4542 =
+                                             let uu____4549 =
+                                               let uu____4550 =
+                                                 let uu____4577 =
+                                                   let uu____4594 =
+                                                     let uu____4603 =
                                                        FStar_Syntax_Syntax.mk_Total
                                                          ite_t_applied
                                                         in
                                                      FStar_Util.Inr
-                                                       uu____4581
+                                                       uu____4603
                                                       in
-                                                   (uu____4572,
+                                                   (uu____4594,
                                                      FStar_Pervasives_Native.None)
                                                     in
-                                                 (t, uu____4555,
+                                                 (t, uu____4577,
                                                    FStar_Pervasives_Native.None)
                                                   in
                                                FStar_Syntax_Syntax.Tm_ascribed
-                                                 uu____4528
+                                                 uu____4550
                                                 in
                                              FStar_Syntax_Syntax.mk
-                                               uu____4527
+                                               uu____4549
                                               in
-                                           uu____4520
+                                           uu____4542
                                              FStar_Pervasives_Native.None r
                                             in
-                                         let uu____4622 = aux subcomp_f  in
-                                         let uu____4623 = aux subcomp_g  in
-                                         (uu____4622, uu____4623)  in
-                                       (match uu____4503 with
+                                         let uu____4644 = aux subcomp_f  in
+                                         let uu____4645 = aux subcomp_g  in
+                                         (uu____4644, uu____4645)  in
+                                       (match uu____4525 with
                                         | (tm_subcomp_ascribed_f,tm_subcomp_ascribed_g)
                                             ->
-                                            ((let uu____4627 =
+                                            ((let uu____4649 =
                                                 FStar_All.pipe_left
                                                   (FStar_TypeChecker_Env.debug
                                                      env)
                                                   (FStar_Options.Other
                                                      "LayeredEffects")
                                                  in
-                                              if uu____4627
+                                              if uu____4649
                                               then
-                                                let uu____4632 =
+                                                let uu____4654 =
                                                   FStar_Syntax_Print.term_to_string
                                                     tm_subcomp_ascribed_f
                                                    in
-                                                let uu____4634 =
+                                                let uu____4656 =
                                                   FStar_Syntax_Print.term_to_string
                                                     tm_subcomp_ascribed_g
                                                    in
                                                 FStar_Util.print2
                                                   "Checking the soundness of the if_then_else combinators, f: %s, g: %s\n"
-                                                  uu____4632 uu____4634
+                                                  uu____4654 uu____4656
                                               else ());
-                                             (let uu____4639 =
+                                             (let uu____4661 =
                                                 FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                   env tm_subcomp_ascribed_f
                                                  in
-                                              match uu____4639 with
-                                              | (uu____4646,uu____4647,g_f)
+                                              match uu____4661 with
+                                              | (uu____4668,uu____4669,g_f)
                                                   ->
                                                   let g_f1 =
-                                                    let uu____4650 =
+                                                    let uu____4672 =
                                                       FStar_TypeChecker_Env.guard_of_guard_formula
                                                         (FStar_TypeChecker_Common.NonTrivial
                                                            p_t)
                                                        in
                                                     FStar_TypeChecker_Env.imp_guard
-                                                      uu____4650 g_f
+                                                      uu____4672 g_f
                                                      in
                                                   (FStar_TypeChecker_Rel.force_trivial_guard
                                                      env g_f1;
-                                                   (let uu____4652 =
+                                                   (let uu____4674 =
                                                       FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                         env
                                                         tm_subcomp_ascribed_g
                                                        in
-                                                    match uu____4652 with
-                                                    | (uu____4659,uu____4660,g_g)
+                                                    match uu____4674 with
+                                                    | (uu____4681,uu____4682,g_g)
                                                         ->
                                                         let g_g1 =
                                                           let not_p =
-                                                            let uu____4666 =
-                                                              let uu____4671
+                                                            let uu____4688 =
+                                                              let uu____4693
                                                                 =
-                                                                let uu____4672
+                                                                let uu____4694
                                                                   =
                                                                   FStar_Syntax_Syntax.lid_as_fv
                                                                     FStar_Parser_Const.not_lid
@@ -1812,34 +1829,34 @@ let (tc_layered_eff_decl :
                                                                     FStar_Pervasives_Native.None
                                                                    in
                                                                 FStar_All.pipe_right
-                                                                  uu____4672
+                                                                  uu____4694
                                                                   FStar_Syntax_Syntax.fv_to_tm
                                                                  in
-                                                              let uu____4673
+                                                              let uu____4695
                                                                 =
-                                                                let uu____4674
+                                                                let uu____4696
                                                                   =
                                                                   FStar_All.pipe_right
                                                                     p_t
                                                                     FStar_Syntax_Syntax.as_arg
                                                                    in
-                                                                [uu____4674]
+                                                                [uu____4696]
                                                                  in
                                                               FStar_Syntax_Syntax.mk_Tm_app
-                                                                uu____4671
-                                                                uu____4673
+                                                                uu____4693
+                                                                uu____4695
                                                                in
-                                                            uu____4666
+                                                            uu____4688
                                                               FStar_Pervasives_Native.None
                                                               r
                                                              in
-                                                          let uu____4707 =
+                                                          let uu____4729 =
                                                             FStar_TypeChecker_Env.guard_of_guard_formula
                                                               (FStar_TypeChecker_Common.NonTrivial
                                                                  not_p)
                                                              in
                                                           FStar_TypeChecker_Env.imp_guard
-                                                            uu____4707 g_g
+                                                            uu____4729 g_g
                                                            in
                                                         FStar_TypeChecker_Rel.force_trivial_guard
                                                           env g_g1)))))))));
@@ -1853,277 +1870,283 @@ let (tc_layered_eff_decl :
                            act.FStar_Syntax_Syntax.action_params)
                           <> Prims.int_zero
                       then
-                        (let uu____4731 =
-                           let uu____4737 =
-                             let uu____4739 =
+                        (let uu____4753 =
+                           let uu____4759 =
+                             let uu____4761 =
+                               FStar_Ident.string_of_lid
+                                 ed.FStar_Syntax_Syntax.mname
+                                in
+                             let uu____4763 =
+                               FStar_Ident.string_of_lid
+                                 act.FStar_Syntax_Syntax.action_name
+                                in
+                             let uu____4765 =
                                FStar_Syntax_Print.binders_to_string "; "
                                  act.FStar_Syntax_Syntax.action_params
                                 in
                              FStar_Util.format3
                                "Action %s:%s has non-empty action params (%s)"
-                               (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                               (act.FStar_Syntax_Syntax.action_name).FStar_Ident.str
-                               uu____4739
+                               uu____4761 uu____4763 uu____4765
                               in
                            (FStar_Errors.Fatal_MalformedActionDeclaration,
-                             uu____4737)
+                             uu____4759)
                             in
-                         FStar_Errors.raise_error uu____4731 r)
+                         FStar_Errors.raise_error uu____4753 r)
                       else ();
-                      (let uu____4746 =
-                         let uu____4751 =
+                      (let uu____4772 =
+                         let uu____4777 =
                            FStar_Syntax_Subst.univ_var_opening
                              act.FStar_Syntax_Syntax.action_univs
                             in
-                         match uu____4751 with
+                         match uu____4777 with
                          | (usubst,us) ->
-                             let uu____4774 =
+                             let uu____4800 =
                                FStar_TypeChecker_Env.push_univ_vars env us
                                 in
-                             let uu____4775 =
-                               let uu___452_4776 = act  in
-                               let uu____4777 =
+                             let uu____4801 =
+                               let uu___452_4802 = act  in
+                               let uu____4803 =
                                  FStar_Syntax_Subst.subst usubst
                                    act.FStar_Syntax_Syntax.action_defn
                                   in
-                               let uu____4778 =
+                               let uu____4804 =
                                  FStar_Syntax_Subst.subst usubst
                                    act.FStar_Syntax_Syntax.action_typ
                                   in
                                {
                                  FStar_Syntax_Syntax.action_name =
-                                   (uu___452_4776.FStar_Syntax_Syntax.action_name);
+                                   (uu___452_4802.FStar_Syntax_Syntax.action_name);
                                  FStar_Syntax_Syntax.action_unqualified_name
                                    =
-                                   (uu___452_4776.FStar_Syntax_Syntax.action_unqualified_name);
+                                   (uu___452_4802.FStar_Syntax_Syntax.action_unqualified_name);
                                  FStar_Syntax_Syntax.action_univs = us;
                                  FStar_Syntax_Syntax.action_params =
-                                   (uu___452_4776.FStar_Syntax_Syntax.action_params);
-                                 FStar_Syntax_Syntax.action_defn = uu____4777;
-                                 FStar_Syntax_Syntax.action_typ = uu____4778
+                                   (uu___452_4802.FStar_Syntax_Syntax.action_params);
+                                 FStar_Syntax_Syntax.action_defn = uu____4803;
+                                 FStar_Syntax_Syntax.action_typ = uu____4804
                                }  in
-                             (uu____4774, uu____4775)
+                             (uu____4800, uu____4801)
                           in
-                       match uu____4746 with
+                       match uu____4772 with
                        | (env1,act1) ->
                            let act_typ =
-                             let uu____4782 =
-                               let uu____4783 =
+                             let uu____4808 =
+                               let uu____4809 =
                                  FStar_Syntax_Subst.compress
                                    act1.FStar_Syntax_Syntax.action_typ
                                   in
-                               uu____4783.FStar_Syntax_Syntax.n  in
-                             match uu____4782 with
+                               uu____4809.FStar_Syntax_Syntax.n  in
+                             match uu____4808 with
                              | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                                  let ct =
                                    FStar_Syntax_Util.comp_to_comp_typ c  in
-                                 let uu____4809 =
+                                 let uu____4835 =
                                    FStar_Ident.lid_equals
                                      ct.FStar_Syntax_Syntax.effect_name
                                      ed.FStar_Syntax_Syntax.mname
                                     in
-                                 if uu____4809
+                                 if uu____4835
                                  then
                                    let repr_ts =
-                                     let uu____4813 = repr  in
-                                     match uu____4813 with
-                                     | (us,t,uu____4828) -> (us, t)  in
+                                     let uu____4839 = repr  in
+                                     match uu____4839 with
+                                     | (us,t,uu____4854) -> (us, t)  in
                                    let repr1 =
-                                     let uu____4846 =
+                                     let uu____4872 =
                                        FStar_TypeChecker_Env.inst_tscheme_with
                                          repr_ts
                                          ct.FStar_Syntax_Syntax.comp_univs
                                         in
-                                     FStar_All.pipe_right uu____4846
+                                     FStar_All.pipe_right uu____4872
                                        FStar_Pervasives_Native.snd
                                       in
                                    let repr2 =
-                                     let uu____4858 =
-                                       let uu____4863 =
-                                         let uu____4864 =
+                                     let uu____4884 =
+                                       let uu____4889 =
+                                         let uu____4890 =
                                            FStar_Syntax_Syntax.as_arg
                                              ct.FStar_Syntax_Syntax.result_typ
                                             in
-                                         uu____4864 ::
+                                         uu____4890 ::
                                            (ct.FStar_Syntax_Syntax.effect_args)
                                           in
                                        FStar_Syntax_Syntax.mk_Tm_app repr1
-                                         uu____4863
+                                         uu____4889
                                         in
-                                     uu____4858 FStar_Pervasives_Native.None
+                                     uu____4884 FStar_Pervasives_Native.None
                                        r
                                       in
                                    let c1 =
-                                     let uu____4882 =
-                                       let uu____4885 =
+                                     let uu____4908 =
+                                       let uu____4911 =
                                          FStar_TypeChecker_Env.new_u_univ ()
                                           in
                                        FStar_Pervasives_Native.Some
-                                         uu____4885
+                                         uu____4911
                                         in
                                      FStar_Syntax_Syntax.mk_Total' repr2
-                                       uu____4882
+                                       uu____4908
                                       in
                                    FStar_Syntax_Util.arrow bs c1
                                  else act1.FStar_Syntax_Syntax.action_typ
-                             | uu____4888 ->
+                             | uu____4914 ->
                                  act1.FStar_Syntax_Syntax.action_typ
                               in
-                           let uu____4889 =
+                           let uu____4915 =
                              FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                env1 act_typ
                               in
-                           (match uu____4889 with
-                            | (act_typ1,uu____4897,g_t) ->
-                                let uu____4899 =
-                                  let uu____4906 =
-                                    let uu___477_4907 =
+                           (match uu____4915 with
+                            | (act_typ1,uu____4923,g_t) ->
+                                let uu____4925 =
+                                  let uu____4932 =
+                                    let uu___477_4933 =
                                       FStar_TypeChecker_Env.set_expected_typ
                                         env1 act_typ1
                                        in
                                     {
                                       FStar_TypeChecker_Env.solver =
-                                        (uu___477_4907.FStar_TypeChecker_Env.solver);
+                                        (uu___477_4933.FStar_TypeChecker_Env.solver);
                                       FStar_TypeChecker_Env.range =
-                                        (uu___477_4907.FStar_TypeChecker_Env.range);
+                                        (uu___477_4933.FStar_TypeChecker_Env.range);
                                       FStar_TypeChecker_Env.curmodule =
-                                        (uu___477_4907.FStar_TypeChecker_Env.curmodule);
+                                        (uu___477_4933.FStar_TypeChecker_Env.curmodule);
                                       FStar_TypeChecker_Env.gamma =
-                                        (uu___477_4907.FStar_TypeChecker_Env.gamma);
+                                        (uu___477_4933.FStar_TypeChecker_Env.gamma);
                                       FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___477_4907.FStar_TypeChecker_Env.gamma_sig);
+                                        (uu___477_4933.FStar_TypeChecker_Env.gamma_sig);
                                       FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___477_4907.FStar_TypeChecker_Env.gamma_cache);
+                                        (uu___477_4933.FStar_TypeChecker_Env.gamma_cache);
                                       FStar_TypeChecker_Env.modules =
-                                        (uu___477_4907.FStar_TypeChecker_Env.modules);
+                                        (uu___477_4933.FStar_TypeChecker_Env.modules);
                                       FStar_TypeChecker_Env.expected_typ =
-                                        (uu___477_4907.FStar_TypeChecker_Env.expected_typ);
+                                        (uu___477_4933.FStar_TypeChecker_Env.expected_typ);
                                       FStar_TypeChecker_Env.sigtab =
-                                        (uu___477_4907.FStar_TypeChecker_Env.sigtab);
+                                        (uu___477_4933.FStar_TypeChecker_Env.sigtab);
                                       FStar_TypeChecker_Env.attrtab =
-                                        (uu___477_4907.FStar_TypeChecker_Env.attrtab);
+                                        (uu___477_4933.FStar_TypeChecker_Env.attrtab);
                                       FStar_TypeChecker_Env.instantiate_imp =
                                         false;
                                       FStar_TypeChecker_Env.effects =
-                                        (uu___477_4907.FStar_TypeChecker_Env.effects);
+                                        (uu___477_4933.FStar_TypeChecker_Env.effects);
                                       FStar_TypeChecker_Env.generalize =
-                                        (uu___477_4907.FStar_TypeChecker_Env.generalize);
+                                        (uu___477_4933.FStar_TypeChecker_Env.generalize);
                                       FStar_TypeChecker_Env.letrecs =
-                                        (uu___477_4907.FStar_TypeChecker_Env.letrecs);
+                                        (uu___477_4933.FStar_TypeChecker_Env.letrecs);
                                       FStar_TypeChecker_Env.top_level =
-                                        (uu___477_4907.FStar_TypeChecker_Env.top_level);
+                                        (uu___477_4933.FStar_TypeChecker_Env.top_level);
                                       FStar_TypeChecker_Env.check_uvars =
-                                        (uu___477_4907.FStar_TypeChecker_Env.check_uvars);
+                                        (uu___477_4933.FStar_TypeChecker_Env.check_uvars);
                                       FStar_TypeChecker_Env.use_eq =
-                                        (uu___477_4907.FStar_TypeChecker_Env.use_eq);
+                                        (uu___477_4933.FStar_TypeChecker_Env.use_eq);
                                       FStar_TypeChecker_Env.use_eq_strict =
-                                        (uu___477_4907.FStar_TypeChecker_Env.use_eq_strict);
+                                        (uu___477_4933.FStar_TypeChecker_Env.use_eq_strict);
                                       FStar_TypeChecker_Env.is_iface =
-                                        (uu___477_4907.FStar_TypeChecker_Env.is_iface);
+                                        (uu___477_4933.FStar_TypeChecker_Env.is_iface);
                                       FStar_TypeChecker_Env.admit =
-                                        (uu___477_4907.FStar_TypeChecker_Env.admit);
+                                        (uu___477_4933.FStar_TypeChecker_Env.admit);
                                       FStar_TypeChecker_Env.lax =
-                                        (uu___477_4907.FStar_TypeChecker_Env.lax);
+                                        (uu___477_4933.FStar_TypeChecker_Env.lax);
                                       FStar_TypeChecker_Env.lax_universes =
-                                        (uu___477_4907.FStar_TypeChecker_Env.lax_universes);
+                                        (uu___477_4933.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 =
-                                        (uu___477_4907.FStar_TypeChecker_Env.phase1);
+                                        (uu___477_4933.FStar_TypeChecker_Env.phase1);
                                       FStar_TypeChecker_Env.failhard =
-                                        (uu___477_4907.FStar_TypeChecker_Env.failhard);
+                                        (uu___477_4933.FStar_TypeChecker_Env.failhard);
                                       FStar_TypeChecker_Env.nosynth =
-                                        (uu___477_4907.FStar_TypeChecker_Env.nosynth);
+                                        (uu___477_4933.FStar_TypeChecker_Env.nosynth);
                                       FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___477_4907.FStar_TypeChecker_Env.uvar_subtyping);
+                                        (uu___477_4933.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.tc_term =
-                                        (uu___477_4907.FStar_TypeChecker_Env.tc_term);
+                                        (uu___477_4933.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.type_of =
-                                        (uu___477_4907.FStar_TypeChecker_Env.type_of);
+                                        (uu___477_4933.FStar_TypeChecker_Env.type_of);
                                       FStar_TypeChecker_Env.universe_of =
-                                        (uu___477_4907.FStar_TypeChecker_Env.universe_of);
+                                        (uu___477_4933.FStar_TypeChecker_Env.universe_of);
                                       FStar_TypeChecker_Env.check_type_of =
-                                        (uu___477_4907.FStar_TypeChecker_Env.check_type_of);
+                                        (uu___477_4933.FStar_TypeChecker_Env.check_type_of);
                                       FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___477_4907.FStar_TypeChecker_Env.use_bv_sorts);
+                                        (uu___477_4933.FStar_TypeChecker_Env.use_bv_sorts);
                                       FStar_TypeChecker_Env.qtbl_name_and_index
                                         =
-                                        (uu___477_4907.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                        (uu___477_4933.FStar_TypeChecker_Env.qtbl_name_and_index);
                                       FStar_TypeChecker_Env.normalized_eff_names
                                         =
-                                        (uu___477_4907.FStar_TypeChecker_Env.normalized_eff_names);
+                                        (uu___477_4933.FStar_TypeChecker_Env.normalized_eff_names);
                                       FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___477_4907.FStar_TypeChecker_Env.fv_delta_depths);
+                                        (uu___477_4933.FStar_TypeChecker_Env.fv_delta_depths);
                                       FStar_TypeChecker_Env.proof_ns =
-                                        (uu___477_4907.FStar_TypeChecker_Env.proof_ns);
+                                        (uu___477_4933.FStar_TypeChecker_Env.proof_ns);
                                       FStar_TypeChecker_Env.synth_hook =
-                                        (uu___477_4907.FStar_TypeChecker_Env.synth_hook);
+                                        (uu___477_4933.FStar_TypeChecker_Env.synth_hook);
                                       FStar_TypeChecker_Env.try_solve_implicits_hook
                                         =
-                                        (uu___477_4907.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                        (uu___477_4933.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                       FStar_TypeChecker_Env.splice =
-                                        (uu___477_4907.FStar_TypeChecker_Env.splice);
+                                        (uu___477_4933.FStar_TypeChecker_Env.splice);
                                       FStar_TypeChecker_Env.mpreprocess =
-                                        (uu___477_4907.FStar_TypeChecker_Env.mpreprocess);
+                                        (uu___477_4933.FStar_TypeChecker_Env.mpreprocess);
                                       FStar_TypeChecker_Env.postprocess =
-                                        (uu___477_4907.FStar_TypeChecker_Env.postprocess);
+                                        (uu___477_4933.FStar_TypeChecker_Env.postprocess);
                                       FStar_TypeChecker_Env.is_native_tactic
                                         =
-                                        (uu___477_4907.FStar_TypeChecker_Env.is_native_tactic);
+                                        (uu___477_4933.FStar_TypeChecker_Env.is_native_tactic);
                                       FStar_TypeChecker_Env.identifier_info =
-                                        (uu___477_4907.FStar_TypeChecker_Env.identifier_info);
+                                        (uu___477_4933.FStar_TypeChecker_Env.identifier_info);
                                       FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___477_4907.FStar_TypeChecker_Env.tc_hooks);
+                                        (uu___477_4933.FStar_TypeChecker_Env.tc_hooks);
                                       FStar_TypeChecker_Env.dsenv =
-                                        (uu___477_4907.FStar_TypeChecker_Env.dsenv);
+                                        (uu___477_4933.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.nbe =
-                                        (uu___477_4907.FStar_TypeChecker_Env.nbe);
+                                        (uu___477_4933.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___477_4907.FStar_TypeChecker_Env.strict_args_tab);
+                                        (uu___477_4933.FStar_TypeChecker_Env.strict_args_tab);
                                       FStar_TypeChecker_Env.erasable_types_tab
                                         =
-                                        (uu___477_4907.FStar_TypeChecker_Env.erasable_types_tab)
+                                        (uu___477_4933.FStar_TypeChecker_Env.erasable_types_tab)
                                     }  in
                                   FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                    uu____4906
+                                    uu____4932
                                     act1.FStar_Syntax_Syntax.action_defn
                                    in
-                                (match uu____4899 with
-                                 | (act_defn,uu____4910,g_d) ->
-                                     ((let uu____4913 =
+                                (match uu____4925 with
+                                 | (act_defn,uu____4936,g_d) ->
+                                     ((let uu____4939 =
                                          FStar_All.pipe_left
                                            (FStar_TypeChecker_Env.debug env1)
                                            (FStar_Options.Other
                                               "LayeredEffects")
                                           in
-                                       if uu____4913
+                                       if uu____4939
                                        then
-                                         let uu____4918 =
+                                         let uu____4944 =
                                            FStar_Syntax_Print.term_to_string
                                              act_defn
                                             in
-                                         let uu____4920 =
+                                         let uu____4946 =
                                            FStar_Syntax_Print.term_to_string
                                              act_typ1
                                             in
                                          FStar_Util.print2
                                            "Typechecked action definition: %s and action type: %s\n"
-                                           uu____4918 uu____4920
+                                           uu____4944 uu____4946
                                        else ());
-                                      (let uu____4925 =
+                                      (let uu____4951 =
                                          let act_typ2 =
                                            FStar_TypeChecker_Normalize.normalize
                                              [FStar_TypeChecker_Env.Beta]
                                              env1 act_typ1
                                             in
-                                         let uu____4933 =
-                                           let uu____4934 =
+                                         let uu____4959 =
+                                           let uu____4960 =
                                              FStar_Syntax_Subst.compress
                                                act_typ2
                                               in
-                                           uu____4934.FStar_Syntax_Syntax.n
+                                           uu____4960.FStar_Syntax_Syntax.n
                                             in
-                                         match uu____4933 with
+                                         match uu____4959 with
                                          | FStar_Syntax_Syntax.Tm_arrow
-                                             (bs,uu____4944) ->
+                                             (bs,uu____4970) ->
                                              let bs1 =
                                                FStar_Syntax_Subst.open_binders
                                                  bs
@@ -2132,99 +2155,113 @@ let (tc_layered_eff_decl :
                                                FStar_TypeChecker_Env.push_binders
                                                  env1 bs1
                                                 in
-                                             let uu____4967 =
+                                             let uu____4993 =
                                                FStar_Syntax_Util.type_u ()
                                                 in
-                                             (match uu____4967 with
+                                             (match uu____4993 with
                                               | (t,u) ->
                                                   let reason =
+                                                    let uu____5008 =
+                                                      FStar_Ident.string_of_lid
+                                                        ed.FStar_Syntax_Syntax.mname
+                                                       in
+                                                    let uu____5010 =
+                                                      FStar_Ident.string_of_lid
+                                                        act1.FStar_Syntax_Syntax.action_name
+                                                       in
                                                     FStar_Util.format2
                                                       "implicit for return type of action %s:%s"
-                                                      (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                                                      (act1.FStar_Syntax_Syntax.action_name).FStar_Ident.str
+                                                      uu____5008 uu____5010
                                                      in
-                                                  let uu____4983 =
+                                                  let uu____5013 =
                                                     FStar_TypeChecker_Util.new_implicit_var
                                                       reason r env2 t
                                                      in
-                                                  (match uu____4983 with
-                                                   | (a_tm,uu____5003,g_tm)
+                                                  (match uu____5013 with
+                                                   | (a_tm,uu____5033,g_tm)
                                                        ->
-                                                       let uu____5017 =
+                                                       let uu____5047 =
                                                          fresh_repr r env2 u
                                                            a_tm
                                                           in
-                                                       (match uu____5017 with
+                                                       (match uu____5047 with
                                                         | (repr1,g) ->
-                                                            let uu____5030 =
-                                                              let uu____5033
+                                                            let uu____5060 =
+                                                              let uu____5063
                                                                 =
-                                                                let uu____5036
+                                                                let uu____5066
                                                                   =
-                                                                  let uu____5039
+                                                                  let uu____5069
                                                                     =
                                                                     FStar_TypeChecker_Env.new_u_univ
                                                                     ()  in
                                                                   FStar_All.pipe_right
-                                                                    uu____5039
+                                                                    uu____5069
                                                                     (
                                                                     fun
-                                                                    uu____5042
+                                                                    uu____5072
                                                                      ->
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____5042)
+                                                                    uu____5072)
                                                                    in
                                                                 FStar_Syntax_Syntax.mk_Total'
                                                                   repr1
-                                                                  uu____5036
+                                                                  uu____5066
                                                                  in
                                                               FStar_Syntax_Util.arrow
                                                                 bs1
-                                                                uu____5033
+                                                                uu____5063
                                                                in
-                                                            let uu____5043 =
+                                                            let uu____5073 =
                                                               FStar_TypeChecker_Env.conj_guard
                                                                 g g_tm
                                                                in
-                                                            (uu____5030,
-                                                              uu____5043))))
-                                         | uu____5046 ->
-                                             let uu____5047 =
-                                               let uu____5053 =
-                                                 let uu____5055 =
+                                                            (uu____5060,
+                                                              uu____5073))))
+                                         | uu____5076 ->
+                                             let uu____5077 =
+                                               let uu____5083 =
+                                                 let uu____5085 =
+                                                   FStar_Ident.string_of_lid
+                                                     ed.FStar_Syntax_Syntax.mname
+                                                    in
+                                                 let uu____5087 =
+                                                   FStar_Ident.string_of_lid
+                                                     act1.FStar_Syntax_Syntax.action_name
+                                                    in
+                                                 let uu____5089 =
                                                    FStar_Syntax_Print.term_to_string
                                                      act_typ2
                                                     in
                                                  FStar_Util.format3
                                                    "Unexpected non-function type for action %s:%s (%s)"
-                                                   (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                                                   (act1.FStar_Syntax_Syntax.action_name).FStar_Ident.str
-                                                   uu____5055
+                                                   uu____5085 uu____5087
+                                                   uu____5089
                                                   in
                                                (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                 uu____5053)
+                                                 uu____5083)
                                                 in
                                              FStar_Errors.raise_error
-                                               uu____5047 r
+                                               uu____5077 r
                                           in
-                                       match uu____4925 with
+                                       match uu____4951 with
                                        | (k,g_k) ->
-                                           ((let uu____5072 =
+                                           ((let uu____5106 =
                                                FStar_All.pipe_left
                                                  (FStar_TypeChecker_Env.debug
                                                     env1)
                                                  (FStar_Options.Other
                                                     "LayeredEffects")
                                                 in
-                                             if uu____5072
+                                             if uu____5106
                                              then
-                                               let uu____5077 =
+                                               let uu____5111 =
                                                  FStar_Syntax_Print.term_to_string
                                                    k
                                                   in
                                                FStar_Util.print1
                                                  "Expected action type: %s\n"
-                                                 uu____5077
+                                                 uu____5111
                                              else ());
                                             (let g =
                                                FStar_TypeChecker_Rel.teq env1
@@ -2233,105 +2270,112 @@ let (tc_layered_eff_decl :
                                              FStar_List.iter
                                                (FStar_TypeChecker_Rel.force_trivial_guard
                                                   env1) [g_t; g_d; g_k; g];
-                                             (let uu____5085 =
+                                             (let uu____5119 =
                                                 FStar_All.pipe_left
                                                   (FStar_TypeChecker_Env.debug
                                                      env1)
                                                   (FStar_Options.Other
                                                      "LayeredEffects")
                                                  in
-                                              if uu____5085
+                                              if uu____5119
                                               then
-                                                let uu____5090 =
+                                                let uu____5124 =
                                                   FStar_Syntax_Print.term_to_string
                                                     k
                                                    in
                                                 FStar_Util.print1
                                                   "Expected action type after unification: %s\n"
-                                                  uu____5090
+                                                  uu____5124
                                               else ());
                                              (let act_typ2 =
                                                 let err_msg t =
-                                                  let uu____5103 =
+                                                  let uu____5137 =
+                                                    FStar_Ident.string_of_lid
+                                                      ed.FStar_Syntax_Syntax.mname
+                                                     in
+                                                  let uu____5139 =
+                                                    FStar_Ident.string_of_lid
+                                                      act1.FStar_Syntax_Syntax.action_name
+                                                     in
+                                                  let uu____5141 =
                                                     FStar_Syntax_Print.term_to_string
                                                       t
                                                      in
                                                   FStar_Util.format3
                                                     "Unexpected (k-)type of action %s:%s, expected bs -> repr<u> i_1 ... i_n, found: %s"
-                                                    (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                                                    (act1.FStar_Syntax_Syntax.action_name).FStar_Ident.str
-                                                    uu____5103
+                                                    uu____5137 uu____5139
+                                                    uu____5141
                                                    in
                                                 let repr_args t =
-                                                  let uu____5124 =
-                                                    let uu____5125 =
+                                                  let uu____5162 =
+                                                    let uu____5163 =
                                                       FStar_Syntax_Subst.compress
                                                         t
                                                        in
-                                                    uu____5125.FStar_Syntax_Syntax.n
+                                                    uu____5163.FStar_Syntax_Syntax.n
                                                      in
-                                                  match uu____5124 with
+                                                  match uu____5162 with
                                                   | FStar_Syntax_Syntax.Tm_app
                                                       (head,a::is) ->
-                                                      let uu____5177 =
-                                                        let uu____5178 =
+                                                      let uu____5215 =
+                                                        let uu____5216 =
                                                           FStar_Syntax_Subst.compress
                                                             head
                                                            in
-                                                        uu____5178.FStar_Syntax_Syntax.n
+                                                        uu____5216.FStar_Syntax_Syntax.n
                                                          in
-                                                      (match uu____5177 with
+                                                      (match uu____5215 with
                                                        | FStar_Syntax_Syntax.Tm_uinst
-                                                           (uu____5187,us) ->
+                                                           (uu____5225,us) ->
                                                            (us,
                                                              (FStar_Pervasives_Native.fst
                                                                 a), is)
-                                                       | uu____5197 ->
-                                                           let uu____5198 =
-                                                             let uu____5204 =
+                                                       | uu____5235 ->
+                                                           let uu____5236 =
+                                                             let uu____5242 =
                                                                err_msg t  in
                                                              (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                               uu____5204)
+                                                               uu____5242)
                                                               in
                                                            FStar_Errors.raise_error
-                                                             uu____5198 r)
-                                                  | uu____5213 ->
-                                                      let uu____5214 =
-                                                        let uu____5220 =
+                                                             uu____5236 r)
+                                                  | uu____5251 ->
+                                                      let uu____5252 =
+                                                        let uu____5258 =
                                                           err_msg t  in
                                                         (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                          uu____5220)
+                                                          uu____5258)
                                                          in
                                                       FStar_Errors.raise_error
-                                                        uu____5214 r
+                                                        uu____5252 r
                                                    in
                                                 let k1 =
                                                   FStar_TypeChecker_Normalize.normalize
                                                     [FStar_TypeChecker_Env.Beta]
                                                     env1 k
                                                    in
-                                                let uu____5230 =
-                                                  let uu____5231 =
+                                                let uu____5268 =
+                                                  let uu____5269 =
                                                     FStar_Syntax_Subst.compress
                                                       k1
                                                      in
-                                                  uu____5231.FStar_Syntax_Syntax.n
+                                                  uu____5269.FStar_Syntax_Syntax.n
                                                    in
-                                                match uu____5230 with
+                                                match uu____5268 with
                                                 | FStar_Syntax_Syntax.Tm_arrow
                                                     (bs,c) ->
-                                                    let uu____5256 =
+                                                    let uu____5294 =
                                                       FStar_Syntax_Subst.open_comp
                                                         bs c
                                                        in
-                                                    (match uu____5256 with
+                                                    (match uu____5294 with
                                                      | (bs1,c1) ->
-                                                         let uu____5263 =
+                                                         let uu____5301 =
                                                            repr_args
                                                              (FStar_Syntax_Util.comp_result
                                                                 c1)
                                                             in
-                                                         (match uu____5263
+                                                         (match uu____5301
                                                           with
                                                           | (us,a,is) ->
                                                               let ct =
@@ -2349,77 +2393,77 @@ let (tc_layered_eff_decl :
                                                                   FStar_Syntax_Syntax.flags
                                                                     = []
                                                                 }  in
-                                                              let uu____5274
+                                                              let uu____5312
                                                                 =
                                                                 FStar_Syntax_Syntax.mk_Comp
                                                                   ct
                                                                  in
                                                               FStar_Syntax_Util.arrow
                                                                 bs1
-                                                                uu____5274))
-                                                | uu____5277 ->
-                                                    let uu____5278 =
-                                                      let uu____5284 =
+                                                                uu____5312))
+                                                | uu____5315 ->
+                                                    let uu____5316 =
+                                                      let uu____5322 =
                                                         err_msg k1  in
                                                       (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                        uu____5284)
+                                                        uu____5322)
                                                        in
                                                     FStar_Errors.raise_error
-                                                      uu____5278 r
+                                                      uu____5316 r
                                                  in
-                                              (let uu____5288 =
+                                              (let uu____5326 =
                                                  FStar_All.pipe_left
                                                    (FStar_TypeChecker_Env.debug
                                                       env1)
                                                    (FStar_Options.Other
                                                       "LayeredEffects")
                                                   in
-                                               if uu____5288
+                                               if uu____5326
                                                then
-                                                 let uu____5293 =
+                                                 let uu____5331 =
                                                    FStar_Syntax_Print.term_to_string
                                                      act_typ2
                                                     in
                                                  FStar_Util.print1
                                                    "Action type after injecting it into the monad: %s\n"
-                                                   uu____5293
+                                                   uu____5331
                                                else ());
                                               (let act2 =
-                                                 let uu____5299 =
+                                                 let uu____5337 =
                                                    FStar_TypeChecker_Util.generalize_universes
                                                      env1 act_defn
                                                     in
-                                                 match uu____5299 with
+                                                 match uu____5337 with
                                                  | (us,act_defn1) ->
                                                      if
                                                        act1.FStar_Syntax_Syntax.action_univs
                                                          = []
                                                      then
-                                                       let uu___550_5313 =
+                                                       let uu___550_5351 =
                                                          act1  in
-                                                       let uu____5314 =
+                                                       let uu____5352 =
                                                          FStar_Syntax_Subst.close_univ_vars
                                                            us act_typ2
                                                           in
                                                        {
                                                          FStar_Syntax_Syntax.action_name
                                                            =
-                                                           (uu___550_5313.FStar_Syntax_Syntax.action_name);
+                                                           (uu___550_5351.FStar_Syntax_Syntax.action_name);
                                                          FStar_Syntax_Syntax.action_unqualified_name
                                                            =
-                                                           (uu___550_5313.FStar_Syntax_Syntax.action_unqualified_name);
+                                                           (uu___550_5351.FStar_Syntax_Syntax.action_unqualified_name);
                                                          FStar_Syntax_Syntax.action_univs
                                                            = us;
                                                          FStar_Syntax_Syntax.action_params
                                                            =
-                                                           (uu___550_5313.FStar_Syntax_Syntax.action_params);
+                                                           (uu___550_5351.FStar_Syntax_Syntax.action_params);
                                                          FStar_Syntax_Syntax.action_defn
                                                            = act_defn1;
                                                          FStar_Syntax_Syntax.action_typ
-                                                           = uu____5314
+                                                           = uu____5352
                                                        }
                                                      else
-                                                       (let uu____5317 =
+                                                       (let uu____5355 =
                                                           ((FStar_List.length
                                                               us)
                                                              =
@@ -2429,21 +2473,21 @@ let (tc_layered_eff_decl :
                                                             (FStar_List.forall2
                                                                (fun u1  ->
                                                                   fun u2  ->
-                                                                    let uu____5324
+                                                                    let uu____5362
                                                                     =
                                                                     FStar_Syntax_Syntax.order_univ_name
                                                                     u1 u2  in
-                                                                    uu____5324
+                                                                    uu____5362
                                                                     =
                                                                     Prims.int_zero)
                                                                us
                                                                act1.FStar_Syntax_Syntax.action_univs)
                                                            in
-                                                        if uu____5317
+                                                        if uu____5355
                                                         then
-                                                          let uu___555_5329 =
+                                                          let uu___555_5367 =
                                                             act1  in
-                                                          let uu____5330 =
+                                                          let uu____5368 =
                                                             FStar_Syntax_Subst.close_univ_vars
                                                               act1.FStar_Syntax_Syntax.action_univs
                                                               act_typ2
@@ -2451,90 +2495,100 @@ let (tc_layered_eff_decl :
                                                           {
                                                             FStar_Syntax_Syntax.action_name
                                                               =
-                                                              (uu___555_5329.FStar_Syntax_Syntax.action_name);
+                                                              (uu___555_5367.FStar_Syntax_Syntax.action_name);
                                                             FStar_Syntax_Syntax.action_unqualified_name
                                                               =
-                                                              (uu___555_5329.FStar_Syntax_Syntax.action_unqualified_name);
+                                                              (uu___555_5367.FStar_Syntax_Syntax.action_unqualified_name);
                                                             FStar_Syntax_Syntax.action_univs
                                                               =
-                                                              (uu___555_5329.FStar_Syntax_Syntax.action_univs);
+                                                              (uu___555_5367.FStar_Syntax_Syntax.action_univs);
                                                             FStar_Syntax_Syntax.action_params
                                                               =
-                                                              (uu___555_5329.FStar_Syntax_Syntax.action_params);
+                                                              (uu___555_5367.FStar_Syntax_Syntax.action_params);
                                                             FStar_Syntax_Syntax.action_defn
                                                               = act_defn1;
                                                             FStar_Syntax_Syntax.action_typ
-                                                              = uu____5330
+                                                              = uu____5368
                                                           }
                                                         else
-                                                          (let uu____5333 =
-                                                             let uu____5339 =
-                                                               let uu____5341
+                                                          (let uu____5371 =
+                                                             let uu____5377 =
+                                                               let uu____5379
+                                                                 =
+                                                                 FStar_Ident.string_of_lid
+                                                                   ed.FStar_Syntax_Syntax.mname
+                                                                  in
+                                                               let uu____5381
+                                                                 =
+                                                                 FStar_Ident.string_of_lid
+                                                                   act1.FStar_Syntax_Syntax.action_name
+                                                                  in
+                                                               let uu____5383
                                                                  =
                                                                  FStar_Syntax_Print.univ_names_to_string
                                                                    us
                                                                   in
-                                                               let uu____5343
+                                                               let uu____5385
                                                                  =
                                                                  FStar_Syntax_Print.univ_names_to_string
                                                                    act1.FStar_Syntax_Syntax.action_univs
                                                                   in
                                                                FStar_Util.format4
                                                                  "Expected and generalized universes in the declaration for %s:%s are different, input: %s, but after gen: %s"
-                                                                 (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                                                                 (act1.FStar_Syntax_Syntax.action_name).FStar_Ident.str
-                                                                 uu____5341
-                                                                 uu____5343
+                                                                 uu____5379
+                                                                 uu____5381
+                                                                 uu____5383
+                                                                 uu____5385
                                                                 in
                                                              (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                                               uu____5339)
+                                                               uu____5377)
                                                               in
                                                            FStar_Errors.raise_error
-                                                             uu____5333 r))
+                                                             uu____5371 r))
                                                   in
                                                act2)))))))))
                        in
-                    let tschemes_of uu____5368 =
-                      match uu____5368 with
+                    let tschemes_of uu____5410 =
+                      match uu____5410 with
                       | (us,t,ty) -> ((us, t), (us, ty))  in
                     let combinators =
-                      let uu____5413 =
-                        let uu____5414 = tschemes_of repr  in
-                        let uu____5419 = tschemes_of return_repr  in
-                        let uu____5424 = tschemes_of bind_repr  in
-                        let uu____5429 = tschemes_of stronger_repr  in
-                        let uu____5434 = tschemes_of if_then_else  in
+                      let uu____5455 =
+                        let uu____5456 = tschemes_of repr  in
+                        let uu____5461 = tschemes_of return_repr  in
+                        let uu____5466 = tschemes_of bind_repr  in
+                        let uu____5471 = tschemes_of stronger_repr  in
+                        let uu____5476 = tschemes_of if_then_else  in
                         {
                           FStar_Syntax_Syntax.l_base_effect =
                             underlying_effect_lid;
-                          FStar_Syntax_Syntax.l_repr = uu____5414;
-                          FStar_Syntax_Syntax.l_return = uu____5419;
-                          FStar_Syntax_Syntax.l_bind = uu____5424;
-                          FStar_Syntax_Syntax.l_subcomp = uu____5429;
-                          FStar_Syntax_Syntax.l_if_then_else = uu____5434
+                          FStar_Syntax_Syntax.l_repr = uu____5456;
+                          FStar_Syntax_Syntax.l_return = uu____5461;
+                          FStar_Syntax_Syntax.l_bind = uu____5466;
+                          FStar_Syntax_Syntax.l_subcomp = uu____5471;
+                          FStar_Syntax_Syntax.l_if_then_else = uu____5476
                         }  in
-                      FStar_Syntax_Syntax.Layered_eff uu____5413  in
-                    let uu___564_5439 = ed  in
-                    let uu____5440 =
+                      FStar_Syntax_Syntax.Layered_eff uu____5455  in
+                    let uu___564_5481 = ed  in
+                    let uu____5482 =
                       FStar_List.map (tc_action env0)
                         ed.FStar_Syntax_Syntax.actions
                        in
                     {
                       FStar_Syntax_Syntax.mname =
-                        (uu___564_5439.FStar_Syntax_Syntax.mname);
+                        (uu___564_5481.FStar_Syntax_Syntax.mname);
                       FStar_Syntax_Syntax.cattributes =
-                        (uu___564_5439.FStar_Syntax_Syntax.cattributes);
+                        (uu___564_5481.FStar_Syntax_Syntax.cattributes);
                       FStar_Syntax_Syntax.univs =
-                        (uu___564_5439.FStar_Syntax_Syntax.univs);
+                        (uu___564_5481.FStar_Syntax_Syntax.univs);
                       FStar_Syntax_Syntax.binders =
-                        (uu___564_5439.FStar_Syntax_Syntax.binders);
+                        (uu___564_5481.FStar_Syntax_Syntax.binders);
                       FStar_Syntax_Syntax.signature =
-                        (let uu____5447 = signature  in
-                         match uu____5447 with | (us,t,uu____5462) -> (us, t));
+                        (let uu____5489 = signature  in
+                         match uu____5489 with | (us,t,uu____5504) -> (us, t));
                       FStar_Syntax_Syntax.combinators = combinators;
-                      FStar_Syntax_Syntax.actions = uu____5440;
+                      FStar_Syntax_Syntax.actions = uu____5482;
                       FStar_Syntax_Syntax.eff_attrs =
-                        (uu___564_5439.FStar_Syntax_Syntax.eff_attrs)
+                        (uu___564_5481.FStar_Syntax_Syntax.eff_attrs)
                     }))))))))
   
 let (tc_non_layered_eff_decl :
@@ -2546,241 +2600,244 @@ let (tc_non_layered_eff_decl :
   fun env0  ->
     fun ed  ->
       fun _quals  ->
-        (let uu____5500 =
+        (let uu____5542 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
              (FStar_Options.Other "ED")
             in
-         if uu____5500
+         if uu____5542
          then
-           let uu____5505 = FStar_Syntax_Print.eff_decl_to_string false ed
+           let uu____5547 = FStar_Syntax_Print.eff_decl_to_string false ed
               in
-           FStar_Util.print1 "Typechecking eff_decl: \n\t%s\n" uu____5505
+           FStar_Util.print1 "Typechecking eff_decl: \n\t%s\n" uu____5547
          else ());
-        (let uu____5511 =
-           let uu____5516 =
+        (let uu____5553 =
+           let uu____5558 =
              FStar_Syntax_Subst.univ_var_opening ed.FStar_Syntax_Syntax.univs
               in
-           match uu____5516 with
+           match uu____5558 with
            | (ed_univs_subst,ed_univs) ->
                let bs =
-                 let uu____5540 =
+                 let uu____5582 =
                    FStar_Syntax_Subst.subst_binders ed_univs_subst
                      ed.FStar_Syntax_Syntax.binders
                     in
-                 FStar_Syntax_Subst.open_binders uu____5540  in
-               let uu____5541 =
-                 let uu____5548 =
+                 FStar_Syntax_Subst.open_binders uu____5582  in
+               let uu____5583 =
+                 let uu____5590 =
                    FStar_TypeChecker_Env.push_univ_vars env0 ed_univs  in
-                 FStar_TypeChecker_TcTerm.tc_tparams uu____5548 bs  in
-               (match uu____5541 with
-                | (bs1,uu____5554,uu____5555) ->
-                    let uu____5556 =
+                 FStar_TypeChecker_TcTerm.tc_tparams uu____5590 bs  in
+               (match uu____5583 with
+                | (bs1,uu____5596,uu____5597) ->
+                    let uu____5598 =
                       let tmp_t =
-                        let uu____5566 =
-                          let uu____5569 =
+                        let uu____5608 =
+                          let uu____5611 =
                             FStar_All.pipe_right FStar_Syntax_Syntax.U_zero
-                              (fun uu____5574  ->
-                                 FStar_Pervasives_Native.Some uu____5574)
+                              (fun uu____5616  ->
+                                 FStar_Pervasives_Native.Some uu____5616)
                              in
                           FStar_Syntax_Syntax.mk_Total'
-                            FStar_Syntax_Syntax.t_unit uu____5569
+                            FStar_Syntax_Syntax.t_unit uu____5611
                            in
-                        FStar_Syntax_Util.arrow bs1 uu____5566  in
-                      let uu____5575 =
+                        FStar_Syntax_Util.arrow bs1 uu____5608  in
+                      let uu____5617 =
                         FStar_TypeChecker_Util.generalize_universes env0
                           tmp_t
                          in
-                      match uu____5575 with
+                      match uu____5617 with
                       | (us,tmp_t1) ->
-                          let uu____5592 =
-                            let uu____5593 =
-                              let uu____5594 =
+                          let uu____5634 =
+                            let uu____5635 =
+                              let uu____5636 =
                                 FStar_All.pipe_right tmp_t1
                                   FStar_Syntax_Util.arrow_formals
                                  in
-                              FStar_All.pipe_right uu____5594
+                              FStar_All.pipe_right uu____5636
                                 FStar_Pervasives_Native.fst
                                in
-                            FStar_All.pipe_right uu____5593
+                            FStar_All.pipe_right uu____5635
                               FStar_Syntax_Subst.close_binders
                              in
-                          (us, uu____5592)
+                          (us, uu____5634)
                        in
-                    (match uu____5556 with
+                    (match uu____5598 with
                      | (us,bs2) ->
                          (match ed_univs with
                           | [] -> (us, bs2)
-                          | uu____5631 ->
-                              let uu____5634 =
+                          | uu____5673 ->
+                              let uu____5676 =
                                 ((FStar_List.length ed_univs) =
                                    (FStar_List.length us))
                                   &&
                                   (FStar_List.forall2
                                      (fun u1  ->
                                         fun u2  ->
-                                          let uu____5641 =
+                                          let uu____5683 =
                                             FStar_Syntax_Syntax.order_univ_name
                                               u1 u2
                                              in
-                                          uu____5641 = Prims.int_zero)
+                                          uu____5683 = Prims.int_zero)
                                      ed_univs us)
                                  in
-                              if uu____5634
+                              if uu____5676
                               then (us, bs2)
                               else
-                                (let uu____5652 =
-                                   let uu____5658 =
-                                     let uu____5660 =
+                                (let uu____5694 =
+                                   let uu____5700 =
+                                     let uu____5702 =
+                                       FStar_Ident.string_of_lid
+                                         ed.FStar_Syntax_Syntax.mname
+                                        in
+                                     let uu____5704 =
                                        FStar_Util.string_of_int
                                          (FStar_List.length ed_univs)
                                         in
-                                     let uu____5662 =
+                                     let uu____5706 =
                                        FStar_Util.string_of_int
                                          (FStar_List.length us)
                                         in
                                      FStar_Util.format3
                                        "Expected and generalized universes in effect declaration for %s are different, expected: %s, but found %s"
-                                       (ed.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                                       uu____5660 uu____5662
+                                       uu____5702 uu____5704 uu____5706
                                       in
                                    (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                     uu____5658)
+                                     uu____5700)
                                     in
-                                 let uu____5666 =
+                                 let uu____5710 =
                                    FStar_Ident.range_of_lid
                                      ed.FStar_Syntax_Syntax.mname
                                     in
-                                 FStar_Errors.raise_error uu____5652
-                                   uu____5666))))
+                                 FStar_Errors.raise_error uu____5694
+                                   uu____5710))))
             in
-         match uu____5511 with
+         match uu____5553 with
          | (us,bs) ->
              let ed1 =
-               let uu___598_5674 = ed  in
+               let uu___598_5718 = ed  in
                {
                  FStar_Syntax_Syntax.mname =
-                   (uu___598_5674.FStar_Syntax_Syntax.mname);
+                   (uu___598_5718.FStar_Syntax_Syntax.mname);
                  FStar_Syntax_Syntax.cattributes =
-                   (uu___598_5674.FStar_Syntax_Syntax.cattributes);
+                   (uu___598_5718.FStar_Syntax_Syntax.cattributes);
                  FStar_Syntax_Syntax.univs = us;
                  FStar_Syntax_Syntax.binders = bs;
                  FStar_Syntax_Syntax.signature =
-                   (uu___598_5674.FStar_Syntax_Syntax.signature);
+                   (uu___598_5718.FStar_Syntax_Syntax.signature);
                  FStar_Syntax_Syntax.combinators =
-                   (uu___598_5674.FStar_Syntax_Syntax.combinators);
+                   (uu___598_5718.FStar_Syntax_Syntax.combinators);
                  FStar_Syntax_Syntax.actions =
-                   (uu___598_5674.FStar_Syntax_Syntax.actions);
+                   (uu___598_5718.FStar_Syntax_Syntax.actions);
                  FStar_Syntax_Syntax.eff_attrs =
-                   (uu___598_5674.FStar_Syntax_Syntax.eff_attrs)
+                   (uu___598_5718.FStar_Syntax_Syntax.eff_attrs)
                }  in
-             let uu____5675 = FStar_Syntax_Subst.univ_var_opening us  in
-             (match uu____5675 with
+             let uu____5719 = FStar_Syntax_Subst.univ_var_opening us  in
+             (match uu____5719 with
               | (ed_univs_subst,ed_univs) ->
-                  let uu____5694 =
-                    let uu____5699 =
+                  let uu____5738 =
+                    let uu____5743 =
                       FStar_Syntax_Subst.subst_binders ed_univs_subst bs  in
-                    FStar_Syntax_Subst.open_binders' uu____5699  in
-                  (match uu____5694 with
+                    FStar_Syntax_Subst.open_binders' uu____5743  in
+                  (match uu____5738 with
                    | (ed_bs,ed_bs_subst) ->
                        let ed2 =
-                         let op uu____5720 =
-                           match uu____5720 with
+                         let op uu____5764 =
+                           match uu____5764 with
                            | (us1,t) ->
                                let t1 =
-                                 let uu____5740 =
+                                 let uu____5784 =
                                    FStar_Syntax_Subst.shift_subst
                                      ((FStar_List.length ed_bs) +
                                         (FStar_List.length us1))
                                      ed_univs_subst
                                     in
-                                 FStar_Syntax_Subst.subst uu____5740 t  in
-                               let uu____5749 =
-                                 let uu____5750 =
+                                 FStar_Syntax_Subst.subst uu____5784 t  in
+                               let uu____5793 =
+                                 let uu____5794 =
                                    FStar_Syntax_Subst.shift_subst
                                      (FStar_List.length us1) ed_bs_subst
                                     in
-                                 FStar_Syntax_Subst.subst uu____5750 t1  in
-                               (us1, uu____5749)
+                                 FStar_Syntax_Subst.subst uu____5794 t1  in
+                               (us1, uu____5793)
                             in
-                         let uu___612_5755 = ed1  in
-                         let uu____5756 =
+                         let uu___612_5799 = ed1  in
+                         let uu____5800 =
                            op ed1.FStar_Syntax_Syntax.signature  in
-                         let uu____5757 =
+                         let uu____5801 =
                            FStar_Syntax_Util.apply_eff_combinators op
                              ed1.FStar_Syntax_Syntax.combinators
                             in
-                         let uu____5758 =
+                         let uu____5802 =
                            FStar_List.map
                              (fun a  ->
-                                let uu___615_5766 = a  in
-                                let uu____5767 =
-                                  let uu____5768 =
+                                let uu___615_5810 = a  in
+                                let uu____5811 =
+                                  let uu____5812 =
                                     op
                                       ((a.FStar_Syntax_Syntax.action_univs),
                                         (a.FStar_Syntax_Syntax.action_defn))
                                      in
-                                  FStar_Pervasives_Native.snd uu____5768  in
-                                let uu____5779 =
-                                  let uu____5780 =
+                                  FStar_Pervasives_Native.snd uu____5812  in
+                                let uu____5823 =
+                                  let uu____5824 =
                                     op
                                       ((a.FStar_Syntax_Syntax.action_univs),
                                         (a.FStar_Syntax_Syntax.action_typ))
                                      in
-                                  FStar_Pervasives_Native.snd uu____5780  in
+                                  FStar_Pervasives_Native.snd uu____5824  in
                                 {
                                   FStar_Syntax_Syntax.action_name =
-                                    (uu___615_5766.FStar_Syntax_Syntax.action_name);
+                                    (uu___615_5810.FStar_Syntax_Syntax.action_name);
                                   FStar_Syntax_Syntax.action_unqualified_name
                                     =
-                                    (uu___615_5766.FStar_Syntax_Syntax.action_unqualified_name);
+                                    (uu___615_5810.FStar_Syntax_Syntax.action_unqualified_name);
                                   FStar_Syntax_Syntax.action_univs =
-                                    (uu___615_5766.FStar_Syntax_Syntax.action_univs);
+                                    (uu___615_5810.FStar_Syntax_Syntax.action_univs);
                                   FStar_Syntax_Syntax.action_params =
-                                    (uu___615_5766.FStar_Syntax_Syntax.action_params);
+                                    (uu___615_5810.FStar_Syntax_Syntax.action_params);
                                   FStar_Syntax_Syntax.action_defn =
-                                    uu____5767;
-                                  FStar_Syntax_Syntax.action_typ = uu____5779
+                                    uu____5811;
+                                  FStar_Syntax_Syntax.action_typ = uu____5823
                                 }) ed1.FStar_Syntax_Syntax.actions
                             in
                          {
                            FStar_Syntax_Syntax.mname =
-                             (uu___612_5755.FStar_Syntax_Syntax.mname);
+                             (uu___612_5799.FStar_Syntax_Syntax.mname);
                            FStar_Syntax_Syntax.cattributes =
-                             (uu___612_5755.FStar_Syntax_Syntax.cattributes);
+                             (uu___612_5799.FStar_Syntax_Syntax.cattributes);
                            FStar_Syntax_Syntax.univs =
-                             (uu___612_5755.FStar_Syntax_Syntax.univs);
+                             (uu___612_5799.FStar_Syntax_Syntax.univs);
                            FStar_Syntax_Syntax.binders =
-                             (uu___612_5755.FStar_Syntax_Syntax.binders);
-                           FStar_Syntax_Syntax.signature = uu____5756;
-                           FStar_Syntax_Syntax.combinators = uu____5757;
-                           FStar_Syntax_Syntax.actions = uu____5758;
+                             (uu___612_5799.FStar_Syntax_Syntax.binders);
+                           FStar_Syntax_Syntax.signature = uu____5800;
+                           FStar_Syntax_Syntax.combinators = uu____5801;
+                           FStar_Syntax_Syntax.actions = uu____5802;
                            FStar_Syntax_Syntax.eff_attrs =
-                             (uu___612_5755.FStar_Syntax_Syntax.eff_attrs)
+                             (uu___612_5799.FStar_Syntax_Syntax.eff_attrs)
                          }  in
-                       ((let uu____5792 =
+                       ((let uu____5836 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env0)
                              (FStar_Options.Other "ED")
                             in
-                         if uu____5792
+                         if uu____5836
                          then
-                           let uu____5797 =
+                           let uu____5841 =
                              FStar_Syntax_Print.eff_decl_to_string false ed2
                               in
                            FStar_Util.print1
                              "After typechecking binders eff_decl: \n\t%s\n"
-                             uu____5797
+                             uu____5841
                          else ());
                         (let env =
-                           let uu____5804 =
+                           let uu____5848 =
                              FStar_TypeChecker_Env.push_univ_vars env0
                                ed_univs
                               in
-                           FStar_TypeChecker_Env.push_binders uu____5804
+                           FStar_TypeChecker_Env.push_binders uu____5848
                              ed_bs
                             in
-                         let check_and_gen' comb n env_opt uu____5839 k =
-                           match uu____5839 with
+                         let check_and_gen' comb n env_opt uu____5883 k =
+                           match uu____5883 with
                            | (us1,t) ->
                                let env1 =
                                  if FStar_Util.is_some env_opt
@@ -2788,59 +2845,63 @@ let (tc_non_layered_eff_decl :
                                    FStar_All.pipe_right env_opt
                                      FStar_Util.must
                                  else env  in
-                               let uu____5859 =
+                               let uu____5903 =
                                  FStar_Syntax_Subst.open_univ_vars us1 t  in
-                               (match uu____5859 with
+                               (match uu____5903 with
                                 | (us2,t1) ->
                                     let t2 =
                                       match k with
                                       | FStar_Pervasives_Native.Some k1 ->
-                                          let uu____5868 =
+                                          let uu____5912 =
                                             FStar_TypeChecker_Env.push_univ_vars
                                               env1 us2
                                              in
                                           FStar_TypeChecker_TcTerm.tc_check_trivial_guard
-                                            uu____5868 t1 k1
+                                            uu____5912 t1 k1
                                       | FStar_Pervasives_Native.None  ->
-                                          let uu____5869 =
-                                            let uu____5876 =
+                                          let uu____5913 =
+                                            let uu____5920 =
                                               FStar_TypeChecker_Env.push_univ_vars
                                                 env1 us2
                                                in
                                             FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                              uu____5876 t1
+                                              uu____5920 t1
                                              in
-                                          (match uu____5869 with
-                                           | (t2,uu____5878,g) ->
+                                          (match uu____5913 with
+                                           | (t2,uu____5922,g) ->
                                                (FStar_TypeChecker_Rel.force_trivial_guard
                                                   env1 g;
                                                 t2))
                                        in
-                                    let uu____5881 =
+                                    let uu____5925 =
                                       FStar_TypeChecker_Util.generalize_universes
                                         env1 t2
                                        in
-                                    (match uu____5881 with
+                                    (match uu____5925 with
                                      | (g_us,t3) ->
                                          (if (FStar_List.length g_us) <> n
                                           then
                                             (let error =
-                                               let uu____5897 =
+                                               let uu____5941 =
+                                                 FStar_Ident.string_of_lid
+                                                   ed2.FStar_Syntax_Syntax.mname
+                                                  in
+                                               let uu____5943 =
                                                  FStar_Util.string_of_int n
                                                   in
-                                               let uu____5899 =
-                                                 let uu____5901 =
+                                               let uu____5945 =
+                                                 let uu____5947 =
                                                    FStar_All.pipe_right g_us
                                                      FStar_List.length
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____5901
+                                                   uu____5947
                                                    FStar_Util.string_of_int
                                                   in
                                                FStar_Util.format4
                                                  "Expected %s:%s to be universe-polymorphic in %s universes, found %s"
-                                                 (ed2.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                                                 comb uu____5897 uu____5899
+                                                 uu____5941 comb uu____5943
+                                                 uu____5945
                                                 in
                                              FStar_Errors.raise_error
                                                (FStar_Errors.Fatal_MismatchUniversePolymorphic,
@@ -2849,48 +2910,51 @@ let (tc_non_layered_eff_decl :
                                           else ();
                                           (match us2 with
                                            | [] -> (g_us, t3)
-                                           | uu____5916 ->
-                                               let uu____5917 =
+                                           | uu____5962 ->
+                                               let uu____5963 =
                                                  ((FStar_List.length us2) =
                                                     (FStar_List.length g_us))
                                                    &&
                                                    (FStar_List.forall2
                                                       (fun u1  ->
                                                          fun u2  ->
-                                                           let uu____5924 =
+                                                           let uu____5970 =
                                                              FStar_Syntax_Syntax.order_univ_name
                                                                u1 u2
                                                               in
-                                                           uu____5924 =
+                                                           uu____5970 =
                                                              Prims.int_zero)
                                                       us2 g_us)
                                                   in
-                                               if uu____5917
+                                               if uu____5963
                                                then (g_us, t3)
                                                else
-                                                 (let uu____5935 =
-                                                    let uu____5941 =
-                                                      let uu____5943 =
+                                                 (let uu____5981 =
+                                                    let uu____5987 =
+                                                      let uu____5989 =
+                                                        FStar_Ident.string_of_lid
+                                                          ed2.FStar_Syntax_Syntax.mname
+                                                         in
+                                                      let uu____5991 =
                                                         FStar_Util.string_of_int
                                                           (FStar_List.length
                                                              us2)
                                                          in
-                                                      let uu____5945 =
+                                                      let uu____5993 =
                                                         FStar_Util.string_of_int
                                                           (FStar_List.length
                                                              g_us)
                                                          in
                                                       FStar_Util.format4
                                                         "Expected and generalized universes in the declaration for %s:%s are different, expected: %s, but found %s"
-                                                        (ed2.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                                                        comb uu____5943
-                                                        uu____5945
+                                                        uu____5989 comb
+                                                        uu____5991 uu____5993
                                                        in
                                                     (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                                      uu____5941)
+                                                      uu____5987)
                                                      in
                                                   FStar_Errors.raise_error
-                                                    uu____5935
+                                                    uu____5981
                                                     t3.FStar_Syntax_Syntax.pos)))))
                             in
                          let signature =
@@ -2899,663 +2963,666 @@ let (tc_non_layered_eff_decl :
                              ed2.FStar_Syntax_Syntax.signature
                              FStar_Pervasives_Native.None
                             in
-                         (let uu____5953 =
+                         (let uu____6001 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env0)
                               (FStar_Options.Other "ED")
                              in
-                          if uu____5953
+                          if uu____6001
                           then
-                            let uu____5958 =
+                            let uu____6006 =
                               FStar_Syntax_Print.tscheme_to_string signature
                                in
                             FStar_Util.print1 "Typechecked signature: %s\n"
-                              uu____5958
+                              uu____6006
                           else ());
-                         (let fresh_a_and_wp uu____5974 =
+                         (let fresh_a_and_wp uu____6022 =
                             let fail t =
-                              let uu____5987 =
+                              let uu____6035 =
                                 FStar_TypeChecker_Err.unexpected_signature_for_monad
                                   env ed2.FStar_Syntax_Syntax.mname t
                                  in
-                              FStar_Errors.raise_error uu____5987
+                              FStar_Errors.raise_error uu____6035
                                 (FStar_Pervasives_Native.snd
                                    ed2.FStar_Syntax_Syntax.signature).FStar_Syntax_Syntax.pos
                                in
-                            let uu____6003 =
+                            let uu____6051 =
                               FStar_TypeChecker_Env.inst_tscheme signature
                                in
-                            match uu____6003 with
-                            | (uu____6014,signature1) ->
-                                let uu____6016 =
-                                  let uu____6017 =
+                            match uu____6051 with
+                            | (uu____6062,signature1) ->
+                                let uu____6064 =
+                                  let uu____6065 =
                                     FStar_Syntax_Subst.compress signature1
                                      in
-                                  uu____6017.FStar_Syntax_Syntax.n  in
-                                (match uu____6016 with
+                                  uu____6065.FStar_Syntax_Syntax.n  in
+                                (match uu____6064 with
                                  | FStar_Syntax_Syntax.Tm_arrow
-                                     (bs1,uu____6027) ->
+                                     (bs1,uu____6075) ->
                                      let bs2 =
                                        FStar_Syntax_Subst.open_binders bs1
                                         in
                                      (match bs2 with
-                                      | (a,uu____6056)::(wp,uu____6058)::[]
+                                      | (a,uu____6104)::(wp,uu____6106)::[]
                                           ->
                                           (a, (wp.FStar_Syntax_Syntax.sort))
-                                      | uu____6087 -> fail signature1)
-                                 | uu____6088 -> fail signature1)
+                                      | uu____6135 -> fail signature1)
+                                 | uu____6136 -> fail signature1)
                              in
                           let log_combinator s ts =
-                            let uu____6102 =
+                            let uu____6150 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "ED")
                                in
-                            if uu____6102
+                            if uu____6150
                             then
-                              let uu____6107 =
+                              let uu____6155 =
+                                FStar_Ident.string_of_lid
+                                  ed2.FStar_Syntax_Syntax.mname
+                                 in
+                              let uu____6157 =
                                 FStar_Syntax_Print.tscheme_to_string ts  in
                               FStar_Util.print3 "Typechecked %s:%s = %s\n"
-                                (ed2.FStar_Syntax_Syntax.mname).FStar_Ident.str
-                                s uu____6107
+                                uu____6155 s uu____6157
                             else ()  in
                           let ret_wp =
-                            let uu____6113 = fresh_a_and_wp ()  in
-                            match uu____6113 with
+                            let uu____6163 = fresh_a_and_wp ()  in
+                            match uu____6163 with
                             | (a,wp_sort) ->
                                 let k =
-                                  let uu____6129 =
-                                    let uu____6138 =
+                                  let uu____6179 =
+                                    let uu____6188 =
                                       FStar_Syntax_Syntax.mk_binder a  in
-                                    let uu____6145 =
-                                      let uu____6154 =
-                                        let uu____6161 =
+                                    let uu____6195 =
+                                      let uu____6204 =
+                                        let uu____6211 =
                                           FStar_Syntax_Syntax.bv_to_name a
                                            in
                                         FStar_Syntax_Syntax.null_binder
-                                          uu____6161
+                                          uu____6211
                                          in
-                                      [uu____6154]  in
-                                    uu____6138 :: uu____6145  in
-                                  let uu____6180 =
+                                      [uu____6204]  in
+                                    uu____6188 :: uu____6195  in
+                                  let uu____6230 =
                                     FStar_Syntax_Syntax.mk_GTotal wp_sort  in
-                                  FStar_Syntax_Util.arrow uu____6129
-                                    uu____6180
+                                  FStar_Syntax_Util.arrow uu____6179
+                                    uu____6230
                                    in
-                                let uu____6183 =
+                                let uu____6233 =
                                   FStar_All.pipe_right ed2
                                     FStar_Syntax_Util.get_return_vc_combinator
                                    in
                                 check_and_gen' "ret_wp" Prims.int_one
-                                  FStar_Pervasives_Native.None uu____6183
+                                  FStar_Pervasives_Native.None uu____6233
                                   (FStar_Pervasives_Native.Some k)
                              in
                           log_combinator "ret_wp" ret_wp;
                           (let bind_wp =
-                             let uu____6197 = fresh_a_and_wp ()  in
-                             match uu____6197 with
+                             let uu____6247 = fresh_a_and_wp ()  in
+                             match uu____6247 with
                              | (a,wp_sort_a) ->
-                                 let uu____6210 = fresh_a_and_wp ()  in
-                                 (match uu____6210 with
+                                 let uu____6260 = fresh_a_and_wp ()  in
+                                 (match uu____6260 with
                                   | (b,wp_sort_b) ->
                                       let wp_sort_a_b =
-                                        let uu____6226 =
-                                          let uu____6235 =
-                                            let uu____6242 =
+                                        let uu____6276 =
+                                          let uu____6285 =
+                                            let uu____6292 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 a
                                                in
                                             FStar_Syntax_Syntax.null_binder
-                                              uu____6242
+                                              uu____6292
                                              in
-                                          [uu____6235]  in
-                                        let uu____6255 =
+                                          [uu____6285]  in
+                                        let uu____6305 =
                                           FStar_Syntax_Syntax.mk_Total
                                             wp_sort_b
                                            in
-                                        FStar_Syntax_Util.arrow uu____6226
-                                          uu____6255
+                                        FStar_Syntax_Util.arrow uu____6276
+                                          uu____6305
                                          in
                                       let k =
-                                        let uu____6261 =
-                                          let uu____6270 =
+                                        let uu____6311 =
+                                          let uu____6320 =
                                             FStar_Syntax_Syntax.null_binder
                                               FStar_Syntax_Syntax.t_range
                                              in
-                                          let uu____6277 =
-                                            let uu____6286 =
+                                          let uu____6327 =
+                                            let uu____6336 =
                                               FStar_Syntax_Syntax.mk_binder a
                                                in
-                                            let uu____6293 =
-                                              let uu____6302 =
+                                            let uu____6343 =
+                                              let uu____6352 =
                                                 FStar_Syntax_Syntax.mk_binder
                                                   b
                                                  in
-                                              let uu____6309 =
-                                                let uu____6318 =
+                                              let uu____6359 =
+                                                let uu____6368 =
                                                   FStar_Syntax_Syntax.null_binder
                                                     wp_sort_a
                                                    in
-                                                let uu____6325 =
-                                                  let uu____6334 =
+                                                let uu____6375 =
+                                                  let uu____6384 =
                                                     FStar_Syntax_Syntax.null_binder
                                                       wp_sort_a_b
                                                      in
-                                                  [uu____6334]  in
-                                                uu____6318 :: uu____6325  in
-                                              uu____6302 :: uu____6309  in
-                                            uu____6286 :: uu____6293  in
-                                          uu____6270 :: uu____6277  in
-                                        let uu____6377 =
+                                                  [uu____6384]  in
+                                                uu____6368 :: uu____6375  in
+                                              uu____6352 :: uu____6359  in
+                                            uu____6336 :: uu____6343  in
+                                          uu____6320 :: uu____6327  in
+                                        let uu____6427 =
                                           FStar_Syntax_Syntax.mk_Total
                                             wp_sort_b
                                            in
-                                        FStar_Syntax_Util.arrow uu____6261
-                                          uu____6377
+                                        FStar_Syntax_Util.arrow uu____6311
+                                          uu____6427
                                          in
-                                      let uu____6380 =
+                                      let uu____6430 =
                                         FStar_All.pipe_right ed2
                                           FStar_Syntax_Util.get_bind_vc_combinator
                                          in
                                       check_and_gen' "bind_wp"
                                         (Prims.of_int (2))
                                         FStar_Pervasives_Native.None
-                                        uu____6380
+                                        uu____6430
                                         (FStar_Pervasives_Native.Some k))
                               in
                            log_combinator "bind_wp" bind_wp;
                            (let stronger =
-                              let uu____6394 = fresh_a_and_wp ()  in
-                              match uu____6394 with
+                              let uu____6444 = fresh_a_and_wp ()  in
+                              match uu____6444 with
                               | (a,wp_sort_a) ->
-                                  let uu____6407 =
+                                  let uu____6457 =
                                     FStar_Syntax_Util.type_u ()  in
-                                  (match uu____6407 with
-                                   | (t,uu____6413) ->
+                                  (match uu____6457 with
+                                   | (t,uu____6463) ->
                                        let k =
-                                         let uu____6417 =
-                                           let uu____6426 =
+                                         let uu____6467 =
+                                           let uu____6476 =
                                              FStar_Syntax_Syntax.mk_binder a
                                               in
-                                           let uu____6433 =
-                                             let uu____6442 =
+                                           let uu____6483 =
+                                             let uu____6492 =
                                                FStar_Syntax_Syntax.null_binder
                                                  wp_sort_a
                                                 in
-                                             let uu____6449 =
-                                               let uu____6458 =
+                                             let uu____6499 =
+                                               let uu____6508 =
                                                  FStar_Syntax_Syntax.null_binder
                                                    wp_sort_a
                                                   in
-                                               [uu____6458]  in
-                                             uu____6442 :: uu____6449  in
-                                           uu____6426 :: uu____6433  in
-                                         let uu____6489 =
+                                               [uu____6508]  in
+                                             uu____6492 :: uu____6499  in
+                                           uu____6476 :: uu____6483  in
+                                         let uu____6539 =
                                            FStar_Syntax_Syntax.mk_Total t  in
-                                         FStar_Syntax_Util.arrow uu____6417
-                                           uu____6489
+                                         FStar_Syntax_Util.arrow uu____6467
+                                           uu____6539
                                           in
-                                       let uu____6492 =
+                                       let uu____6542 =
                                          FStar_All.pipe_right ed2
                                            FStar_Syntax_Util.get_stronger_vc_combinator
                                           in
                                        check_and_gen' "stronger"
                                          Prims.int_one
                                          FStar_Pervasives_Native.None
-                                         uu____6492
+                                         uu____6542
                                          (FStar_Pervasives_Native.Some k))
                                in
                             log_combinator "stronger" stronger;
                             (let if_then_else =
-                               let uu____6506 = fresh_a_and_wp ()  in
-                               match uu____6506 with
+                               let uu____6556 = fresh_a_and_wp ()  in
+                               match uu____6556 with
                                | (a,wp_sort_a) ->
                                    let p =
-                                     let uu____6520 =
-                                       let uu____6523 =
+                                     let uu____6570 =
+                                       let uu____6573 =
                                          FStar_Ident.range_of_lid
                                            ed2.FStar_Syntax_Syntax.mname
                                           in
                                        FStar_Pervasives_Native.Some
-                                         uu____6523
+                                         uu____6573
                                         in
-                                     let uu____6524 =
-                                       let uu____6525 =
+                                     let uu____6574 =
+                                       let uu____6575 =
                                          FStar_Syntax_Util.type_u ()  in
-                                       FStar_All.pipe_right uu____6525
+                                       FStar_All.pipe_right uu____6575
                                          FStar_Pervasives_Native.fst
                                         in
-                                     FStar_Syntax_Syntax.new_bv uu____6520
-                                       uu____6524
+                                     FStar_Syntax_Syntax.new_bv uu____6570
+                                       uu____6574
                                       in
                                    let k =
-                                     let uu____6537 =
-                                       let uu____6546 =
+                                     let uu____6587 =
+                                       let uu____6596 =
                                          FStar_Syntax_Syntax.mk_binder a  in
-                                       let uu____6553 =
-                                         let uu____6562 =
+                                       let uu____6603 =
+                                         let uu____6612 =
                                            FStar_Syntax_Syntax.mk_binder p
                                             in
-                                         let uu____6569 =
-                                           let uu____6578 =
+                                         let uu____6619 =
+                                           let uu____6628 =
                                              FStar_Syntax_Syntax.null_binder
                                                wp_sort_a
                                               in
-                                           let uu____6585 =
-                                             let uu____6594 =
+                                           let uu____6635 =
+                                             let uu____6644 =
                                                FStar_Syntax_Syntax.null_binder
                                                  wp_sort_a
                                                 in
-                                             [uu____6594]  in
-                                           uu____6578 :: uu____6585  in
-                                         uu____6562 :: uu____6569  in
-                                       uu____6546 :: uu____6553  in
-                                     let uu____6631 =
+                                             [uu____6644]  in
+                                           uu____6628 :: uu____6635  in
+                                         uu____6612 :: uu____6619  in
+                                       uu____6596 :: uu____6603  in
+                                     let uu____6681 =
                                        FStar_Syntax_Syntax.mk_Total wp_sort_a
                                         in
-                                     FStar_Syntax_Util.arrow uu____6537
-                                       uu____6631
+                                     FStar_Syntax_Util.arrow uu____6587
+                                       uu____6681
                                       in
-                                   let uu____6634 =
-                                     let uu____6639 =
+                                   let uu____6684 =
+                                     let uu____6689 =
                                        FStar_All.pipe_right ed2
                                          FStar_Syntax_Util.get_wp_if_then_else_combinator
                                         in
-                                     FStar_All.pipe_right uu____6639
+                                     FStar_All.pipe_right uu____6689
                                        FStar_Util.must
                                       in
                                    check_and_gen' "if_then_else"
                                      Prims.int_one
-                                     FStar_Pervasives_Native.None uu____6634
+                                     FStar_Pervasives_Native.None uu____6684
                                      (FStar_Pervasives_Native.Some k)
                                 in
                              log_combinator "if_then_else" if_then_else;
                              (let ite_wp =
-                                let uu____6671 = fresh_a_and_wp ()  in
-                                match uu____6671 with
+                                let uu____6721 = fresh_a_and_wp ()  in
+                                match uu____6721 with
                                 | (a,wp_sort_a) ->
                                     let k =
-                                      let uu____6687 =
-                                        let uu____6696 =
+                                      let uu____6737 =
+                                        let uu____6746 =
                                           FStar_Syntax_Syntax.mk_binder a  in
-                                        let uu____6703 =
-                                          let uu____6712 =
+                                        let uu____6753 =
+                                          let uu____6762 =
                                             FStar_Syntax_Syntax.null_binder
                                               wp_sort_a
                                              in
-                                          [uu____6712]  in
-                                        uu____6696 :: uu____6703  in
-                                      let uu____6737 =
+                                          [uu____6762]  in
+                                        uu____6746 :: uu____6753  in
+                                      let uu____6787 =
                                         FStar_Syntax_Syntax.mk_Total
                                           wp_sort_a
                                          in
-                                      FStar_Syntax_Util.arrow uu____6687
-                                        uu____6737
+                                      FStar_Syntax_Util.arrow uu____6737
+                                        uu____6787
                                        in
-                                    let uu____6740 =
-                                      let uu____6745 =
+                                    let uu____6790 =
+                                      let uu____6795 =
                                         FStar_All.pipe_right ed2
                                           FStar_Syntax_Util.get_wp_ite_combinator
                                          in
-                                      FStar_All.pipe_right uu____6745
+                                      FStar_All.pipe_right uu____6795
                                         FStar_Util.must
                                        in
                                     check_and_gen' "ite_wp" Prims.int_one
-                                      FStar_Pervasives_Native.None uu____6740
+                                      FStar_Pervasives_Native.None uu____6790
                                       (FStar_Pervasives_Native.Some k)
                                  in
                               log_combinator "ite_wp" ite_wp;
                               (let close_wp =
-                                 let uu____6761 = fresh_a_and_wp ()  in
-                                 match uu____6761 with
+                                 let uu____6811 = fresh_a_and_wp ()  in
+                                 match uu____6811 with
                                  | (a,wp_sort_a) ->
                                      let b =
-                                       let uu____6775 =
-                                         let uu____6778 =
+                                       let uu____6825 =
+                                         let uu____6828 =
                                            FStar_Ident.range_of_lid
                                              ed2.FStar_Syntax_Syntax.mname
                                             in
                                          FStar_Pervasives_Native.Some
-                                           uu____6778
+                                           uu____6828
                                           in
-                                       let uu____6779 =
-                                         let uu____6780 =
+                                       let uu____6829 =
+                                         let uu____6830 =
                                            FStar_Syntax_Util.type_u ()  in
-                                         FStar_All.pipe_right uu____6780
+                                         FStar_All.pipe_right uu____6830
                                            FStar_Pervasives_Native.fst
                                           in
-                                       FStar_Syntax_Syntax.new_bv uu____6775
-                                         uu____6779
+                                       FStar_Syntax_Syntax.new_bv uu____6825
+                                         uu____6829
                                         in
                                      let wp_sort_b_a =
-                                       let uu____6792 =
-                                         let uu____6801 =
-                                           let uu____6808 =
+                                       let uu____6842 =
+                                         let uu____6851 =
+                                           let uu____6858 =
                                              FStar_Syntax_Syntax.bv_to_name b
                                               in
                                            FStar_Syntax_Syntax.null_binder
-                                             uu____6808
+                                             uu____6858
                                             in
-                                         [uu____6801]  in
-                                       let uu____6821 =
+                                         [uu____6851]  in
+                                       let uu____6871 =
                                          FStar_Syntax_Syntax.mk_Total
                                            wp_sort_a
                                           in
-                                       FStar_Syntax_Util.arrow uu____6792
-                                         uu____6821
+                                       FStar_Syntax_Util.arrow uu____6842
+                                         uu____6871
                                         in
                                      let k =
-                                       let uu____6827 =
-                                         let uu____6836 =
+                                       let uu____6877 =
+                                         let uu____6886 =
                                            FStar_Syntax_Syntax.mk_binder a
                                             in
-                                         let uu____6843 =
-                                           let uu____6852 =
+                                         let uu____6893 =
+                                           let uu____6902 =
                                              FStar_Syntax_Syntax.mk_binder b
                                               in
-                                           let uu____6859 =
-                                             let uu____6868 =
+                                           let uu____6909 =
+                                             let uu____6918 =
                                                FStar_Syntax_Syntax.null_binder
                                                  wp_sort_b_a
                                                 in
-                                             [uu____6868]  in
-                                           uu____6852 :: uu____6859  in
-                                         uu____6836 :: uu____6843  in
-                                       let uu____6899 =
+                                             [uu____6918]  in
+                                           uu____6902 :: uu____6909  in
+                                         uu____6886 :: uu____6893  in
+                                       let uu____6949 =
                                          FStar_Syntax_Syntax.mk_Total
                                            wp_sort_a
                                           in
-                                       FStar_Syntax_Util.arrow uu____6827
-                                         uu____6899
+                                       FStar_Syntax_Util.arrow uu____6877
+                                         uu____6949
                                         in
-                                     let uu____6902 =
-                                       let uu____6907 =
+                                     let uu____6952 =
+                                       let uu____6957 =
                                          FStar_All.pipe_right ed2
                                            FStar_Syntax_Util.get_wp_close_combinator
                                           in
-                                       FStar_All.pipe_right uu____6907
+                                       FStar_All.pipe_right uu____6957
                                          FStar_Util.must
                                         in
                                      check_and_gen' "close_wp"
                                        (Prims.of_int (2))
                                        FStar_Pervasives_Native.None
-                                       uu____6902
+                                       uu____6952
                                        (FStar_Pervasives_Native.Some k)
                                   in
                                log_combinator "close_wp" close_wp;
                                (let trivial =
-                                  let uu____6923 = fresh_a_and_wp ()  in
-                                  match uu____6923 with
+                                  let uu____6973 = fresh_a_and_wp ()  in
+                                  match uu____6973 with
                                   | (a,wp_sort_a) ->
-                                      let uu____6936 =
+                                      let uu____6986 =
                                         FStar_Syntax_Util.type_u ()  in
-                                      (match uu____6936 with
-                                       | (t,uu____6942) ->
+                                      (match uu____6986 with
+                                       | (t,uu____6992) ->
                                            let k =
-                                             let uu____6946 =
-                                               let uu____6955 =
+                                             let uu____6996 =
+                                               let uu____7005 =
                                                  FStar_Syntax_Syntax.mk_binder
                                                    a
                                                   in
-                                               let uu____6962 =
-                                                 let uu____6971 =
+                                               let uu____7012 =
+                                                 let uu____7021 =
                                                    FStar_Syntax_Syntax.null_binder
                                                      wp_sort_a
                                                     in
-                                                 [uu____6971]  in
-                                               uu____6955 :: uu____6962  in
-                                             let uu____6996 =
+                                                 [uu____7021]  in
+                                               uu____7005 :: uu____7012  in
+                                             let uu____7046 =
                                                FStar_Syntax_Syntax.mk_GTotal
                                                  t
                                                 in
                                              FStar_Syntax_Util.arrow
-                                               uu____6946 uu____6996
+                                               uu____6996 uu____7046
                                               in
                                            let trivial =
-                                             let uu____7000 =
-                                               let uu____7005 =
+                                             let uu____7050 =
+                                               let uu____7055 =
                                                  FStar_All.pipe_right ed2
                                                    FStar_Syntax_Util.get_wp_trivial_combinator
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____7005 FStar_Util.must
+                                                 uu____7055 FStar_Util.must
                                                 in
                                              check_and_gen' "trivial"
                                                Prims.int_one
                                                FStar_Pervasives_Native.None
-                                               uu____7000
+                                               uu____7050
                                                (FStar_Pervasives_Native.Some
                                                   k)
                                               in
                                            (log_combinator "trivial" trivial;
                                             trivial))
                                    in
-                                let uu____7020 =
-                                  let uu____7037 =
+                                let uu____7070 =
+                                  let uu____7087 =
                                     FStar_All.pipe_right ed2
                                       FStar_Syntax_Util.get_eff_repr
                                      in
-                                  match uu____7037 with
+                                  match uu____7087 with
                                   | FStar_Pervasives_Native.None  ->
                                       (FStar_Pervasives_Native.None,
                                         FStar_Pervasives_Native.None,
                                         FStar_Pervasives_Native.None,
                                         (ed2.FStar_Syntax_Syntax.actions))
-                                  | uu____7066 ->
+                                  | uu____7116 ->
                                       let repr =
-                                        let uu____7070 = fresh_a_and_wp ()
+                                        let uu____7120 = fresh_a_and_wp ()
                                            in
-                                        match uu____7070 with
+                                        match uu____7120 with
                                         | (a,wp_sort_a) ->
-                                            let uu____7083 =
+                                            let uu____7133 =
                                               FStar_Syntax_Util.type_u ()  in
-                                            (match uu____7083 with
-                                             | (t,uu____7089) ->
+                                            (match uu____7133 with
+                                             | (t,uu____7139) ->
                                                  let k =
-                                                   let uu____7093 =
-                                                     let uu____7102 =
+                                                   let uu____7143 =
+                                                     let uu____7152 =
                                                        FStar_Syntax_Syntax.mk_binder
                                                          a
                                                         in
-                                                     let uu____7109 =
-                                                       let uu____7118 =
+                                                     let uu____7159 =
+                                                       let uu____7168 =
                                                          FStar_Syntax_Syntax.null_binder
                                                            wp_sort_a
                                                           in
-                                                       [uu____7118]  in
-                                                     uu____7102 :: uu____7109
+                                                       [uu____7168]  in
+                                                     uu____7152 :: uu____7159
                                                       in
-                                                   let uu____7143 =
+                                                   let uu____7193 =
                                                      FStar_Syntax_Syntax.mk_GTotal
                                                        t
                                                       in
                                                    FStar_Syntax_Util.arrow
-                                                     uu____7093 uu____7143
+                                                     uu____7143 uu____7193
                                                     in
-                                                 let uu____7146 =
-                                                   let uu____7151 =
+                                                 let uu____7196 =
+                                                   let uu____7201 =
                                                      FStar_All.pipe_right ed2
                                                        FStar_Syntax_Util.get_eff_repr
                                                       in
                                                    FStar_All.pipe_right
-                                                     uu____7151
+                                                     uu____7201
                                                      FStar_Util.must
                                                     in
                                                  check_and_gen' "repr"
                                                    Prims.int_one
                                                    FStar_Pervasives_Native.None
-                                                   uu____7146
+                                                   uu____7196
                                                    (FStar_Pervasives_Native.Some
                                                       k))
                                          in
                                       (log_combinator "repr" repr;
                                        (let mk_repr' t wp =
-                                          let uu____7195 =
+                                          let uu____7245 =
                                             FStar_TypeChecker_Env.inst_tscheme
                                               repr
                                              in
-                                          match uu____7195 with
-                                          | (uu____7202,repr1) ->
+                                          match uu____7245 with
+                                          | (uu____7252,repr1) ->
                                               let repr2 =
                                                 FStar_TypeChecker_Normalize.normalize
                                                   [FStar_TypeChecker_Env.EraseUniverses;
                                                   FStar_TypeChecker_Env.AllowUnboundUniverses]
                                                   env repr1
                                                  in
-                                              let uu____7205 =
-                                                let uu____7212 =
-                                                  let uu____7213 =
-                                                    let uu____7230 =
-                                                      let uu____7241 =
+                                              let uu____7255 =
+                                                let uu____7262 =
+                                                  let uu____7263 =
+                                                    let uu____7280 =
+                                                      let uu____7291 =
                                                         FStar_All.pipe_right
                                                           t
                                                           FStar_Syntax_Syntax.as_arg
                                                          in
-                                                      let uu____7258 =
-                                                        let uu____7269 =
+                                                      let uu____7308 =
+                                                        let uu____7319 =
                                                           FStar_All.pipe_right
                                                             wp
                                                             FStar_Syntax_Syntax.as_arg
                                                            in
-                                                        [uu____7269]  in
-                                                      uu____7241 ::
-                                                        uu____7258
+                                                        [uu____7319]  in
+                                                      uu____7291 ::
+                                                        uu____7308
                                                        in
-                                                    (repr2, uu____7230)  in
+                                                    (repr2, uu____7280)  in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____7213
+                                                    uu____7263
                                                    in
                                                 FStar_Syntax_Syntax.mk
-                                                  uu____7212
+                                                  uu____7262
                                                  in
-                                              uu____7205
+                                              uu____7255
                                                 FStar_Pervasives_Native.None
                                                 FStar_Range.dummyRange
                                            in
                                         let mk_repr a wp =
-                                          let uu____7335 =
+                                          let uu____7385 =
                                             FStar_Syntax_Syntax.bv_to_name a
                                              in
-                                          mk_repr' uu____7335 wp  in
+                                          mk_repr' uu____7385 wp  in
                                         let destruct_repr t =
-                                          let uu____7350 =
-                                            let uu____7351 =
+                                          let uu____7400 =
+                                            let uu____7401 =
                                               FStar_Syntax_Subst.compress t
                                                in
-                                            uu____7351.FStar_Syntax_Syntax.n
+                                            uu____7401.FStar_Syntax_Syntax.n
                                              in
-                                          match uu____7350 with
+                                          match uu____7400 with
                                           | FStar_Syntax_Syntax.Tm_app
-                                              (uu____7362,(t1,uu____7364)::
-                                               (wp,uu____7366)::[])
+                                              (uu____7412,(t1,uu____7414)::
+                                               (wp,uu____7416)::[])
                                               -> (t1, wp)
-                                          | uu____7425 ->
+                                          | uu____7475 ->
                                               failwith "Unexpected repr type"
                                            in
                                         let return_repr =
                                           let return_repr_ts =
-                                            let uu____7441 =
+                                            let uu____7491 =
                                               FStar_All.pipe_right ed2
                                                 FStar_Syntax_Util.get_return_repr
                                                in
-                                            FStar_All.pipe_right uu____7441
+                                            FStar_All.pipe_right uu____7491
                                               FStar_Util.must
                                              in
-                                          let uu____7468 = fresh_a_and_wp ()
+                                          let uu____7518 = fresh_a_and_wp ()
                                              in
-                                          match uu____7468 with
-                                          | (a,uu____7476) ->
+                                          match uu____7518 with
+                                          | (a,uu____7526) ->
                                               let x_a =
-                                                let uu____7482 =
+                                                let uu____7532 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     a
                                                    in
                                                 FStar_Syntax_Syntax.gen_bv
                                                   "x_a"
                                                   FStar_Pervasives_Native.None
-                                                  uu____7482
+                                                  uu____7532
                                                  in
                                               let res =
                                                 let wp =
-                                                  let uu____7490 =
-                                                    let uu____7495 =
-                                                      let uu____7496 =
+                                                  let uu____7540 =
+                                                    let uu____7545 =
+                                                      let uu____7546 =
                                                         FStar_TypeChecker_Env.inst_tscheme
                                                           ret_wp
                                                          in
                                                       FStar_All.pipe_right
-                                                        uu____7496
+                                                        uu____7546
                                                         FStar_Pervasives_Native.snd
                                                        in
-                                                    let uu____7505 =
-                                                      let uu____7506 =
-                                                        let uu____7515 =
+                                                    let uu____7555 =
+                                                      let uu____7556 =
+                                                        let uu____7565 =
                                                           FStar_Syntax_Syntax.bv_to_name
                                                             a
                                                            in
                                                         FStar_All.pipe_right
-                                                          uu____7515
+                                                          uu____7565
                                                           FStar_Syntax_Syntax.as_arg
                                                          in
-                                                      let uu____7524 =
-                                                        let uu____7535 =
-                                                          let uu____7544 =
+                                                      let uu____7574 =
+                                                        let uu____7585 =
+                                                          let uu____7594 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x_a
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____7544
+                                                            uu____7594
                                                             FStar_Syntax_Syntax.as_arg
                                                            in
-                                                        [uu____7535]  in
-                                                      uu____7506 ::
-                                                        uu____7524
+                                                        [uu____7585]  in
+                                                      uu____7556 ::
+                                                        uu____7574
                                                        in
                                                     FStar_Syntax_Syntax.mk_Tm_app
-                                                      uu____7495 uu____7505
+                                                      uu____7545 uu____7555
                                                      in
-                                                  uu____7490
+                                                  uu____7540
                                                     FStar_Pervasives_Native.None
                                                     FStar_Range.dummyRange
                                                    in
                                                 mk_repr a wp  in
                                               let k =
-                                                let uu____7580 =
-                                                  let uu____7589 =
+                                                let uu____7630 =
+                                                  let uu____7639 =
                                                     FStar_Syntax_Syntax.mk_binder
                                                       a
                                                      in
-                                                  let uu____7596 =
-                                                    let uu____7605 =
+                                                  let uu____7646 =
+                                                    let uu____7655 =
                                                       FStar_Syntax_Syntax.mk_binder
                                                         x_a
                                                        in
-                                                    [uu____7605]  in
-                                                  uu____7589 :: uu____7596
+                                                    [uu____7655]  in
+                                                  uu____7639 :: uu____7646
                                                    in
-                                                let uu____7630 =
+                                                let uu____7680 =
                                                   FStar_Syntax_Syntax.mk_Total
                                                     res
                                                    in
                                                 FStar_Syntax_Util.arrow
-                                                  uu____7580 uu____7630
+                                                  uu____7630 uu____7680
                                                  in
-                                              let uu____7633 =
+                                              let uu____7683 =
                                                 FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                   env k
                                                  in
-                                              (match uu____7633 with
-                                               | (k1,uu____7641,uu____7642)
+                                              (match uu____7683 with
+                                               | (k1,uu____7691,uu____7692)
                                                    ->
                                                    let env1 =
-                                                     let uu____7646 =
+                                                     let uu____7696 =
                                                        FStar_TypeChecker_Env.set_range
                                                          env
                                                          (FStar_Pervasives_Native.snd
                                                             return_repr_ts).FStar_Syntax_Syntax.pos
                                                         in
                                                      FStar_Pervasives_Native.Some
-                                                       uu____7646
+                                                       uu____7696
                                                       in
                                                    check_and_gen'
                                                      "return_repr"
@@ -3568,48 +3635,48 @@ let (tc_non_layered_eff_decl :
                                           return_repr;
                                         (let bind_repr =
                                            let bind_repr_ts =
-                                             let uu____7659 =
+                                             let uu____7709 =
                                                FStar_All.pipe_right ed2
                                                  FStar_Syntax_Util.get_bind_repr
                                                 in
-                                             FStar_All.pipe_right uu____7659
+                                             FStar_All.pipe_right uu____7709
                                                FStar_Util.must
                                               in
                                            let r =
-                                             let uu____7697 =
+                                             let uu____7747 =
                                                FStar_Syntax_Syntax.lid_as_fv
                                                  FStar_Parser_Const.range_0
                                                  FStar_Syntax_Syntax.delta_constant
                                                  FStar_Pervasives_Native.None
                                                 in
-                                             FStar_All.pipe_right uu____7697
+                                             FStar_All.pipe_right uu____7747
                                                FStar_Syntax_Syntax.fv_to_tm
                                               in
-                                           let uu____7698 = fresh_a_and_wp ()
+                                           let uu____7748 = fresh_a_and_wp ()
                                               in
-                                           match uu____7698 with
+                                           match uu____7748 with
                                            | (a,wp_sort_a) ->
-                                               let uu____7711 =
+                                               let uu____7761 =
                                                  fresh_a_and_wp ()  in
-                                               (match uu____7711 with
+                                               (match uu____7761 with
                                                 | (b,wp_sort_b) ->
                                                     let wp_sort_a_b =
-                                                      let uu____7727 =
-                                                        let uu____7736 =
-                                                          let uu____7743 =
+                                                      let uu____7777 =
+                                                        let uu____7786 =
+                                                          let uu____7793 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               a
                                                              in
                                                           FStar_Syntax_Syntax.null_binder
-                                                            uu____7743
+                                                            uu____7793
                                                            in
-                                                        [uu____7736]  in
-                                                      let uu____7756 =
+                                                        [uu____7786]  in
+                                                      let uu____7806 =
                                                         FStar_Syntax_Syntax.mk_Total
                                                           wp_sort_b
                                                          in
                                                       FStar_Syntax_Util.arrow
-                                                        uu____7727 uu____7756
+                                                        uu____7777 uu____7806
                                                        in
                                                     let wp_f =
                                                       FStar_Syntax_Syntax.gen_bv
@@ -3624,237 +3691,237 @@ let (tc_non_layered_eff_decl :
                                                         wp_sort_a_b
                                                        in
                                                     let x_a =
-                                                      let uu____7764 =
+                                                      let uu____7814 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           a
                                                          in
                                                       FStar_Syntax_Syntax.gen_bv
                                                         "x_a"
                                                         FStar_Pervasives_Native.None
-                                                        uu____7764
+                                                        uu____7814
                                                        in
                                                     let wp_g_x =
-                                                      let uu____7769 =
-                                                        let uu____7774 =
+                                                      let uu____7819 =
+                                                        let uu____7824 =
                                                           FStar_Syntax_Syntax.bv_to_name
                                                             wp_g
                                                            in
-                                                        let uu____7775 =
-                                                          let uu____7776 =
-                                                            let uu____7785 =
+                                                        let uu____7825 =
+                                                          let uu____7826 =
+                                                            let uu____7835 =
                                                               FStar_Syntax_Syntax.bv_to_name
                                                                 x_a
                                                                in
                                                             FStar_All.pipe_right
-                                                              uu____7785
+                                                              uu____7835
                                                               FStar_Syntax_Syntax.as_arg
                                                              in
-                                                          [uu____7776]  in
+                                                          [uu____7826]  in
                                                         FStar_Syntax_Syntax.mk_Tm_app
-                                                          uu____7774
-                                                          uu____7775
+                                                          uu____7824
+                                                          uu____7825
                                                          in
-                                                      uu____7769
+                                                      uu____7819
                                                         FStar_Pervasives_Native.None
                                                         FStar_Range.dummyRange
                                                        in
                                                     let res =
                                                       let wp =
-                                                        let uu____7816 =
-                                                          let uu____7821 =
-                                                            let uu____7822 =
+                                                        let uu____7866 =
+                                                          let uu____7871 =
+                                                            let uu____7872 =
                                                               FStar_TypeChecker_Env.inst_tscheme
                                                                 bind_wp
                                                                in
                                                             FStar_All.pipe_right
-                                                              uu____7822
+                                                              uu____7872
                                                               FStar_Pervasives_Native.snd
                                                              in
-                                                          let uu____7831 =
-                                                            let uu____7832 =
-                                                              let uu____7835
+                                                          let uu____7881 =
+                                                            let uu____7882 =
+                                                              let uu____7885
                                                                 =
-                                                                let uu____7838
+                                                                let uu____7888
                                                                   =
                                                                   FStar_Syntax_Syntax.bv_to_name
                                                                     a
                                                                    in
-                                                                let uu____7839
+                                                                let uu____7889
                                                                   =
-                                                                  let uu____7842
+                                                                  let uu____7892
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     b  in
-                                                                  let uu____7843
+                                                                  let uu____7893
                                                                     =
-                                                                    let uu____7846
+                                                                    let uu____7896
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_f  in
-                                                                    let uu____7847
+                                                                    let uu____7897
                                                                     =
-                                                                    let uu____7850
+                                                                    let uu____7900
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_g  in
-                                                                    [uu____7850]
+                                                                    [uu____7900]
                                                                      in
-                                                                    uu____7846
+                                                                    uu____7896
                                                                     ::
-                                                                    uu____7847
+                                                                    uu____7897
                                                                      in
-                                                                  uu____7842
+                                                                  uu____7892
                                                                     ::
-                                                                    uu____7843
+                                                                    uu____7893
                                                                    in
-                                                                uu____7838 ::
-                                                                  uu____7839
+                                                                uu____7888 ::
+                                                                  uu____7889
                                                                  in
-                                                              r :: uu____7835
+                                                              r :: uu____7885
                                                                in
                                                             FStar_List.map
                                                               FStar_Syntax_Syntax.as_arg
-                                                              uu____7832
+                                                              uu____7882
                                                              in
                                                           FStar_Syntax_Syntax.mk_Tm_app
-                                                            uu____7821
-                                                            uu____7831
+                                                            uu____7871
+                                                            uu____7881
                                                            in
-                                                        uu____7816
+                                                        uu____7866
                                                           FStar_Pervasives_Native.None
                                                           FStar_Range.dummyRange
                                                          in
                                                       mk_repr b wp  in
                                                     let maybe_range_arg =
-                                                      let uu____7868 =
+                                                      let uu____7918 =
                                                         FStar_Util.for_some
                                                           (FStar_Syntax_Util.attr_eq
                                                              FStar_Syntax_Util.dm4f_bind_range_attr)
                                                           ed2.FStar_Syntax_Syntax.eff_attrs
                                                          in
-                                                      if uu____7868
+                                                      if uu____7918
                                                       then
-                                                        let uu____7879 =
+                                                        let uu____7929 =
                                                           FStar_Syntax_Syntax.null_binder
                                                             FStar_Syntax_Syntax.t_range
                                                            in
-                                                        let uu____7886 =
-                                                          let uu____7895 =
+                                                        let uu____7936 =
+                                                          let uu____7945 =
                                                             FStar_Syntax_Syntax.null_binder
                                                               FStar_Syntax_Syntax.t_range
                                                              in
-                                                          [uu____7895]  in
-                                                        uu____7879 ::
-                                                          uu____7886
+                                                          [uu____7945]  in
+                                                        uu____7929 ::
+                                                          uu____7936
                                                       else []  in
                                                     let k =
-                                                      let uu____7931 =
-                                                        let uu____7940 =
-                                                          let uu____7949 =
+                                                      let uu____7981 =
+                                                        let uu____7990 =
+                                                          let uu____7999 =
                                                             FStar_Syntax_Syntax.mk_binder
                                                               a
                                                              in
-                                                          let uu____7956 =
-                                                            let uu____7965 =
+                                                          let uu____8006 =
+                                                            let uu____8015 =
                                                               FStar_Syntax_Syntax.mk_binder
                                                                 b
                                                                in
-                                                            [uu____7965]  in
-                                                          uu____7949 ::
-                                                            uu____7956
+                                                            [uu____8015]  in
+                                                          uu____7999 ::
+                                                            uu____8006
                                                            in
-                                                        let uu____7990 =
-                                                          let uu____7999 =
-                                                            let uu____8008 =
+                                                        let uu____8040 =
+                                                          let uu____8049 =
+                                                            let uu____8058 =
                                                               FStar_Syntax_Syntax.mk_binder
                                                                 wp_f
                                                                in
-                                                            let uu____8015 =
-                                                              let uu____8024
+                                                            let uu____8065 =
+                                                              let uu____8074
                                                                 =
-                                                                let uu____8031
+                                                                let uu____8081
                                                                   =
-                                                                  let uu____8032
+                                                                  let uu____8082
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_f  in
                                                                   mk_repr a
-                                                                    uu____8032
+                                                                    uu____8082
                                                                    in
                                                                 FStar_Syntax_Syntax.null_binder
-                                                                  uu____8031
+                                                                  uu____8081
                                                                  in
-                                                              let uu____8033
+                                                              let uu____8083
                                                                 =
-                                                                let uu____8042
+                                                                let uu____8092
                                                                   =
                                                                   FStar_Syntax_Syntax.mk_binder
                                                                     wp_g
                                                                    in
-                                                                let uu____8049
+                                                                let uu____8099
                                                                   =
-                                                                  let uu____8058
+                                                                  let uu____8108
                                                                     =
-                                                                    let uu____8065
+                                                                    let uu____8115
                                                                     =
-                                                                    let uu____8066
+                                                                    let uu____8116
                                                                     =
-                                                                    let uu____8075
+                                                                    let uu____8125
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     x_a  in
-                                                                    [uu____8075]
+                                                                    [uu____8125]
                                                                      in
-                                                                    let uu____8094
+                                                                    let uu____8144
                                                                     =
-                                                                    let uu____8097
+                                                                    let uu____8147
                                                                     =
                                                                     mk_repr b
                                                                     wp_g_x
                                                                      in
                                                                     FStar_All.pipe_left
                                                                     FStar_Syntax_Syntax.mk_Total
-                                                                    uu____8097
+                                                                    uu____8147
                                                                      in
                                                                     FStar_Syntax_Util.arrow
-                                                                    uu____8066
-                                                                    uu____8094
+                                                                    uu____8116
+                                                                    uu____8144
                                                                      in
                                                                     FStar_Syntax_Syntax.null_binder
-                                                                    uu____8065
+                                                                    uu____8115
                                                                      in
-                                                                  [uu____8058]
+                                                                  [uu____8108]
                                                                    in
-                                                                uu____8042 ::
-                                                                  uu____8049
+                                                                uu____8092 ::
+                                                                  uu____8099
                                                                  in
-                                                              uu____8024 ::
-                                                                uu____8033
+                                                              uu____8074 ::
+                                                                uu____8083
                                                                in
-                                                            uu____8008 ::
-                                                              uu____8015
+                                                            uu____8058 ::
+                                                              uu____8065
                                                              in
                                                           FStar_List.append
                                                             maybe_range_arg
-                                                            uu____7999
+                                                            uu____8049
                                                            in
                                                         FStar_List.append
-                                                          uu____7940
                                                           uu____7990
+                                                          uu____8040
                                                          in
-                                                      let uu____8142 =
+                                                      let uu____8192 =
                                                         FStar_Syntax_Syntax.mk_Total
                                                           res
                                                          in
                                                       FStar_Syntax_Util.arrow
-                                                        uu____7931 uu____8142
+                                                        uu____7981 uu____8192
                                                        in
-                                                    let uu____8145 =
+                                                    let uu____8195 =
                                                       FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                         env k
                                                        in
-                                                    (match uu____8145 with
-                                                     | (k1,uu____8153,uu____8154)
+                                                    (match uu____8195 with
+                                                     | (k1,uu____8203,uu____8204)
                                                          ->
                                                          let env1 =
                                                            FStar_TypeChecker_Env.set_range
@@ -3864,154 +3931,154 @@ let (tc_non_layered_eff_decl :
                                                             in
                                                          let env2 =
                                                            FStar_All.pipe_right
-                                                             (let uu___810_8164
+                                                             (let uu___810_8214
                                                                 = env1  in
                                                               {
                                                                 FStar_TypeChecker_Env.solver
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.solver);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.solver);
                                                                 FStar_TypeChecker_Env.range
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.range);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.range);
                                                                 FStar_TypeChecker_Env.curmodule
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.curmodule);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.curmodule);
                                                                 FStar_TypeChecker_Env.gamma
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.gamma);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.gamma);
                                                                 FStar_TypeChecker_Env.gamma_sig
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.gamma_sig);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.gamma_sig);
                                                                 FStar_TypeChecker_Env.gamma_cache
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.gamma_cache);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.gamma_cache);
                                                                 FStar_TypeChecker_Env.modules
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.modules);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.modules);
                                                                 FStar_TypeChecker_Env.expected_typ
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.expected_typ);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.expected_typ);
                                                                 FStar_TypeChecker_Env.sigtab
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.sigtab);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.sigtab);
                                                                 FStar_TypeChecker_Env.attrtab
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.attrtab);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.attrtab);
                                                                 FStar_TypeChecker_Env.instantiate_imp
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.instantiate_imp);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.instantiate_imp);
                                                                 FStar_TypeChecker_Env.effects
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.effects);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.effects);
                                                                 FStar_TypeChecker_Env.generalize
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.generalize);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.generalize);
                                                                 FStar_TypeChecker_Env.letrecs
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.letrecs);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.letrecs);
                                                                 FStar_TypeChecker_Env.top_level
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.top_level);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.top_level);
                                                                 FStar_TypeChecker_Env.check_uvars
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.check_uvars);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.check_uvars);
                                                                 FStar_TypeChecker_Env.use_eq
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.use_eq);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.use_eq);
                                                                 FStar_TypeChecker_Env.use_eq_strict
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.use_eq_strict);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.use_eq_strict);
                                                                 FStar_TypeChecker_Env.is_iface
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.is_iface);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.is_iface);
                                                                 FStar_TypeChecker_Env.admit
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.admit);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.admit);
                                                                 FStar_TypeChecker_Env.lax
                                                                   = true;
                                                                 FStar_TypeChecker_Env.lax_universes
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.lax_universes);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.lax_universes);
                                                                 FStar_TypeChecker_Env.phase1
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.phase1);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.phase1);
                                                                 FStar_TypeChecker_Env.failhard
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.failhard);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.failhard);
                                                                 FStar_TypeChecker_Env.nosynth
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.nosynth);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.nosynth);
                                                                 FStar_TypeChecker_Env.uvar_subtyping
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.uvar_subtyping);
                                                                 FStar_TypeChecker_Env.tc_term
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.tc_term);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.tc_term);
                                                                 FStar_TypeChecker_Env.type_of
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.type_of);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.type_of);
                                                                 FStar_TypeChecker_Env.universe_of
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.universe_of);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.universe_of);
                                                                 FStar_TypeChecker_Env.check_type_of
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.check_type_of);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.check_type_of);
                                                                 FStar_TypeChecker_Env.use_bv_sorts
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.use_bv_sorts);
                                                                 FStar_TypeChecker_Env.qtbl_name_and_index
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                 FStar_TypeChecker_Env.normalized_eff_names
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.normalized_eff_names);
                                                                 FStar_TypeChecker_Env.fv_delta_depths
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.fv_delta_depths);
                                                                 FStar_TypeChecker_Env.proof_ns
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.proof_ns);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.proof_ns);
                                                                 FStar_TypeChecker_Env.synth_hook
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.synth_hook);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.synth_hook);
                                                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                 FStar_TypeChecker_Env.splice
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.splice);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.splice);
                                                                 FStar_TypeChecker_Env.mpreprocess
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.mpreprocess);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.mpreprocess);
                                                                 FStar_TypeChecker_Env.postprocess
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.postprocess);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.postprocess);
                                                                 FStar_TypeChecker_Env.is_native_tactic
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.is_native_tactic);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.is_native_tactic);
                                                                 FStar_TypeChecker_Env.identifier_info
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.identifier_info);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.identifier_info);
                                                                 FStar_TypeChecker_Env.tc_hooks
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.tc_hooks);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.tc_hooks);
                                                                 FStar_TypeChecker_Env.dsenv
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.dsenv);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.dsenv);
                                                                 FStar_TypeChecker_Env.nbe
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.nbe);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.nbe);
                                                                 FStar_TypeChecker_Env.strict_args_tab
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.strict_args_tab);
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.strict_args_tab);
                                                                 FStar_TypeChecker_Env.erasable_types_tab
                                                                   =
-                                                                  (uu___810_8164.FStar_TypeChecker_Env.erasable_types_tab)
+                                                                  (uu___810_8214.FStar_TypeChecker_Env.erasable_types_tab)
                                                               })
-                                                             (fun uu____8166 
+                                                             (fun uu____8216 
                                                                 ->
                                                                 FStar_Pervasives_Native.Some
-                                                                  uu____8166)
+                                                                  uu____8216)
                                                             in
                                                          check_and_gen'
                                                            "bind_repr"
@@ -4031,31 +4098,31 @@ let (tc_non_layered_eff_decl :
                                                 failwith
                                                   "tc_eff_decl: expected action_params to be empty"
                                               else ();
-                                              (let uu____8193 =
+                                              (let uu____8243 =
                                                  if
                                                    act.FStar_Syntax_Syntax.action_univs
                                                      = []
                                                  then (env, act)
                                                  else
-                                                   (let uu____8207 =
+                                                   (let uu____8257 =
                                                       FStar_Syntax_Subst.univ_var_opening
                                                         act.FStar_Syntax_Syntax.action_univs
                                                        in
-                                                    match uu____8207 with
+                                                    match uu____8257 with
                                                     | (usubst,uvs) ->
-                                                        let uu____8230 =
+                                                        let uu____8280 =
                                                           FStar_TypeChecker_Env.push_univ_vars
                                                             env uvs
                                                            in
-                                                        let uu____8231 =
-                                                          let uu___823_8232 =
+                                                        let uu____8281 =
+                                                          let uu___823_8282 =
                                                             act  in
-                                                          let uu____8233 =
+                                                          let uu____8283 =
                                                             FStar_Syntax_Subst.subst
                                                               usubst
                                                               act.FStar_Syntax_Syntax.action_defn
                                                              in
-                                                          let uu____8234 =
+                                                          let uu____8284 =
                                                             FStar_Syntax_Subst.subst
                                                               usubst
                                                               act.FStar_Syntax_Syntax.action_typ
@@ -4063,261 +4130,261 @@ let (tc_non_layered_eff_decl :
                                                           {
                                                             FStar_Syntax_Syntax.action_name
                                                               =
-                                                              (uu___823_8232.FStar_Syntax_Syntax.action_name);
+                                                              (uu___823_8282.FStar_Syntax_Syntax.action_name);
                                                             FStar_Syntax_Syntax.action_unqualified_name
                                                               =
-                                                              (uu___823_8232.FStar_Syntax_Syntax.action_unqualified_name);
+                                                              (uu___823_8282.FStar_Syntax_Syntax.action_unqualified_name);
                                                             FStar_Syntax_Syntax.action_univs
                                                               = uvs;
                                                             FStar_Syntax_Syntax.action_params
                                                               =
-                                                              (uu___823_8232.FStar_Syntax_Syntax.action_params);
+                                                              (uu___823_8282.FStar_Syntax_Syntax.action_params);
                                                             FStar_Syntax_Syntax.action_defn
-                                                              = uu____8233;
+                                                              = uu____8283;
                                                             FStar_Syntax_Syntax.action_typ
-                                                              = uu____8234
+                                                              = uu____8284
                                                           }  in
-                                                        (uu____8230,
-                                                          uu____8231))
+                                                        (uu____8280,
+                                                          uu____8281))
                                                   in
-                                               match uu____8193 with
+                                               match uu____8243 with
                                                | (env1,act1) ->
                                                    let act_typ =
-                                                     let uu____8238 =
-                                                       let uu____8239 =
+                                                     let uu____8288 =
+                                                       let uu____8289 =
                                                          FStar_Syntax_Subst.compress
                                                            act1.FStar_Syntax_Syntax.action_typ
                                                           in
-                                                       uu____8239.FStar_Syntax_Syntax.n
+                                                       uu____8289.FStar_Syntax_Syntax.n
                                                         in
-                                                     match uu____8238 with
+                                                     match uu____8288 with
                                                      | FStar_Syntax_Syntax.Tm_arrow
                                                          (bs1,c) ->
                                                          let c1 =
                                                            FStar_Syntax_Util.comp_to_comp_typ
                                                              c
                                                             in
-                                                         let uu____8265 =
+                                                         let uu____8315 =
                                                            FStar_Ident.lid_equals
                                                              c1.FStar_Syntax_Syntax.effect_name
                                                              ed2.FStar_Syntax_Syntax.mname
                                                             in
-                                                         if uu____8265
+                                                         if uu____8315
                                                          then
-                                                           let uu____8268 =
-                                                             let uu____8271 =
-                                                               let uu____8272
+                                                           let uu____8318 =
+                                                             let uu____8321 =
+                                                               let uu____8322
                                                                  =
-                                                                 let uu____8273
+                                                                 let uu____8323
                                                                    =
                                                                    FStar_List.hd
                                                                     c1.FStar_Syntax_Syntax.effect_args
                                                                     in
                                                                  FStar_Pervasives_Native.fst
-                                                                   uu____8273
+                                                                   uu____8323
                                                                   in
                                                                mk_repr'
                                                                  c1.FStar_Syntax_Syntax.result_typ
-                                                                 uu____8272
+                                                                 uu____8322
                                                                 in
                                                              FStar_Syntax_Syntax.mk_Total
-                                                               uu____8271
+                                                               uu____8321
                                                               in
                                                            FStar_Syntax_Util.arrow
-                                                             bs1 uu____8268
+                                                             bs1 uu____8318
                                                          else
                                                            act1.FStar_Syntax_Syntax.action_typ
-                                                     | uu____8296 ->
+                                                     | uu____8346 ->
                                                          act1.FStar_Syntax_Syntax.action_typ
                                                       in
-                                                   let uu____8297 =
+                                                   let uu____8347 =
                                                      FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                        env1 act_typ
                                                       in
-                                                   (match uu____8297 with
-                                                    | (act_typ1,uu____8305,g_t)
+                                                   (match uu____8347 with
+                                                    | (act_typ1,uu____8355,g_t)
                                                         ->
                                                         let env' =
-                                                          let uu___840_8308 =
+                                                          let uu___840_8358 =
                                                             FStar_TypeChecker_Env.set_expected_typ
                                                               env1 act_typ1
                                                              in
                                                           {
                                                             FStar_TypeChecker_Env.solver
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.solver);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.solver);
                                                             FStar_TypeChecker_Env.range
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.range);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.range);
                                                             FStar_TypeChecker_Env.curmodule
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.curmodule);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.curmodule);
                                                             FStar_TypeChecker_Env.gamma
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.gamma);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.gamma);
                                                             FStar_TypeChecker_Env.gamma_sig
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.gamma_sig);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.gamma_sig);
                                                             FStar_TypeChecker_Env.gamma_cache
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.gamma_cache);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.gamma_cache);
                                                             FStar_TypeChecker_Env.modules
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.modules);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.modules);
                                                             FStar_TypeChecker_Env.expected_typ
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.expected_typ);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.expected_typ);
                                                             FStar_TypeChecker_Env.sigtab
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.sigtab);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.sigtab);
                                                             FStar_TypeChecker_Env.attrtab
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.attrtab);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.attrtab);
                                                             FStar_TypeChecker_Env.instantiate_imp
                                                               = false;
                                                             FStar_TypeChecker_Env.effects
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.effects);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.effects);
                                                             FStar_TypeChecker_Env.generalize
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.generalize);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.generalize);
                                                             FStar_TypeChecker_Env.letrecs
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.letrecs);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.letrecs);
                                                             FStar_TypeChecker_Env.top_level
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.top_level);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.top_level);
                                                             FStar_TypeChecker_Env.check_uvars
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.check_uvars);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.check_uvars);
                                                             FStar_TypeChecker_Env.use_eq
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.use_eq);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.use_eq);
                                                             FStar_TypeChecker_Env.use_eq_strict
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.use_eq_strict);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.use_eq_strict);
                                                             FStar_TypeChecker_Env.is_iface
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.is_iface);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.is_iface);
                                                             FStar_TypeChecker_Env.admit
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.admit);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.admit);
                                                             FStar_TypeChecker_Env.lax
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.lax);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.lax);
                                                             FStar_TypeChecker_Env.lax_universes
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.lax_universes);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.lax_universes);
                                                             FStar_TypeChecker_Env.phase1
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.phase1);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.phase1);
                                                             FStar_TypeChecker_Env.failhard
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.failhard);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.failhard);
                                                             FStar_TypeChecker_Env.nosynth
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.nosynth);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.nosynth);
                                                             FStar_TypeChecker_Env.uvar_subtyping
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.uvar_subtyping);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.uvar_subtyping);
                                                             FStar_TypeChecker_Env.tc_term
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.tc_term);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.tc_term);
                                                             FStar_TypeChecker_Env.type_of
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.type_of);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.type_of);
                                                             FStar_TypeChecker_Env.universe_of
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.universe_of);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.universe_of);
                                                             FStar_TypeChecker_Env.check_type_of
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.check_type_of);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.check_type_of);
                                                             FStar_TypeChecker_Env.use_bv_sorts
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.use_bv_sorts);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.use_bv_sorts);
                                                             FStar_TypeChecker_Env.qtbl_name_and_index
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                             FStar_TypeChecker_Env.normalized_eff_names
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.normalized_eff_names);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.normalized_eff_names);
                                                             FStar_TypeChecker_Env.fv_delta_depths
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.fv_delta_depths);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.fv_delta_depths);
                                                             FStar_TypeChecker_Env.proof_ns
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.proof_ns);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.proof_ns);
                                                             FStar_TypeChecker_Env.synth_hook
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.synth_hook);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.synth_hook);
                                                             FStar_TypeChecker_Env.try_solve_implicits_hook
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                             FStar_TypeChecker_Env.splice
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.splice);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.splice);
                                                             FStar_TypeChecker_Env.mpreprocess
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.mpreprocess);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.mpreprocess);
                                                             FStar_TypeChecker_Env.postprocess
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.postprocess);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.postprocess);
                                                             FStar_TypeChecker_Env.is_native_tactic
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.is_native_tactic);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.is_native_tactic);
                                                             FStar_TypeChecker_Env.identifier_info
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.identifier_info);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.identifier_info);
                                                             FStar_TypeChecker_Env.tc_hooks
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.tc_hooks);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.tc_hooks);
                                                             FStar_TypeChecker_Env.dsenv
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.dsenv);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.dsenv);
                                                             FStar_TypeChecker_Env.nbe
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.nbe);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.nbe);
                                                             FStar_TypeChecker_Env.strict_args_tab
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.strict_args_tab);
+                                                              (uu___840_8358.FStar_TypeChecker_Env.strict_args_tab);
                                                             FStar_TypeChecker_Env.erasable_types_tab
                                                               =
-                                                              (uu___840_8308.FStar_TypeChecker_Env.erasable_types_tab)
+                                                              (uu___840_8358.FStar_TypeChecker_Env.erasable_types_tab)
                                                           }  in
-                                                        ((let uu____8311 =
+                                                        ((let uu____8361 =
                                                             FStar_TypeChecker_Env.debug
                                                               env1
                                                               (FStar_Options.Other
                                                                  "ED")
                                                              in
-                                                          if uu____8311
+                                                          if uu____8361
                                                           then
-                                                            let uu____8315 =
-                                                              FStar_Ident.text_of_lid
+                                                            let uu____8365 =
+                                                              FStar_Ident.string_of_lid
                                                                 act1.FStar_Syntax_Syntax.action_name
                                                                in
-                                                            let uu____8317 =
+                                                            let uu____8367 =
                                                               FStar_Syntax_Print.term_to_string
                                                                 act1.FStar_Syntax_Syntax.action_defn
                                                                in
-                                                            let uu____8319 =
+                                                            let uu____8369 =
                                                               FStar_Syntax_Print.term_to_string
                                                                 act_typ1
                                                                in
                                                             FStar_Util.print3
                                                               "Checking action %s:\n[definition]: %s\n[cps'd type]: %s\n"
-                                                              uu____8315
-                                                              uu____8317
-                                                              uu____8319
+                                                              uu____8365
+                                                              uu____8367
+                                                              uu____8369
                                                           else ());
-                                                         (let uu____8324 =
+                                                         (let uu____8374 =
                                                             FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                               env'
                                                               act1.FStar_Syntax_Syntax.action_defn
                                                              in
-                                                          match uu____8324
+                                                          match uu____8374
                                                           with
-                                                          | (act_defn,uu____8332,g_a)
+                                                          | (act_defn,uu____8382,g_a)
                                                               ->
                                                               let act_defn1 =
                                                                 FStar_TypeChecker_Normalize.normalize
@@ -4335,7 +4402,7 @@ let (tc_non_layered_eff_decl :
                                                                   env1
                                                                   act_typ1
                                                                  in
-                                                              let uu____8336
+                                                              let uu____8386
                                                                 =
                                                                 let act_typ3
                                                                   =
@@ -4348,14 +4415,14 @@ let (tc_non_layered_eff_decl :
                                                                 | FStar_Syntax_Syntax.Tm_arrow
                                                                     (bs1,c)
                                                                     ->
-                                                                    let uu____8372
+                                                                    let uu____8422
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     bs1 c  in
-                                                                    (match uu____8372
+                                                                    (match uu____8422
                                                                     with
                                                                     | 
-                                                                    (bs2,uu____8384)
+                                                                    (bs2,uu____8434)
                                                                     ->
                                                                     let res =
                                                                     mk_repr'
@@ -4363,54 +4430,54 @@ let (tc_non_layered_eff_decl :
                                                                     FStar_Syntax_Syntax.tun
                                                                      in
                                                                     let k =
-                                                                    let uu____8391
+                                                                    let uu____8441
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     res  in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs2
-                                                                    uu____8391
+                                                                    uu____8441
                                                                      in
-                                                                    let uu____8394
+                                                                    let uu____8444
                                                                     =
                                                                     FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                                     env1 k
                                                                      in
-                                                                    (match uu____8394
+                                                                    (match uu____8444
                                                                     with
                                                                     | 
-                                                                    (k1,uu____8408,g)
+                                                                    (k1,uu____8458,g)
                                                                     ->
                                                                     (k1, g)))
-                                                                | uu____8412
+                                                                | uu____8462
                                                                     ->
-                                                                    let uu____8413
+                                                                    let uu____8463
                                                                     =
-                                                                    let uu____8419
+                                                                    let uu____8469
                                                                     =
-                                                                    let uu____8421
+                                                                    let uu____8471
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     act_typ3
                                                                      in
-                                                                    let uu____8423
+                                                                    let uu____8473
                                                                     =
                                                                     FStar_Syntax_Print.tag_of_term
                                                                     act_typ3
                                                                      in
                                                                     FStar_Util.format2
                                                                     "Actions must have function types (not: %s, a.k.a. %s)"
-                                                                    uu____8421
-                                                                    uu____8423
+                                                                    uu____8471
+                                                                    uu____8473
                                                                      in
                                                                     (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                                    uu____8419)
+                                                                    uu____8469)
                                                                      in
                                                                     FStar_Errors.raise_error
-                                                                    uu____8413
+                                                                    uu____8463
                                                                     act_defn1.FStar_Syntax_Syntax.pos
                                                                  in
-                                                              (match uu____8336
+                                                              (match uu____8386
                                                                with
                                                                | (expected_k,g_k)
                                                                    ->
@@ -4421,83 +4488,83 @@ let (tc_non_layered_eff_decl :
                                                                     expected_k
                                                                      in
                                                                    ((
-                                                                    let uu____8441
+                                                                    let uu____8491
                                                                     =
-                                                                    let uu____8442
+                                                                    let uu____8492
                                                                     =
-                                                                    let uu____8443
+                                                                    let uu____8493
                                                                     =
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_t g  in
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_k
-                                                                    uu____8443
+                                                                    uu____8493
                                                                      in
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_a
-                                                                    uu____8442
+                                                                    uu____8492
                                                                      in
                                                                     FStar_TypeChecker_Rel.force_trivial_guard
                                                                     env1
-                                                                    uu____8441);
+                                                                    uu____8491);
                                                                     (
                                                                     let act_typ3
                                                                     =
-                                                                    let uu____8445
+                                                                    let uu____8495
                                                                     =
-                                                                    let uu____8446
+                                                                    let uu____8496
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     expected_k
                                                                      in
-                                                                    uu____8446.FStar_Syntax_Syntax.n
+                                                                    uu____8496.FStar_Syntax_Syntax.n
                                                                      in
-                                                                    match uu____8445
+                                                                    match uu____8495
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_arrow
                                                                     (bs1,c)
                                                                     ->
-                                                                    let uu____8471
+                                                                    let uu____8521
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     bs1 c  in
-                                                                    (match uu____8471
+                                                                    (match uu____8521
                                                                     with
                                                                     | 
                                                                     (bs2,c1)
                                                                     ->
-                                                                    let uu____8478
+                                                                    let uu____8528
                                                                     =
                                                                     destruct_repr
                                                                     (FStar_Syntax_Util.comp_result
                                                                     c1)  in
-                                                                    (match uu____8478
+                                                                    (match uu____8528
                                                                     with
                                                                     | 
                                                                     (a,wp) ->
                                                                     let c2 =
-                                                                    let uu____8498
+                                                                    let uu____8548
                                                                     =
-                                                                    let uu____8499
+                                                                    let uu____8549
                                                                     =
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1 a
                                                                      in
-                                                                    [uu____8499]
+                                                                    [uu____8549]
                                                                      in
-                                                                    let uu____8500
+                                                                    let uu____8550
                                                                     =
-                                                                    let uu____8511
+                                                                    let uu____8561
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     wp  in
-                                                                    [uu____8511]
+                                                                    [uu____8561]
                                                                      in
                                                                     {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____8498;
+                                                                    uu____8548;
                                                                     FStar_Syntax_Syntax.effect_name
                                                                     =
                                                                     (ed2.FStar_Syntax_Syntax.mname);
@@ -4505,24 +4572,24 @@ let (tc_non_layered_eff_decl :
                                                                     = a;
                                                                     FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____8500;
+                                                                    uu____8550;
                                                                     FStar_Syntax_Syntax.flags
                                                                     = []
                                                                     }  in
-                                                                    let uu____8536
+                                                                    let uu____8586
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Comp
                                                                     c2  in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs2
-                                                                    uu____8536))
+                                                                    uu____8586))
                                                                     | 
-                                                                    uu____8539
+                                                                    uu____8589
                                                                     ->
                                                                     failwith
                                                                     "Impossible (expected_k is an arrow)"
                                                                      in
-                                                                    let uu____8541
+                                                                    let uu____8591
                                                                     =
                                                                     if
                                                                     act1.FStar_Syntax_Syntax.action_univs
@@ -4532,16 +4599,16 @@ let (tc_non_layered_eff_decl :
                                                                     env1
                                                                     act_defn1
                                                                     else
-                                                                    (let uu____8563
+                                                                    (let uu____8613
                                                                     =
                                                                     FStar_Syntax_Subst.close_univ_vars
                                                                     act1.FStar_Syntax_Syntax.action_univs
                                                                     act_defn1
                                                                      in
                                                                     ((act1.FStar_Syntax_Syntax.action_univs),
-                                                                    uu____8563))
+                                                                    uu____8613))
                                                                      in
-                                                                    match uu____8541
+                                                                    match uu____8591
                                                                     with
                                                                     | 
                                                                     (univs,act_defn2)
@@ -4559,21 +4626,21 @@ let (tc_non_layered_eff_decl :
                                                                     univs
                                                                     act_typ4
                                                                      in
-                                                                    let uu___890_8582
+                                                                    let uu___890_8632
                                                                     = act1
                                                                      in
                                                                     {
                                                                     FStar_Syntax_Syntax.action_name
                                                                     =
-                                                                    (uu___890_8582.FStar_Syntax_Syntax.action_name);
+                                                                    (uu___890_8632.FStar_Syntax_Syntax.action_name);
                                                                     FStar_Syntax_Syntax.action_unqualified_name
                                                                     =
-                                                                    (uu___890_8582.FStar_Syntax_Syntax.action_unqualified_name);
+                                                                    (uu___890_8632.FStar_Syntax_Syntax.action_unqualified_name);
                                                                     FStar_Syntax_Syntax.action_univs
                                                                     = univs;
                                                                     FStar_Syntax_Syntax.action_params
                                                                     =
-                                                                    (uu___890_8582.FStar_Syntax_Syntax.action_params);
+                                                                    (uu___890_8632.FStar_Syntax_Syntax.action_params);
                                                                     FStar_Syntax_Syntax.action_defn
                                                                     =
                                                                     act_defn2;
@@ -4592,7 +4659,7 @@ let (tc_non_layered_eff_decl :
                                             (FStar_Pervasives_Native.Some
                                                bind_repr), actions)))))
                                    in
-                                match uu____7020 with
+                                match uu____7070 with
                                 | (repr,return_repr,bind_repr,actions) ->
                                     let cl ts =
                                       let ts1 =
@@ -4603,13 +4670,13 @@ let (tc_non_layered_eff_decl :
                                         FStar_Syntax_Subst.univ_var_closing
                                           ed_univs
                                          in
-                                      let uu____8625 =
+                                      let uu____8675 =
                                         FStar_Syntax_Subst.shift_subst
                                           (FStar_List.length ed_bs)
                                           ed_univs_closing
                                          in
                                       FStar_Syntax_Subst.subst_tscheme
-                                        uu____8625 ts1
+                                        uu____8675 ts1
                                        in
                                     let combinators =
                                       {
@@ -4637,95 +4704,95 @@ let (tc_non_layered_eff_decl :
                                       match ed2.FStar_Syntax_Syntax.combinators
                                       with
                                       | FStar_Syntax_Syntax.Primitive_eff
-                                          uu____8637 ->
+                                          uu____8687 ->
                                           FStar_Syntax_Syntax.Primitive_eff
                                             combinators1
                                       | FStar_Syntax_Syntax.DM4F_eff
-                                          uu____8638 ->
+                                          uu____8688 ->
                                           FStar_Syntax_Syntax.DM4F_eff
                                             combinators1
-                                      | uu____8639 ->
+                                      | uu____8689 ->
                                           failwith
                                             "Impossible! tc_eff_decl on a layered effect is not expected"
                                        in
                                     let ed3 =
-                                      let uu___910_8642 = ed2  in
-                                      let uu____8643 = cl signature  in
-                                      let uu____8644 =
+                                      let uu___910_8692 = ed2  in
+                                      let uu____8693 = cl signature  in
+                                      let uu____8694 =
                                         FStar_List.map
                                           (fun a  ->
-                                             let uu___913_8652 = a  in
-                                             let uu____8653 =
-                                               let uu____8654 =
+                                             let uu___913_8702 = a  in
+                                             let uu____8703 =
+                                               let uu____8704 =
                                                  cl
                                                    ((a.FStar_Syntax_Syntax.action_univs),
                                                      (a.FStar_Syntax_Syntax.action_defn))
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____8654
+                                                 uu____8704
                                                  FStar_Pervasives_Native.snd
                                                 in
-                                             let uu____8679 =
-                                               let uu____8680 =
+                                             let uu____8729 =
+                                               let uu____8730 =
                                                  cl
                                                    ((a.FStar_Syntax_Syntax.action_univs),
                                                      (a.FStar_Syntax_Syntax.action_typ))
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____8680
+                                                 uu____8730
                                                  FStar_Pervasives_Native.snd
                                                 in
                                              {
                                                FStar_Syntax_Syntax.action_name
                                                  =
-                                                 (uu___913_8652.FStar_Syntax_Syntax.action_name);
+                                                 (uu___913_8702.FStar_Syntax_Syntax.action_name);
                                                FStar_Syntax_Syntax.action_unqualified_name
                                                  =
-                                                 (uu___913_8652.FStar_Syntax_Syntax.action_unqualified_name);
+                                                 (uu___913_8702.FStar_Syntax_Syntax.action_unqualified_name);
                                                FStar_Syntax_Syntax.action_univs
                                                  =
-                                                 (uu___913_8652.FStar_Syntax_Syntax.action_univs);
+                                                 (uu___913_8702.FStar_Syntax_Syntax.action_univs);
                                                FStar_Syntax_Syntax.action_params
                                                  =
-                                                 (uu___913_8652.FStar_Syntax_Syntax.action_params);
+                                                 (uu___913_8702.FStar_Syntax_Syntax.action_params);
                                                FStar_Syntax_Syntax.action_defn
-                                                 = uu____8653;
+                                                 = uu____8703;
                                                FStar_Syntax_Syntax.action_typ
-                                                 = uu____8679
+                                                 = uu____8729
                                              }) actions
                                          in
                                       {
                                         FStar_Syntax_Syntax.mname =
-                                          (uu___910_8642.FStar_Syntax_Syntax.mname);
+                                          (uu___910_8692.FStar_Syntax_Syntax.mname);
                                         FStar_Syntax_Syntax.cattributes =
-                                          (uu___910_8642.FStar_Syntax_Syntax.cattributes);
+                                          (uu___910_8692.FStar_Syntax_Syntax.cattributes);
                                         FStar_Syntax_Syntax.univs =
-                                          (uu___910_8642.FStar_Syntax_Syntax.univs);
+                                          (uu___910_8692.FStar_Syntax_Syntax.univs);
                                         FStar_Syntax_Syntax.binders =
-                                          (uu___910_8642.FStar_Syntax_Syntax.binders);
+                                          (uu___910_8692.FStar_Syntax_Syntax.binders);
                                         FStar_Syntax_Syntax.signature =
-                                          uu____8643;
+                                          uu____8693;
                                         FStar_Syntax_Syntax.combinators =
                                           combinators2;
                                         FStar_Syntax_Syntax.actions =
-                                          uu____8644;
+                                          uu____8694;
                                         FStar_Syntax_Syntax.eff_attrs =
-                                          (uu___910_8642.FStar_Syntax_Syntax.eff_attrs)
+                                          (uu___910_8692.FStar_Syntax_Syntax.eff_attrs)
                                       }  in
-                                    ((let uu____8706 =
+                                    ((let uu____8756 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env)
                                           (FStar_Options.Other "ED")
                                          in
-                                      if uu____8706
+                                      if uu____8756
                                       then
-                                        let uu____8711 =
+                                        let uu____8761 =
                                           FStar_Syntax_Print.eff_decl_to_string
                                             false ed3
                                            in
                                         FStar_Util.print1
                                           "Typechecked effect declaration:\n\t%s\n"
-                                          uu____8711
+                                          uu____8761
                                       else ());
                                      ed3)))))))))))))
   
@@ -4738,12 +4805,12 @@ let (tc_eff_decl :
   fun env  ->
     fun ed  ->
       fun quals  ->
-        let uu____8737 =
-          let uu____8752 =
+        let uu____8787 =
+          let uu____8802 =
             FStar_All.pipe_right ed FStar_Syntax_Util.is_layered  in
-          if uu____8752 then tc_layered_eff_decl else tc_non_layered_eff_decl
+          if uu____8802 then tc_layered_eff_decl else tc_non_layered_eff_decl
            in
-        uu____8737 env ed quals
+        uu____8787 env ed quals
   
 let (monad_signature :
   FStar_TypeChecker_Env.env ->
@@ -4755,20 +4822,20 @@ let (monad_signature :
   fun env  ->
     fun m  ->
       fun s  ->
-        let fail uu____8802 =
-          let uu____8803 =
+        let fail uu____8852 =
+          let uu____8853 =
             FStar_TypeChecker_Err.unexpected_signature_for_monad env m s  in
-          let uu____8809 = FStar_Ident.range_of_lid m  in
-          FStar_Errors.raise_error uu____8803 uu____8809  in
+          let uu____8859 = FStar_Ident.range_of_lid m  in
+          FStar_Errors.raise_error uu____8853 uu____8859  in
         let s1 = FStar_Syntax_Subst.compress s  in
         match s1.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
             let bs1 = FStar_Syntax_Subst.open_binders bs  in
             (match bs1 with
-             | (a,uu____8853)::(wp,uu____8855)::[] ->
+             | (a,uu____8903)::(wp,uu____8905)::[] ->
                  (a, (wp.FStar_Syntax_Syntax.sort))
-             | uu____8884 -> fail ())
-        | uu____8885 -> fail ()
+             | uu____8934 -> fail ())
+        | uu____8935 -> fail ()
   
 let (tc_layered_lift :
   FStar_TypeChecker_Env.env ->
@@ -4776,22 +4843,22 @@ let (tc_layered_lift :
   =
   fun env0  ->
     fun sub  ->
-      (let uu____8898 =
+      (let uu____8948 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
            (FStar_Options.Other "LayeredEffects")
           in
-       if uu____8898
+       if uu____8948
        then
-         let uu____8903 = FStar_Syntax_Print.sub_eff_to_string sub  in
-         FStar_Util.print1 "Typechecking sub_effect: %s\n" uu____8903
+         let uu____8953 = FStar_Syntax_Print.sub_eff_to_string sub  in
+         FStar_Util.print1 "Typechecking sub_effect: %s\n" uu____8953
        else ());
       (let lift_ts =
          FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift FStar_Util.must
           in
        let r =
-         let uu____8920 =
+         let uu____8970 =
            FStar_All.pipe_right lift_ts FStar_Pervasives_Native.snd  in
-         uu____8920.FStar_Syntax_Syntax.pos  in
+         uu____8970.FStar_Syntax_Syntax.pos  in
        (let src_ed =
           FStar_TypeChecker_Env.get_effect_decl env0
             sub.FStar_Syntax_Syntax.source
@@ -4800,347 +4867,347 @@ let (tc_layered_lift :
           FStar_TypeChecker_Env.get_effect_decl env0
             sub.FStar_Syntax_Syntax.target
            in
-        let uu____8932 =
+        let uu____8982 =
           ((FStar_All.pipe_right src_ed FStar_Syntax_Util.is_layered) &&
-             (let uu____8936 =
-                let uu____8937 =
+             (let uu____8986 =
+                let uu____8987 =
                   FStar_All.pipe_right src_ed
                     FStar_Syntax_Util.get_layered_effect_base
                    in
-                FStar_All.pipe_right uu____8937 FStar_Util.must  in
-              FStar_Ident.lid_equals uu____8936
+                FStar_All.pipe_right uu____8987 FStar_Util.must  in
+              FStar_Ident.lid_equals uu____8986
                 tgt_ed.FStar_Syntax_Syntax.mname))
             ||
             (((FStar_All.pipe_right tgt_ed FStar_Syntax_Util.is_layered) &&
-                (let uu____8946 =
-                   let uu____8947 =
+                (let uu____8996 =
+                   let uu____8997 =
                      FStar_All.pipe_right tgt_ed
                        FStar_Syntax_Util.get_layered_effect_base
                       in
-                   FStar_All.pipe_right uu____8947 FStar_Util.must  in
-                 FStar_Ident.lid_equals uu____8946
+                   FStar_All.pipe_right uu____8997 FStar_Util.must  in
+                 FStar_Ident.lid_equals uu____8996
                    src_ed.FStar_Syntax_Syntax.mname))
                &&
-               (let uu____8955 =
+               (let uu____9005 =
                   FStar_Ident.lid_equals src_ed.FStar_Syntax_Syntax.mname
                     FStar_Parser_Const.effect_PURE_lid
                    in
-                Prims.op_Negation uu____8955))
+                Prims.op_Negation uu____9005))
            in
-        if uu____8932
+        if uu____8982
         then
-          let uu____8958 =
-            let uu____8964 =
-              let uu____8966 =
+          let uu____9008 =
+            let uu____9014 =
+              let uu____9016 =
                 FStar_All.pipe_right src_ed.FStar_Syntax_Syntax.mname
                   FStar_Ident.string_of_lid
                  in
-              let uu____8969 =
+              let uu____9019 =
                 FStar_All.pipe_right tgt_ed.FStar_Syntax_Syntax.mname
                   FStar_Ident.string_of_lid
                  in
               FStar_Util.format2
                 "Lifts cannot be defined from a layered effect to its repr or vice versa (%s and %s here)"
-                uu____8966 uu____8969
+                uu____9016 uu____9019
                in
-            (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____8964)  in
-          FStar_Errors.raise_error uu____8958 r
+            (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____9014)  in
+          FStar_Errors.raise_error uu____9008 r
         else ());
-       (let uu____8976 = check_and_gen env0 "" "lift" Prims.int_one lift_ts
+       (let uu____9026 = check_and_gen env0 "" "lift" Prims.int_one lift_ts
            in
-        match uu____8976 with
+        match uu____9026 with
         | (us,lift,lift_ty) ->
-            ((let uu____8990 =
+            ((let uu____9040 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
                   (FStar_Options.Other "LayeredEffects")
                  in
-              if uu____8990
+              if uu____9040
               then
-                let uu____8995 =
+                let uu____9045 =
                   FStar_Syntax_Print.tscheme_to_string (us, lift)  in
-                let uu____9001 =
+                let uu____9051 =
                   FStar_Syntax_Print.tscheme_to_string (us, lift_ty)  in
                 FStar_Util.print2 "Typechecked lift: %s and lift_ty: %s\n"
-                  uu____8995 uu____9001
+                  uu____9045 uu____9051
               else ());
-             (let uu____9010 = FStar_Syntax_Subst.open_univ_vars us lift_ty
+             (let uu____9060 = FStar_Syntax_Subst.open_univ_vars us lift_ty
                  in
-              match uu____9010 with
+              match uu____9060 with
               | (us1,lift_ty1) ->
                   let env = FStar_TypeChecker_Env.push_univ_vars env0 us1  in
                   (check_no_subtyping_for_layered_combinator env lift_ty1
                      FStar_Pervasives_Native.None;
                    (let lift_t_shape_error s =
-                      let uu____9028 =
+                      let uu____9078 =
                         FStar_Ident.string_of_lid
                           sub.FStar_Syntax_Syntax.source
                          in
-                      let uu____9030 =
+                      let uu____9080 =
                         FStar_Ident.string_of_lid
                           sub.FStar_Syntax_Syntax.target
                          in
-                      let uu____9032 =
+                      let uu____9082 =
                         FStar_Syntax_Print.term_to_string lift_ty1  in
                       FStar_Util.format4
                         "Unexpected shape of lift %s~>%s, reason:%s (t:%s)"
-                        uu____9028 uu____9030 s uu____9032
+                        uu____9078 uu____9080 s uu____9082
                        in
-                    let uu____9035 =
-                      let uu____9042 =
-                        let uu____9047 = FStar_Syntax_Util.type_u ()  in
-                        FStar_All.pipe_right uu____9047
-                          (fun uu____9064  ->
-                             match uu____9064 with
+                    let uu____9085 =
+                      let uu____9092 =
+                        let uu____9097 = FStar_Syntax_Util.type_u ()  in
+                        FStar_All.pipe_right uu____9097
+                          (fun uu____9114  ->
+                             match uu____9114 with
                              | (t,u) ->
-                                 let uu____9075 =
-                                   let uu____9076 =
+                                 let uu____9125 =
+                                   let uu____9126 =
                                      FStar_Syntax_Syntax.gen_bv "a"
                                        FStar_Pervasives_Native.None t
                                       in
-                                   FStar_All.pipe_right uu____9076
+                                   FStar_All.pipe_right uu____9126
                                      FStar_Syntax_Syntax.mk_binder
                                     in
-                                 (uu____9075, u))
+                                 (uu____9125, u))
                          in
-                      match uu____9042 with
+                      match uu____9092 with
                       | (a,u_a) ->
                           let rest_bs =
-                            let uu____9095 =
-                              let uu____9096 =
+                            let uu____9145 =
+                              let uu____9146 =
                                 FStar_Syntax_Subst.compress lift_ty1  in
-                              uu____9096.FStar_Syntax_Syntax.n  in
-                            match uu____9095 with
-                            | FStar_Syntax_Syntax.Tm_arrow (bs,uu____9108)
+                              uu____9146.FStar_Syntax_Syntax.n  in
+                            match uu____9145 with
+                            | FStar_Syntax_Syntax.Tm_arrow (bs,uu____9158)
                                 when
                                 (FStar_List.length bs) >= (Prims.of_int (2))
                                 ->
-                                let uu____9136 =
+                                let uu____9186 =
                                   FStar_Syntax_Subst.open_binders bs  in
-                                (match uu____9136 with
-                                 | (a',uu____9146)::bs1 ->
-                                     let uu____9166 =
-                                       let uu____9167 =
+                                (match uu____9186 with
+                                 | (a',uu____9196)::bs1 ->
+                                     let uu____9216 =
+                                       let uu____9217 =
                                          FStar_All.pipe_right bs1
                                            (FStar_List.splitAt
                                               ((FStar_List.length bs1) -
                                                  Prims.int_one))
                                           in
-                                       FStar_All.pipe_right uu____9167
+                                       FStar_All.pipe_right uu____9217
                                          FStar_Pervasives_Native.fst
                                         in
-                                     let uu____9233 =
-                                       let uu____9246 =
-                                         let uu____9249 =
-                                           let uu____9250 =
-                                             let uu____9257 =
+                                     let uu____9283 =
+                                       let uu____9296 =
+                                         let uu____9299 =
+                                           let uu____9300 =
+                                             let uu____9307 =
                                                FStar_Syntax_Syntax.bv_to_name
                                                  (FStar_Pervasives_Native.fst
                                                     a)
                                                 in
-                                             (a', uu____9257)  in
-                                           FStar_Syntax_Syntax.NT uu____9250
+                                             (a', uu____9307)  in
+                                           FStar_Syntax_Syntax.NT uu____9300
                                             in
-                                         [uu____9249]  in
+                                         [uu____9299]  in
                                        FStar_Syntax_Subst.subst_binders
-                                         uu____9246
+                                         uu____9296
                                         in
-                                     FStar_All.pipe_right uu____9166
-                                       uu____9233)
-                            | uu____9272 ->
-                                let uu____9273 =
-                                  let uu____9279 =
+                                     FStar_All.pipe_right uu____9216
+                                       uu____9283)
+                            | uu____9322 ->
+                                let uu____9323 =
+                                  let uu____9329 =
                                     lift_t_shape_error
                                       "either not an arrow, or not enough binders"
                                      in
                                   (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                    uu____9279)
+                                    uu____9329)
                                    in
-                                FStar_Errors.raise_error uu____9273 r
+                                FStar_Errors.raise_error uu____9323 r
                              in
-                          let uu____9291 =
-                            let uu____9302 =
-                              let uu____9307 =
+                          let uu____9341 =
+                            let uu____9352 =
+                              let uu____9357 =
                                 FStar_TypeChecker_Env.push_binders env (a ::
                                   rest_bs)
                                  in
-                              let uu____9314 =
-                                let uu____9315 =
+                              let uu____9364 =
+                                let uu____9365 =
                                   FStar_All.pipe_right a
                                     FStar_Pervasives_Native.fst
                                    in
-                                FStar_All.pipe_right uu____9315
+                                FStar_All.pipe_right uu____9365
                                   FStar_Syntax_Syntax.bv_to_name
                                  in
                               FStar_TypeChecker_Util.fresh_effect_repr_en
-                                uu____9307 r sub.FStar_Syntax_Syntax.source
-                                u_a uu____9314
+                                uu____9357 r sub.FStar_Syntax_Syntax.source
+                                u_a uu____9364
                                in
-                            match uu____9302 with
+                            match uu____9352 with
                             | (f_sort,g) ->
-                                let uu____9336 =
-                                  let uu____9343 =
+                                let uu____9386 =
+                                  let uu____9393 =
                                     FStar_Syntax_Syntax.gen_bv "f"
                                       FStar_Pervasives_Native.None f_sort
                                      in
-                                  FStar_All.pipe_right uu____9343
+                                  FStar_All.pipe_right uu____9393
                                     FStar_Syntax_Syntax.mk_binder
                                    in
-                                (uu____9336, g)
+                                (uu____9386, g)
                              in
-                          (match uu____9291 with
+                          (match uu____9341 with
                            | (f_b,g_f_b) ->
                                let bs = a ::
                                  (FStar_List.append rest_bs [f_b])  in
-                               let uu____9410 =
-                                 let uu____9415 =
+                               let uu____9460 =
+                                 let uu____9465 =
                                    FStar_TypeChecker_Env.push_binders env bs
                                     in
-                                 let uu____9416 =
-                                   let uu____9417 =
+                                 let uu____9466 =
+                                   let uu____9467 =
                                      FStar_All.pipe_right a
                                        FStar_Pervasives_Native.fst
                                       in
-                                   FStar_All.pipe_right uu____9417
+                                   FStar_All.pipe_right uu____9467
                                      FStar_Syntax_Syntax.bv_to_name
                                     in
                                  FStar_TypeChecker_Util.fresh_effect_repr_en
-                                   uu____9415 r
+                                   uu____9465 r
                                    sub.FStar_Syntax_Syntax.target u_a
-                                   uu____9416
+                                   uu____9466
                                   in
-                               (match uu____9410 with
+                               (match uu____9460 with
                                 | (repr,g_repr) ->
-                                    let uu____9434 =
-                                      let uu____9439 =
+                                    let uu____9484 =
+                                      let uu____9489 =
                                         FStar_TypeChecker_Env.push_binders
                                           env bs
                                          in
-                                      let uu____9440 =
-                                        let uu____9442 =
+                                      let uu____9490 =
+                                        let uu____9492 =
                                           FStar_Ident.string_of_lid
                                             sub.FStar_Syntax_Syntax.source
                                            in
-                                        let uu____9444 =
+                                        let uu____9494 =
                                           FStar_Ident.string_of_lid
                                             sub.FStar_Syntax_Syntax.target
                                            in
                                         FStar_Util.format2
                                           "implicit for pure_wp in typechecking lift %s~>%s"
-                                          uu____9442 uu____9444
+                                          uu____9492 uu____9494
                                          in
-                                      pure_wp_uvar uu____9439 repr uu____9440
+                                      pure_wp_uvar uu____9489 repr uu____9490
                                         r
                                        in
-                                    (match uu____9434 with
+                                    (match uu____9484 with
                                      | (pure_wp_uvar1,guard_wp) ->
                                          let c =
-                                           let uu____9456 =
-                                             let uu____9457 =
-                                               let uu____9458 =
+                                           let uu____9506 =
+                                             let uu____9507 =
+                                               let uu____9508 =
                                                  FStar_TypeChecker_Env.new_u_univ
                                                    ()
                                                   in
-                                               [uu____9458]  in
-                                             let uu____9459 =
-                                               let uu____9470 =
+                                               [uu____9508]  in
+                                             let uu____9509 =
+                                               let uu____9520 =
                                                  FStar_All.pipe_right
                                                    pure_wp_uvar1
                                                    FStar_Syntax_Syntax.as_arg
                                                   in
-                                               [uu____9470]  in
+                                               [uu____9520]  in
                                              {
                                                FStar_Syntax_Syntax.comp_univs
-                                                 = uu____9457;
+                                                 = uu____9507;
                                                FStar_Syntax_Syntax.effect_name
                                                  =
                                                  FStar_Parser_Const.effect_PURE_lid;
                                                FStar_Syntax_Syntax.result_typ
                                                  = repr;
                                                FStar_Syntax_Syntax.effect_args
-                                                 = uu____9459;
+                                                 = uu____9509;
                                                FStar_Syntax_Syntax.flags = []
                                              }  in
                                            FStar_Syntax_Syntax.mk_Comp
-                                             uu____9456
+                                             uu____9506
                                             in
-                                         let uu____9503 =
+                                         let uu____9553 =
                                            FStar_Syntax_Util.arrow bs c  in
-                                         let uu____9506 =
-                                           let uu____9507 =
+                                         let uu____9556 =
+                                           let uu____9557 =
                                              FStar_TypeChecker_Env.conj_guard
                                                g_f_b g_repr
                                               in
                                            FStar_TypeChecker_Env.conj_guard
-                                             uu____9507 guard_wp
+                                             uu____9557 guard_wp
                                             in
-                                         (uu____9503, uu____9506))))
+                                         (uu____9553, uu____9556))))
                        in
-                    match uu____9035 with
+                    match uu____9085 with
                     | (k,g_k) ->
-                        ((let uu____9517 =
+                        ((let uu____9567 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
                               (FStar_Options.Other "LayeredEffects")
                              in
-                          if uu____9517
+                          if uu____9567
                           then
-                            let uu____9522 =
+                            let uu____9572 =
                               FStar_Syntax_Print.term_to_string k  in
                             FStar_Util.print1
                               "tc_layered_lift: before unification k: %s\n"
-                              uu____9522
+                              uu____9572
                           else ());
                          (let g = FStar_TypeChecker_Rel.teq env lift_ty1 k
                              in
                           FStar_TypeChecker_Rel.force_trivial_guard env g_k;
                           FStar_TypeChecker_Rel.force_trivial_guard env g;
-                          (let uu____9531 =
+                          (let uu____9581 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env0)
                                (FStar_Options.Other "LayeredEffects")
                               in
-                           if uu____9531
+                           if uu____9581
                            then
-                             let uu____9536 =
+                             let uu____9586 =
                                FStar_Syntax_Print.term_to_string k  in
                              FStar_Util.print1 "After unification k: %s\n"
-                               uu____9536
+                               uu____9586
                            else ());
                           (let sub1 =
-                             let uu___1006_9542 = sub  in
-                             let uu____9543 =
-                               let uu____9546 =
-                                 let uu____9547 =
-                                   let uu____9550 =
+                             let uu___1006_9592 = sub  in
+                             let uu____9593 =
+                               let uu____9596 =
+                                 let uu____9597 =
+                                   let uu____9600 =
                                      FStar_All.pipe_right k
                                        (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                           env)
                                       in
-                                   FStar_All.pipe_right uu____9550
+                                   FStar_All.pipe_right uu____9600
                                      (FStar_Syntax_Subst.close_univ_vars us1)
                                     in
-                                 (us1, uu____9547)  in
-                               FStar_Pervasives_Native.Some uu____9546  in
+                                 (us1, uu____9597)  in
+                               FStar_Pervasives_Native.Some uu____9596  in
                              {
                                FStar_Syntax_Syntax.source =
-                                 (uu___1006_9542.FStar_Syntax_Syntax.source);
+                                 (uu___1006_9592.FStar_Syntax_Syntax.source);
                                FStar_Syntax_Syntax.target =
-                                 (uu___1006_9542.FStar_Syntax_Syntax.target);
-                               FStar_Syntax_Syntax.lift_wp = uu____9543;
+                                 (uu___1006_9592.FStar_Syntax_Syntax.target);
+                               FStar_Syntax_Syntax.lift_wp = uu____9593;
                                FStar_Syntax_Syntax.lift =
                                  (FStar_Pervasives_Native.Some (us1, lift))
                              }  in
-                           (let uu____9562 =
+                           (let uu____9612 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env0)
                                 (FStar_Options.Other "LayeredEffects")
                                in
-                            if uu____9562
+                            if uu____9612
                             then
-                              let uu____9567 =
+                              let uu____9617 =
                                 FStar_Syntax_Print.sub_eff_to_string sub1  in
                               FStar_Util.print1 "Final sub_effect: %s\n"
-                                uu____9567
+                                uu____9617
                             else ());
                            sub1)))))))))
   
@@ -5153,9 +5220,9 @@ let (tc_lift :
     fun sub  ->
       fun r  ->
         let check_and_gen1 env1 t k =
-          let uu____9604 =
+          let uu____9654 =
             FStar_TypeChecker_TcTerm.tc_check_trivial_guard env1 t k  in
-          FStar_TypeChecker_Util.generalize_universes env1 uu____9604  in
+          FStar_TypeChecker_Util.generalize_universes env1 uu____9654  in
         let ed_src =
           FStar_TypeChecker_Env.get_effect_decl env
             sub.FStar_Syntax_Syntax.source
@@ -5164,114 +5231,116 @@ let (tc_lift :
           FStar_TypeChecker_Env.get_effect_decl env
             sub.FStar_Syntax_Syntax.target
            in
-        let uu____9607 =
+        let uu____9657 =
           (FStar_All.pipe_right ed_src FStar_Syntax_Util.is_layered) ||
             (FStar_All.pipe_right ed_tgt FStar_Syntax_Util.is_layered)
            in
-        if uu____9607
+        if uu____9657
         then tc_layered_lift env sub
         else
-          (let uu____9614 =
-             let uu____9621 =
+          (let uu____9664 =
+             let uu____9671 =
                FStar_TypeChecker_Env.lookup_effect_lid env
                  sub.FStar_Syntax_Syntax.source
                 in
-             monad_signature env sub.FStar_Syntax_Syntax.source uu____9621
+             monad_signature env sub.FStar_Syntax_Syntax.source uu____9671
               in
-           match uu____9614 with
+           match uu____9664 with
            | (a,wp_a_src) ->
-               let uu____9628 =
-                 let uu____9635 =
+               let uu____9678 =
+                 let uu____9685 =
                    FStar_TypeChecker_Env.lookup_effect_lid env
                      sub.FStar_Syntax_Syntax.target
                     in
                  monad_signature env sub.FStar_Syntax_Syntax.target
-                   uu____9635
+                   uu____9685
                   in
-               (match uu____9628 with
+               (match uu____9678 with
                 | (b,wp_b_tgt) ->
                     let wp_a_tgt =
-                      let uu____9643 =
-                        let uu____9646 =
-                          let uu____9647 =
-                            let uu____9654 = FStar_Syntax_Syntax.bv_to_name a
+                      let uu____9693 =
+                        let uu____9696 =
+                          let uu____9697 =
+                            let uu____9704 = FStar_Syntax_Syntax.bv_to_name a
                                in
-                            (b, uu____9654)  in
-                          FStar_Syntax_Syntax.NT uu____9647  in
-                        [uu____9646]  in
-                      FStar_Syntax_Subst.subst uu____9643 wp_b_tgt  in
+                            (b, uu____9704)  in
+                          FStar_Syntax_Syntax.NT uu____9697  in
+                        [uu____9696]  in
+                      FStar_Syntax_Subst.subst uu____9693 wp_b_tgt  in
                     let expected_k =
-                      let uu____9662 =
-                        let uu____9671 = FStar_Syntax_Syntax.mk_binder a  in
-                        let uu____9678 =
-                          let uu____9687 =
+                      let uu____9712 =
+                        let uu____9721 = FStar_Syntax_Syntax.mk_binder a  in
+                        let uu____9728 =
+                          let uu____9737 =
                             FStar_Syntax_Syntax.null_binder wp_a_src  in
-                          [uu____9687]  in
-                        uu____9671 :: uu____9678  in
-                      let uu____9712 = FStar_Syntax_Syntax.mk_Total wp_a_tgt
+                          [uu____9737]  in
+                        uu____9721 :: uu____9728  in
+                      let uu____9762 = FStar_Syntax_Syntax.mk_Total wp_a_tgt
                          in
-                      FStar_Syntax_Util.arrow uu____9662 uu____9712  in
+                      FStar_Syntax_Util.arrow uu____9712 uu____9762  in
                     let repr_type eff_name a1 wp =
-                      (let uu____9734 =
-                         let uu____9736 =
+                      (let uu____9784 =
+                         let uu____9786 =
                            FStar_TypeChecker_Env.is_reifiable_effect env
                              eff_name
                             in
-                         Prims.op_Negation uu____9736  in
-                       if uu____9734
+                         Prims.op_Negation uu____9786  in
+                       if uu____9784
                        then
-                         let uu____9739 =
-                           let uu____9745 =
+                         let uu____9789 =
+                           let uu____9795 =
+                             let uu____9797 =
+                               FStar_Ident.string_of_lid eff_name  in
                              FStar_Util.format1 "Effect %s cannot be reified"
-                               eff_name.FStar_Ident.str
+                               uu____9797
                               in
                            (FStar_Errors.Fatal_EffectCannotBeReified,
-                             uu____9745)
+                             uu____9795)
                             in
-                         let uu____9749 = FStar_TypeChecker_Env.get_range env
+                         let uu____9801 = FStar_TypeChecker_Env.get_range env
                             in
-                         FStar_Errors.raise_error uu____9739 uu____9749
+                         FStar_Errors.raise_error uu____9789 uu____9801
                        else ());
-                      (let uu____9752 =
+                      (let uu____9804 =
                          FStar_TypeChecker_Env.effect_decl_opt env eff_name
                           in
-                       match uu____9752 with
+                       match uu____9804 with
                        | FStar_Pervasives_Native.None  ->
                            failwith
                              "internal error: reifiable effect has no decl?"
                        | FStar_Pervasives_Native.Some (ed,qualifiers) ->
                            let repr =
-                             let uu____9785 =
-                               let uu____9786 =
+                             let uu____9837 =
+                               let uu____9838 =
                                  FStar_All.pipe_right ed
                                    FStar_Syntax_Util.get_eff_repr
                                   in
-                               FStar_All.pipe_right uu____9786
+                               FStar_All.pipe_right uu____9838
                                  FStar_Util.must
                                 in
                              FStar_TypeChecker_Env.inst_effect_fun_with
                                [FStar_Syntax_Syntax.U_unknown] env ed
-                               uu____9785
+                               uu____9837
                               in
-                           let uu____9793 =
+                           let uu____9845 =
                              FStar_TypeChecker_Env.get_range env  in
-                           let uu____9794 =
-                             let uu____9801 =
-                               let uu____9802 =
-                                 let uu____9819 =
-                                   let uu____9830 =
+                           let uu____9846 =
+                             let uu____9853 =
+                               let uu____9854 =
+                                 let uu____9871 =
+                                   let uu____9882 =
                                      FStar_Syntax_Syntax.as_arg a1  in
-                                   let uu____9839 =
-                                     let uu____9850 =
+                                   let uu____9891 =
+                                     let uu____9902 =
                                        FStar_Syntax_Syntax.as_arg wp  in
-                                     [uu____9850]  in
-                                   uu____9830 :: uu____9839  in
-                                 (repr, uu____9819)  in
-                               FStar_Syntax_Syntax.Tm_app uu____9802  in
-                             FStar_Syntax_Syntax.mk uu____9801  in
-                           uu____9794 FStar_Pervasives_Native.None uu____9793)
+                                     [uu____9902]  in
+                                   uu____9882 :: uu____9891  in
+                                 (repr, uu____9871)  in
+                               FStar_Syntax_Syntax.Tm_app uu____9854  in
+                             FStar_Syntax_Syntax.mk uu____9853  in
+                           uu____9846 FStar_Pervasives_Native.None uu____9845)
                        in
-                    let uu____9895 =
+                    let uu____9947 =
                       match ((sub.FStar_Syntax_Syntax.lift),
                               (sub.FStar_Syntax_Syntax.lift_wp))
                       with
@@ -5279,23 +5348,23 @@ let (tc_lift :
                          ,FStar_Pervasives_Native.None ) ->
                           failwith "Impossible (parser)"
                       | (lift,FStar_Pervasives_Native.Some (uvs,lift_wp)) ->
-                          let uu____10068 =
+                          let uu____10120 =
                             if (FStar_List.length uvs) > Prims.int_zero
                             then
-                              let uu____10079 =
+                              let uu____10131 =
                                 FStar_Syntax_Subst.univ_var_opening uvs  in
-                              match uu____10079 with
+                              match uu____10131 with
                               | (usubst,uvs1) ->
-                                  let uu____10102 =
+                                  let uu____10154 =
                                     FStar_TypeChecker_Env.push_univ_vars env
                                       uvs1
                                      in
-                                  let uu____10103 =
+                                  let uu____10155 =
                                     FStar_Syntax_Subst.subst usubst lift_wp
                                      in
-                                  (uu____10102, uu____10103)
+                                  (uu____10154, uu____10155)
                             else (env, lift_wp)  in
-                          (match uu____10068 with
+                          (match uu____10120 with
                            | (env1,lift_wp1) ->
                                let lift_wp2 =
                                  if (FStar_List.length uvs) = Prims.int_zero
@@ -5305,61 +5374,61 @@ let (tc_lift :
                                       FStar_TypeChecker_TcTerm.tc_check_trivial_guard
                                         env1 lift_wp1 expected_k
                                        in
-                                    let uu____10153 =
+                                    let uu____10205 =
                                       FStar_Syntax_Subst.close_univ_vars uvs
                                         lift_wp2
                                        in
-                                    (uvs, uu____10153))
+                                    (uvs, uu____10205))
                                   in
                                (lift, lift_wp2))
                       | (FStar_Pervasives_Native.Some
                          (what,lift),FStar_Pervasives_Native.None ) ->
-                          let uu____10224 =
+                          let uu____10276 =
                             if (FStar_List.length what) > Prims.int_zero
                             then
-                              let uu____10239 =
+                              let uu____10291 =
                                 FStar_Syntax_Subst.univ_var_opening what  in
-                              match uu____10239 with
+                              match uu____10291 with
                               | (usubst,uvs) ->
-                                  let uu____10264 =
+                                  let uu____10316 =
                                     FStar_Syntax_Subst.subst usubst lift  in
-                                  (uvs, uu____10264)
+                                  (uvs, uu____10316)
                             else ([], lift)  in
-                          (match uu____10224 with
+                          (match uu____10276 with
                            | (uvs,lift1) ->
-                               ((let uu____10300 =
+                               ((let uu____10352 =
                                    FStar_TypeChecker_Env.debug env
                                      (FStar_Options.Other "ED")
                                     in
-                                 if uu____10300
+                                 if uu____10352
                                  then
-                                   let uu____10304 =
+                                   let uu____10356 =
                                      FStar_Syntax_Print.term_to_string lift1
                                       in
                                    FStar_Util.print1 "Lift for free : %s\n"
-                                     uu____10304
+                                     uu____10356
                                  else ());
                                 (let dmff_env =
                                    FStar_TypeChecker_DMFF.empty env
                                      (FStar_TypeChecker_TcTerm.tc_constant
                                         env FStar_Range.dummyRange)
                                     in
-                                 let uu____10310 =
-                                   let uu____10317 =
+                                 let uu____10362 =
+                                   let uu____10369 =
                                      FStar_TypeChecker_Env.push_univ_vars env
                                        uvs
                                       in
                                    FStar_TypeChecker_TcTerm.tc_term
-                                     uu____10317 lift1
+                                     uu____10369 lift1
                                     in
-                                 match uu____10310 with
-                                 | (lift2,comp,uu____10342) ->
-                                     let uu____10343 =
+                                 match uu____10362 with
+                                 | (lift2,comp,uu____10394) ->
+                                     let uu____10395 =
                                        FStar_TypeChecker_DMFF.star_expr
                                          dmff_env lift2
                                         in
-                                     (match uu____10343 with
-                                      | (uu____10372,lift_wp,lift_elab) ->
+                                     (match uu____10395 with
+                                      | (uu____10424,lift_wp,lift_elab) ->
                                           let lift_wp1 =
                                             FStar_TypeChecker_DMFF.recheck_debug
                                               "lift-wp" env lift_wp
@@ -5372,169 +5441,169 @@ let (tc_lift :
                                             (FStar_List.length uvs) =
                                               Prims.int_zero
                                           then
-                                            let uu____10404 =
-                                              let uu____10415 =
+                                            let uu____10456 =
+                                              let uu____10467 =
                                                 FStar_TypeChecker_Util.generalize_universes
                                                   env lift_elab1
                                                  in
                                               FStar_Pervasives_Native.Some
-                                                uu____10415
+                                                uu____10467
                                                in
-                                            let uu____10432 =
+                                            let uu____10484 =
                                               FStar_TypeChecker_Util.generalize_universes
                                                 env lift_wp1
                                                in
-                                            (uu____10404, uu____10432)
+                                            (uu____10456, uu____10484)
                                           else
-                                            (let uu____10461 =
-                                               let uu____10472 =
-                                                 let uu____10481 =
+                                            (let uu____10513 =
+                                               let uu____10524 =
+                                                 let uu____10533 =
                                                    FStar_Syntax_Subst.close_univ_vars
                                                      uvs lift_elab1
                                                     in
-                                                 (uvs, uu____10481)  in
+                                                 (uvs, uu____10533)  in
                                                FStar_Pervasives_Native.Some
-                                                 uu____10472
+                                                 uu____10524
                                                 in
-                                             let uu____10496 =
-                                               let uu____10505 =
+                                             let uu____10548 =
+                                               let uu____10557 =
                                                  FStar_Syntax_Subst.close_univ_vars
                                                    uvs lift_wp1
                                                   in
-                                               (uvs, uu____10505)  in
-                                             (uu____10461, uu____10496))))))
+                                               (uvs, uu____10557)  in
+                                             (uu____10513, uu____10548))))))
                        in
-                    (match uu____9895 with
+                    (match uu____9947 with
                      | (lift,lift_wp) ->
                          let env1 =
-                           let uu___1090_10569 = env  in
+                           let uu___1090_10621 = env  in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___1090_10569.FStar_TypeChecker_Env.solver);
+                               (uu___1090_10621.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___1090_10569.FStar_TypeChecker_Env.range);
+                               (uu___1090_10621.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___1090_10569.FStar_TypeChecker_Env.curmodule);
+                               (uu___1090_10621.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___1090_10569.FStar_TypeChecker_Env.gamma);
+                               (uu___1090_10621.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___1090_10569.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___1090_10621.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___1090_10569.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___1090_10621.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___1090_10569.FStar_TypeChecker_Env.modules);
+                               (uu___1090_10621.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___1090_10569.FStar_TypeChecker_Env.expected_typ);
+                               (uu___1090_10621.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___1090_10569.FStar_TypeChecker_Env.sigtab);
+                               (uu___1090_10621.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___1090_10569.FStar_TypeChecker_Env.attrtab);
+                               (uu___1090_10621.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___1090_10569.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___1090_10621.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___1090_10569.FStar_TypeChecker_Env.effects);
+                               (uu___1090_10621.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
-                               (uu___1090_10569.FStar_TypeChecker_Env.generalize);
+                               (uu___1090_10621.FStar_TypeChecker_Env.generalize);
                              FStar_TypeChecker_Env.letrecs =
-                               (uu___1090_10569.FStar_TypeChecker_Env.letrecs);
+                               (uu___1090_10621.FStar_TypeChecker_Env.letrecs);
                              FStar_TypeChecker_Env.top_level =
-                               (uu___1090_10569.FStar_TypeChecker_Env.top_level);
+                               (uu___1090_10621.FStar_TypeChecker_Env.top_level);
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___1090_10569.FStar_TypeChecker_Env.check_uvars);
+                               (uu___1090_10621.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___1090_10569.FStar_TypeChecker_Env.use_eq);
+                               (uu___1090_10621.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___1090_10569.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___1090_10621.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___1090_10569.FStar_TypeChecker_Env.is_iface);
+                               (uu___1090_10621.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___1090_10569.FStar_TypeChecker_Env.admit);
+                               (uu___1090_10621.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax = true;
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___1090_10569.FStar_TypeChecker_Env.lax_universes);
+                               (uu___1090_10621.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___1090_10569.FStar_TypeChecker_Env.phase1);
+                               (uu___1090_10621.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___1090_10569.FStar_TypeChecker_Env.failhard);
+                               (uu___1090_10621.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___1090_10569.FStar_TypeChecker_Env.nosynth);
+                               (uu___1090_10621.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___1090_10569.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___1090_10621.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___1090_10569.FStar_TypeChecker_Env.tc_term);
+                               (uu___1090_10621.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___1090_10569.FStar_TypeChecker_Env.type_of);
+                               (uu___1090_10621.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___1090_10569.FStar_TypeChecker_Env.universe_of);
+                               (uu___1090_10621.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___1090_10569.FStar_TypeChecker_Env.check_type_of);
+                               (uu___1090_10621.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___1090_10569.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___1090_10621.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___1090_10569.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___1090_10621.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___1090_10569.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___1090_10621.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___1090_10569.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___1090_10621.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___1090_10569.FStar_TypeChecker_Env.proof_ns);
+                               (uu___1090_10621.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___1090_10569.FStar_TypeChecker_Env.synth_hook);
+                               (uu___1090_10621.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___1090_10569.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___1090_10621.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___1090_10569.FStar_TypeChecker_Env.splice);
+                               (uu___1090_10621.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___1090_10569.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___1090_10621.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___1090_10569.FStar_TypeChecker_Env.postprocess);
+                               (uu___1090_10621.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.is_native_tactic =
-                               (uu___1090_10569.FStar_TypeChecker_Env.is_native_tactic);
+                               (uu___1090_10621.FStar_TypeChecker_Env.is_native_tactic);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___1090_10569.FStar_TypeChecker_Env.identifier_info);
+                               (uu___1090_10621.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___1090_10569.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___1090_10621.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___1090_10569.FStar_TypeChecker_Env.dsenv);
+                               (uu___1090_10621.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___1090_10569.FStar_TypeChecker_Env.nbe);
+                               (uu___1090_10621.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___1090_10569.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___1090_10621.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___1090_10569.FStar_TypeChecker_Env.erasable_types_tab)
+                               (uu___1090_10621.FStar_TypeChecker_Env.erasable_types_tab)
                            }  in
                          let lift1 =
                            match lift with
                            | FStar_Pervasives_Native.None  ->
                                FStar_Pervasives_Native.None
                            | FStar_Pervasives_Native.Some (uvs,lift1) ->
-                               let uu____10602 =
-                                 let uu____10607 =
+                               let uu____10654 =
+                                 let uu____10659 =
                                    FStar_Syntax_Subst.univ_var_opening uvs
                                     in
-                                 match uu____10607 with
+                                 match uu____10659 with
                                  | (usubst,uvs1) ->
-                                     let uu____10630 =
+                                     let uu____10682 =
                                        FStar_TypeChecker_Env.push_univ_vars
                                          env1 uvs1
                                         in
-                                     let uu____10631 =
+                                     let uu____10683 =
                                        FStar_Syntax_Subst.subst usubst lift1
                                         in
-                                     (uu____10630, uu____10631)
+                                     (uu____10682, uu____10683)
                                   in
-                               (match uu____10602 with
+                               (match uu____10654 with
                                 | (env2,lift2) ->
-                                    let uu____10636 =
-                                      let uu____10643 =
+                                    let uu____10688 =
+                                      let uu____10695 =
                                         FStar_TypeChecker_Env.lookup_effect_lid
                                           env2 sub.FStar_Syntax_Syntax.source
                                          in
                                       monad_signature env2
                                         sub.FStar_Syntax_Syntax.source
-                                        uu____10643
+                                        uu____10695
                                        in
-                                    (match uu____10636 with
+                                    (match uu____10688 with
                                      | (a1,wp_a_src1) ->
                                          let wp_a =
                                            FStar_Syntax_Syntax.new_bv
@@ -5563,75 +5632,75 @@ let (tc_lift :
                                                   lift_wp)
                                               in
                                            let lift_wp_a =
-                                             let uu____10669 =
+                                             let uu____10721 =
                                                FStar_TypeChecker_Env.get_range
                                                  env2
                                                 in
-                                             let uu____10670 =
-                                               let uu____10677 =
-                                                 let uu____10678 =
-                                                   let uu____10695 =
-                                                     let uu____10706 =
+                                             let uu____10722 =
+                                               let uu____10729 =
+                                                 let uu____10730 =
+                                                   let uu____10747 =
+                                                     let uu____10758 =
                                                        FStar_Syntax_Syntax.as_arg
                                                          a_typ
                                                         in
-                                                     let uu____10715 =
-                                                       let uu____10726 =
+                                                     let uu____10767 =
+                                                       let uu____10778 =
                                                          FStar_Syntax_Syntax.as_arg
                                                            wp_a_typ
                                                           in
-                                                       [uu____10726]  in
-                                                     uu____10706 ::
-                                                       uu____10715
+                                                       [uu____10778]  in
+                                                     uu____10758 ::
+                                                       uu____10767
                                                       in
-                                                   (lift_wp1, uu____10695)
+                                                   (lift_wp1, uu____10747)
                                                     in
                                                  FStar_Syntax_Syntax.Tm_app
-                                                   uu____10678
+                                                   uu____10730
                                                   in
                                                FStar_Syntax_Syntax.mk
-                                                 uu____10677
+                                                 uu____10729
                                                 in
-                                             uu____10670
+                                             uu____10722
                                                FStar_Pervasives_Native.None
-                                               uu____10669
+                                               uu____10721
                                               in
                                            repr_type
                                              sub.FStar_Syntax_Syntax.target
                                              a_typ lift_wp_a
                                             in
                                          let expected_k1 =
-                                           let uu____10774 =
-                                             let uu____10783 =
+                                           let uu____10826 =
+                                             let uu____10835 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  a1
                                                 in
-                                             let uu____10790 =
-                                               let uu____10799 =
+                                             let uu____10842 =
+                                               let uu____10851 =
                                                  FStar_Syntax_Syntax.mk_binder
                                                    wp_a
                                                   in
-                                               let uu____10806 =
-                                                 let uu____10815 =
+                                               let uu____10858 =
+                                                 let uu____10867 =
                                                    FStar_Syntax_Syntax.null_binder
                                                      repr_f
                                                     in
-                                                 [uu____10815]  in
-                                               uu____10799 :: uu____10806  in
-                                             uu____10783 :: uu____10790  in
-                                           let uu____10846 =
+                                                 [uu____10867]  in
+                                               uu____10851 :: uu____10858  in
+                                             uu____10835 :: uu____10842  in
+                                           let uu____10898 =
                                              FStar_Syntax_Syntax.mk_Total
                                                repr_result
                                               in
                                            FStar_Syntax_Util.arrow
-                                             uu____10774 uu____10846
+                                             uu____10826 uu____10898
                                             in
-                                         let uu____10849 =
+                                         let uu____10901 =
                                            FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                              env2 expected_k1
                                             in
-                                         (match uu____10849 with
-                                          | (expected_k2,uu____10859,uu____10860)
+                                         (match uu____10901 with
+                                          | (expected_k2,uu____10911,uu____10912)
                                               ->
                                               let lift3 =
                                                 if
@@ -5645,117 +5714,117 @@ let (tc_lift :
                                                      FStar_TypeChecker_TcTerm.tc_check_trivial_guard
                                                        env2 lift2 expected_k2
                                                       in
-                                                   let uu____10868 =
+                                                   let uu____10920 =
                                                      FStar_Syntax_Subst.close_univ_vars
                                                        uvs lift3
                                                       in
-                                                   (uvs, uu____10868))
+                                                   (uvs, uu____10920))
                                                  in
                                               FStar_Pervasives_Native.Some
                                                 lift3)))
                             in
-                         ((let uu____10876 =
-                             let uu____10878 =
-                               let uu____10880 =
+                         ((let uu____10928 =
+                             let uu____10930 =
+                               let uu____10932 =
                                  FStar_All.pipe_right lift_wp
                                    FStar_Pervasives_Native.fst
                                   in
-                               FStar_All.pipe_right uu____10880
+                               FStar_All.pipe_right uu____10932
                                  FStar_List.length
                                 in
-                             uu____10878 <> Prims.int_one  in
-                           if uu____10876
+                             uu____10930 <> Prims.int_one  in
+                           if uu____10928
                            then
-                             let uu____10903 =
-                               let uu____10909 =
-                                 let uu____10911 =
+                             let uu____10955 =
+                               let uu____10961 =
+                                 let uu____10963 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.source
                                     in
-                                 let uu____10913 =
+                                 let uu____10965 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.target
                                     in
-                                 let uu____10915 =
-                                   let uu____10917 =
-                                     let uu____10919 =
+                                 let uu____10967 =
+                                   let uu____10969 =
+                                     let uu____10971 =
                                        FStar_All.pipe_right lift_wp
                                          FStar_Pervasives_Native.fst
                                         in
-                                     FStar_All.pipe_right uu____10919
+                                     FStar_All.pipe_right uu____10971
                                        FStar_List.length
                                       in
-                                   FStar_All.pipe_right uu____10917
+                                   FStar_All.pipe_right uu____10969
                                      FStar_Util.string_of_int
                                     in
                                  FStar_Util.format3
                                    "Sub effect wp must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                   uu____10911 uu____10913 uu____10915
+                                   uu____10963 uu____10965 uu____10967
                                   in
                                (FStar_Errors.Fatal_TooManyUniverse,
-                                 uu____10909)
+                                 uu____10961)
                                 in
-                             FStar_Errors.raise_error uu____10903 r
+                             FStar_Errors.raise_error uu____10955 r
                            else ());
-                          (let uu____10946 =
+                          (let uu____10998 =
                              (FStar_Util.is_some lift1) &&
-                               (let uu____10949 =
-                                  let uu____10951 =
-                                    let uu____10954 =
+                               (let uu____11001 =
+                                  let uu____11003 =
+                                    let uu____11006 =
                                       FStar_All.pipe_right lift1
                                         FStar_Util.must
                                        in
-                                    FStar_All.pipe_right uu____10954
+                                    FStar_All.pipe_right uu____11006
                                       FStar_Pervasives_Native.fst
                                      in
-                                  FStar_All.pipe_right uu____10951
+                                  FStar_All.pipe_right uu____11003
                                     FStar_List.length
                                    in
-                                uu____10949 <> Prims.int_one)
+                                uu____11001 <> Prims.int_one)
                               in
-                           if uu____10946
+                           if uu____10998
                            then
-                             let uu____10993 =
-                               let uu____10999 =
-                                 let uu____11001 =
+                             let uu____11045 =
+                               let uu____11051 =
+                                 let uu____11053 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.source
                                     in
-                                 let uu____11003 =
+                                 let uu____11055 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.target
                                     in
-                                 let uu____11005 =
-                                   let uu____11007 =
-                                     let uu____11009 =
-                                       let uu____11012 =
+                                 let uu____11057 =
+                                   let uu____11059 =
+                                     let uu____11061 =
+                                       let uu____11064 =
                                          FStar_All.pipe_right lift1
                                            FStar_Util.must
                                           in
-                                       FStar_All.pipe_right uu____11012
+                                       FStar_All.pipe_right uu____11064
                                          FStar_Pervasives_Native.fst
                                         in
-                                     FStar_All.pipe_right uu____11009
+                                     FStar_All.pipe_right uu____11061
                                        FStar_List.length
                                       in
-                                   FStar_All.pipe_right uu____11007
+                                   FStar_All.pipe_right uu____11059
                                      FStar_Util.string_of_int
                                     in
                                  FStar_Util.format3
                                    "Sub effect lift must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                   uu____11001 uu____11003 uu____11005
+                                   uu____11053 uu____11055 uu____11057
                                   in
                                (FStar_Errors.Fatal_TooManyUniverse,
-                                 uu____10999)
+                                 uu____11051)
                                 in
-                             FStar_Errors.raise_error uu____10993 r
+                             FStar_Errors.raise_error uu____11045 r
                            else ());
-                          (let uu___1127_11054 = sub  in
+                          (let uu___1127_11106 = sub  in
                            {
                              FStar_Syntax_Syntax.source =
-                               (uu___1127_11054.FStar_Syntax_Syntax.source);
+                               (uu___1127_11106.FStar_Syntax_Syntax.source);
                              FStar_Syntax_Syntax.target =
-                               (uu___1127_11054.FStar_Syntax_Syntax.target);
+                               (uu___1127_11106.FStar_Syntax_Syntax.target);
                              FStar_Syntax_Syntax.lift_wp =
                                (FStar_Pervasives_Native.Some lift_wp);
                              FStar_Syntax_Syntax.lift = lift1
@@ -5770,52 +5839,52 @@ let (tc_effect_abbrev :
           FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp))
   =
   fun env  ->
-    fun uu____11085  ->
+    fun uu____11137  ->
       fun r  ->
-        match uu____11085 with
+        match uu____11137 with
         | (lid,uvs,tps,c) ->
             let env0 = env  in
-            let uu____11108 =
+            let uu____11160 =
               if (FStar_List.length uvs) = Prims.int_zero
               then (env, uvs, tps, c)
               else
-                (let uu____11136 = FStar_Syntax_Subst.univ_var_opening uvs
+                (let uu____11188 = FStar_Syntax_Subst.univ_var_opening uvs
                     in
-                 match uu____11136 with
+                 match uu____11188 with
                  | (usubst,uvs1) ->
                      let tps1 = FStar_Syntax_Subst.subst_binders usubst tps
                         in
                      let c1 =
-                       let uu____11167 =
+                       let uu____11219 =
                          FStar_Syntax_Subst.shift_subst
                            (FStar_List.length tps1) usubst
                           in
-                       FStar_Syntax_Subst.subst_comp uu____11167 c  in
-                     let uu____11176 =
+                       FStar_Syntax_Subst.subst_comp uu____11219 c  in
+                     let uu____11228 =
                        FStar_TypeChecker_Env.push_univ_vars env uvs1  in
-                     (uu____11176, uvs1, tps1, c1))
+                     (uu____11228, uvs1, tps1, c1))
                in
-            (match uu____11108 with
+            (match uu____11160 with
              | (env1,uvs1,tps1,c1) ->
                  let env2 = FStar_TypeChecker_Env.set_range env1 r  in
-                 let uu____11196 = FStar_Syntax_Subst.open_comp tps1 c1  in
-                 (match uu____11196 with
+                 let uu____11248 = FStar_Syntax_Subst.open_comp tps1 c1  in
+                 (match uu____11248 with
                   | (tps2,c2) ->
-                      let uu____11211 =
+                      let uu____11263 =
                         FStar_TypeChecker_TcTerm.tc_tparams env2 tps2  in
-                      (match uu____11211 with
+                      (match uu____11263 with
                        | (tps3,env3,us) ->
-                           let uu____11229 =
+                           let uu____11281 =
                              FStar_TypeChecker_TcTerm.tc_comp env3 c2  in
-                           (match uu____11229 with
+                           (match uu____11281 with
                             | (c3,u,g) ->
                                 (FStar_TypeChecker_Rel.force_trivial_guard
                                    env3 g;
                                  (let expected_result_typ =
                                     match tps3 with
-                                    | (x,uu____11255)::uu____11256 ->
+                                    | (x,uu____11307)::uu____11308 ->
                                         FStar_Syntax_Syntax.bv_to_name x
-                                    | uu____11275 ->
+                                    | uu____11327 ->
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
                                             "Effect abbreviations must bind at least the result type")
@@ -5823,107 +5892,107 @@ let (tc_effect_abbrev :
                                      in
                                   let def_result_typ =
                                     FStar_Syntax_Util.comp_result c3  in
-                                  let uu____11283 =
-                                    let uu____11285 =
+                                  let uu____11335 =
+                                    let uu____11337 =
                                       FStar_TypeChecker_Rel.teq_nosmt_force
                                         env3 expected_result_typ
                                         def_result_typ
                                        in
-                                    Prims.op_Negation uu____11285  in
-                                  if uu____11283
+                                    Prims.op_Negation uu____11337  in
+                                  if uu____11335
                                   then
-                                    let uu____11288 =
-                                      let uu____11294 =
-                                        let uu____11296 =
+                                    let uu____11340 =
+                                      let uu____11346 =
+                                        let uu____11348 =
                                           FStar_Syntax_Print.term_to_string
                                             expected_result_typ
                                            in
-                                        let uu____11298 =
+                                        let uu____11350 =
                                           FStar_Syntax_Print.term_to_string
                                             def_result_typ
                                            in
                                         FStar_Util.format2
                                           "Result type of effect abbreviation `%s` does not match the result type of its definition `%s`"
-                                          uu____11296 uu____11298
+                                          uu____11348 uu____11350
                                          in
                                       (FStar_Errors.Fatal_EffectAbbreviationResultTypeMismatch,
-                                        uu____11294)
+                                        uu____11346)
                                        in
-                                    FStar_Errors.raise_error uu____11288 r
+                                    FStar_Errors.raise_error uu____11340 r
                                   else ());
                                  (let tps4 =
                                     FStar_Syntax_Subst.close_binders tps3  in
                                   let c4 =
                                     FStar_Syntax_Subst.close_comp tps4 c3  in
-                                  let uu____11306 =
-                                    let uu____11307 =
+                                  let uu____11358 =
+                                    let uu____11359 =
                                       FStar_Syntax_Syntax.mk
                                         (FStar_Syntax_Syntax.Tm_arrow
                                            (tps4, c4))
                                         FStar_Pervasives_Native.None r
                                        in
                                     FStar_TypeChecker_Util.generalize_universes
-                                      env0 uu____11307
+                                      env0 uu____11359
                                      in
-                                  match uu____11306 with
+                                  match uu____11358 with
                                   | (uvs2,t) ->
-                                      let uu____11336 =
-                                        let uu____11341 =
-                                          let uu____11354 =
-                                            let uu____11355 =
+                                      let uu____11388 =
+                                        let uu____11393 =
+                                          let uu____11406 =
+                                            let uu____11407 =
                                               FStar_Syntax_Subst.compress t
                                                in
-                                            uu____11355.FStar_Syntax_Syntax.n
+                                            uu____11407.FStar_Syntax_Syntax.n
                                              in
-                                          (tps4, uu____11354)  in
-                                        match uu____11341 with
+                                          (tps4, uu____11406)  in
+                                        match uu____11393 with
                                         | ([],FStar_Syntax_Syntax.Tm_arrow
-                                           (uu____11370,c5)) -> ([], c5)
-                                        | (uu____11412,FStar_Syntax_Syntax.Tm_arrow
+                                           (uu____11422,c5)) -> ([], c5)
+                                        | (uu____11464,FStar_Syntax_Syntax.Tm_arrow
                                            (tps5,c5)) -> (tps5, c5)
-                                        | uu____11451 ->
+                                        | uu____11503 ->
                                             failwith
                                               "Impossible (t is an arrow)"
                                          in
-                                      (match uu____11336 with
+                                      (match uu____11388 with
                                        | (tps5,c5) ->
                                            (if
                                               (FStar_List.length uvs2) <>
                                                 Prims.int_one
                                             then
-                                              (let uu____11483 =
+                                              (let uu____11535 =
                                                  FStar_Syntax_Subst.open_univ_vars
                                                    uvs2 t
                                                   in
-                                               match uu____11483 with
-                                               | (uu____11488,t1) ->
-                                                   let uu____11490 =
-                                                     let uu____11496 =
-                                                       let uu____11498 =
+                                               match uu____11535 with
+                                               | (uu____11540,t1) ->
+                                                   let uu____11542 =
+                                                     let uu____11548 =
+                                                       let uu____11550 =
                                                          FStar_Syntax_Print.lid_to_string
                                                            lid
                                                           in
-                                                       let uu____11500 =
+                                                       let uu____11552 =
                                                          FStar_All.pipe_right
                                                            (FStar_List.length
                                                               uvs2)
                                                            FStar_Util.string_of_int
                                                           in
-                                                       let uu____11504 =
+                                                       let uu____11556 =
                                                          FStar_Syntax_Print.term_to_string
                                                            t1
                                                           in
                                                        FStar_Util.format3
                                                          "Effect abbreviations must be polymorphic in exactly 1 universe; %s has %s universes (%s)"
-                                                         uu____11498
-                                                         uu____11500
-                                                         uu____11504
+                                                         uu____11550
+                                                         uu____11552
+                                                         uu____11556
                                                         in
                                                      (FStar_Errors.Fatal_TooManyUniverse,
-                                                       uu____11496)
+                                                       uu____11548)
                                                       in
                                                    FStar_Errors.raise_error
-                                                     uu____11490 r)
+                                                     uu____11542 r)
                                             else ();
                                             (lid, uvs2, tps5, c5)))))))))
   
@@ -5941,321 +6010,321 @@ let (tc_polymonadic_bind :
         fun p  ->
           fun ts  ->
             let eff_name =
-              let uu____11546 = FStar_Ident.string_of_lid m  in
-              let uu____11548 = FStar_Ident.string_of_lid n  in
-              let uu____11550 = FStar_Ident.string_of_lid p  in
-              FStar_Util.format3 "(%s, %s) |> %s)" uu____11546 uu____11548
-                uu____11550
+              let uu____11598 = FStar_Ident.string_of_lid m  in
+              let uu____11600 = FStar_Ident.string_of_lid n  in
+              let uu____11602 = FStar_Ident.string_of_lid p  in
+              FStar_Util.format3 "(%s, %s) |> %s)" uu____11598 uu____11600
+                uu____11602
                in
             let r = (FStar_Pervasives_Native.snd ts).FStar_Syntax_Syntax.pos
                in
-            let uu____11558 =
+            let uu____11610 =
               check_and_gen env eff_name "polymonadic_bind"
                 (Prims.of_int (2)) ts
                in
-            match uu____11558 with
+            match uu____11610 with
             | (us,t,ty) ->
-                let uu____11574 = FStar_Syntax_Subst.open_univ_vars us ty  in
-                (match uu____11574 with
+                let uu____11626 = FStar_Syntax_Subst.open_univ_vars us ty  in
+                (match uu____11626 with
                  | (us1,ty1) ->
                      let env1 = FStar_TypeChecker_Env.push_univ_vars env us1
                         in
                      (check_no_subtyping_for_layered_combinator env1 ty1
                         FStar_Pervasives_Native.None;
-                      (let uu____11587 =
-                         let uu____11592 = FStar_Syntax_Util.type_u ()  in
-                         FStar_All.pipe_right uu____11592
-                           (fun uu____11609  ->
-                              match uu____11609 with
+                      (let uu____11639 =
+                         let uu____11644 = FStar_Syntax_Util.type_u ()  in
+                         FStar_All.pipe_right uu____11644
+                           (fun uu____11661  ->
+                              match uu____11661 with
                               | (t1,u) ->
-                                  let uu____11620 =
-                                    let uu____11621 =
+                                  let uu____11672 =
+                                    let uu____11673 =
                                       FStar_Syntax_Syntax.gen_bv "a"
                                         FStar_Pervasives_Native.None t1
                                        in
-                                    FStar_All.pipe_right uu____11621
+                                    FStar_All.pipe_right uu____11673
                                       FStar_Syntax_Syntax.mk_binder
                                      in
-                                  (uu____11620, u))
+                                  (uu____11672, u))
                           in
-                       match uu____11587 with
+                       match uu____11639 with
                        | (a,u_a) ->
-                           let uu____11629 =
-                             let uu____11634 = FStar_Syntax_Util.type_u ()
+                           let uu____11681 =
+                             let uu____11686 = FStar_Syntax_Util.type_u ()
                                 in
-                             FStar_All.pipe_right uu____11634
-                               (fun uu____11651  ->
-                                  match uu____11651 with
+                             FStar_All.pipe_right uu____11686
+                               (fun uu____11703  ->
+                                  match uu____11703 with
                                   | (t1,u) ->
-                                      let uu____11662 =
-                                        let uu____11663 =
+                                      let uu____11714 =
+                                        let uu____11715 =
                                           FStar_Syntax_Syntax.gen_bv "b"
                                             FStar_Pervasives_Native.None t1
                                            in
-                                        FStar_All.pipe_right uu____11663
+                                        FStar_All.pipe_right uu____11715
                                           FStar_Syntax_Syntax.mk_binder
                                          in
-                                      (uu____11662, u))
+                                      (uu____11714, u))
                               in
-                           (match uu____11629 with
+                           (match uu____11681 with
                             | (b,u_b) ->
                                 let rest_bs =
-                                  let uu____11680 =
-                                    let uu____11681 =
+                                  let uu____11732 =
+                                    let uu____11733 =
                                       FStar_Syntax_Subst.compress ty1  in
-                                    uu____11681.FStar_Syntax_Syntax.n  in
-                                  match uu____11680 with
+                                    uu____11733.FStar_Syntax_Syntax.n  in
+                                  match uu____11732 with
                                   | FStar_Syntax_Syntax.Tm_arrow
-                                      (bs,uu____11693) when
+                                      (bs,uu____11745) when
                                       (FStar_List.length bs) >=
                                         (Prims.of_int (4))
                                       ->
-                                      let uu____11721 =
+                                      let uu____11773 =
                                         FStar_Syntax_Subst.open_binders bs
                                          in
-                                      (match uu____11721 with
-                                       | (a',uu____11731)::(b',uu____11733)::bs1
+                                      (match uu____11773 with
+                                       | (a',uu____11783)::(b',uu____11785)::bs1
                                            ->
-                                           let uu____11763 =
-                                             let uu____11764 =
+                                           let uu____11815 =
+                                             let uu____11816 =
                                                FStar_All.pipe_right bs1
                                                  (FStar_List.splitAt
                                                     ((FStar_List.length bs1)
                                                        - (Prims.of_int (2))))
                                                 in
-                                             FStar_All.pipe_right uu____11764
+                                             FStar_All.pipe_right uu____11816
                                                FStar_Pervasives_Native.fst
                                               in
-                                           let uu____11830 =
-                                             let uu____11843 =
-                                               let uu____11846 =
-                                                 let uu____11847 =
-                                                   let uu____11854 =
-                                                     let uu____11857 =
+                                           let uu____11882 =
+                                             let uu____11895 =
+                                               let uu____11898 =
+                                                 let uu____11899 =
+                                                   let uu____11906 =
+                                                     let uu____11909 =
                                                        FStar_All.pipe_right a
                                                          FStar_Pervasives_Native.fst
                                                         in
                                                      FStar_All.pipe_right
-                                                       uu____11857
+                                                       uu____11909
                                                        FStar_Syntax_Syntax.bv_to_name
                                                       in
-                                                   (a', uu____11854)  in
+                                                   (a', uu____11906)  in
                                                  FStar_Syntax_Syntax.NT
-                                                   uu____11847
+                                                   uu____11899
                                                   in
-                                               let uu____11870 =
-                                                 let uu____11873 =
-                                                   let uu____11874 =
-                                                     let uu____11881 =
-                                                       let uu____11884 =
+                                               let uu____11922 =
+                                                 let uu____11925 =
+                                                   let uu____11926 =
+                                                     let uu____11933 =
+                                                       let uu____11936 =
                                                          FStar_All.pipe_right
                                                            b
                                                            FStar_Pervasives_Native.fst
                                                           in
                                                        FStar_All.pipe_right
-                                                         uu____11884
+                                                         uu____11936
                                                          FStar_Syntax_Syntax.bv_to_name
                                                         in
-                                                     (b', uu____11881)  in
+                                                     (b', uu____11933)  in
                                                    FStar_Syntax_Syntax.NT
-                                                     uu____11874
+                                                     uu____11926
                                                     in
-                                                 [uu____11873]  in
-                                               uu____11846 :: uu____11870  in
+                                                 [uu____11925]  in
+                                               uu____11898 :: uu____11922  in
                                              FStar_Syntax_Subst.subst_binders
-                                               uu____11843
+                                               uu____11895
                                               in
-                                           FStar_All.pipe_right uu____11763
-                                             uu____11830)
-                                  | uu____11905 ->
-                                      let uu____11906 =
-                                        let uu____11912 =
-                                          let uu____11914 =
+                                           FStar_All.pipe_right uu____11815
+                                             uu____11882)
+                                  | uu____11957 ->
+                                      let uu____11958 =
+                                        let uu____11964 =
+                                          let uu____11966 =
                                             FStar_Syntax_Print.tag_of_term
                                               ty1
                                              in
-                                          let uu____11916 =
+                                          let uu____11968 =
                                             FStar_Syntax_Print.term_to_string
                                               ty1
                                              in
                                           FStar_Util.format3
                                             "Type of %s is not an arrow with >= 4 binders (%s::%s)"
-                                            eff_name uu____11914 uu____11916
+                                            eff_name uu____11966 uu____11968
                                            in
                                         (FStar_Errors.Fatal_UnexpectedEffect,
-                                          uu____11912)
+                                          uu____11964)
                                          in
-                                      FStar_Errors.raise_error uu____11906 r
+                                      FStar_Errors.raise_error uu____11958 r
                                    in
                                 let bs = a :: b :: rest_bs  in
-                                let uu____11949 =
-                                  let uu____11960 =
-                                    let uu____11965 =
+                                let uu____12001 =
+                                  let uu____12012 =
+                                    let uu____12017 =
                                       FStar_TypeChecker_Env.push_binders env1
                                         bs
                                        in
-                                    let uu____11966 =
-                                      let uu____11967 =
+                                    let uu____12018 =
+                                      let uu____12019 =
                                         FStar_All.pipe_right a
                                           FStar_Pervasives_Native.fst
                                          in
-                                      FStar_All.pipe_right uu____11967
+                                      FStar_All.pipe_right uu____12019
                                         FStar_Syntax_Syntax.bv_to_name
                                        in
                                     FStar_TypeChecker_Util.fresh_effect_repr_en
-                                      uu____11965 r m u_a uu____11966
+                                      uu____12017 r m u_a uu____12018
                                      in
-                                  match uu____11960 with
+                                  match uu____12012 with
                                   | (repr,g) ->
-                                      let uu____11988 =
-                                        let uu____11995 =
+                                      let uu____12040 =
+                                        let uu____12047 =
                                           FStar_Syntax_Syntax.gen_bv "f"
                                             FStar_Pervasives_Native.None repr
                                            in
-                                        FStar_All.pipe_right uu____11995
+                                        FStar_All.pipe_right uu____12047
                                           FStar_Syntax_Syntax.mk_binder
                                          in
-                                      (uu____11988, g)
+                                      (uu____12040, g)
                                    in
-                                (match uu____11949 with
+                                (match uu____12001 with
                                  | (f,guard_f) ->
-                                     let uu____12027 =
+                                     let uu____12079 =
                                        let x_a =
-                                         let uu____12045 =
-                                           let uu____12046 =
-                                             let uu____12047 =
+                                         let uu____12097 =
+                                           let uu____12098 =
+                                             let uu____12099 =
                                                FStar_All.pipe_right a
                                                  FStar_Pervasives_Native.fst
                                                 in
-                                             FStar_All.pipe_right uu____12047
+                                             FStar_All.pipe_right uu____12099
                                                FStar_Syntax_Syntax.bv_to_name
                                               in
                                            FStar_Syntax_Syntax.gen_bv "x"
                                              FStar_Pervasives_Native.None
-                                             uu____12046
+                                             uu____12098
                                             in
-                                         FStar_All.pipe_right uu____12045
+                                         FStar_All.pipe_right uu____12097
                                            FStar_Syntax_Syntax.mk_binder
                                           in
-                                       let uu____12063 =
-                                         let uu____12068 =
+                                       let uu____12115 =
+                                         let uu____12120 =
                                            FStar_TypeChecker_Env.push_binders
                                              env1
                                              (FStar_List.append bs [x_a])
                                             in
-                                         let uu____12087 =
-                                           let uu____12088 =
+                                         let uu____12139 =
+                                           let uu____12140 =
                                              FStar_All.pipe_right b
                                                FStar_Pervasives_Native.fst
                                               in
-                                           FStar_All.pipe_right uu____12088
+                                           FStar_All.pipe_right uu____12140
                                              FStar_Syntax_Syntax.bv_to_name
                                             in
                                          FStar_TypeChecker_Util.fresh_effect_repr_en
-                                           uu____12068 r n u_b uu____12087
+                                           uu____12120 r n u_b uu____12139
                                           in
-                                       match uu____12063 with
+                                       match uu____12115 with
                                        | (repr,g) ->
-                                           let uu____12109 =
-                                             let uu____12116 =
-                                               let uu____12117 =
-                                                 let uu____12118 =
-                                                   let uu____12121 =
-                                                     let uu____12124 =
+                                           let uu____12161 =
+                                             let uu____12168 =
+                                               let uu____12169 =
+                                                 let uu____12170 =
+                                                   let uu____12173 =
+                                                     let uu____12176 =
                                                        FStar_TypeChecker_Env.new_u_univ
                                                          ()
                                                         in
                                                      FStar_Pervasives_Native.Some
-                                                       uu____12124
+                                                       uu____12176
                                                       in
                                                    FStar_Syntax_Syntax.mk_Total'
-                                                     repr uu____12121
+                                                     repr uu____12173
                                                     in
                                                  FStar_Syntax_Util.arrow
-                                                   [x_a] uu____12118
+                                                   [x_a] uu____12170
                                                   in
                                                FStar_Syntax_Syntax.gen_bv "g"
                                                  FStar_Pervasives_Native.None
-                                                 uu____12117
+                                                 uu____12169
                                                 in
-                                             FStar_All.pipe_right uu____12116
+                                             FStar_All.pipe_right uu____12168
                                                FStar_Syntax_Syntax.mk_binder
                                               in
-                                           (uu____12109, g)
+                                           (uu____12161, g)
                                         in
-                                     (match uu____12027 with
+                                     (match uu____12079 with
                                       | (g,guard_g) ->
-                                          let uu____12168 =
-                                            let uu____12173 =
+                                          let uu____12220 =
+                                            let uu____12225 =
                                               FStar_TypeChecker_Env.push_binders
                                                 env1 bs
                                                in
-                                            let uu____12174 =
-                                              let uu____12175 =
+                                            let uu____12226 =
+                                              let uu____12227 =
                                                 FStar_All.pipe_right b
                                                   FStar_Pervasives_Native.fst
                                                  in
                                               FStar_All.pipe_right
-                                                uu____12175
+                                                uu____12227
                                                 FStar_Syntax_Syntax.bv_to_name
                                                in
                                             FStar_TypeChecker_Util.fresh_effect_repr_en
-                                              uu____12173 r p u_b uu____12174
+                                              uu____12225 r p u_b uu____12226
                                              in
-                                          (match uu____12168 with
+                                          (match uu____12220 with
                                            | (repr,guard_repr) ->
-                                               let uu____12190 =
-                                                 let uu____12195 =
+                                               let uu____12242 =
+                                                 let uu____12247 =
                                                    FStar_TypeChecker_Env.push_binders
                                                      env1 bs
                                                     in
-                                                 let uu____12196 =
+                                                 let uu____12248 =
                                                    FStar_Util.format1
                                                      "implicit for pure_wp in checking %s"
                                                      eff_name
                                                     in
-                                                 pure_wp_uvar uu____12195
-                                                   repr uu____12196 r
+                                                 pure_wp_uvar uu____12247
+                                                   repr uu____12248 r
                                                   in
-                                               (match uu____12190 with
+                                               (match uu____12242 with
                                                 | (pure_wp_uvar1,g_pure_wp_uvar)
                                                     ->
                                                     let k =
-                                                      let uu____12208 =
-                                                        let uu____12211 =
-                                                          let uu____12212 =
-                                                            let uu____12213 =
+                                                      let uu____12260 =
+                                                        let uu____12263 =
+                                                          let uu____12264 =
+                                                            let uu____12265 =
                                                               FStar_TypeChecker_Env.new_u_univ
                                                                 ()
                                                                in
-                                                            [uu____12213]  in
-                                                          let uu____12214 =
-                                                            let uu____12225 =
+                                                            [uu____12265]  in
+                                                          let uu____12266 =
+                                                            let uu____12277 =
                                                               FStar_All.pipe_right
                                                                 pure_wp_uvar1
                                                                 FStar_Syntax_Syntax.as_arg
                                                                in
-                                                            [uu____12225]  in
+                                                            [uu____12277]  in
                                                           {
                                                             FStar_Syntax_Syntax.comp_univs
-                                                              = uu____12212;
+                                                              = uu____12264;
                                                             FStar_Syntax_Syntax.effect_name
                                                               =
                                                               FStar_Parser_Const.effect_PURE_lid;
                                                             FStar_Syntax_Syntax.result_typ
                                                               = repr;
                                                             FStar_Syntax_Syntax.effect_args
-                                                              = uu____12214;
+                                                              = uu____12266;
                                                             FStar_Syntax_Syntax.flags
                                                               = []
                                                           }  in
                                                         FStar_Syntax_Syntax.mk_Comp
-                                                          uu____12211
+                                                          uu____12263
                                                          in
                                                       FStar_Syntax_Util.arrow
                                                         (FStar_List.append bs
                                                            [f; g])
-                                                        uu____12208
+                                                        uu____12260
                                                        in
                                                     let guard_eq =
                                                       FStar_TypeChecker_Rel.teq
@@ -6269,53 +6338,53 @@ let (tc_polymonadic_bind :
                                                        guard_repr;
                                                        g_pure_wp_uvar;
                                                        guard_eq];
-                                                     (let uu____12285 =
+                                                     (let uu____12337 =
                                                         FStar_All.pipe_left
                                                           (FStar_TypeChecker_Env.debug
                                                              env1)
                                                           FStar_Options.Extreme
                                                          in
-                                                      if uu____12285
+                                                      if uu____12337
                                                       then
-                                                        let uu____12289 =
+                                                        let uu____12341 =
                                                           FStar_Syntax_Print.tscheme_to_string
                                                             (us1, t)
                                                            in
-                                                        let uu____12295 =
+                                                        let uu____12347 =
                                                           FStar_Syntax_Print.tscheme_to_string
                                                             (us1, k)
                                                            in
                                                         FStar_Util.print3
                                                           "Polymonadic bind %s after typechecking (%s::%s)\n"
                                                           eff_name
-                                                          uu____12289
-                                                          uu____12295
+                                                          uu____12341
+                                                          uu____12347
                                                       else ());
-                                                     (let uu____12305 =
-                                                        let uu____12311 =
+                                                     (let uu____12357 =
+                                                        let uu____12363 =
                                                           FStar_Util.format1
                                                             "Polymonadic binds (%s in this case) is a bleeding edge F* feature;it is subject to some redesign in the future. Please keep us informed (on github etc.) about how you are using it"
                                                             eff_name
                                                            in
                                                         (FStar_Errors.Warning_BleedingEdge_Feature,
-                                                          uu____12311)
+                                                          uu____12363)
                                                          in
                                                       FStar_Errors.log_issue
-                                                        r uu____12305);
-                                                     (let uu____12315 =
-                                                        let uu____12316 =
-                                                          let uu____12319 =
+                                                        r uu____12357);
+                                                     (let uu____12367 =
+                                                        let uu____12368 =
+                                                          let uu____12371 =
                                                             FStar_All.pipe_right
                                                               k
                                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                                  env1)
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____12319
+                                                            uu____12371
                                                             (FStar_Syntax_Subst.close_univ_vars
                                                                us1)
                                                            in
-                                                        (us1, uu____12316)
+                                                        (us1, uu____12368)
                                                          in
-                                                      ((us1, t), uu____12315)))))))))))
+                                                      ((us1, t), uu____12367)))))))))))
   

--- a/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
@@ -787,7 +787,7 @@ let (generalize_and_inst_within :
                  let uu____1672 =
                    let uu____1674 =
                      FStar_All.pipe_right uvs
-                       (FStar_List.map (fun u  -> u.FStar_Ident.idText))
+                       (FStar_List.map (fun u  -> FStar_Ident.text_of_id u))
                       in
                    FStar_All.pipe_right uu____1674 (FStar_String.concat ", ")
                     in
@@ -1244,83 +1244,84 @@ and (ty_nested_positive_in_inductive :
               debug_log env
                 (fun uu____3006  ->
                    let uu____3007 =
-                     let uu____3009 =
-                       let uu____3011 =
+                     let uu____3009 = FStar_Ident.string_of_lid ilid  in
+                     let uu____3011 =
+                       let uu____3013 =
                          FStar_Syntax_Print.args_to_string args  in
-                       Prims.op_Hat " applied to arguments: " uu____3011  in
-                     Prims.op_Hat ilid.FStar_Ident.str uu____3009  in
+                       Prims.op_Hat " applied to arguments: " uu____3013  in
+                     Prims.op_Hat uu____3009 uu____3011  in
                    Prims.op_Hat
                      "Checking nested positivity in the inductive "
                      uu____3007);
-              (let uu____3015 =
+              (let uu____3017 =
                  FStar_TypeChecker_Env.datacons_of_typ env ilid  in
-               match uu____3015 with
+               match uu____3017 with
                | (b,idatas) ->
                    if Prims.op_Negation b
                    then
-                     let uu____3034 =
-                       let uu____3036 =
+                     let uu____3036 =
+                       let uu____3038 =
                          FStar_Syntax_Syntax.lid_as_fv ilid
                            FStar_Syntax_Syntax.delta_constant
                            FStar_Pervasives_Native.None
                           in
-                       FStar_TypeChecker_Env.fv_has_attr env uu____3036
+                       FStar_TypeChecker_Env.fv_has_attr env uu____3038
                          FStar_Parser_Const.assume_strictly_positive_attr_lid
                         in
-                     (if uu____3034
+                     (if uu____3036
                       then
                         (debug_log env
-                           (fun uu____3042  ->
-                              let uu____3043 = FStar_Ident.string_of_lid ilid
+                           (fun uu____3044  ->
+                              let uu____3045 = FStar_Ident.string_of_lid ilid
                                  in
                               FStar_Util.format1
                                 "Checking nested positivity, special case decorated with `assume_strictly_positive` %s; return true"
-                                uu____3043);
+                                uu____3045);
                          true)
                       else
                         (debug_log env
-                           (fun uu____3051  ->
+                           (fun uu____3053  ->
                               "Checking nested positivity, not an inductive, return false");
                          false))
                    else
-                     (let uu____3056 =
+                     (let uu____3058 =
                         already_unfolded ilid args unfolded env  in
-                      if uu____3056
+                      if uu____3058
                       then
                         (debug_log env
-                           (fun uu____3062  ->
+                           (fun uu____3064  ->
                               "Checking nested positivity, we have already unfolded this inductive with these args");
                          true)
                       else
                         (let num_ibs =
-                           let uu____3069 =
+                           let uu____3071 =
                              FStar_TypeChecker_Env.num_inductive_ty_params
                                env ilid
                               in
-                           FStar_Option.get uu____3069  in
+                           FStar_Option.get uu____3071  in
                          debug_log env
-                           (fun uu____3077  ->
-                              let uu____3078 =
-                                let uu____3080 =
+                           (fun uu____3079  ->
+                              let uu____3080 =
+                                let uu____3082 =
                                   FStar_Util.string_of_int num_ibs  in
-                                Prims.op_Hat uu____3080
+                                Prims.op_Hat uu____3082
                                   ", also adding to the memo table"
                                  in
                               Prims.op_Hat
                                 "Checking nested positivity, number of type parameters is "
-                                uu____3078);
-                         (let uu____3085 =
-                            let uu____3086 = FStar_ST.op_Bang unfolded  in
-                            let uu____3112 =
-                              let uu____3119 =
-                                let uu____3124 =
-                                  let uu____3125 =
+                                uu____3080);
+                         (let uu____3087 =
+                            let uu____3088 = FStar_ST.op_Bang unfolded  in
+                            let uu____3114 =
+                              let uu____3121 =
+                                let uu____3126 =
+                                  let uu____3127 =
                                     FStar_List.splitAt num_ibs args  in
-                                  FStar_Pervasives_Native.fst uu____3125  in
-                                (ilid, uu____3124)  in
-                              [uu____3119]  in
-                            FStar_List.append uu____3086 uu____3112  in
-                          FStar_ST.op_Colon_Equals unfolded uu____3085);
+                                  FStar_Pervasives_Native.fst uu____3127  in
+                                (ilid, uu____3126)  in
+                              [uu____3121]  in
+                            FStar_List.append uu____3088 uu____3114  in
+                          FStar_ST.op_Colon_Equals unfolded uu____3087);
                          FStar_List.for_all
                            (fun d  ->
                               ty_nested_positive_in_dlid ty_lid d ilid us
@@ -1344,15 +1345,20 @@ and (ty_nested_positive_in_dlid :
               fun unfolded  ->
                 fun env  ->
                   debug_log env
-                    (fun uu____3223  ->
+                    (fun uu____3226  ->
+                       let uu____3227 =
+                         let uu____3229 = FStar_Ident.string_of_lid dlid  in
+                         let uu____3231 =
+                           let uu____3233 = FStar_Ident.string_of_lid ilid
+                              in
+                           Prims.op_Hat " of the inductive " uu____3233  in
+                         Prims.op_Hat uu____3229 uu____3231  in
                        Prims.op_Hat
                          "Checking nested positivity in data constructor "
-                         (Prims.op_Hat dlid.FStar_Ident.str
-                            (Prims.op_Hat " of the inductive "
-                               ilid.FStar_Ident.str)));
-                  (let uu____3226 =
+                         uu____3227);
+                  (let uu____3237 =
                      FStar_TypeChecker_Env.lookup_datacon env dlid  in
-                   match uu____3226 with
+                   match uu____3237 with
                    | (univ_unif_vars,dt) ->
                        (FStar_List.iter2
                           (fun u'  ->
@@ -1360,7 +1366,7 @@ and (ty_nested_positive_in_dlid :
                                match u' with
                                | FStar_Syntax_Syntax.U_unif u'' ->
                                    FStar_Syntax_Unionfind.univ_change u'' u
-                               | uu____3249 ->
+                               | uu____3260 ->
                                    failwith
                                      "Impossible! Expected universe unification variables")
                           univ_unif_vars us;
@@ -1376,47 +1382,47 @@ and (ty_nested_positive_in_dlid :
                              dt
                             in
                          debug_log env
-                           (fun uu____3255  ->
-                              let uu____3256 =
+                           (fun uu____3266  ->
+                              let uu____3267 =
                                 FStar_Syntax_Print.term_to_string dt1  in
                               Prims.op_Hat
                                 "Checking nested positivity in the data constructor type: "
-                                uu____3256);
-                         (let uu____3259 =
-                            let uu____3260 = FStar_Syntax_Subst.compress dt1
+                                uu____3267);
+                         (let uu____3270 =
+                            let uu____3271 = FStar_Syntax_Subst.compress dt1
                                in
-                            uu____3260.FStar_Syntax_Syntax.n  in
-                          match uu____3259 with
+                            uu____3271.FStar_Syntax_Syntax.n  in
+                          match uu____3270 with
                           | FStar_Syntax_Syntax.Tm_arrow (dbs,c) ->
                               (debug_log env
-                                 (fun uu____3288  ->
+                                 (fun uu____3299  ->
                                     "Checked nested positivity in Tm_arrow data constructor type");
-                               (let uu____3290 =
+                               (let uu____3301 =
                                   FStar_List.splitAt num_ibs dbs  in
-                                match uu____3290 with
+                                match uu____3301 with
                                 | (ibs,dbs1) ->
                                     let ibs1 =
                                       FStar_Syntax_Subst.open_binders ibs  in
                                     let dbs2 =
-                                      let uu____3354 =
+                                      let uu____3365 =
                                         FStar_Syntax_Subst.opening_of_binders
                                           ibs1
                                          in
                                       FStar_Syntax_Subst.subst_binders
-                                        uu____3354 dbs1
+                                        uu____3365 dbs1
                                        in
                                     let c1 =
-                                      let uu____3358 =
+                                      let uu____3369 =
                                         FStar_Syntax_Subst.opening_of_binders
                                           ibs1
                                          in
                                       FStar_Syntax_Subst.subst_comp
-                                        uu____3358 c
+                                        uu____3369 c
                                        in
-                                    let uu____3361 =
+                                    let uu____3372 =
                                       FStar_List.splitAt num_ibs args  in
-                                    (match uu____3361 with
-                                     | (args1,uu____3396) ->
+                                    (match uu____3372 with
+                                     | (args1,uu____3407) ->
                                          let subst =
                                            FStar_List.fold_left2
                                              (fun subst  ->
@@ -1435,47 +1441,47 @@ and (ty_nested_positive_in_dlid :
                                              subst dbs2
                                             in
                                          let c2 =
-                                           let uu____3488 =
+                                           let uu____3499 =
                                              FStar_Syntax_Subst.shift_subst
                                                (FStar_List.length dbs3) subst
                                               in
                                            FStar_Syntax_Subst.subst_comp
-                                             uu____3488 c1
+                                             uu____3499 c1
                                             in
                                          (debug_log env
-                                            (fun uu____3500  ->
-                                               let uu____3501 =
-                                                 let uu____3503 =
+                                            (fun uu____3511  ->
+                                               let uu____3512 =
+                                                 let uu____3514 =
                                                    FStar_Syntax_Print.binders_to_string
                                                      "; " dbs3
                                                     in
-                                                 let uu____3506 =
-                                                   let uu____3508 =
+                                                 let uu____3517 =
+                                                   let uu____3519 =
                                                      FStar_Syntax_Print.comp_to_string
                                                        c2
                                                       in
                                                    Prims.op_Hat ", and c: "
-                                                     uu____3508
+                                                     uu____3519
                                                     in
-                                                 Prims.op_Hat uu____3503
-                                                   uu____3506
+                                                 Prims.op_Hat uu____3514
+                                                   uu____3517
                                                   in
                                                Prims.op_Hat
                                                  "Checking nested positivity in the unfolded data constructor binders as: "
-                                                 uu____3501);
+                                                 uu____3512);
                                           ty_nested_positive_in_type ty_lid
                                             (FStar_Syntax_Syntax.Tm_arrow
                                                (dbs3, c2)) ilid num_ibs
                                             unfolded env))))
-                          | uu____3522 ->
+                          | uu____3533 ->
                               (debug_log env
-                                 (fun uu____3525  ->
+                                 (fun uu____3536  ->
                                     "Checking nested positivity in the data constructor type that is not an arrow");
-                               (let uu____3527 =
-                                  let uu____3528 =
+                               (let uu____3538 =
+                                  let uu____3539 =
                                     FStar_Syntax_Subst.compress dt1  in
-                                  uu____3528.FStar_Syntax_Syntax.n  in
-                                ty_nested_positive_in_type ty_lid uu____3527
+                                  uu____3539.FStar_Syntax_Syntax.n  in
+                                ty_nested_positive_in_type ty_lid uu____3538
                                   ilid num_ibs unfolded env))))))
 
 and (ty_nested_positive_in_type :
@@ -1494,52 +1500,52 @@ and (ty_nested_positive_in_type :
               match t with
               | FStar_Syntax_Syntax.Tm_app (t1,args) ->
                   (debug_log env
-                     (fun uu____3567  ->
+                     (fun uu____3578  ->
                         "Checking nested positivity in an Tm_app node, which is expected to be the ilid itself");
-                   (let uu____3569 = try_get_fv t1  in
-                    match uu____3569 with
-                    | (fv,uu____3576) ->
-                        let uu____3577 =
+                   (let uu____3580 = try_get_fv t1  in
+                    match uu____3580 with
+                    | (fv,uu____3587) ->
+                        let uu____3588 =
                           FStar_Ident.lid_equals
                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                             ilid
                            in
-                        if uu____3577
+                        if uu____3588
                         then true
                         else
                           failwith "Impossible, expected the type to be ilid"))
               | FStar_Syntax_Syntax.Tm_arrow (sbs,c) ->
                   (debug_log env
-                     (fun uu____3611  ->
-                        let uu____3612 =
+                     (fun uu____3622  ->
+                        let uu____3623 =
                           FStar_Syntax_Print.binders_to_string "; " sbs  in
                         Prims.op_Hat
                           "Checking nested positivity in an Tm_arrow node, with binders as: "
-                          uu____3612);
+                          uu____3623);
                    (let sbs1 = FStar_Syntax_Subst.open_binders sbs  in
-                    let uu____3617 =
+                    let uu____3628 =
                       FStar_List.fold_left
-                        (fun uu____3638  ->
+                        (fun uu____3649  ->
                            fun b  ->
-                             match uu____3638 with
+                             match uu____3649 with
                              | (r,env1) ->
                                  if Prims.op_Negation r
                                  then (r, env1)
                                  else
-                                   (let uu____3669 =
+                                   (let uu____3680 =
                                       ty_strictly_positive_in_type ty_lid
                                         (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                         unfolded env1
                                        in
-                                    let uu____3673 =
+                                    let uu____3684 =
                                       FStar_TypeChecker_Env.push_binders env1
                                         [b]
                                        in
-                                    (uu____3669, uu____3673))) (true, env)
+                                    (uu____3680, uu____3684))) (true, env)
                         sbs1
                        in
-                    match uu____3617 with | (b,uu____3691) -> b))
-              | uu____3694 ->
+                    match uu____3628 with | (b,uu____3702) -> b))
+              | uu____3705 ->
                   failwith "Nested positive check, unhandled case"
 
 let (ty_positive_in_datacon :
@@ -1555,9 +1561,9 @@ let (ty_positive_in_datacon :
         fun us  ->
           fun unfolded  ->
             fun env  ->
-              let uu____3730 = FStar_TypeChecker_Env.lookup_datacon env dlid
+              let uu____3741 = FStar_TypeChecker_Env.lookup_datacon env dlid
                  in
-              match uu____3730 with
+              match uu____3741 with
               | (univ_unif_vars,dt) ->
                   (FStar_List.iter2
                      (fun u'  ->
@@ -1565,82 +1571,82 @@ let (ty_positive_in_datacon :
                           match u' with
                           | FStar_Syntax_Syntax.U_unif u'' ->
                               FStar_Syntax_Unionfind.univ_change u'' u
-                          | uu____3753 ->
+                          | uu____3764 ->
                               failwith
                                 "Impossible! Expected universe unification variables")
                      univ_unif_vars us;
                    debug_log env
-                     (fun uu____3758  ->
-                        let uu____3759 = FStar_Syntax_Print.term_to_string dt
+                     (fun uu____3769  ->
+                        let uu____3770 = FStar_Syntax_Print.term_to_string dt
                            in
                         Prims.op_Hat "Checking data constructor type: "
-                          uu____3759);
-                   (let uu____3762 =
-                      let uu____3763 = FStar_Syntax_Subst.compress dt  in
-                      uu____3763.FStar_Syntax_Syntax.n  in
-                    match uu____3762 with
-                    | FStar_Syntax_Syntax.Tm_fvar uu____3767 ->
+                          uu____3770);
+                   (let uu____3773 =
+                      let uu____3774 = FStar_Syntax_Subst.compress dt  in
+                      uu____3774.FStar_Syntax_Syntax.n  in
+                    match uu____3773 with
+                    | FStar_Syntax_Syntax.Tm_fvar uu____3778 ->
                         (debug_log env
-                           (fun uu____3770  ->
+                           (fun uu____3781  ->
                               "Data constructor type is simply an fvar, returning true");
                          true)
-                    | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____3774) ->
+                    | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____3785) ->
                         let dbs1 =
-                          let uu____3804 =
+                          let uu____3815 =
                             FStar_List.splitAt (FStar_List.length ty_bs) dbs
                              in
-                          FStar_Pervasives_Native.snd uu____3804  in
+                          FStar_Pervasives_Native.snd uu____3815  in
                         let dbs2 =
-                          let uu____3854 =
+                          let uu____3865 =
                             FStar_Syntax_Subst.opening_of_binders ty_bs  in
-                          FStar_Syntax_Subst.subst_binders uu____3854 dbs1
+                          FStar_Syntax_Subst.subst_binders uu____3865 dbs1
                            in
                         let dbs3 = FStar_Syntax_Subst.open_binders dbs2  in
                         (debug_log env
-                           (fun uu____3861  ->
-                              let uu____3862 =
-                                let uu____3864 =
+                           (fun uu____3872  ->
+                              let uu____3873 =
+                                let uu____3875 =
                                   FStar_Util.string_of_int
                                     (FStar_List.length dbs3)
                                    in
-                                Prims.op_Hat uu____3864 " binders"  in
+                                Prims.op_Hat uu____3875 " binders"  in
                               Prims.op_Hat
                                 "Data constructor type is an arrow type, so checking strict positivity in "
-                                uu____3862);
-                         (let uu____3874 =
+                                uu____3873);
+                         (let uu____3885 =
                             FStar_List.fold_left
-                              (fun uu____3895  ->
+                              (fun uu____3906  ->
                                  fun b  ->
-                                   match uu____3895 with
+                                   match uu____3906 with
                                    | (r,env1) ->
                                        if Prims.op_Negation r
                                        then (r, env1)
                                        else
-                                         (let uu____3926 =
+                                         (let uu____3937 =
                                             ty_strictly_positive_in_type
                                               ty_lid
                                               (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                               unfolded env1
                                              in
-                                          let uu____3930 =
+                                          let uu____3941 =
                                             FStar_TypeChecker_Env.push_binders
                                               env1 [b]
                                              in
-                                          (uu____3926, uu____3930)))
+                                          (uu____3937, uu____3941)))
                               (true, env) dbs3
                              in
-                          match uu____3874 with | (b,uu____3948) -> b))
-                    | FStar_Syntax_Syntax.Tm_app (uu____3951,uu____3952) ->
+                          match uu____3885 with | (b,uu____3959) -> b))
+                    | FStar_Syntax_Syntax.Tm_app (uu____3962,uu____3963) ->
                         (debug_log env
-                           (fun uu____3979  ->
+                           (fun uu____3990  ->
                               "Data constructor type is a Tm_app, so returning true");
                          true)
                     | FStar_Syntax_Syntax.Tm_uinst (t,univs) ->
                         (debug_log env
-                           (fun uu____3990  ->
+                           (fun uu____4001  ->
                               "Data constructor type is a Tm_uinst, so recursing in the base type");
                          ty_strictly_positive_in_type ty_lid t unfolded env)
-                    | uu____3992 ->
+                    | uu____4003 ->
                         failwith
                           "Unexpected data constructor type when checking positivity"))
   
@@ -1649,33 +1655,33 @@ let (check_positivity :
   fun ty  ->
     fun env  ->
       let unfolded_inductives = FStar_Util.mk_ref []  in
-      let uu____4015 =
+      let uu____4026 =
         match ty.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ
-            (lid,us,bs,uu____4031,uu____4032,uu____4033) -> (lid, us, bs)
-        | uu____4042 -> failwith "Impossible!"  in
-      match uu____4015 with
+            (lid,us,bs,uu____4042,uu____4043,uu____4044) -> (lid, us, bs)
+        | uu____4053 -> failwith "Impossible!"  in
+      match uu____4026 with
       | (ty_lid,ty_us,ty_bs) ->
-          let uu____4054 = FStar_Syntax_Subst.univ_var_opening ty_us  in
-          (match uu____4054 with
+          let uu____4065 = FStar_Syntax_Subst.univ_var_opening ty_us  in
+          (match uu____4065 with
            | (ty_usubst,ty_us1) ->
                let env1 = FStar_TypeChecker_Env.push_univ_vars env ty_us1  in
                let env2 = FStar_TypeChecker_Env.push_binders env1 ty_bs  in
                let ty_bs1 = FStar_Syntax_Subst.subst_binders ty_usubst ty_bs
                   in
                let ty_bs2 = FStar_Syntax_Subst.open_binders ty_bs1  in
-               let uu____4078 =
-                 let uu____4081 =
+               let uu____4089 =
+                 let uu____4092 =
                    FStar_TypeChecker_Env.datacons_of_typ env2 ty_lid  in
-                 FStar_Pervasives_Native.snd uu____4081  in
+                 FStar_Pervasives_Native.snd uu____4092  in
                FStar_List.for_all
                  (fun d  ->
-                    let uu____4095 =
+                    let uu____4106 =
                       FStar_List.map (fun s  -> FStar_Syntax_Syntax.U_name s)
                         ty_us1
                        in
-                    ty_positive_in_datacon ty_lid d ty_bs2 uu____4095
-                      unfolded_inductives env2) uu____4078)
+                    ty_positive_in_datacon ty_lid d ty_bs2 uu____4106
+                      unfolded_inductives env2) uu____4089)
   
 let (check_exn_positivity :
   FStar_Ident.lid -> FStar_TypeChecker_Env.env -> Prims.bool) =
@@ -1689,36 +1695,39 @@ let (datacon_typ : FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.term) =
   fun data  ->
     match data.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_datacon
-        (uu____4130,uu____4131,t,uu____4133,uu____4134,uu____4135) -> t
-    | uu____4142 -> failwith "Impossible!"
+        (uu____4141,uu____4142,t,uu____4144,uu____4145,uu____4146) -> t
+    | uu____4153 -> failwith "Impossible!"
   
 let (haseq_suffix : Prims.string) = "__uu___haseq" 
 let (is_haseq_lid : FStar_Ident.lid -> Prims.bool) =
   fun lid  ->
-    let str = lid.FStar_Ident.str  in
+    let str = FStar_Ident.string_of_lid lid  in
     let len = FStar_String.length str  in
     let haseq_suffix_len = FStar_String.length haseq_suffix  in
     (len > haseq_suffix_len) &&
-      (let uu____4159 =
-         let uu____4161 =
+      (let uu____4170 =
+         let uu____4172 =
            FStar_String.substring str (len - haseq_suffix_len)
              haseq_suffix_len
             in
-         FStar_String.compare uu____4161 haseq_suffix  in
-       uu____4159 = Prims.int_zero)
+         FStar_String.compare uu____4172 haseq_suffix  in
+       uu____4170 = Prims.int_zero)
   
 let (get_haseq_axiom_lid : FStar_Ident.lid -> FStar_Ident.lid) =
   fun lid  ->
-    let uu____4171 =
-      let uu____4174 =
-        let uu____4177 =
-          FStar_Ident.id_of_text
-            (Prims.op_Hat (lid.FStar_Ident.ident).FStar_Ident.idText
-               haseq_suffix)
-           in
-        [uu____4177]  in
-      FStar_List.append lid.FStar_Ident.ns uu____4174  in
-    FStar_Ident.lid_of_ids uu____4171
+    let uu____4182 =
+      let uu____4183 = FStar_Ident.ns_of_lid lid  in
+      let uu____4186 =
+        let uu____4189 =
+          let uu____4190 =
+            let uu____4192 =
+              let uu____4194 = FStar_Ident.ident_of_lid lid  in
+              FStar_Ident.text_of_id uu____4194  in
+            Prims.op_Hat uu____4192 haseq_suffix  in
+          FStar_Ident.id_of_text uu____4190  in
+        [uu____4189]  in
+      FStar_List.append uu____4183 uu____4186  in
+    FStar_Ident.lid_of_ids uu____4182
   
 let (get_optimized_haseq_axiom :
   FStar_TypeChecker_Env.env ->
@@ -1733,187 +1742,187 @@ let (get_optimized_haseq_axiom :
     fun ty  ->
       fun usubst  ->
         fun us  ->
-          let uu____4223 =
+          let uu____4240 =
             match ty.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_inductive_typ
-                (lid,uu____4237,bs,t,uu____4240,uu____4241) -> (lid, bs, t)
-            | uu____4250 -> failwith "Impossible!"  in
-          match uu____4223 with
+                (lid,uu____4254,bs,t,uu____4257,uu____4258) -> (lid, bs, t)
+            | uu____4267 -> failwith "Impossible!"  in
+          match uu____4240 with
           | (lid,bs,t) ->
               let bs1 = FStar_Syntax_Subst.subst_binders usubst bs  in
               let t1 =
-                let uu____4273 =
+                let uu____4290 =
                   FStar_Syntax_Subst.shift_subst (FStar_List.length bs1)
                     usubst
                    in
-                FStar_Syntax_Subst.subst uu____4273 t  in
-              let uu____4282 = FStar_Syntax_Subst.open_term bs1 t1  in
-              (match uu____4282 with
+                FStar_Syntax_Subst.subst uu____4290 t  in
+              let uu____4299 = FStar_Syntax_Subst.open_term bs1 t1  in
+              (match uu____4299 with
                | (bs2,t2) ->
                    let ibs =
-                     let uu____4300 =
-                       let uu____4301 = FStar_Syntax_Subst.compress t2  in
-                       uu____4301.FStar_Syntax_Syntax.n  in
-                     match uu____4300 with
-                     | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____4305) -> ibs
-                     | uu____4326 -> []  in
+                     let uu____4317 =
+                       let uu____4318 = FStar_Syntax_Subst.compress t2  in
+                       uu____4318.FStar_Syntax_Syntax.n  in
+                     match uu____4317 with
+                     | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____4322) -> ibs
+                     | uu____4343 -> []  in
                    let ibs1 = FStar_Syntax_Subst.open_binders ibs  in
                    let ind =
-                     let uu____4335 =
+                     let uu____4352 =
                        FStar_Syntax_Syntax.fvar lid
                          FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None
                         in
-                     let uu____4336 =
+                     let uu____4353 =
                        FStar_List.map
                          (fun u  -> FStar_Syntax_Syntax.U_name u) us
                         in
-                     FStar_Syntax_Syntax.mk_Tm_uinst uu____4335 uu____4336
+                     FStar_Syntax_Syntax.mk_Tm_uinst uu____4352 uu____4353
                       in
                    let ind1 =
-                     let uu____4342 =
-                       let uu____4347 =
+                     let uu____4359 =
+                       let uu____4364 =
                          FStar_List.map
-                           (fun uu____4364  ->
-                              match uu____4364 with
+                           (fun uu____4381  ->
+                              match uu____4381 with
                               | (bv,aq) ->
-                                  let uu____4383 =
+                                  let uu____4400 =
                                     FStar_Syntax_Syntax.bv_to_name bv  in
-                                  (uu____4383, aq)) bs2
+                                  (uu____4400, aq)) bs2
                           in
-                       FStar_Syntax_Syntax.mk_Tm_app ind uu____4347  in
-                     uu____4342 FStar_Pervasives_Native.None
+                       FStar_Syntax_Syntax.mk_Tm_app ind uu____4364  in
+                     uu____4359 FStar_Pervasives_Native.None
                        FStar_Range.dummyRange
                       in
                    let ind2 =
-                     let uu____4389 =
-                       let uu____4394 =
+                     let uu____4406 =
+                       let uu____4411 =
                          FStar_List.map
-                           (fun uu____4411  ->
-                              match uu____4411 with
+                           (fun uu____4428  ->
+                              match uu____4428 with
                               | (bv,aq) ->
-                                  let uu____4430 =
+                                  let uu____4447 =
                                     FStar_Syntax_Syntax.bv_to_name bv  in
-                                  (uu____4430, aq)) ibs1
+                                  (uu____4447, aq)) ibs1
                           in
-                       FStar_Syntax_Syntax.mk_Tm_app ind1 uu____4394  in
-                     uu____4389 FStar_Pervasives_Native.None
+                       FStar_Syntax_Syntax.mk_Tm_app ind1 uu____4411  in
+                     uu____4406 FStar_Pervasives_Native.None
                        FStar_Range.dummyRange
                       in
                    let haseq_ind =
-                     let uu____4436 =
-                       let uu____4441 =
-                         let uu____4442 = FStar_Syntax_Syntax.as_arg ind2  in
-                         [uu____4442]  in
+                     let uu____4453 =
+                       let uu____4458 =
+                         let uu____4459 = FStar_Syntax_Syntax.as_arg ind2  in
+                         [uu____4459]  in
                        FStar_Syntax_Syntax.mk_Tm_app
-                         FStar_Syntax_Util.t_haseq uu____4441
+                         FStar_Syntax_Util.t_haseq uu____4458
                         in
-                     uu____4436 FStar_Pervasives_Native.None
+                     uu____4453 FStar_Pervasives_Native.None
                        FStar_Range.dummyRange
                       in
                    let bs' =
                      FStar_List.filter
                        (fun b  ->
-                          let uu____4491 =
-                            let uu____4492 = FStar_Syntax_Util.type_u ()  in
-                            FStar_Pervasives_Native.fst uu____4492  in
+                          let uu____4508 =
+                            let uu____4509 = FStar_Syntax_Util.type_u ()  in
+                            FStar_Pervasives_Native.fst uu____4509  in
                           FStar_TypeChecker_Rel.subtype_nosmt_force en
                             (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                            uu____4491) bs2
+                            uu____4508) bs2
                       in
                    let haseq_bs =
                      FStar_List.fold_left
                        (fun t3  ->
                           fun b  ->
-                            let uu____4505 =
-                              let uu____4508 =
-                                let uu____4513 =
-                                  let uu____4514 =
-                                    let uu____4523 =
+                            let uu____4522 =
+                              let uu____4525 =
+                                let uu____4530 =
+                                  let uu____4531 =
+                                    let uu____4540 =
                                       FStar_Syntax_Syntax.bv_to_name
                                         (FStar_Pervasives_Native.fst b)
                                        in
-                                    FStar_Syntax_Syntax.as_arg uu____4523  in
-                                  [uu____4514]  in
+                                    FStar_Syntax_Syntax.as_arg uu____4540  in
+                                  [uu____4531]  in
                                 FStar_Syntax_Syntax.mk_Tm_app
-                                  FStar_Syntax_Util.t_haseq uu____4513
+                                  FStar_Syntax_Util.t_haseq uu____4530
                                  in
-                              uu____4508 FStar_Pervasives_Native.None
+                              uu____4525 FStar_Pervasives_Native.None
                                 FStar_Range.dummyRange
                                in
-                            FStar_Syntax_Util.mk_conj t3 uu____4505)
+                            FStar_Syntax_Util.mk_conj t3 uu____4522)
                        FStar_Syntax_Util.t_true bs'
                       in
                    let fml = FStar_Syntax_Util.mk_imp haseq_bs haseq_ind  in
                    let fml1 =
-                     let uu___667_4546 = fml  in
-                     let uu____4547 =
-                       let uu____4548 =
-                         let uu____4555 =
-                           let uu____4556 =
-                             let uu____4577 =
+                     let uu___667_4563 = fml  in
+                     let uu____4564 =
+                       let uu____4565 =
+                         let uu____4572 =
+                           let uu____4573 =
+                             let uu____4594 =
                                FStar_Syntax_Syntax.binders_to_names ibs1  in
-                             let uu____4582 =
-                               let uu____4595 =
-                                 let uu____4606 =
+                             let uu____4599 =
+                               let uu____4612 =
+                                 let uu____4623 =
                                    FStar_Syntax_Syntax.as_arg haseq_ind  in
-                                 [uu____4606]  in
-                               [uu____4595]  in
-                             (uu____4577, uu____4582)  in
-                           FStar_Syntax_Syntax.Meta_pattern uu____4556  in
-                         (fml, uu____4555)  in
-                       FStar_Syntax_Syntax.Tm_meta uu____4548  in
+                                 [uu____4623]  in
+                               [uu____4612]  in
+                             (uu____4594, uu____4599)  in
+                           FStar_Syntax_Syntax.Meta_pattern uu____4573  in
+                         (fml, uu____4572)  in
+                       FStar_Syntax_Syntax.Tm_meta uu____4565  in
                      {
-                       FStar_Syntax_Syntax.n = uu____4547;
+                       FStar_Syntax_Syntax.n = uu____4564;
                        FStar_Syntax_Syntax.pos =
-                         (uu___667_4546.FStar_Syntax_Syntax.pos);
+                         (uu___667_4563.FStar_Syntax_Syntax.pos);
                        FStar_Syntax_Syntax.vars =
-                         (uu___667_4546.FStar_Syntax_Syntax.vars)
+                         (uu___667_4563.FStar_Syntax_Syntax.vars)
                      }  in
                    let fml2 =
                      FStar_List.fold_right
                        (fun b  ->
                           fun t3  ->
-                            let uu____4675 =
-                              let uu____4680 =
-                                let uu____4681 =
-                                  let uu____4690 =
-                                    let uu____4691 =
+                            let uu____4692 =
+                              let uu____4697 =
+                                let uu____4698 =
+                                  let uu____4707 =
+                                    let uu____4708 =
                                       FStar_Syntax_Subst.close [b] t3  in
                                     FStar_Syntax_Util.abs
                                       [((FStar_Pervasives_Native.fst b),
                                          FStar_Pervasives_Native.None)]
-                                      uu____4691 FStar_Pervasives_Native.None
+                                      uu____4708 FStar_Pervasives_Native.None
                                      in
-                                  FStar_Syntax_Syntax.as_arg uu____4690  in
-                                [uu____4681]  in
+                                  FStar_Syntax_Syntax.as_arg uu____4707  in
+                                [uu____4698]  in
                               FStar_Syntax_Syntax.mk_Tm_app
-                                FStar_Syntax_Util.tforall uu____4680
+                                FStar_Syntax_Util.tforall uu____4697
                                in
-                            uu____4675 FStar_Pervasives_Native.None
+                            uu____4692 FStar_Pervasives_Native.None
                               FStar_Range.dummyRange) ibs1 fml1
                       in
                    let fml3 =
                      FStar_List.fold_right
                        (fun b  ->
                           fun t3  ->
-                            let uu____4744 =
-                              let uu____4749 =
-                                let uu____4750 =
-                                  let uu____4759 =
-                                    let uu____4760 =
+                            let uu____4761 =
+                              let uu____4766 =
+                                let uu____4767 =
+                                  let uu____4776 =
+                                    let uu____4777 =
                                       FStar_Syntax_Subst.close [b] t3  in
                                     FStar_Syntax_Util.abs
                                       [((FStar_Pervasives_Native.fst b),
                                          FStar_Pervasives_Native.None)]
-                                      uu____4760 FStar_Pervasives_Native.None
+                                      uu____4777 FStar_Pervasives_Native.None
                                      in
-                                  FStar_Syntax_Syntax.as_arg uu____4759  in
-                                [uu____4750]  in
+                                  FStar_Syntax_Syntax.as_arg uu____4776  in
+                                [uu____4767]  in
                               FStar_Syntax_Syntax.mk_Tm_app
-                                FStar_Syntax_Util.tforall uu____4749
+                                FStar_Syntax_Util.tforall uu____4766
                                in
-                            uu____4744 FStar_Pervasives_Native.None
+                            uu____4761 FStar_Pervasives_Native.None
                               FStar_Range.dummyRange) bs2 fml2
                       in
                    let axiom_lid = get_haseq_axiom_lid lid  in
@@ -1931,47 +1940,49 @@ let (optimized_haseq_soundness_for_data :
         fun bs  ->
           let dt = datacon_typ data  in
           let dt1 = FStar_Syntax_Subst.subst usubst dt  in
-          let uu____4835 =
-            let uu____4836 = FStar_Syntax_Subst.compress dt1  in
-            uu____4836.FStar_Syntax_Syntax.n  in
-          match uu____4835 with
-          | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____4840) ->
+          let uu____4852 =
+            let uu____4853 = FStar_Syntax_Subst.compress dt1  in
+            uu____4853.FStar_Syntax_Syntax.n  in
+          match uu____4852 with
+          | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____4857) ->
               let dbs1 =
-                let uu____4870 =
+                let uu____4887 =
                   FStar_List.splitAt (FStar_List.length bs) dbs  in
-                FStar_Pervasives_Native.snd uu____4870  in
+                FStar_Pervasives_Native.snd uu____4887  in
               let dbs2 =
-                let uu____4920 = FStar_Syntax_Subst.opening_of_binders bs  in
-                FStar_Syntax_Subst.subst_binders uu____4920 dbs1  in
+                let uu____4937 = FStar_Syntax_Subst.opening_of_binders bs  in
+                FStar_Syntax_Subst.subst_binders uu____4937 dbs1  in
               let dbs3 = FStar_Syntax_Subst.open_binders dbs2  in
               let cond =
                 FStar_List.fold_left
                   (fun t  ->
                      fun b  ->
                        let haseq_b =
-                         let uu____4935 =
-                           let uu____4940 =
-                             let uu____4941 =
+                         let uu____4952 =
+                           let uu____4957 =
+                             let uu____4958 =
                                FStar_Syntax_Syntax.as_arg
                                  (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                 in
-                             [uu____4941]  in
+                             [uu____4958]  in
                            FStar_Syntax_Syntax.mk_Tm_app
-                             FStar_Syntax_Util.t_haseq uu____4940
+                             FStar_Syntax_Util.t_haseq uu____4957
                             in
-                         uu____4935 FStar_Pervasives_Native.None
+                         uu____4952 FStar_Pervasives_Native.None
                            FStar_Range.dummyRange
                           in
                        let sort_range =
                          ((FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos
                           in
                        let haseq_b1 =
-                         let uu____4972 =
+                         let uu____4989 =
+                           let uu____4991 = FStar_Ident.string_of_lid ty_lid
+                              in
                            FStar_Util.format1
                              "Failed to prove that the type '%s' supports decidable equality because of this argument; add either the 'noeq' or 'unopteq' qualifier"
-                             ty_lid.FStar_Ident.str
+                             uu____4991
                             in
-                         FStar_TypeChecker_Util.label uu____4972 sort_range
+                         FStar_TypeChecker_Util.label uu____4989 sort_range
                            haseq_b
                           in
                        FStar_Syntax_Util.mk_conj t haseq_b1)
@@ -1980,25 +1991,25 @@ let (optimized_haseq_soundness_for_data :
               FStar_List.fold_right
                 (fun b  ->
                    fun t  ->
-                     let uu____4980 =
-                       let uu____4985 =
-                         let uu____4986 =
-                           let uu____4995 =
-                             let uu____4996 = FStar_Syntax_Subst.close [b] t
+                     let uu____4999 =
+                       let uu____5004 =
+                         let uu____5005 =
+                           let uu____5014 =
+                             let uu____5015 = FStar_Syntax_Subst.close [b] t
                                 in
                              FStar_Syntax_Util.abs
                                [((FStar_Pervasives_Native.fst b),
-                                  FStar_Pervasives_Native.None)] uu____4996
+                                  FStar_Pervasives_Native.None)] uu____5015
                                FStar_Pervasives_Native.None
                               in
-                           FStar_Syntax_Syntax.as_arg uu____4995  in
-                         [uu____4986]  in
+                           FStar_Syntax_Syntax.as_arg uu____5014  in
+                         [uu____5005]  in
                        FStar_Syntax_Syntax.mk_Tm_app
-                         FStar_Syntax_Util.tforall uu____4985
+                         FStar_Syntax_Util.tforall uu____5004
                         in
-                     uu____4980 FStar_Pervasives_Native.None
+                     uu____4999 FStar_Pervasives_Native.None
                        FStar_Range.dummyRange) dbs3 cond
-          | uu____5043 -> FStar_Syntax_Util.t_true
+          | uu____5062 -> FStar_Syntax_Util.t_true
   
 let (optimized_haseq_ty :
   FStar_Syntax_Syntax.sigelts ->
@@ -2022,19 +2033,19 @@ let (optimized_haseq_ty :
             let lid =
               match ty.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_inductive_typ
-                  (lid,uu____5134,uu____5135,uu____5136,uu____5137,uu____5138)
+                  (lid,uu____5153,uu____5154,uu____5155,uu____5156,uu____5157)
                   -> lid
-              | uu____5147 -> failwith "Impossible!"  in
-            let uu____5149 = acc  in
-            match uu____5149 with
-            | (uu____5186,en,uu____5188,uu____5189) ->
-                let uu____5210 = get_optimized_haseq_axiom en ty usubst us
+              | uu____5166 -> failwith "Impossible!"  in
+            let uu____5168 = acc  in
+            match uu____5168 with
+            | (uu____5205,en,uu____5207,uu____5208) ->
+                let uu____5229 = get_optimized_haseq_axiom en ty usubst us
                    in
-                (match uu____5210 with
+                (match uu____5229 with
                  | (axiom_lid,fml,bs,ibs,haseq_bs) ->
                      let guard = FStar_Syntax_Util.mk_conj haseq_bs fml  in
-                     let uu____5247 = acc  in
-                     (match uu____5247 with
+                     let uu____5266 = acc  in
+                     (match uu____5266 with
                       | (l_axioms,env,guard',cond') ->
                           let env1 =
                             FStar_TypeChecker_Env.push_binders env bs  in
@@ -2045,28 +2056,28 @@ let (optimized_haseq_ty :
                               (fun s  ->
                                  match s.FStar_Syntax_Syntax.sigel with
                                  | FStar_Syntax_Syntax.Sig_datacon
-                                     (uu____5322,uu____5323,uu____5324,t_lid,uu____5326,uu____5327)
+                                     (uu____5341,uu____5342,uu____5343,t_lid,uu____5345,uu____5346)
                                      -> t_lid = lid
-                                 | uu____5334 -> failwith "Impossible")
+                                 | uu____5353 -> failwith "Impossible")
                               all_datas_in_the_bundle
                              in
                           let cond =
                             FStar_List.fold_left
                               (fun acc1  ->
                                  fun d  ->
-                                   let uu____5349 =
+                                   let uu____5368 =
                                      optimized_haseq_soundness_for_data lid d
                                        usubst bs
                                       in
-                                   FStar_Syntax_Util.mk_conj acc1 uu____5349)
+                                   FStar_Syntax_Util.mk_conj acc1 uu____5368)
                               FStar_Syntax_Util.t_true t_datas
                              in
-                          let uu____5352 =
+                          let uu____5371 =
                             FStar_Syntax_Util.mk_conj guard' guard  in
-                          let uu____5355 =
+                          let uu____5374 =
                             FStar_Syntax_Util.mk_conj cond' cond  in
                           ((FStar_List.append l_axioms [(axiom_lid, fml)]),
-                            env2, uu____5352, uu____5355)))
+                            env2, uu____5371, uu____5374)))
   
 let (optimized_haseq_scheme :
   FStar_Syntax_Syntax.sigelt ->
@@ -2078,17 +2089,17 @@ let (optimized_haseq_scheme :
     fun tcs  ->
       fun datas  ->
         fun env0  ->
-          let uu____5413 =
+          let uu____5432 =
             let ty = FStar_List.hd tcs  in
             match ty.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____5423,us,uu____5425,t,uu____5427,uu____5428) -> 
+                (uu____5442,us,uu____5444,t,uu____5446,uu____5447) -> 
                 (us, t)
-            | uu____5437 -> failwith "Impossible!"  in
-          match uu____5413 with
+            | uu____5456 -> failwith "Impossible!"  in
+          match uu____5432 with
           | (us,t) ->
-              let uu____5447 = FStar_Syntax_Subst.univ_var_opening us  in
-              (match uu____5447 with
+              let uu____5466 = FStar_Syntax_Subst.univ_var_opening us  in
+              (match uu____5466 with
                | (usubst,us1) ->
                    let env = FStar_TypeChecker_Env.push_sigelt env0 sig_bndle
                       in
@@ -2098,49 +2109,49 @@ let (optimized_haseq_scheme :
                       env sig_bndle;
                     (let env1 = FStar_TypeChecker_Env.push_univ_vars env us1
                         in
-                     let uu____5473 =
+                     let uu____5492 =
                        FStar_List.fold_left
                          (optimized_haseq_ty datas usubst us1)
                          ([], env1, FStar_Syntax_Util.t_true,
                            FStar_Syntax_Util.t_true) tcs
                         in
-                     match uu____5473 with
+                     match uu____5492 with
                      | (axioms,env2,guard,cond) ->
                          let phi =
-                           let uu____5551 = FStar_Syntax_Util.arrow_formals t
+                           let uu____5570 = FStar_Syntax_Util.arrow_formals t
                               in
-                           match uu____5551 with
-                           | (uu____5558,t1) ->
-                               let uu____5564 =
+                           match uu____5570 with
+                           | (uu____5577,t1) ->
+                               let uu____5583 =
                                  FStar_Syntax_Util.is_eqtype_no_unrefine t1
                                   in
-                               if uu____5564
+                               if uu____5583
                                then cond
                                else FStar_Syntax_Util.mk_imp guard cond
                             in
-                         let uu____5569 =
+                         let uu____5588 =
                            FStar_TypeChecker_TcTerm.tc_trivial_guard env2 phi
                             in
-                         (match uu____5569 with
-                          | (phi1,uu____5577) ->
-                              ((let uu____5579 =
+                         (match uu____5588 with
+                          | (phi1,uu____5596) ->
+                              ((let uu____5598 =
                                   FStar_TypeChecker_Env.should_verify env2
                                    in
-                                if uu____5579
+                                if uu____5598
                                 then
-                                  let uu____5582 =
+                                  let uu____5601 =
                                     FStar_TypeChecker_Env.guard_of_guard_formula
                                       (FStar_TypeChecker_Common.NonTrivial
                                          phi1)
                                      in
                                   FStar_TypeChecker_Rel.force_trivial_guard
-                                    env2 uu____5582
+                                    env2 uu____5601
                                 else ());
                                (let ses =
                                   FStar_List.fold_left
                                     (fun l  ->
-                                       fun uu____5600  ->
-                                         match uu____5600 with
+                                       fun uu____5619  ->
+                                         match uu____5619 with
                                          | (lid,fml) ->
                                              let fml1 =
                                                FStar_Syntax_Subst.close_univ_vars
@@ -2185,51 +2196,51 @@ let (unoptimized_haseq_data :
           fun acc  ->
             fun data  ->
               let rec is_mutual t =
-                let uu____5672 =
-                  let uu____5673 = FStar_Syntax_Subst.compress t  in
-                  uu____5673.FStar_Syntax_Syntax.n  in
-                match uu____5672 with
+                let uu____5691 =
+                  let uu____5692 = FStar_Syntax_Subst.compress t  in
+                  uu____5692.FStar_Syntax_Syntax.n  in
+                match uu____5691 with
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     FStar_List.existsb
                       (fun lid  ->
                          FStar_Ident.lid_equals lid
                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                       mutuals
-                | FStar_Syntax_Syntax.Tm_uinst (t',uu____5681) ->
+                | FStar_Syntax_Syntax.Tm_uinst (t',uu____5700) ->
                     is_mutual t'
                 | FStar_Syntax_Syntax.Tm_refine (bv,t') ->
                     is_mutual bv.FStar_Syntax_Syntax.sort
                 | FStar_Syntax_Syntax.Tm_app (t',args) ->
-                    let uu____5718 = is_mutual t'  in
-                    if uu____5718
+                    let uu____5737 = is_mutual t'  in
+                    if uu____5737
                     then true
                     else
-                      (let uu____5725 =
+                      (let uu____5744 =
                          FStar_List.map FStar_Pervasives_Native.fst args  in
-                       exists_mutual uu____5725)
-                | FStar_Syntax_Syntax.Tm_meta (t',uu____5745) -> is_mutual t'
-                | uu____5750 -> false
+                       exists_mutual uu____5744)
+                | FStar_Syntax_Syntax.Tm_meta (t',uu____5764) -> is_mutual t'
+                | uu____5769 -> false
               
-              and exists_mutual uu___1_5752 =
-                match uu___1_5752 with
+              and exists_mutual uu___1_5771 =
+                match uu___1_5771 with
                 | [] -> false
                 | hd::tl -> (is_mutual hd) || (exists_mutual tl)
                in
               let dt = datacon_typ data  in
               let dt1 = FStar_Syntax_Subst.subst usubst dt  in
-              let uu____5773 =
-                let uu____5774 = FStar_Syntax_Subst.compress dt1  in
-                uu____5774.FStar_Syntax_Syntax.n  in
-              match uu____5773 with
-              | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____5780) ->
+              let uu____5792 =
+                let uu____5793 = FStar_Syntax_Subst.compress dt1  in
+                uu____5793.FStar_Syntax_Syntax.n  in
+              match uu____5792 with
+              | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____5799) ->
                   let dbs1 =
-                    let uu____5810 =
+                    let uu____5829 =
                       FStar_List.splitAt (FStar_List.length bs) dbs  in
-                    FStar_Pervasives_Native.snd uu____5810  in
+                    FStar_Pervasives_Native.snd uu____5829  in
                   let dbs2 =
-                    let uu____5860 = FStar_Syntax_Subst.opening_of_binders bs
+                    let uu____5879 = FStar_Syntax_Subst.opening_of_binders bs
                        in
-                    FStar_Syntax_Subst.subst_binders uu____5860 dbs1  in
+                    FStar_Syntax_Subst.subst_binders uu____5879 dbs1  in
                   let dbs3 = FStar_Syntax_Subst.open_binders dbs2  in
                   let cond =
                     FStar_List.fold_left
@@ -2239,22 +2250,22 @@ let (unoptimized_haseq_data :
                              (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                               in
                            let haseq_sort =
-                             let uu____5880 =
-                               let uu____5885 =
-                                 let uu____5886 =
+                             let uu____5899 =
+                               let uu____5904 =
+                                 let uu____5905 =
                                    FStar_Syntax_Syntax.as_arg
                                      (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                     in
-                                 [uu____5886]  in
+                                 [uu____5905]  in
                                FStar_Syntax_Syntax.mk_Tm_app
-                                 FStar_Syntax_Util.t_haseq uu____5885
+                                 FStar_Syntax_Util.t_haseq uu____5904
                                 in
-                             uu____5880 FStar_Pervasives_Native.None
+                             uu____5899 FStar_Pervasives_Native.None
                                FStar_Range.dummyRange
                               in
                            let haseq_sort1 =
-                             let uu____5916 = is_mutual sort  in
-                             if uu____5916
+                             let uu____5935 = is_mutual sort  in
+                             if uu____5935
                              then
                                FStar_Syntax_Util.mk_imp haseq_ind haseq_sort
                              else haseq_sort  in
@@ -2265,27 +2276,27 @@ let (unoptimized_haseq_data :
                     FStar_List.fold_right
                       (fun b  ->
                          fun t  ->
-                           let uu____5929 =
-                             let uu____5934 =
-                               let uu____5935 =
-                                 let uu____5944 =
-                                   let uu____5945 =
+                           let uu____5948 =
+                             let uu____5953 =
+                               let uu____5954 =
+                                 let uu____5963 =
+                                   let uu____5964 =
                                      FStar_Syntax_Subst.close [b] t  in
                                    FStar_Syntax_Util.abs
                                      [((FStar_Pervasives_Native.fst b),
                                         FStar_Pervasives_Native.None)]
-                                     uu____5945 FStar_Pervasives_Native.None
+                                     uu____5964 FStar_Pervasives_Native.None
                                     in
-                                 FStar_Syntax_Syntax.as_arg uu____5944  in
-                               [uu____5935]  in
+                                 FStar_Syntax_Syntax.as_arg uu____5963  in
+                               [uu____5954]  in
                              FStar_Syntax_Syntax.mk_Tm_app
-                               FStar_Syntax_Util.tforall uu____5934
+                               FStar_Syntax_Util.tforall uu____5953
                               in
-                           uu____5929 FStar_Pervasives_Native.None
+                           uu____5948 FStar_Pervasives_Native.None
                              FStar_Range.dummyRange) dbs3 cond
                      in
                   FStar_Syntax_Util.mk_conj acc cond1
-              | uu____5992 -> acc
+              | uu____6011 -> acc
   
 let (unoptimized_haseq_ty :
   FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -2302,87 +2313,87 @@ let (unoptimized_haseq_ty :
         fun us  ->
           fun acc  ->
             fun ty  ->
-              let uu____6042 =
+              let uu____6061 =
                 match ty.FStar_Syntax_Syntax.sigel with
                 | FStar_Syntax_Syntax.Sig_inductive_typ
-                    (lid,uu____6064,bs,t,uu____6067,d_lids) ->
+                    (lid,uu____6083,bs,t,uu____6086,d_lids) ->
                     (lid, bs, t, d_lids)
-                | uu____6079 -> failwith "Impossible!"  in
-              match uu____6042 with
+                | uu____6098 -> failwith "Impossible!"  in
+              match uu____6061 with
               | (lid,bs,t,d_lids) ->
                   let bs1 = FStar_Syntax_Subst.subst_binders usubst bs  in
                   let t1 =
-                    let uu____6103 =
+                    let uu____6122 =
                       FStar_Syntax_Subst.shift_subst (FStar_List.length bs1)
                         usubst
                        in
-                    FStar_Syntax_Subst.subst uu____6103 t  in
-                  let uu____6112 = FStar_Syntax_Subst.open_term bs1 t1  in
-                  (match uu____6112 with
+                    FStar_Syntax_Subst.subst uu____6122 t  in
+                  let uu____6131 = FStar_Syntax_Subst.open_term bs1 t1  in
+                  (match uu____6131 with
                    | (bs2,t2) ->
                        let ibs =
-                         let uu____6122 =
-                           let uu____6123 = FStar_Syntax_Subst.compress t2
+                         let uu____6141 =
+                           let uu____6142 = FStar_Syntax_Subst.compress t2
                               in
-                           uu____6123.FStar_Syntax_Syntax.n  in
-                         match uu____6122 with
-                         | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____6127) ->
+                           uu____6142.FStar_Syntax_Syntax.n  in
+                         match uu____6141 with
+                         | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____6146) ->
                              ibs
-                         | uu____6148 -> []  in
+                         | uu____6167 -> []  in
                        let ibs1 = FStar_Syntax_Subst.open_binders ibs  in
                        let ind =
-                         let uu____6157 =
+                         let uu____6176 =
                            FStar_Syntax_Syntax.fvar lid
                              FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None
                             in
-                         let uu____6158 =
+                         let uu____6177 =
                            FStar_List.map
                              (fun u  -> FStar_Syntax_Syntax.U_name u) us
                             in
-                         FStar_Syntax_Syntax.mk_Tm_uinst uu____6157
-                           uu____6158
+                         FStar_Syntax_Syntax.mk_Tm_uinst uu____6176
+                           uu____6177
                           in
                        let ind1 =
-                         let uu____6164 =
-                           let uu____6169 =
+                         let uu____6183 =
+                           let uu____6188 =
                              FStar_List.map
-                               (fun uu____6186  ->
-                                  match uu____6186 with
+                               (fun uu____6205  ->
+                                  match uu____6205 with
                                   | (bv,aq) ->
-                                      let uu____6205 =
+                                      let uu____6224 =
                                         FStar_Syntax_Syntax.bv_to_name bv  in
-                                      (uu____6205, aq)) bs2
+                                      (uu____6224, aq)) bs2
                               in
-                           FStar_Syntax_Syntax.mk_Tm_app ind uu____6169  in
-                         uu____6164 FStar_Pervasives_Native.None
+                           FStar_Syntax_Syntax.mk_Tm_app ind uu____6188  in
+                         uu____6183 FStar_Pervasives_Native.None
                            FStar_Range.dummyRange
                           in
                        let ind2 =
-                         let uu____6211 =
-                           let uu____6216 =
+                         let uu____6230 =
+                           let uu____6235 =
                              FStar_List.map
-                               (fun uu____6233  ->
-                                  match uu____6233 with
+                               (fun uu____6252  ->
+                                  match uu____6252 with
                                   | (bv,aq) ->
-                                      let uu____6252 =
+                                      let uu____6271 =
                                         FStar_Syntax_Syntax.bv_to_name bv  in
-                                      (uu____6252, aq)) ibs1
+                                      (uu____6271, aq)) ibs1
                               in
-                           FStar_Syntax_Syntax.mk_Tm_app ind1 uu____6216  in
-                         uu____6211 FStar_Pervasives_Native.None
+                           FStar_Syntax_Syntax.mk_Tm_app ind1 uu____6235  in
+                         uu____6230 FStar_Pervasives_Native.None
                            FStar_Range.dummyRange
                           in
                        let haseq_ind =
-                         let uu____6258 =
-                           let uu____6263 =
-                             let uu____6264 = FStar_Syntax_Syntax.as_arg ind2
+                         let uu____6277 =
+                           let uu____6282 =
+                             let uu____6283 = FStar_Syntax_Syntax.as_arg ind2
                                 in
-                             [uu____6264]  in
+                             [uu____6283]  in
                            FStar_Syntax_Syntax.mk_Tm_app
-                             FStar_Syntax_Util.t_haseq uu____6263
+                             FStar_Syntax_Util.t_haseq uu____6282
                             in
-                         uu____6258 FStar_Pervasives_Native.None
+                         uu____6277 FStar_Pervasives_Native.None
                            FStar_Range.dummyRange
                           in
                        let t_datas =
@@ -2390,9 +2401,9 @@ let (unoptimized_haseq_ty :
                            (fun s  ->
                               match s.FStar_Syntax_Syntax.sigel with
                               | FStar_Syntax_Syntax.Sig_datacon
-                                  (uu____6301,uu____6302,uu____6303,t_lid,uu____6305,uu____6306)
+                                  (uu____6320,uu____6321,uu____6322,t_lid,uu____6324,uu____6325)
                                   -> t_lid = lid
-                              | uu____6313 -> failwith "Impossible")
+                              | uu____6332 -> failwith "Impossible")
                            all_datas_in_the_bundle
                           in
                        let data_cond =
@@ -2403,81 +2414,81 @@ let (unoptimized_haseq_ty :
                        let fml = FStar_Syntax_Util.mk_imp data_cond haseq_ind
                           in
                        let fml1 =
-                         let uu___904_6325 = fml  in
-                         let uu____6326 =
-                           let uu____6327 =
-                             let uu____6334 =
-                               let uu____6335 =
-                                 let uu____6356 =
+                         let uu___904_6344 = fml  in
+                         let uu____6345 =
+                           let uu____6346 =
+                             let uu____6353 =
+                               let uu____6354 =
+                                 let uu____6375 =
                                    FStar_Syntax_Syntax.binders_to_names ibs1
                                     in
-                                 let uu____6361 =
-                                   let uu____6374 =
-                                     let uu____6385 =
+                                 let uu____6380 =
+                                   let uu____6393 =
+                                     let uu____6404 =
                                        FStar_Syntax_Syntax.as_arg haseq_ind
                                         in
-                                     [uu____6385]  in
-                                   [uu____6374]  in
-                                 (uu____6356, uu____6361)  in
-                               FStar_Syntax_Syntax.Meta_pattern uu____6335
+                                     [uu____6404]  in
+                                   [uu____6393]  in
+                                 (uu____6375, uu____6380)  in
+                               FStar_Syntax_Syntax.Meta_pattern uu____6354
                                 in
-                             (fml, uu____6334)  in
-                           FStar_Syntax_Syntax.Tm_meta uu____6327  in
+                             (fml, uu____6353)  in
+                           FStar_Syntax_Syntax.Tm_meta uu____6346  in
                          {
-                           FStar_Syntax_Syntax.n = uu____6326;
+                           FStar_Syntax_Syntax.n = uu____6345;
                            FStar_Syntax_Syntax.pos =
-                             (uu___904_6325.FStar_Syntax_Syntax.pos);
+                             (uu___904_6344.FStar_Syntax_Syntax.pos);
                            FStar_Syntax_Syntax.vars =
-                             (uu___904_6325.FStar_Syntax_Syntax.vars)
+                             (uu___904_6344.FStar_Syntax_Syntax.vars)
                          }  in
                        let fml2 =
                          FStar_List.fold_right
                            (fun b  ->
                               fun t3  ->
-                                let uu____6454 =
-                                  let uu____6459 =
-                                    let uu____6460 =
-                                      let uu____6469 =
-                                        let uu____6470 =
+                                let uu____6473 =
+                                  let uu____6478 =
+                                    let uu____6479 =
+                                      let uu____6488 =
+                                        let uu____6489 =
                                           FStar_Syntax_Subst.close [b] t3  in
                                         FStar_Syntax_Util.abs
                                           [((FStar_Pervasives_Native.fst b),
                                              FStar_Pervasives_Native.None)]
-                                          uu____6470
+                                          uu____6489
                                           FStar_Pervasives_Native.None
                                          in
-                                      FStar_Syntax_Syntax.as_arg uu____6469
+                                      FStar_Syntax_Syntax.as_arg uu____6488
                                        in
-                                    [uu____6460]  in
+                                    [uu____6479]  in
                                   FStar_Syntax_Syntax.mk_Tm_app
-                                    FStar_Syntax_Util.tforall uu____6459
+                                    FStar_Syntax_Util.tforall uu____6478
                                    in
-                                uu____6454 FStar_Pervasives_Native.None
+                                uu____6473 FStar_Pervasives_Native.None
                                   FStar_Range.dummyRange) ibs1 fml1
                           in
                        let fml3 =
                          FStar_List.fold_right
                            (fun b  ->
                               fun t3  ->
-                                let uu____6523 =
-                                  let uu____6528 =
-                                    let uu____6529 =
-                                      let uu____6538 =
-                                        let uu____6539 =
+                                let uu____6542 =
+                                  let uu____6547 =
+                                    let uu____6548 =
+                                      let uu____6557 =
+                                        let uu____6558 =
                                           FStar_Syntax_Subst.close [b] t3  in
                                         FStar_Syntax_Util.abs
                                           [((FStar_Pervasives_Native.fst b),
                                              FStar_Pervasives_Native.None)]
-                                          uu____6539
+                                          uu____6558
                                           FStar_Pervasives_Native.None
                                          in
-                                      FStar_Syntax_Syntax.as_arg uu____6538
+                                      FStar_Syntax_Syntax.as_arg uu____6557
                                        in
-                                    [uu____6529]  in
+                                    [uu____6548]  in
                                   FStar_Syntax_Syntax.mk_Tm_app
-                                    FStar_Syntax_Util.tforall uu____6528
+                                    FStar_Syntax_Util.tforall uu____6547
                                    in
-                                uu____6523 FStar_Pervasives_Native.None
+                                uu____6542 FStar_Pervasives_Native.None
                                   FStar_Range.dummyRange) bs2 fml2
                           in
                        FStar_Syntax_Util.mk_conj acc fml3)
@@ -2497,21 +2508,21 @@ let (unoptimized_haseq_scheme :
               (fun ty  ->
                  match ty.FStar_Syntax_Syntax.sigel with
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid,uu____6631,uu____6632,uu____6633,uu____6634,uu____6635)
+                     (lid,uu____6650,uu____6651,uu____6652,uu____6653,uu____6654)
                      -> lid
-                 | uu____6644 -> failwith "Impossible!") tcs
+                 | uu____6663 -> failwith "Impossible!") tcs
              in
-          let uu____6646 =
+          let uu____6665 =
             let ty = FStar_List.hd tcs  in
             match ty.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_inductive_typ
-                (lid,us,uu____6658,uu____6659,uu____6660,uu____6661) ->
+                (lid,us,uu____6677,uu____6678,uu____6679,uu____6680) ->
                 (lid, us)
-            | uu____6670 -> failwith "Impossible!"  in
-          match uu____6646 with
+            | uu____6689 -> failwith "Impossible!"  in
+          match uu____6665 with
           | (lid,us) ->
-              let uu____6680 = FStar_Syntax_Subst.univ_var_opening us  in
-              (match uu____6680 with
+              let uu____6699 = FStar_Syntax_Subst.univ_var_opening us  in
+              (match uu____6699 with
                | (usubst,us1) ->
                    let fml =
                      FStar_List.fold_left
@@ -2519,13 +2530,13 @@ let (unoptimized_haseq_scheme :
                        FStar_Syntax_Util.t_true tcs
                       in
                    let se =
-                     let uu____6707 =
-                       let uu____6708 =
-                         let uu____6715 = get_haseq_axiom_lid lid  in
-                         (uu____6715, us1, fml)  in
-                       FStar_Syntax_Syntax.Sig_assume uu____6708  in
+                     let uu____6726 =
+                       let uu____6727 =
+                         let uu____6734 = get_haseq_axiom_lid lid  in
+                         (uu____6734, us1, fml)  in
+                       FStar_Syntax_Syntax.Sig_assume uu____6727  in
                      {
-                       FStar_Syntax_Syntax.sigel = uu____6707;
+                       FStar_Syntax_Syntax.sigel = uu____6726;
                        FStar_Syntax_Syntax.sigrng = FStar_Range.dummyRange;
                        FStar_Syntax_Syntax.sigquals = [];
                        FStar_Syntax_Syntax.sigmeta =
@@ -2548,169 +2559,169 @@ let (check_inductive_well_typedness :
     fun ses  ->
       fun quals  ->
         fun lids  ->
-          let uu____6769 =
+          let uu____6788 =
             FStar_All.pipe_right ses
               (FStar_List.partition
-                 (fun uu___2_6795  ->
-                    match uu___2_6795 with
+                 (fun uu___2_6814  ->
+                    match uu___2_6814 with
                     | {
                         FStar_Syntax_Syntax.sigel =
-                          FStar_Syntax_Syntax.Sig_inductive_typ uu____6797;
-                        FStar_Syntax_Syntax.sigrng = uu____6798;
-                        FStar_Syntax_Syntax.sigquals = uu____6799;
-                        FStar_Syntax_Syntax.sigmeta = uu____6800;
-                        FStar_Syntax_Syntax.sigattrs = uu____6801;
-                        FStar_Syntax_Syntax.sigopts = uu____6802;_} -> true
-                    | uu____6826 -> false))
+                          FStar_Syntax_Syntax.Sig_inductive_typ uu____6816;
+                        FStar_Syntax_Syntax.sigrng = uu____6817;
+                        FStar_Syntax_Syntax.sigquals = uu____6818;
+                        FStar_Syntax_Syntax.sigmeta = uu____6819;
+                        FStar_Syntax_Syntax.sigattrs = uu____6820;
+                        FStar_Syntax_Syntax.sigopts = uu____6821;_} -> true
+                    | uu____6845 -> false))
              in
-          match uu____6769 with
+          match uu____6788 with
           | (tys,datas) ->
-              ((let uu____6849 =
+              ((let uu____6868 =
                   FStar_All.pipe_right datas
                     (FStar_Util.for_some
-                       (fun uu___3_6861  ->
-                          match uu___3_6861 with
+                       (fun uu___3_6880  ->
+                          match uu___3_6880 with
                           | {
                               FStar_Syntax_Syntax.sigel =
-                                FStar_Syntax_Syntax.Sig_datacon uu____6863;
-                              FStar_Syntax_Syntax.sigrng = uu____6864;
-                              FStar_Syntax_Syntax.sigquals = uu____6865;
-                              FStar_Syntax_Syntax.sigmeta = uu____6866;
-                              FStar_Syntax_Syntax.sigattrs = uu____6867;
-                              FStar_Syntax_Syntax.sigopts = uu____6868;_} ->
+                                FStar_Syntax_Syntax.Sig_datacon uu____6882;
+                              FStar_Syntax_Syntax.sigrng = uu____6883;
+                              FStar_Syntax_Syntax.sigquals = uu____6884;
+                              FStar_Syntax_Syntax.sigmeta = uu____6885;
+                              FStar_Syntax_Syntax.sigattrs = uu____6886;
+                              FStar_Syntax_Syntax.sigopts = uu____6887;_} ->
                               false
-                          | uu____6891 -> true))
+                          | uu____6910 -> true))
                    in
-                if uu____6849
+                if uu____6868
                 then
-                  let uu____6894 = FStar_TypeChecker_Env.get_range env  in
+                  let uu____6913 = FStar_TypeChecker_Env.get_range env  in
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_NonInductiveInMutuallyDefinedType,
                       "Mutually defined type contains a non-inductive element")
-                    uu____6894
+                    uu____6913
                 else ());
                (let univs =
                   if (FStar_List.length tys) = Prims.int_zero
                   then []
                   else
-                    (let uu____6909 =
-                       let uu____6910 = FStar_List.hd tys  in
-                       uu____6910.FStar_Syntax_Syntax.sigel  in
-                     match uu____6909 with
+                    (let uu____6928 =
+                       let uu____6929 = FStar_List.hd tys  in
+                       uu____6929.FStar_Syntax_Syntax.sigel  in
+                     match uu____6928 with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (uu____6913,uvs,uu____6915,uu____6916,uu____6917,uu____6918)
+                         (uu____6932,uvs,uu____6934,uu____6935,uu____6936,uu____6937)
                          -> uvs
-                     | uu____6927 -> failwith "Impossible, can't happen!")
+                     | uu____6946 -> failwith "Impossible, can't happen!")
                    in
                 let env0 = env  in
-                let uu____6932 =
+                let uu____6951 =
                   FStar_List.fold_right
                     (fun tc  ->
-                       fun uu____6971  ->
-                         match uu____6971 with
+                       fun uu____6990  ->
+                         match uu____6990 with
                          | (env1,all_tcs,g) ->
-                             let uu____7011 = tc_tycon env1 tc  in
-                             (match uu____7011 with
+                             let uu____7030 = tc_tycon env1 tc  in
+                             (match uu____7030 with
                               | (env2,tc1,tc_u,guard) ->
                                   let g' =
                                     FStar_TypeChecker_Rel.universe_inequality
                                       FStar_Syntax_Syntax.U_zero tc_u
                                      in
-                                  ((let uu____7038 =
+                                  ((let uu____7057 =
                                       FStar_TypeChecker_Env.debug env2
                                         FStar_Options.Low
                                        in
-                                    if uu____7038
+                                    if uu____7057
                                     then
-                                      let uu____7041 =
+                                      let uu____7060 =
                                         FStar_Syntax_Print.sigelt_to_string
                                           tc1
                                          in
                                       FStar_Util.print1
-                                        "Checked inductive: %s\n" uu____7041
+                                        "Checked inductive: %s\n" uu____7060
                                     else ());
-                                   (let uu____7046 =
-                                      let uu____7047 =
+                                   (let uu____7065 =
+                                      let uu____7066 =
                                         FStar_TypeChecker_Env.conj_guard
                                           guard g'
                                          in
                                       FStar_TypeChecker_Env.conj_guard g
-                                        uu____7047
+                                        uu____7066
                                        in
                                     (env2, ((tc1, tc_u) :: all_tcs),
-                                      uu____7046))))) tys
+                                      uu____7065))))) tys
                     (env, [], FStar_TypeChecker_Env.trivial_guard)
                    in
-                match uu____6932 with
+                match uu____6951 with
                 | (env1,tcs,g) ->
-                    let uu____7093 =
+                    let uu____7112 =
                       FStar_List.fold_right
                         (fun se  ->
-                           fun uu____7115  ->
-                             match uu____7115 with
+                           fun uu____7134  ->
+                             match uu____7134 with
                              | (datas1,g1) ->
-                                 let uu____7134 =
-                                   let uu____7139 = tc_data env1 tcs  in
-                                   uu____7139 se  in
-                                 (match uu____7134 with
+                                 let uu____7153 =
+                                   let uu____7158 = tc_data env1 tcs  in
+                                   uu____7158 se  in
+                                 (match uu____7153 with
                                   | (data,g') ->
-                                      let uu____7156 =
+                                      let uu____7175 =
                                         FStar_TypeChecker_Env.conj_guard g1
                                           g'
                                          in
-                                      ((data :: datas1), uu____7156))) datas
+                                      ((data :: datas1), uu____7175))) datas
                         ([], g)
                        in
-                    (match uu____7093 with
+                    (match uu____7112 with
                      | (datas1,g1) ->
-                         let uu____7177 =
+                         let uu____7196 =
                            let tc_universe_vars =
                              FStar_List.map FStar_Pervasives_Native.snd tcs
                               in
                            let g2 =
-                             let uu___1015_7194 = g1  in
+                             let uu___1015_7213 = g1  in
                              {
                                FStar_TypeChecker_Common.guard_f =
-                                 (uu___1015_7194.FStar_TypeChecker_Common.guard_f);
+                                 (uu___1015_7213.FStar_TypeChecker_Common.guard_f);
                                FStar_TypeChecker_Common.deferred =
-                                 (uu___1015_7194.FStar_TypeChecker_Common.deferred);
+                                 (uu___1015_7213.FStar_TypeChecker_Common.deferred);
                                FStar_TypeChecker_Common.univ_ineqs =
                                  (tc_universe_vars,
                                    (FStar_Pervasives_Native.snd
                                       g1.FStar_TypeChecker_Common.univ_ineqs));
                                FStar_TypeChecker_Common.implicits =
-                                 (uu___1015_7194.FStar_TypeChecker_Common.implicits)
+                                 (uu___1015_7213.FStar_TypeChecker_Common.implicits)
                              }  in
-                           (let uu____7204 =
+                           (let uu____7223 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env0)
                                 (FStar_Options.Other "GenUniverses")
                                in
-                            if uu____7204
+                            if uu____7223
                             then
-                              let uu____7209 =
+                              let uu____7228 =
                                 FStar_TypeChecker_Rel.guard_to_string env1 g2
                                  in
                               FStar_Util.print1
                                 "@@@@@@Guard before (possible) generalization: %s\n"
-                                uu____7209
+                                uu____7228
                             else ());
                            FStar_TypeChecker_Rel.force_trivial_guard env0 g2;
                            if (FStar_List.length univs) = Prims.int_zero
                            then generalize_and_inst_within env0 tcs datas1
                            else
-                             (let uu____7228 =
+                             (let uu____7247 =
                                 FStar_List.map FStar_Pervasives_Native.fst
                                   tcs
                                  in
-                              (uu____7228, datas1))
+                              (uu____7247, datas1))
                             in
-                         (match uu____7177 with
+                         (match uu____7196 with
                           | (tcs1,datas2) ->
                               let sig_bndle =
-                                let uu____7260 =
+                                let uu____7279 =
                                   FStar_TypeChecker_Env.get_range env0  in
-                                let uu____7261 =
+                                let uu____7280 =
                                   FStar_List.collect
                                     (fun s  -> s.FStar_Syntax_Syntax.sigattrs)
                                     ses
@@ -2720,11 +2731,11 @@ let (check_inductive_well_typedness :
                                     (FStar_Syntax_Syntax.Sig_bundle
                                        ((FStar_List.append tcs1 datas2),
                                          lids));
-                                  FStar_Syntax_Syntax.sigrng = uu____7260;
+                                  FStar_Syntax_Syntax.sigrng = uu____7279;
                                   FStar_Syntax_Syntax.sigquals = quals;
                                   FStar_Syntax_Syntax.sigmeta =
                                     FStar_Syntax_Syntax.default_sigmeta;
-                                  FStar_Syntax_Syntax.sigattrs = uu____7261;
+                                  FStar_Syntax_Syntax.sigattrs = uu____7280;
                                   FStar_Syntax_Syntax.sigopts =
                                     FStar_Pervasives_Native.None
                                 }  in
@@ -2734,62 +2745,62 @@ let (check_inductive_well_typedness :
                                        match se.FStar_Syntax_Syntax.sigel
                                        with
                                        | FStar_Syntax_Syntax.Sig_inductive_typ
-                                           (l,univs1,binders,typ,uu____7287,uu____7288)
+                                           (l,univs1,binders,typ,uu____7306,uu____7307)
                                            ->
                                            let fail expected inferred =
-                                             let uu____7308 =
-                                               let uu____7314 =
-                                                 let uu____7316 =
+                                             let uu____7327 =
+                                               let uu____7333 =
+                                                 let uu____7335 =
                                                    FStar_Syntax_Print.tscheme_to_string
                                                      expected
                                                     in
-                                                 let uu____7318 =
+                                                 let uu____7337 =
                                                    FStar_Syntax_Print.tscheme_to_string
                                                      inferred
                                                     in
                                                  FStar_Util.format2
                                                    "Expected an inductive with type %s; got %s"
-                                                   uu____7316 uu____7318
+                                                   uu____7335 uu____7337
                                                   in
                                                (FStar_Errors.Fatal_UnexpectedInductivetype,
-                                                 uu____7314)
+                                                 uu____7333)
                                                 in
                                              FStar_Errors.raise_error
-                                               uu____7308
+                                               uu____7327
                                                se.FStar_Syntax_Syntax.sigrng
                                               in
-                                           let uu____7322 =
+                                           let uu____7341 =
                                              FStar_TypeChecker_Env.try_lookup_val_decl
                                                env0 l
                                               in
-                                           (match uu____7322 with
+                                           (match uu____7341 with
                                             | FStar_Pervasives_Native.None 
                                                 -> ()
                                             | FStar_Pervasives_Native.Some
-                                                (expected_typ,uu____7338) ->
+                                                (expected_typ,uu____7357) ->
                                                 let inferred_typ =
                                                   let body =
                                                     match binders with
                                                     | [] -> typ
-                                                    | uu____7369 ->
-                                                        let uu____7370 =
-                                                          let uu____7377 =
-                                                            let uu____7378 =
-                                                              let uu____7393
+                                                    | uu____7388 ->
+                                                        let uu____7389 =
+                                                          let uu____7396 =
+                                                            let uu____7397 =
+                                                              let uu____7412
                                                                 =
                                                                 FStar_Syntax_Syntax.mk_Total
                                                                   typ
                                                                  in
                                                               (binders,
-                                                                uu____7393)
+                                                                uu____7412)
                                                                in
                                                             FStar_Syntax_Syntax.Tm_arrow
-                                                              uu____7378
+                                                              uu____7397
                                                              in
                                                           FStar_Syntax_Syntax.mk
-                                                            uu____7377
+                                                            uu____7396
                                                            in
-                                                        uu____7370
+                                                        uu____7389
                                                           FStar_Pervasives_Native.None
                                                           se.FStar_Syntax_Syntax.sigrng
                                                      in
@@ -2801,25 +2812,25 @@ let (check_inductive_well_typedness :
                                                        (FStar_Pervasives_Native.fst
                                                           expected_typ))
                                                 then
-                                                  let uu____7415 =
+                                                  let uu____7434 =
                                                     FStar_TypeChecker_Env.inst_tscheme
                                                       inferred_typ
                                                      in
-                                                  (match uu____7415 with
-                                                   | (uu____7420,inferred) ->
-                                                       let uu____7422 =
+                                                  (match uu____7434 with
+                                                   | (uu____7439,inferred) ->
+                                                       let uu____7441 =
                                                          FStar_TypeChecker_Env.inst_tscheme
                                                            expected_typ
                                                           in
-                                                       (match uu____7422 with
-                                                        | (uu____7427,expected)
+                                                       (match uu____7441 with
+                                                        | (uu____7446,expected)
                                                             ->
-                                                            let uu____7429 =
+                                                            let uu____7448 =
                                                               FStar_TypeChecker_Rel.teq_nosmt_force
                                                                 env0 inferred
                                                                 expected
                                                                in
-                                                            if uu____7429
+                                                            if uu____7448
                                                             then ()
                                                             else
                                                               fail
@@ -2828,7 +2839,7 @@ let (check_inductive_well_typedness :
                                                 else
                                                   fail expected_typ
                                                     inferred_typ)
-                                       | uu____7436 -> ()));
+                                       | uu____7455 -> ()));
                                (sig_bndle, tcs1, datas2))))))
   
 let (early_prims_inductives : Prims.string Prims.list) =
@@ -2872,39 +2883,39 @@ let (mk_discriminator_and_indexed_projectors :
                           let tps = inductive_tps  in
                           let arg_typ =
                             let inst_tc =
-                              let uu____7563 =
-                                let uu____7570 =
-                                  let uu____7571 =
-                                    let uu____7578 =
-                                      let uu____7581 =
+                              let uu____7582 =
+                                let uu____7589 =
+                                  let uu____7590 =
+                                    let uu____7597 =
+                                      let uu____7600 =
                                         FStar_Syntax_Syntax.lid_as_fv tc
                                           FStar_Syntax_Syntax.delta_constant
                                           FStar_Pervasives_Native.None
                                          in
-                                      FStar_Syntax_Syntax.fv_to_tm uu____7581
+                                      FStar_Syntax_Syntax.fv_to_tm uu____7600
                                        in
-                                    (uu____7578, inst_univs)  in
-                                  FStar_Syntax_Syntax.Tm_uinst uu____7571  in
-                                FStar_Syntax_Syntax.mk uu____7570  in
-                              uu____7563 FStar_Pervasives_Native.None p  in
+                                    (uu____7597, inst_univs)  in
+                                  FStar_Syntax_Syntax.Tm_uinst uu____7590  in
+                                FStar_Syntax_Syntax.mk uu____7589  in
+                              uu____7582 FStar_Pervasives_Native.None p  in
                             let args =
                               FStar_All.pipe_right
                                 (FStar_List.append tps indices)
                                 (FStar_List.map
-                                   (fun uu____7615  ->
-                                      match uu____7615 with
+                                   (fun uu____7634  ->
+                                      match uu____7634 with
                                       | (x,imp) ->
-                                          let uu____7634 =
+                                          let uu____7653 =
                                             FStar_Syntax_Syntax.bv_to_name x
                                              in
-                                          (uu____7634, imp)))
+                                          (uu____7653, imp)))
                                in
                             FStar_Syntax_Syntax.mk_Tm_app inst_tc args
                               FStar_Pervasives_Native.None p
                              in
                           let unrefined_arg_binder =
-                            let uu____7638 = projectee arg_typ  in
-                            FStar_Syntax_Syntax.mk_binder uu____7638  in
+                            let uu____7657 = projectee arg_typ  in
+                            FStar_Syntax_Syntax.mk_binder uu____7657  in
                           let arg_binder =
                             if Prims.op_Negation refine_domain
                             then unrefined_arg_binder
@@ -2917,85 +2928,87 @@ let (mk_discriminator_and_indexed_projectors :
                                   in
                                let sort =
                                  let disc_fvar =
-                                   let uu____7661 =
+                                   let uu____7680 =
                                      FStar_Ident.set_lid_range disc_name p
                                       in
-                                   FStar_Syntax_Syntax.fvar uu____7661
+                                   FStar_Syntax_Syntax.fvar uu____7680
                                      (FStar_Syntax_Syntax.Delta_equational_at_level
                                         Prims.int_one)
                                      FStar_Pervasives_Native.None
                                     in
-                                 let uu____7663 =
-                                   let uu____7666 =
-                                     let uu____7669 =
-                                       let uu____7674 =
+                                 let uu____7682 =
+                                   let uu____7685 =
+                                     let uu____7688 =
+                                       let uu____7693 =
                                          FStar_Syntax_Syntax.mk_Tm_uinst
                                            disc_fvar inst_univs
                                           in
-                                       let uu____7675 =
-                                         let uu____7676 =
-                                           let uu____7685 =
+                                       let uu____7694 =
+                                         let uu____7695 =
+                                           let uu____7704 =
                                              FStar_Syntax_Syntax.bv_to_name x
                                               in
                                            FStar_All.pipe_left
                                              FStar_Syntax_Syntax.as_arg
-                                             uu____7685
+                                             uu____7704
                                             in
-                                         [uu____7676]  in
+                                         [uu____7695]  in
                                        FStar_Syntax_Syntax.mk_Tm_app
-                                         uu____7674 uu____7675
+                                         uu____7693 uu____7694
                                         in
-                                     uu____7669 FStar_Pervasives_Native.None
+                                     uu____7688 FStar_Pervasives_Native.None
                                        p
                                       in
-                                   FStar_Syntax_Util.b2t uu____7666  in
-                                 FStar_Syntax_Util.refine x uu____7663  in
-                               let uu____7710 =
-                                 let uu___1090_7711 = projectee arg_typ  in
+                                   FStar_Syntax_Util.b2t uu____7685  in
+                                 FStar_Syntax_Util.refine x uu____7682  in
+                               let uu____7729 =
+                                 let uu___1090_7730 = projectee arg_typ  in
                                  {
                                    FStar_Syntax_Syntax.ppname =
-                                     (uu___1090_7711.FStar_Syntax_Syntax.ppname);
+                                     (uu___1090_7730.FStar_Syntax_Syntax.ppname);
                                    FStar_Syntax_Syntax.index =
-                                     (uu___1090_7711.FStar_Syntax_Syntax.index);
+                                     (uu___1090_7730.FStar_Syntax_Syntax.index);
                                    FStar_Syntax_Syntax.sort = sort
                                  }  in
-                               FStar_Syntax_Syntax.mk_binder uu____7710)
+                               FStar_Syntax_Syntax.mk_binder uu____7729)
                              in
                           let ntps = FStar_List.length tps  in
                           let all_params =
-                            let uu____7728 =
+                            let uu____7747 =
                               FStar_List.map
-                                (fun uu____7752  ->
-                                   match uu____7752 with
-                                   | (x,uu____7766) ->
+                                (fun uu____7771  ->
+                                   match uu____7771 with
+                                   | (x,uu____7785) ->
                                        (x,
                                          (FStar_Pervasives_Native.Some
                                             FStar_Syntax_Syntax.imp_tag)))
                                 tps
                                in
-                            FStar_List.append uu____7728 fields  in
+                            FStar_List.append uu____7747 fields  in
                           let imp_binders =
                             FStar_All.pipe_right
                               (FStar_List.append tps indices)
                               (FStar_List.map
-                                 (fun uu____7825  ->
-                                    match uu____7825 with
-                                    | (x,uu____7839) ->
+                                 (fun uu____7844  ->
+                                    match uu____7844 with
+                                    | (x,uu____7858) ->
                                         (x,
                                           (FStar_Pervasives_Native.Some
                                              FStar_Syntax_Syntax.imp_tag))))
                              in
                           let early_prims_inductive =
-                            (let uu____7850 =
+                            (let uu____7869 =
                                FStar_TypeChecker_Env.current_module env  in
                              FStar_Ident.lid_equals
-                               FStar_Parser_Const.prims_lid uu____7850)
+                               FStar_Parser_Const.prims_lid uu____7869)
                               &&
                               (FStar_List.existsb
                                  (fun s  ->
-                                    s =
-                                      (tc.FStar_Ident.ident).FStar_Ident.idText)
-                                 early_prims_inductives)
+                                    let uu____7875 =
+                                      let uu____7877 =
+                                        FStar_Ident.ident_of_lid tc  in
+                                      FStar_Ident.text_of_id uu____7877  in
+                                    s = uu____7875) early_prims_inductives)
                              in
                           let discriminator_ses =
                             if fvq <> FStar_Syntax_Syntax.Data_ctor
@@ -3006,20 +3019,21 @@ let (mk_discriminator_and_indexed_projectors :
                                let no_decl = false  in
                                let only_decl =
                                  early_prims_inductive ||
-                                   (let uu____7871 =
-                                      let uu____7873 =
+                                   (let uu____7894 =
+                                      let uu____7896 =
                                         FStar_TypeChecker_Env.current_module
                                           env
                                          in
-                                      uu____7873.FStar_Ident.str  in
+                                      FStar_Ident.string_of_lid uu____7896
+                                       in
                                     FStar_Options.dont_gen_projectors
-                                      uu____7871)
+                                      uu____7894)
                                   in
                                let quals =
-                                 let uu____7877 =
+                                 let uu____7900 =
                                    FStar_List.filter
-                                     (fun uu___4_7881  ->
-                                        match uu___4_7881 with
+                                     (fun uu___4_7904  ->
+                                        match uu___4_7904 with
                                         | FStar_Syntax_Syntax.Abstract  ->
                                             Prims.op_Negation only_decl
                                         | FStar_Syntax_Syntax.Inline_for_extraction
@@ -3028,7 +3042,7 @@ let (mk_discriminator_and_indexed_projectors :
                                             true
                                         | FStar_Syntax_Syntax.Private  ->
                                             true
-                                        | uu____7886 -> false) iquals
+                                        | uu____7909 -> false) iquals
                                     in
                                  FStar_List.append
                                    ((FStar_Syntax_Syntax.Discriminator lid)
@@ -3037,7 +3051,7 @@ let (mk_discriminator_and_indexed_projectors :
                                     then
                                       [FStar_Syntax_Syntax.Logic;
                                       FStar_Syntax_Syntax.Assumption]
-                                    else [])) uu____7877
+                                    else [])) uu____7900
                                   in
                                let binders =
                                  FStar_List.append imp_binders
@@ -3053,15 +3067,15 @@ let (mk_discriminator_and_indexed_projectors :
                                      FStar_Syntax_Syntax.mk_Total
                                        FStar_Syntax_Util.t_bool
                                     in
-                                 let uu____7931 =
+                                 let uu____7954 =
                                    FStar_Syntax_Util.arrow binders bool_typ
                                     in
                                  FStar_All.pipe_left
                                    (FStar_Syntax_Subst.close_univ_vars uvs)
-                                   uu____7931
+                                   uu____7954
                                   in
                                let decl =
-                                 let uu____7935 =
+                                 let uu____7958 =
                                    FStar_Ident.range_of_lid
                                      discriminator_name
                                     in
@@ -3069,7 +3083,7 @@ let (mk_discriminator_and_indexed_projectors :
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_declare_typ
                                         (discriminator_name, uvs, t));
-                                   FStar_Syntax_Syntax.sigrng = uu____7935;
+                                   FStar_Syntax_Syntax.sigrng = uu____7958;
                                    FStar_Syntax_Syntax.sigquals = quals;
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
@@ -3077,18 +3091,18 @@ let (mk_discriminator_and_indexed_projectors :
                                    FStar_Syntax_Syntax.sigopts =
                                      FStar_Pervasives_Native.None
                                  }  in
-                               (let uu____7937 =
+                               (let uu____7960 =
                                   FStar_TypeChecker_Env.debug env
                                     (FStar_Options.Other "LogTypes")
                                    in
-                                if uu____7937
+                                if uu____7960
                                 then
-                                  let uu____7941 =
+                                  let uu____7964 =
                                     FStar_Syntax_Print.sigelt_to_string decl
                                      in
                                   FStar_Util.print1
                                     "Declaration of a discriminator %s\n"
-                                    uu____7941
+                                    uu____7964
                                 else ());
                                if only_decl
                                then [decl]
@@ -3101,8 +3115,8 @@ let (mk_discriminator_and_indexed_projectors :
                                          FStar_All.pipe_right all_params
                                            (FStar_List.mapi
                                               (fun j  ->
-                                                 fun uu____8002  ->
-                                                   match uu____8002 with
+                                                 fun uu____8025  ->
+                                                   match uu____8025 with
                                                    | (x,imp) ->
                                                        let b =
                                                          FStar_Syntax_Syntax.is_implicit
@@ -3110,74 +3124,84 @@ let (mk_discriminator_and_indexed_projectors :
                                                           in
                                                        if b && (j < ntps)
                                                        then
-                                                         let uu____8027 =
-                                                           let uu____8030 =
-                                                             let uu____8031 =
-                                                               let uu____8038
+                                                         let uu____8050 =
+                                                           let uu____8053 =
+                                                             let uu____8054 =
+                                                               let uu____8061
                                                                  =
+                                                                 let uu____8062
+                                                                   =
+                                                                   FStar_Ident.text_of_id
+                                                                    x.FStar_Syntax_Syntax.ppname
+                                                                    in
                                                                  FStar_Syntax_Syntax.gen_bv
-                                                                   (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                                                                   uu____8062
                                                                    FStar_Pervasives_Native.None
                                                                    FStar_Syntax_Syntax.tun
                                                                   in
-                                                               (uu____8038,
+                                                               (uu____8061,
                                                                  FStar_Syntax_Syntax.tun)
                                                                 in
                                                              FStar_Syntax_Syntax.Pat_dot_term
-                                                               uu____8031
+                                                               uu____8054
                                                               in
-                                                           pos uu____8030  in
-                                                         (uu____8027, b)
+                                                           pos uu____8053  in
+                                                         (uu____8050, b)
                                                        else
-                                                         (let uu____8046 =
-                                                            let uu____8049 =
-                                                              let uu____8050
+                                                         (let uu____8071 =
+                                                            let uu____8074 =
+                                                              let uu____8075
                                                                 =
+                                                                let uu____8076
+                                                                  =
+                                                                  FStar_Ident.text_of_id
+                                                                    x.FStar_Syntax_Syntax.ppname
+                                                                   in
                                                                 FStar_Syntax_Syntax.gen_bv
-                                                                  (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                                                                  uu____8076
                                                                   FStar_Pervasives_Native.None
                                                                   FStar_Syntax_Syntax.tun
                                                                  in
                                                               FStar_Syntax_Syntax.Pat_wild
-                                                                uu____8050
+                                                                uu____8075
                                                                in
-                                                            pos uu____8049
+                                                            pos uu____8074
                                                              in
-                                                          (uu____8046, b))))
+                                                          (uu____8071, b))))
                                           in
                                        let pat_true =
-                                         let uu____8069 =
-                                           let uu____8072 =
-                                             let uu____8073 =
-                                               let uu____8087 =
+                                         let uu____8096 =
+                                           let uu____8099 =
+                                             let uu____8100 =
+                                               let uu____8114 =
                                                  FStar_Syntax_Syntax.lid_as_fv
                                                    lid
                                                    FStar_Syntax_Syntax.delta_constant
                                                    (FStar_Pervasives_Native.Some
                                                       fvq)
                                                   in
-                                               (uu____8087, arg_pats)  in
+                                               (uu____8114, arg_pats)  in
                                              FStar_Syntax_Syntax.Pat_cons
-                                               uu____8073
+                                               uu____8100
                                               in
-                                           pos uu____8072  in
-                                         (uu____8069,
+                                           pos uu____8099  in
+                                         (uu____8096,
                                            FStar_Pervasives_Native.None,
                                            FStar_Syntax_Util.exp_true_bool)
                                           in
                                        let pat_false =
-                                         let uu____8122 =
-                                           let uu____8125 =
-                                             let uu____8126 =
+                                         let uu____8149 =
+                                           let uu____8152 =
+                                             let uu____8153 =
                                                FStar_Syntax_Syntax.new_bv
                                                  FStar_Pervasives_Native.None
                                                  FStar_Syntax_Syntax.tun
                                                 in
                                              FStar_Syntax_Syntax.Pat_wild
-                                               uu____8126
+                                               uu____8153
                                               in
-                                           pos uu____8125  in
-                                         (uu____8122,
+                                           pos uu____8152  in
+                                         (uu____8149,
                                            FStar_Pervasives_Native.None,
                                            FStar_Syntax_Util.exp_false_bool)
                                           in
@@ -3186,37 +3210,37 @@ let (mk_discriminator_and_indexed_projectors :
                                            (FStar_Pervasives_Native.fst
                                               unrefined_arg_binder)
                                           in
-                                       let uu____8140 =
-                                         let uu____8147 =
-                                           let uu____8148 =
-                                             let uu____8171 =
-                                               let uu____8188 =
+                                       let uu____8167 =
+                                         let uu____8174 =
+                                           let uu____8175 =
+                                             let uu____8198 =
+                                               let uu____8215 =
                                                  FStar_Syntax_Util.branch
                                                    pat_true
                                                   in
-                                               let uu____8203 =
-                                                 let uu____8220 =
+                                               let uu____8230 =
+                                                 let uu____8247 =
                                                    FStar_Syntax_Util.branch
                                                      pat_false
                                                     in
-                                                 [uu____8220]  in
-                                               uu____8188 :: uu____8203  in
-                                             (arg_exp, uu____8171)  in
+                                                 [uu____8247]  in
+                                               uu____8215 :: uu____8230  in
+                                             (arg_exp, uu____8198)  in
                                            FStar_Syntax_Syntax.Tm_match
-                                             uu____8148
+                                             uu____8175
                                             in
-                                         FStar_Syntax_Syntax.mk uu____8147
+                                         FStar_Syntax_Syntax.mk uu____8174
                                           in
-                                       uu____8140
+                                       uu____8167
                                          FStar_Pervasives_Native.None p)
                                      in
                                   let dd =
-                                    let uu____8296 =
+                                    let uu____8323 =
                                       FStar_All.pipe_right quals
                                         (FStar_List.contains
                                            FStar_Syntax_Syntax.Abstract)
                                        in
-                                    if uu____8296
+                                    if uu____8323
                                     then
                                       FStar_Syntax_Syntax.Delta_abstract
                                         (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -3234,42 +3258,42 @@ let (mk_discriminator_and_indexed_projectors :
                                     then t
                                     else FStar_Syntax_Syntax.tun  in
                                   let lb =
-                                    let uu____8318 =
-                                      let uu____8323 =
+                                    let uu____8345 =
+                                      let uu____8350 =
                                         FStar_Syntax_Syntax.lid_as_fv
                                           discriminator_name dd
                                           FStar_Pervasives_Native.None
                                          in
-                                      FStar_Util.Inr uu____8323  in
-                                    let uu____8324 =
+                                      FStar_Util.Inr uu____8350  in
+                                    let uu____8351 =
                                       FStar_Syntax_Subst.close_univ_vars uvs
                                         imp
                                        in
                                     FStar_Syntax_Util.mk_letbinding
-                                      uu____8318 uvs lbtyp
+                                      uu____8345 uvs lbtyp
                                       FStar_Parser_Const.effect_Tot_lid
-                                      uu____8324 [] FStar_Range.dummyRange
+                                      uu____8351 [] FStar_Range.dummyRange
                                      in
                                   let impl =
-                                    let uu____8330 =
-                                      let uu____8331 =
-                                        let uu____8338 =
-                                          let uu____8341 =
-                                            let uu____8342 =
+                                    let uu____8357 =
+                                      let uu____8358 =
+                                        let uu____8365 =
+                                          let uu____8368 =
+                                            let uu____8369 =
                                               FStar_All.pipe_right
                                                 lb.FStar_Syntax_Syntax.lbname
                                                 FStar_Util.right
                                                in
-                                            FStar_All.pipe_right uu____8342
+                                            FStar_All.pipe_right uu____8369
                                               (fun fv  ->
                                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                                              in
-                                          [uu____8341]  in
-                                        ((false, [lb]), uu____8338)  in
-                                      FStar_Syntax_Syntax.Sig_let uu____8331
+                                          [uu____8368]  in
+                                        ((false, [lb]), uu____8365)  in
+                                      FStar_Syntax_Syntax.Sig_let uu____8358
                                        in
                                     {
-                                      FStar_Syntax_Syntax.sigel = uu____8330;
+                                      FStar_Syntax_Syntax.sigel = uu____8357;
                                       FStar_Syntax_Syntax.sigrng = p;
                                       FStar_Syntax_Syntax.sigquals = quals;
                                       FStar_Syntax_Syntax.sigmeta =
@@ -3278,19 +3302,19 @@ let (mk_discriminator_and_indexed_projectors :
                                       FStar_Syntax_Syntax.sigopts =
                                         FStar_Pervasives_Native.None
                                     }  in
-                                  (let uu____8356 =
+                                  (let uu____8383 =
                                      FStar_TypeChecker_Env.debug env
                                        (FStar_Options.Other "LogTypes")
                                       in
-                                   if uu____8356
+                                   if uu____8383
                                    then
-                                     let uu____8360 =
+                                     let uu____8387 =
                                        FStar_Syntax_Print.sigelt_to_string
                                          impl
                                         in
                                      FStar_Util.print1
                                        "Implementation of a discriminator %s\n"
-                                       uu____8360
+                                       uu____8387
                                    else ());
                                   [decl; impl]))
                              in
@@ -3308,16 +3332,16 @@ let (mk_discriminator_and_indexed_projectors :
                             FStar_All.pipe_right fields
                               (FStar_List.mapi
                                  (fun i  ->
-                                    fun uu____8431  ->
-                                      match uu____8431 with
-                                      | (a,uu____8440) ->
+                                    fun uu____8458  ->
+                                      match uu____8458 with
+                                      | (a,uu____8467) ->
                                           let field_name =
                                             FStar_Syntax_Util.mk_field_projector_name
                                               lid a i
                                              in
                                           let field_proj_tm =
-                                            let uu____8447 =
-                                              let uu____8448 =
+                                            let uu____8474 =
+                                              let uu____8475 =
                                                 FStar_Syntax_Syntax.lid_as_fv
                                                   field_name
                                                   (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -3325,10 +3349,10 @@ let (mk_discriminator_and_indexed_projectors :
                                                   FStar_Pervasives_Native.None
                                                  in
                                               FStar_Syntax_Syntax.fv_to_tm
-                                                uu____8448
+                                                uu____8475
                                                in
                                             FStar_Syntax_Syntax.mk_Tm_uinst
-                                              uu____8447 inst_univs
+                                              uu____8474 inst_univs
                                              in
                                           let proj =
                                             FStar_Syntax_Syntax.mk_Tm_app
@@ -3338,13 +3362,13 @@ let (mk_discriminator_and_indexed_projectors :
                                           FStar_Syntax_Syntax.NT (a, proj)))
                              in
                           let projectors_ses =
-                            let uu____8474 =
+                            let uu____8501 =
                               FStar_All.pipe_right fields
                                 (FStar_List.mapi
                                    (fun i  ->
-                                      fun uu____8514  ->
-                                        match uu____8514 with
-                                        | (x,uu____8525) ->
+                                      fun uu____8541  ->
+                                        match uu____8541 with
+                                        | (x,uu____8552) ->
                                             let p1 =
                                               FStar_Syntax_Syntax.range_of_bv
                                                 x
@@ -3368,48 +3392,49 @@ let (mk_discriminator_and_indexed_projectors :
                                                   FStar_Syntax_Syntax.mk_Total
                                                     t
                                                  in
-                                              let uu____8544 =
+                                              let uu____8571 =
                                                 FStar_Syntax_Util.arrow
                                                   binders result_comp
                                                  in
                                               FStar_All.pipe_left
                                                 (FStar_Syntax_Subst.close_univ_vars
-                                                   uvs) uu____8544
+                                                   uvs) uu____8571
                                                in
                                             let only_decl =
                                               early_prims_inductive ||
-                                                (let uu____8550 =
-                                                   let uu____8552 =
+                                                (let uu____8577 =
+                                                   let uu____8579 =
                                                      FStar_TypeChecker_Env.current_module
                                                        env
                                                       in
-                                                   uu____8552.FStar_Ident.str
+                                                   FStar_Ident.string_of_lid
+                                                     uu____8579
                                                     in
                                                  FStar_Options.dont_gen_projectors
-                                                   uu____8550)
+                                                   uu____8577)
                                                in
                                             let no_decl = false  in
                                             let quals q =
                                               if only_decl
                                               then
-                                                let uu____8571 =
+                                                let uu____8598 =
                                                   FStar_List.filter
-                                                    (fun uu___5_8575  ->
-                                                       match uu___5_8575 with
+                                                    (fun uu___5_8602  ->
+                                                       match uu___5_8602 with
                                                        | FStar_Syntax_Syntax.Abstract
                                                             -> false
-                                                       | uu____8578 -> true)
+                                                       | uu____8605 -> true)
                                                     q
                                                    in
                                                 FStar_Syntax_Syntax.Assumption
-                                                  :: uu____8571
+                                                  :: uu____8598
                                               else q  in
                                             let quals1 =
                                               let iquals1 =
                                                 FStar_All.pipe_right iquals
                                                   (FStar_List.filter
-                                                     (fun uu___6_8593  ->
-                                                        match uu___6_8593
+                                                     (fun uu___6_8620  ->
+                                                        match uu___6_8620
                                                         with
                                                         | FStar_Syntax_Syntax.Inline_for_extraction
                                                              -> true
@@ -3419,7 +3444,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                              -> true
                                                         | FStar_Syntax_Syntax.Private
                                                              -> true
-                                                        | uu____8599 -> false))
+                                                        | uu____8626 -> false))
                                                  in
                                               quals
                                                 ((FStar_Syntax_Syntax.Projector
@@ -3436,7 +3461,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                 attrs
                                                in
                                             let decl =
-                                              let uu____8610 =
+                                              let uu____8637 =
                                                 FStar_Ident.range_of_lid
                                                   field_name
                                                  in
@@ -3445,7 +3470,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                   (FStar_Syntax_Syntax.Sig_declare_typ
                                                      (field_name, uvs, t));
                                                 FStar_Syntax_Syntax.sigrng =
-                                                  uu____8610;
+                                                  uu____8637;
                                                 FStar_Syntax_Syntax.sigquals
                                                   = quals1;
                                                 FStar_Syntax_Syntax.sigmeta =
@@ -3455,28 +3480,32 @@ let (mk_discriminator_and_indexed_projectors :
                                                 FStar_Syntax_Syntax.sigopts =
                                                   FStar_Pervasives_Native.None
                                               }  in
-                                            ((let uu____8612 =
+                                            ((let uu____8639 =
                                                 FStar_TypeChecker_Env.debug
                                                   env
                                                   (FStar_Options.Other
                                                      "LogTypes")
                                                  in
-                                              if uu____8612
+                                              if uu____8639
                                               then
-                                                let uu____8616 =
+                                                let uu____8643 =
                                                   FStar_Syntax_Print.sigelt_to_string
                                                     decl
                                                    in
                                                 FStar_Util.print1
                                                   "Declaration of a projector %s\n"
-                                                  uu____8616
+                                                  uu____8643
                                               else ());
                                              if only_decl
                                              then [decl]
                                              else
                                                (let projection =
+                                                  let uu____8654 =
+                                                    FStar_Ident.text_of_id
+                                                      x.FStar_Syntax_Syntax.ppname
+                                                     in
                                                   FStar_Syntax_Syntax.gen_bv
-                                                    (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                                                    uu____8654
                                                     FStar_Pervasives_Native.None
                                                     FStar_Syntax_Syntax.tun
                                                    in
@@ -3485,8 +3514,8 @@ let (mk_discriminator_and_indexed_projectors :
                                                     all_params
                                                     (FStar_List.mapi
                                                        (fun j  ->
-                                                          fun uu____8670  ->
-                                                            match uu____8670
+                                                          fun uu____8699  ->
+                                                            match uu____8699
                                                             with
                                                             | (x1,imp) ->
                                                                 let b =
@@ -3497,13 +3526,13 @@ let (mk_discriminator_and_indexed_projectors :
                                                                   (i + ntps)
                                                                     = j
                                                                 then
-                                                                  let uu____8696
+                                                                  let uu____8725
                                                                     =
                                                                     pos
                                                                     (FStar_Syntax_Syntax.Pat_var
                                                                     projection)
                                                                      in
-                                                                  (uu____8696,
+                                                                  (uu____8725,
                                                                     b)
                                                                 else
                                                                   if
@@ -3511,97 +3540,107 @@ let (mk_discriminator_and_indexed_projectors :
                                                                     (j < ntps)
                                                                   then
                                                                     (
-                                                                    let uu____8712
+                                                                    let uu____8741
                                                                     =
-                                                                    let uu____8715
+                                                                    let uu____8744
                                                                     =
-                                                                    let uu____8716
+                                                                    let uu____8745
                                                                     =
-                                                                    let uu____8723
+                                                                    let uu____8752
                                                                     =
+                                                                    let uu____8753
+                                                                    =
+                                                                    FStar_Ident.text_of_id
+                                                                    x1.FStar_Syntax_Syntax.ppname
+                                                                     in
                                                                     FStar_Syntax_Syntax.gen_bv
-                                                                    (x1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                                                                    uu____8753
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun
                                                                      in
-                                                                    (uu____8723,
+                                                                    (uu____8752,
                                                                     FStar_Syntax_Syntax.tun)
                                                                      in
                                                                     FStar_Syntax_Syntax.Pat_dot_term
-                                                                    uu____8716
+                                                                    uu____8745
                                                                      in
                                                                     pos
-                                                                    uu____8715
+                                                                    uu____8744
                                                                      in
-                                                                    (uu____8712,
+                                                                    (uu____8741,
                                                                     b))
                                                                   else
                                                                     (
-                                                                    let uu____8731
+                                                                    let uu____8762
                                                                     =
-                                                                    let uu____8734
+                                                                    let uu____8765
                                                                     =
-                                                                    let uu____8735
+                                                                    let uu____8766
                                                                     =
+                                                                    let uu____8767
+                                                                    =
+                                                                    FStar_Ident.text_of_id
+                                                                    x1.FStar_Syntax_Syntax.ppname
+                                                                     in
                                                                     FStar_Syntax_Syntax.gen_bv
-                                                                    (x1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
+                                                                    uu____8767
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun
                                                                      in
                                                                     FStar_Syntax_Syntax.Pat_wild
-                                                                    uu____8735
+                                                                    uu____8766
                                                                      in
                                                                     pos
-                                                                    uu____8734
+                                                                    uu____8765
                                                                      in
-                                                                    (uu____8731,
+                                                                    (uu____8762,
                                                                     b))))
                                                    in
                                                 let pat =
-                                                  let uu____8754 =
-                                                    let uu____8757 =
-                                                      let uu____8758 =
-                                                        let uu____8772 =
+                                                  let uu____8787 =
+                                                    let uu____8790 =
+                                                      let uu____8791 =
+                                                        let uu____8805 =
                                                           FStar_Syntax_Syntax.lid_as_fv
                                                             lid
                                                             FStar_Syntax_Syntax.delta_constant
                                                             (FStar_Pervasives_Native.Some
                                                                fvq)
                                                            in
-                                                        (uu____8772,
+                                                        (uu____8805,
                                                           arg_pats)
                                                          in
                                                       FStar_Syntax_Syntax.Pat_cons
-                                                        uu____8758
+                                                        uu____8791
                                                        in
-                                                    pos uu____8757  in
-                                                  let uu____8782 =
+                                                    pos uu____8790  in
+                                                  let uu____8815 =
                                                     FStar_Syntax_Syntax.bv_to_name
                                                       projection
                                                      in
-                                                  (uu____8754,
+                                                  (uu____8787,
                                                     FStar_Pervasives_Native.None,
-                                                    uu____8782)
+                                                    uu____8815)
                                                    in
                                                 let body =
-                                                  let uu____8798 =
-                                                    let uu____8805 =
-                                                      let uu____8806 =
-                                                        let uu____8829 =
-                                                          let uu____8846 =
+                                                  let uu____8831 =
+                                                    let uu____8838 =
+                                                      let uu____8839 =
+                                                        let uu____8862 =
+                                                          let uu____8879 =
                                                             FStar_Syntax_Util.branch
                                                               pat
                                                              in
-                                                          [uu____8846]  in
-                                                        (arg_exp, uu____8829)
+                                                          [uu____8879]  in
+                                                        (arg_exp, uu____8862)
                                                          in
                                                       FStar_Syntax_Syntax.Tm_match
-                                                        uu____8806
+                                                        uu____8839
                                                        in
                                                     FStar_Syntax_Syntax.mk
-                                                      uu____8805
+                                                      uu____8838
                                                      in
-                                                  uu____8798
+                                                  uu____8831
                                                     FStar_Pervasives_Native.None
                                                     p1
                                                    in
@@ -3611,13 +3650,13 @@ let (mk_discriminator_and_indexed_projectors :
                                                     FStar_Pervasives_Native.None
                                                    in
                                                 let dd =
-                                                  let uu____8911 =
+                                                  let uu____8944 =
                                                     FStar_All.pipe_right
                                                       quals1
                                                       (FStar_List.contains
                                                          FStar_Syntax_Syntax.Abstract)
                                                      in
-                                                  if uu____8911
+                                                  if uu____8944
                                                   then
                                                     FStar_Syntax_Syntax.Delta_abstract
                                                       (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -3633,21 +3672,21 @@ let (mk_discriminator_and_indexed_projectors :
                                                     FStar_Syntax_Syntax.tun
                                                    in
                                                 let lb =
-                                                  let uu____8930 =
-                                                    let uu____8935 =
+                                                  let uu____8963 =
+                                                    let uu____8968 =
                                                       FStar_Syntax_Syntax.lid_as_fv
                                                         field_name dd
                                                         FStar_Pervasives_Native.None
                                                        in
-                                                    FStar_Util.Inr uu____8935
+                                                    FStar_Util.Inr uu____8968
                                                      in
-                                                  let uu____8936 =
+                                                  let uu____8969 =
                                                     FStar_Syntax_Subst.close_univ_vars
                                                       uvs imp
                                                      in
                                                   {
                                                     FStar_Syntax_Syntax.lbname
-                                                      = uu____8930;
+                                                      = uu____8963;
                                                     FStar_Syntax_Syntax.lbunivs
                                                       = uvs;
                                                     FStar_Syntax_Syntax.lbtyp
@@ -3656,7 +3695,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                       =
                                                       FStar_Parser_Const.effect_Tot_lid;
                                                     FStar_Syntax_Syntax.lbdef
-                                                      = uu____8936;
+                                                      = uu____8969;
                                                     FStar_Syntax_Syntax.lbattrs
                                                       = [];
                                                     FStar_Syntax_Syntax.lbpos
@@ -3664,30 +3703,30 @@ let (mk_discriminator_and_indexed_projectors :
                                                       FStar_Range.dummyRange
                                                   }  in
                                                 let impl =
-                                                  let uu____8942 =
-                                                    let uu____8943 =
-                                                      let uu____8950 =
-                                                        let uu____8953 =
-                                                          let uu____8954 =
+                                                  let uu____8975 =
+                                                    let uu____8976 =
+                                                      let uu____8983 =
+                                                        let uu____8986 =
+                                                          let uu____8987 =
                                                             FStar_All.pipe_right
                                                               lb.FStar_Syntax_Syntax.lbname
                                                               FStar_Util.right
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____8954
+                                                            uu____8987
                                                             (fun fv  ->
                                                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                                                            in
-                                                        [uu____8953]  in
+                                                        [uu____8986]  in
                                                       ((false, [lb]),
-                                                        uu____8950)
+                                                        uu____8983)
                                                        in
                                                     FStar_Syntax_Syntax.Sig_let
-                                                      uu____8943
+                                                      uu____8976
                                                      in
                                                   {
                                                     FStar_Syntax_Syntax.sigel
-                                                      = uu____8942;
+                                                      = uu____8975;
                                                     FStar_Syntax_Syntax.sigrng
                                                       = p1;
                                                     FStar_Syntax_Syntax.sigquals
@@ -3701,27 +3740,27 @@ let (mk_discriminator_and_indexed_projectors :
                                                       =
                                                       FStar_Pervasives_Native.None
                                                   }  in
-                                                (let uu____8968 =
+                                                (let uu____9001 =
                                                    FStar_TypeChecker_Env.debug
                                                      env
                                                      (FStar_Options.Other
                                                         "LogTypes")
                                                     in
-                                                 if uu____8968
+                                                 if uu____9001
                                                  then
-                                                   let uu____8972 =
+                                                   let uu____9005 =
                                                      FStar_Syntax_Print.sigelt_to_string
                                                        impl
                                                       in
                                                    FStar_Util.print1
                                                      "Implementation of a projector %s\n"
-                                                     uu____8972
+                                                     uu____9005
                                                  else ());
                                                 if no_decl
                                                 then [impl]
                                                 else [decl; impl]))))
                                in
-                            FStar_All.pipe_right uu____8474
+                            FStar_All.pipe_right uu____8501
                               FStar_List.flatten
                              in
                           FStar_List.append discriminator_ses projectors_ses
@@ -3740,53 +3779,53 @@ let (mk_data_operations :
           fun se  ->
             match se.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_datacon
-                (constr_lid,uvs,t,typ_lid,n_typars,uu____9035) when
-                let uu____9042 =
+                (constr_lid,uvs,t,typ_lid,n_typars,uu____9068) when
+                let uu____9075 =
                   FStar_Ident.lid_equals constr_lid
                     FStar_Parser_Const.lexcons_lid
                    in
-                Prims.op_Negation uu____9042 ->
-                let uu____9044 = FStar_Syntax_Subst.univ_var_opening uvs  in
-                (match uu____9044 with
+                Prims.op_Negation uu____9075 ->
+                let uu____9077 = FStar_Syntax_Subst.univ_var_opening uvs  in
+                (match uu____9077 with
                  | (univ_opening,uvs1) ->
                      let t1 = FStar_Syntax_Subst.subst univ_opening t  in
-                     let uu____9066 = FStar_Syntax_Util.arrow_formals t1  in
-                     (match uu____9066 with
-                      | (formals,uu____9076) ->
-                          let uu____9081 =
+                     let uu____9099 = FStar_Syntax_Util.arrow_formals t1  in
+                     (match uu____9099 with
+                      | (formals,uu____9109) ->
+                          let uu____9114 =
                             let tps_opt =
                               FStar_Util.find_map tcs
                                 (fun se1  ->
-                                   let uu____9116 =
-                                     let uu____9118 =
-                                       let uu____9119 =
+                                   let uu____9149 =
+                                     let uu____9151 =
+                                       let uu____9152 =
                                          FStar_Syntax_Util.lid_of_sigelt se1
                                           in
-                                       FStar_Util.must uu____9119  in
+                                       FStar_Util.must uu____9152  in
                                      FStar_Ident.lid_equals typ_lid
-                                       uu____9118
+                                       uu____9151
                                       in
-                                   if uu____9116
+                                   if uu____9149
                                    then
                                      match se1.FStar_Syntax_Syntax.sigel with
                                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                                         (uu____9141,uvs',tps,typ0,uu____9145,constrs)
+                                         (uu____9174,uvs',tps,typ0,uu____9178,constrs)
                                          ->
                                          FStar_Pervasives_Native.Some
                                            (tps, typ0,
                                              ((FStar_List.length constrs) >
                                                 Prims.int_one))
-                                     | uu____9165 -> failwith "Impossible"
+                                     | uu____9198 -> failwith "Impossible"
                                    else FStar_Pervasives_Native.None)
                                in
                             match tps_opt with
                             | FStar_Pervasives_Native.Some x -> x
                             | FStar_Pervasives_Native.None  ->
-                                let uu____9214 =
+                                let uu____9247 =
                                   FStar_Ident.lid_equals typ_lid
                                     FStar_Parser_Const.exn_lid
                                    in
-                                if uu____9214
+                                if uu____9247
                                 then ([], FStar_Syntax_Util.ktype0, true)
                                 else
                                   FStar_Errors.raise_error
@@ -3794,7 +3833,7 @@ let (mk_data_operations :
                                       "Unexpected data constructor")
                                     se.FStar_Syntax_Syntax.sigrng
                              in
-                          (match uu____9081 with
+                          (match uu____9114 with
                            | (inductive_tps,typ0,should_refine) ->
                                let inductive_tps1 =
                                  FStar_Syntax_Subst.subst_binders
@@ -3803,41 +3842,41 @@ let (mk_data_operations :
                                let typ01 =
                                  FStar_Syntax_Subst.subst univ_opening typ0
                                   in
-                               let uu____9252 =
+                               let uu____9285 =
                                  FStar_Syntax_Util.arrow_formals typ01  in
-                               (match uu____9252 with
-                                | (indices,uu____9262) ->
+                               (match uu____9285 with
+                                | (indices,uu____9295) ->
                                     let refine_domain =
-                                      let uu____9269 =
+                                      let uu____9302 =
                                         FStar_All.pipe_right
                                           se.FStar_Syntax_Syntax.sigquals
                                           (FStar_Util.for_some
-                                             (fun uu___7_9276  ->
-                                                match uu___7_9276 with
+                                             (fun uu___7_9309  ->
+                                                match uu___7_9309 with
                                                 | FStar_Syntax_Syntax.RecordConstructor
-                                                    uu____9278 -> true
-                                                | uu____9288 -> false))
+                                                    uu____9311 -> true
+                                                | uu____9321 -> false))
                                          in
-                                      if uu____9269
+                                      if uu____9302
                                       then false
                                       else should_refine  in
                                     let fv_qual =
-                                      let filter_records uu___8_9303 =
-                                        match uu___8_9303 with
+                                      let filter_records uu___8_9336 =
+                                        match uu___8_9336 with
                                         | FStar_Syntax_Syntax.RecordConstructor
-                                            (uu____9306,fns) ->
+                                            (uu____9339,fns) ->
                                             FStar_Pervasives_Native.Some
                                               (FStar_Syntax_Syntax.Record_ctor
                                                  (typ_lid, fns))
-                                        | uu____9318 ->
+                                        | uu____9351 ->
                                             FStar_Pervasives_Native.None
                                          in
-                                      let uu____9319 =
+                                      let uu____9352 =
                                         FStar_Util.find_map
                                           se.FStar_Syntax_Syntax.sigquals
                                           filter_records
                                          in
-                                      match uu____9319 with
+                                      match uu____9352 with
                                       | FStar_Pervasives_Native.None  ->
                                           FStar_Syntax_Syntax.Data_ctor
                                       | FStar_Pervasives_Native.Some q -> q
@@ -3856,28 +3895,28 @@ let (mk_data_operations :
                                         iquals
                                       else iquals  in
                                     let fields =
-                                      let uu____9332 =
+                                      let uu____9365 =
                                         FStar_Util.first_N n_typars formals
                                          in
-                                      match uu____9332 with
+                                      match uu____9365 with
                                       | (imp_tps,fields) ->
                                           let rename =
                                             FStar_List.map2
-                                              (fun uu____9415  ->
-                                                 fun uu____9416  ->
-                                                   match (uu____9415,
-                                                           uu____9416)
+                                              (fun uu____9448  ->
+                                                 fun uu____9449  ->
+                                                   match (uu____9448,
+                                                           uu____9449)
                                                    with
-                                                   | ((x,uu____9442),
-                                                      (x',uu____9444)) ->
-                                                       let uu____9465 =
-                                                         let uu____9472 =
+                                                   | ((x,uu____9475),
+                                                      (x',uu____9477)) ->
+                                                       let uu____9498 =
+                                                         let uu____9505 =
                                                            FStar_Syntax_Syntax.bv_to_name
                                                              x'
                                                             in
-                                                         (x, uu____9472)  in
+                                                         (x, uu____9505)  in
                                                        FStar_Syntax_Syntax.NT
-                                                         uu____9465) imp_tps
+                                                         uu____9498) imp_tps
                                               inductive_tps1
                                              in
                                           FStar_Syntax_Subst.subst_binders
@@ -3892,5 +3931,5 @@ let (mk_data_operations :
                                       iquals1 attrs fv_qual refine_domain env
                                       typ_lid constr_lid uvs1 inductive_tps1
                                       indices fields erasable))))
-            | uu____9479 -> []
+            | uu____9512 -> []
   

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -2591,9 +2591,11 @@ and (tc_maybe_toplevel_term :
                                   then
                                     let uu____7461 =
                                       let uu____7467 =
+                                        let uu____7469 =
+                                          FStar_Ident.string_of_lid ef  in
                                         FStar_Util.format1
                                           "Effect %s cannot be reified"
-                                          ef.FStar_Ident.str
+                                          uu____7469
                                          in
                                       (FStar_Errors.Fatal_EffectCannotBeReified,
                                         uu____7467)
@@ -2613,24 +2615,24 @@ and (tc_maybe_toplevel_term :
                                       top.FStar_Syntax_Syntax.pos
                                      in
                                   let c2 =
-                                    let uu____7510 =
+                                    let uu____7512 =
                                       (FStar_TypeChecker_Env.is_total_effect
                                          env1 ef)
                                         ||
-                                        (let uu____7513 =
+                                        (let uu____7515 =
                                            FStar_All.pipe_right ef
                                              (FStar_TypeChecker_Env.norm_eff_name
                                                 env1)
                                             in
-                                         FStar_All.pipe_right uu____7513
+                                         FStar_All.pipe_right uu____7515
                                            (FStar_TypeChecker_Env.is_layered_effect
                                               env1))
                                        in
-                                    if uu____7510
+                                    if uu____7512
                                     then
-                                      let uu____7516 =
+                                      let uu____7518 =
                                         FStar_Syntax_Syntax.mk_Total repr  in
-                                      FStar_All.pipe_right uu____7516
+                                      FStar_All.pipe_right uu____7518
                                         FStar_TypeChecker_Common.lcomp_of_comp
                                     else
                                       (let ct =
@@ -2645,30 +2647,30 @@ and (tc_maybe_toplevel_term :
                                              [];
                                            FStar_Syntax_Syntax.flags = []
                                          }  in
-                                       let uu____7528 =
+                                       let uu____7530 =
                                          FStar_Syntax_Syntax.mk_Comp ct  in
-                                       FStar_All.pipe_right uu____7528
+                                       FStar_All.pipe_right uu____7530
                                          FStar_TypeChecker_Common.lcomp_of_comp)
                                      in
-                                  let uu____7529 =
+                                  let uu____7531 =
                                     comp_check_expected_typ env1 e3 c2  in
-                                  match uu____7529 with
+                                  match uu____7531 with
                                   | (e4,c3,g') ->
-                                      let uu____7545 =
-                                        let uu____7546 =
+                                      let uu____7547 =
+                                        let uu____7548 =
                                           FStar_TypeChecker_Env.conj_guard
                                             g_c g'
                                            in
                                         FStar_TypeChecker_Env.conj_guard g
-                                          uu____7546
+                                          uu____7548
                                          in
-                                      (e4, c3, uu____7545))))))))
+                                      (e4, c3, uu____7547))))))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reflect l);
-              FStar_Syntax_Syntax.pos = uu____7548;
-              FStar_Syntax_Syntax.vars = uu____7549;_},(e1,aqual)::[])
+              FStar_Syntax_Syntax.pos = uu____7550;
+              FStar_Syntax_Syntax.vars = uu____7551;_},(e1,aqual)::[])
            ->
            (if FStar_Option.isSome aqual
             then
@@ -2676,55 +2678,56 @@ and (tc_maybe_toplevel_term :
                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReflect,
                   "Qualifier on argument to reflect is irrelevant and will be ignored")
             else ();
-            (let uu____7597 =
-               let uu____7599 =
+            (let uu____7599 =
+               let uu____7601 =
                  FStar_TypeChecker_Env.is_user_reflectable_effect env1 l  in
-               Prims.op_Negation uu____7599  in
-             if uu____7597
+               Prims.op_Negation uu____7601  in
+             if uu____7599
              then
-               let uu____7602 =
-                 let uu____7608 =
+               let uu____7604 =
+                 let uu____7610 =
+                   let uu____7612 = FStar_Ident.string_of_lid l  in
                    FStar_Util.format1 "Effect %s cannot be reflected"
-                     l.FStar_Ident.str
+                     uu____7612
                     in
-                 (FStar_Errors.Fatal_EffectCannotBeReified, uu____7608)  in
-               FStar_Errors.raise_error uu____7602 e1.FStar_Syntax_Syntax.pos
+                 (FStar_Errors.Fatal_EffectCannotBeReified, uu____7610)  in
+               FStar_Errors.raise_error uu____7604 e1.FStar_Syntax_Syntax.pos
              else ());
-            (let uu____7614 = FStar_Syntax_Util.head_and_args top  in
-             match uu____7614 with
-             | (reflect_op,uu____7638) ->
-                 let uu____7663 =
+            (let uu____7618 = FStar_Syntax_Util.head_and_args top  in
+             match uu____7618 with
+             | (reflect_op,uu____7642) ->
+                 let uu____7667 =
                    FStar_TypeChecker_Env.effect_decl_opt env1 l  in
-                 (match uu____7663 with
+                 (match uu____7667 with
                   | FStar_Pervasives_Native.None  ->
-                      let uu____7684 =
-                        let uu____7690 =
-                          let uu____7692 = FStar_Ident.string_of_lid l  in
+                      let uu____7688 =
+                        let uu____7694 =
+                          let uu____7696 = FStar_Ident.string_of_lid l  in
                           FStar_Util.format1
-                            "Effect %s not found (for reflect)" uu____7692
+                            "Effect %s not found (for reflect)" uu____7696
                            in
-                        (FStar_Errors.Fatal_EffectNotFound, uu____7690)  in
-                      FStar_Errors.raise_error uu____7684
+                        (FStar_Errors.Fatal_EffectNotFound, uu____7694)  in
+                      FStar_Errors.raise_error uu____7688
                         e1.FStar_Syntax_Syntax.pos
                   | FStar_Pervasives_Native.Some (ed,qualifiers) ->
-                      let uu____7714 =
+                      let uu____7718 =
                         FStar_TypeChecker_Env.clear_expected_typ env1  in
-                      (match uu____7714 with
-                       | (env_no_ex,uu____7728) ->
-                           let uu____7733 =
-                             let uu____7742 =
+                      (match uu____7718 with
+                       | (env_no_ex,uu____7732) ->
+                           let uu____7737 =
+                             let uu____7746 =
                                tc_tot_or_gtot_term env_no_ex e1  in
-                             match uu____7742 with
+                             match uu____7746 with
                              | (e2,c,g) ->
-                                 ((let uu____7761 =
-                                     let uu____7763 =
+                                 ((let uu____7765 =
+                                     let uu____7767 =
                                        FStar_TypeChecker_Common.is_total_lcomp
                                          c
                                         in
                                      FStar_All.pipe_left Prims.op_Negation
-                                       uu____7763
+                                       uu____7767
                                       in
-                                   if uu____7761
+                                   if uu____7765
                                    then
                                      FStar_TypeChecker_Err.add_errors env1
                                        [(FStar_Errors.Error_UnexpectedGTotComputation,
@@ -2733,29 +2736,29 @@ and (tc_maybe_toplevel_term :
                                    else ());
                                   (e2, c, g))
                               in
-                           (match uu____7733 with
+                           (match uu____7737 with
                             | (e2,c_e,g_e) ->
-                                let uu____7801 =
-                                  let uu____7816 =
+                                let uu____7805 =
+                                  let uu____7820 =
                                     FStar_Syntax_Util.type_u ()  in
-                                  match uu____7816 with
+                                  match uu____7820 with
                                   | (a,u_a) ->
-                                      let uu____7837 =
+                                      let uu____7841 =
                                         FStar_TypeChecker_Util.new_implicit_var
                                           "" e2.FStar_Syntax_Syntax.pos
                                           env_no_ex a
                                          in
-                                      (match uu____7837 with
-                                       | (a_uvar,uu____7866,g_a) ->
-                                           let uu____7880 =
+                                      (match uu____7841 with
+                                       | (a_uvar,uu____7870,g_a) ->
+                                           let uu____7884 =
                                              FStar_TypeChecker_Util.fresh_effect_repr_en
                                                env_no_ex
                                                e2.FStar_Syntax_Syntax.pos l
                                                u_a a_uvar
                                               in
-                                           (uu____7880, u_a, a_uvar, g_a))
+                                           (uu____7884, u_a, a_uvar, g_a))
                                    in
-                                (match uu____7801 with
+                                (match uu____7805 with
                                  | ((expected_repr_typ,g_repr),u_a,a,g_a) ->
                                      let g_eq =
                                        FStar_TypeChecker_Rel.teq env_no_ex
@@ -2763,44 +2766,44 @@ and (tc_maybe_toplevel_term :
                                          expected_repr_typ
                                         in
                                      let eff_args =
-                                       let uu____7922 =
-                                         let uu____7923 =
+                                       let uu____7926 =
+                                         let uu____7927 =
                                            FStar_Syntax_Subst.compress
                                              expected_repr_typ
                                             in
-                                         uu____7923.FStar_Syntax_Syntax.n  in
-                                       match uu____7922 with
+                                         uu____7927.FStar_Syntax_Syntax.n  in
+                                       match uu____7926 with
                                        | FStar_Syntax_Syntax.Tm_app
-                                           (uu____7936,uu____7937::args) ->
+                                           (uu____7940,uu____7941::args) ->
                                            args
-                                       | uu____7979 ->
-                                           let uu____7980 =
-                                             let uu____7986 =
-                                               let uu____7988 =
+                                       | uu____7983 ->
+                                           let uu____7984 =
+                                             let uu____7990 =
+                                               let uu____7992 =
                                                  FStar_Ident.string_of_lid l
                                                   in
-                                               let uu____7990 =
+                                               let uu____7994 =
                                                  FStar_Syntax_Print.tag_of_term
                                                    expected_repr_typ
                                                   in
-                                               let uu____7992 =
+                                               let uu____7996 =
                                                  FStar_Syntax_Print.term_to_string
                                                    expected_repr_typ
                                                   in
                                                FStar_Util.format3
                                                  "Expected repr type for %s is not an application node (%s:%s)"
-                                                 uu____7988 uu____7990
-                                                 uu____7992
+                                                 uu____7992 uu____7994
+                                                 uu____7996
                                                 in
                                              (FStar_Errors.Fatal_UnexpectedEffect,
-                                               uu____7986)
+                                               uu____7990)
                                               in
                                            FStar_Errors.raise_error
-                                             uu____7980
+                                             uu____7984
                                              top.FStar_Syntax_Syntax.pos
                                         in
                                      let c =
-                                       let uu____8007 =
+                                       let uu____8011 =
                                          FStar_Syntax_Syntax.mk_Comp
                                            {
                                              FStar_Syntax_Syntax.comp_univs =
@@ -2815,7 +2818,7 @@ and (tc_maybe_toplevel_term :
                                              FStar_Syntax_Syntax.flags = []
                                            }
                                           in
-                                       FStar_All.pipe_right uu____8007
+                                       FStar_All.pipe_right uu____8011
                                          FStar_TypeChecker_Common.lcomp_of_comp
                                         in
                                      let e3 =
@@ -2825,9 +2828,9 @@ and (tc_maybe_toplevel_term :
                                          FStar_Pervasives_Native.None
                                          top.FStar_Syntax_Syntax.pos
                                         in
-                                     let uu____8043 =
+                                     let uu____8047 =
                                        comp_check_expected_typ env1 e3 c  in
-                                     (match uu____8043 with
+                                     (match uu____8047 with
                                       | (e4,c1,g') ->
                                           let e5 =
                                             FStar_Syntax_Syntax.mk
@@ -2839,37 +2842,37 @@ and (tc_maybe_toplevel_term :
                                               FStar_Pervasives_Native.None
                                               e4.FStar_Syntax_Syntax.pos
                                              in
-                                          let uu____8066 =
+                                          let uu____8070 =
                                             FStar_TypeChecker_Env.conj_guards
                                               [g_e; g_repr; g_a; g_eq; g']
                                              in
-                                          (e5, c1, uu____8066))))))))
+                                          (e5, c1, uu____8070))))))))
        | FStar_Syntax_Syntax.Tm_app
            (head,(tau,FStar_Pervasives_Native.None )::[]) when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8105 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____8105 with
+           let uu____8109 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____8109 with
             | (head1,args) ->
                 tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
        | FStar_Syntax_Syntax.Tm_app
-           (head,(uu____8155,FStar_Pervasives_Native.Some
-                  (FStar_Syntax_Syntax.Implicit uu____8156))::(tau,FStar_Pervasives_Native.None
+           (head,(uu____8159,FStar_Pervasives_Native.Some
+                  (FStar_Syntax_Syntax.Implicit uu____8160))::(tau,FStar_Pervasives_Native.None
                                                                )::[])
            when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8209 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____8209 with
+           let uu____8213 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____8213 with
             | (head1,args) ->
                 tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
        | FStar_Syntax_Syntax.Tm_app (head,args) when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8284 =
+           let uu____8288 =
              match args with
              | (tau,FStar_Pervasives_Native.None )::rest ->
                  ([(tau, FStar_Pervasives_Native.None)], rest)
@@ -2879,13 +2882,13 @@ and (tc_maybe_toplevel_term :
                      (FStar_Pervasives_Native.Some
                         (FStar_Syntax_Syntax.Implicit b)));
                   (tau, FStar_Pervasives_Native.None)], rest)
-             | uu____8494 ->
+             | uu____8498 ->
                  FStar_Errors.raise_error
                    (FStar_Errors.Fatal_SynthByTacticError,
                      "synth_by_tactic: bad application")
                    top.FStar_Syntax_Syntax.pos
               in
-           (match uu____8284 with
+           (match uu____8288 with
             | (args1,args2) ->
                 let t1 = FStar_Syntax_Util.mk_app head args1  in
                 let t2 = FStar_Syntax_Util.mk_app t1 args2  in
@@ -2893,114 +2896,114 @@ and (tc_maybe_toplevel_term :
        | FStar_Syntax_Syntax.Tm_app (head,args) ->
            let env0 = env1  in
            let env2 =
-             let uu____8613 =
-               let uu____8614 = FStar_TypeChecker_Env.clear_expected_typ env1
+             let uu____8617 =
+               let uu____8618 = FStar_TypeChecker_Env.clear_expected_typ env1
                   in
-               FStar_All.pipe_right uu____8614 FStar_Pervasives_Native.fst
+               FStar_All.pipe_right uu____8618 FStar_Pervasives_Native.fst
                 in
-             FStar_All.pipe_right uu____8613 instantiate_both  in
-           ((let uu____8630 =
+             FStar_All.pipe_right uu____8617 instantiate_both  in
+           ((let uu____8634 =
                FStar_TypeChecker_Env.debug env2 FStar_Options.High  in
-             if uu____8630
+             if uu____8634
              then
-               let uu____8633 =
-                 FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos  in
-               let uu____8635 = FStar_Syntax_Print.term_to_string top  in
                let uu____8637 =
-                 let uu____8639 = FStar_TypeChecker_Env.expected_typ env0  in
-                 FStar_All.pipe_right uu____8639
-                   (fun uu___3_8646  ->
-                      match uu___3_8646 with
+                 FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos  in
+               let uu____8639 = FStar_Syntax_Print.term_to_string top  in
+               let uu____8641 =
+                 let uu____8643 = FStar_TypeChecker_Env.expected_typ env0  in
+                 FStar_All.pipe_right uu____8643
+                   (fun uu___3_8650  ->
+                      match uu___3_8650 with
                       | FStar_Pervasives_Native.None  -> "none"
                       | FStar_Pervasives_Native.Some t ->
                           FStar_Syntax_Print.term_to_string t)
                   in
                FStar_Util.print3
-                 "(%s) Checking app %s, expected type is %s\n" uu____8633
-                 uu____8635 uu____8637
+                 "(%s) Checking app %s, expected type is %s\n" uu____8637
+                 uu____8639 uu____8641
              else ());
-            (let uu____8655 = tc_term (no_inst env2) head  in
-             match uu____8655 with
+            (let uu____8659 = tc_term (no_inst env2) head  in
+             match uu____8659 with
              | (head1,chead,g_head) ->
-                 let uu____8671 =
-                   let uu____8676 = FStar_TypeChecker_Common.lcomp_comp chead
+                 let uu____8675 =
+                   let uu____8680 = FStar_TypeChecker_Common.lcomp_comp chead
                       in
-                   FStar_All.pipe_right uu____8676
-                     (fun uu____8693  ->
-                        match uu____8693 with
+                   FStar_All.pipe_right uu____8680
+                     (fun uu____8697  ->
+                        match uu____8697 with
                         | (c,g) ->
-                            let uu____8704 =
+                            let uu____8708 =
                               FStar_TypeChecker_Env.conj_guard g_head g  in
-                            (c, uu____8704))
+                            (c, uu____8708))
                     in
-                 (match uu____8671 with
+                 (match uu____8675 with
                   | (chead1,g_head1) ->
-                      let uu____8713 =
-                        let uu____8720 =
+                      let uu____8717 =
+                        let uu____8724 =
                           ((Prims.op_Negation env2.FStar_TypeChecker_Env.lax)
                              &&
-                             (let uu____8723 = FStar_Options.lax ()  in
-                              Prims.op_Negation uu____8723))
+                             (let uu____8727 = FStar_Options.lax ()  in
+                              Prims.op_Negation uu____8727))
                             &&
                             (FStar_TypeChecker_Util.short_circuit_head head1)
                            in
-                        if uu____8720
+                        if uu____8724
                         then
-                          let uu____8732 =
-                            let uu____8739 =
+                          let uu____8736 =
+                            let uu____8743 =
                               FStar_TypeChecker_Env.expected_typ env0  in
                             check_short_circuit_args env2 head1 chead1
-                              g_head1 args uu____8739
+                              g_head1 args uu____8743
                              in
-                          match uu____8732 with | (e1,c,g) -> (e1, c, g)
+                          match uu____8736 with | (e1,c,g) -> (e1, c, g)
                         else
-                          (let uu____8753 =
+                          (let uu____8757 =
                              FStar_TypeChecker_Env.expected_typ env0  in
                            check_application_args env2 head1 chead1 g_head1
-                             args uu____8753)
+                             args uu____8757)
                          in
-                      (match uu____8713 with
+                      (match uu____8717 with
                        | (e1,c,g) ->
-                           let uu____8765 =
-                             let uu____8772 =
+                           let uu____8769 =
+                             let uu____8776 =
                                FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                  c
                                 in
-                             if uu____8772
+                             if uu____8776
                              then
-                               let uu____8781 =
+                               let uu____8785 =
                                  FStar_TypeChecker_Util.maybe_instantiate
                                    env0 e1 c.FStar_TypeChecker_Common.res_typ
                                   in
-                               match uu____8781 with
+                               match uu____8785 with
                                | (e2,res_typ,implicits) ->
-                                   let uu____8797 =
+                                   let uu____8801 =
                                      FStar_TypeChecker_Common.set_result_typ_lc
                                        c res_typ
                                       in
-                                   (e2, uu____8797, implicits)
+                                   (e2, uu____8801, implicits)
                              else
                                (e1, c, FStar_TypeChecker_Env.trivial_guard)
                               in
-                           (match uu____8765 with
+                           (match uu____8769 with
                             | (e2,c1,implicits) ->
-                                ((let uu____8810 =
+                                ((let uu____8814 =
                                     FStar_TypeChecker_Env.debug env2
                                       FStar_Options.Extreme
                                      in
-                                  if uu____8810
+                                  if uu____8814
                                   then
-                                    let uu____8813 =
+                                    let uu____8817 =
                                       FStar_TypeChecker_Rel.print_pending_implicits
                                         g
                                        in
                                     FStar_Util.print1
                                       "Introduced {%s} implicits in application\n"
-                                      uu____8813
+                                      uu____8817
                                   else ());
-                                 (let uu____8818 =
+                                 (let uu____8822 =
                                     comp_check_expected_typ env0 e2 c1  in
-                                  match uu____8818 with
+                                  match uu____8822 with
                                   | (e3,c2,g') ->
                                       let gres =
                                         FStar_TypeChecker_Env.conj_guard g g'
@@ -3009,49 +3012,49 @@ and (tc_maybe_toplevel_term :
                                         FStar_TypeChecker_Env.conj_guard gres
                                           implicits
                                          in
-                                      ((let uu____8837 =
+                                      ((let uu____8841 =
                                           FStar_TypeChecker_Env.debug env2
                                             FStar_Options.Extreme
                                            in
-                                        if uu____8837
+                                        if uu____8841
                                         then
-                                          let uu____8840 =
+                                          let uu____8844 =
                                             FStar_Syntax_Print.term_to_string
                                               e3
                                              in
-                                          let uu____8842 =
+                                          let uu____8846 =
                                             FStar_TypeChecker_Rel.guard_to_string
                                               env2 gres1
                                              in
                                           FStar_Util.print2
                                             "Guard from application node %s is %s\n"
-                                            uu____8840 uu____8842
+                                            uu____8844 uu____8846
                                         else ());
                                        (e3, c2, gres1)))))))))
-       | FStar_Syntax_Syntax.Tm_match uu____8847 -> tc_match env1 top
+       | FStar_Syntax_Syntax.Tm_match uu____8851 -> tc_match env1 top
        | FStar_Syntax_Syntax.Tm_let
            ((false
-             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____8870;
-                FStar_Syntax_Syntax.lbunivs = uu____8871;
-                FStar_Syntax_Syntax.lbtyp = uu____8872;
-                FStar_Syntax_Syntax.lbeff = uu____8873;
-                FStar_Syntax_Syntax.lbdef = uu____8874;
-                FStar_Syntax_Syntax.lbattrs = uu____8875;
-                FStar_Syntax_Syntax.lbpos = uu____8876;_}::[]),uu____8877)
+             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____8874;
+                FStar_Syntax_Syntax.lbunivs = uu____8875;
+                FStar_Syntax_Syntax.lbtyp = uu____8876;
+                FStar_Syntax_Syntax.lbeff = uu____8877;
+                FStar_Syntax_Syntax.lbdef = uu____8878;
+                FStar_Syntax_Syntax.lbattrs = uu____8879;
+                FStar_Syntax_Syntax.lbpos = uu____8880;_}::[]),uu____8881)
            -> check_top_level_let env1 top
-       | FStar_Syntax_Syntax.Tm_let ((false ,uu____8903),uu____8904) ->
+       | FStar_Syntax_Syntax.Tm_let ((false ,uu____8907),uu____8908) ->
            check_inner_let env1 top
        | FStar_Syntax_Syntax.Tm_let
            ((true
-             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____8922;
-                FStar_Syntax_Syntax.lbunivs = uu____8923;
-                FStar_Syntax_Syntax.lbtyp = uu____8924;
-                FStar_Syntax_Syntax.lbeff = uu____8925;
-                FStar_Syntax_Syntax.lbdef = uu____8926;
-                FStar_Syntax_Syntax.lbattrs = uu____8927;
-                FStar_Syntax_Syntax.lbpos = uu____8928;_}::uu____8929),uu____8930)
+             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____8926;
+                FStar_Syntax_Syntax.lbunivs = uu____8927;
+                FStar_Syntax_Syntax.lbtyp = uu____8928;
+                FStar_Syntax_Syntax.lbeff = uu____8929;
+                FStar_Syntax_Syntax.lbdef = uu____8930;
+                FStar_Syntax_Syntax.lbattrs = uu____8931;
+                FStar_Syntax_Syntax.lbpos = uu____8932;_}::uu____8933),uu____8934)
            -> check_top_level_let_rec env1 top
-       | FStar_Syntax_Syntax.Tm_let ((true ,uu____8958),uu____8959) ->
+       | FStar_Syntax_Syntax.Tm_let ((true ,uu____8962),uu____8963) ->
            check_inner_let_rec env1 top)
 
 and (tc_match :
@@ -3062,67 +3065,67 @@ and (tc_match :
   =
   fun env  ->
     fun top  ->
-      let uu____8985 =
-        let uu____8986 = FStar_Syntax_Subst.compress top  in
-        uu____8986.FStar_Syntax_Syntax.n  in
-      match uu____8985 with
+      let uu____8989 =
+        let uu____8990 = FStar_Syntax_Subst.compress top  in
+        uu____8990.FStar_Syntax_Syntax.n  in
+      match uu____8989 with
       | FStar_Syntax_Syntax.Tm_match (e1,eqns) ->
-          let uu____9033 = FStar_TypeChecker_Env.clear_expected_typ env  in
-          (match uu____9033 with
+          let uu____9037 = FStar_TypeChecker_Env.clear_expected_typ env  in
+          (match uu____9037 with
            | (env1,topt) ->
                let env11 = instantiate_both env1  in
-               let uu____9053 = tc_term env11 e1  in
-               (match uu____9053 with
+               let uu____9057 = tc_term env11 e1  in
+               (match uu____9057 with
                 | (e11,c1,g1) ->
-                    let uu____9069 =
-                      let uu____9080 =
+                    let uu____9073 =
+                      let uu____9084 =
                         FStar_TypeChecker_Util.coerce_views env e11 c1  in
-                      match uu____9080 with
+                      match uu____9084 with
                       | FStar_Pervasives_Native.Some (e12,c11) ->
                           (e12, c11, eqns)
                       | FStar_Pervasives_Native.None  -> (e11, c1, eqns)  in
-                    (match uu____9069 with
+                    (match uu____9073 with
                      | (e12,c11,eqns1) ->
                          let eqns2 = eqns1  in
-                         let uu____9135 =
+                         let uu____9139 =
                            match topt with
                            | FStar_Pervasives_Native.Some t -> (env, t, g1)
                            | FStar_Pervasives_Native.None  ->
-                               let uu____9149 = FStar_Syntax_Util.type_u ()
+                               let uu____9153 = FStar_Syntax_Util.type_u ()
                                   in
-                               (match uu____9149 with
-                                | (k,uu____9161) ->
-                                    let uu____9162 =
+                               (match uu____9153 with
+                                | (k,uu____9165) ->
+                                    let uu____9166 =
                                       FStar_TypeChecker_Util.new_implicit_var
                                         "match result"
                                         e12.FStar_Syntax_Syntax.pos env k
                                        in
-                                    (match uu____9162 with
-                                     | (res_t,uu____9183,g) ->
-                                         let uu____9197 =
+                                    (match uu____9166 with
+                                     | (res_t,uu____9187,g) ->
+                                         let uu____9201 =
                                            FStar_TypeChecker_Env.set_expected_typ
                                              env res_t
                                             in
-                                         let uu____9198 =
+                                         let uu____9202 =
                                            FStar_TypeChecker_Env.conj_guard
                                              g1 g
                                             in
-                                         (uu____9197, res_t, uu____9198)))
+                                         (uu____9201, res_t, uu____9202)))
                             in
-                         (match uu____9135 with
+                         (match uu____9139 with
                           | (env_branches,res_t,g11) ->
-                              ((let uu____9209 =
+                              ((let uu____9213 =
                                   FStar_TypeChecker_Env.debug env
                                     FStar_Options.Extreme
                                    in
-                                if uu____9209
+                                if uu____9213
                                 then
-                                  let uu____9212 =
+                                  let uu____9216 =
                                     FStar_Syntax_Print.term_to_string res_t
                                      in
                                   FStar_Util.print1
                                     "Tm_match: expected type of branches is %s\n"
-                                    uu____9212
+                                    uu____9216
                                 else ());
                                (let guard_x =
                                   FStar_Syntax_Syntax.new_bv
@@ -3135,36 +3138,36 @@ and (tc_match :
                                     (FStar_List.map
                                        (tc_eqn guard_x env_branches))
                                    in
-                                let uu____9320 =
-                                  let uu____9328 =
+                                let uu____9324 =
+                                  let uu____9332 =
                                     FStar_List.fold_right
-                                      (fun uu____9421  ->
-                                         fun uu____9422  ->
-                                           match (uu____9421, uu____9422)
+                                      (fun uu____9425  ->
+                                         fun uu____9426  ->
+                                           match (uu____9425, uu____9426)
                                            with
                                            | ((branch,f,eff_label,cflags,c,g,erasable_branch),
                                               (caccum,gaccum,erasable)) ->
-                                               let uu____9694 =
+                                               let uu____9698 =
                                                  FStar_TypeChecker_Env.conj_guard
                                                    g gaccum
                                                   in
                                                (((f, eff_label, cflags, c) ::
-                                                 caccum), uu____9694,
+                                                 caccum), uu____9698,
                                                  (erasable || erasable_branch)))
                                       t_eqns
                                       ([],
                                         FStar_TypeChecker_Env.trivial_guard,
                                         false)
                                      in
-                                  match uu____9328 with
+                                  match uu____9332 with
                                   | (cases,g,erasable) ->
-                                      let uu____9808 =
+                                      let uu____9812 =
                                         FStar_TypeChecker_Util.bind_cases env
                                           res_t cases guard_x
                                          in
-                                      (uu____9808, g, erasable)
+                                      (uu____9812, g, erasable)
                                    in
-                                match uu____9320 with
+                                match uu____9324 with
                                 | (c_branches,g_branches,erasable) ->
                                     let cres =
                                       FStar_TypeChecker_Util.bind
@@ -3185,14 +3188,14 @@ and (tc_match :
                                             (FStar_Pervasives_Native.Some
                                                FStar_Syntax_Syntax.U_zero)
                                            in
-                                        let uu____9828 =
+                                        let uu____9832 =
                                           FStar_TypeChecker_Common.lcomp_of_comp
                                             c
                                            in
                                         FStar_TypeChecker_Util.bind
                                           e.FStar_Syntax_Syntax.pos env
                                           (FStar_Pervasives_Native.Some e)
-                                          uu____9828
+                                          uu____9832
                                           (FStar_Pervasives_Native.None,
                                             cres)
                                       else cres  in
@@ -3201,18 +3204,18 @@ and (tc_match :
                                         let branches =
                                           FStar_All.pipe_right t_eqns
                                             (FStar_List.map
-                                               (fun uu____9970  ->
-                                                  match uu____9970 with
-                                                  | ((pat,wopt,br),uu____10018,eff_label,uu____10020,uu____10021,uu____10022,uu____10023)
+                                               (fun uu____9974  ->
+                                                  match uu____9974 with
+                                                  | ((pat,wopt,br),uu____10022,eff_label,uu____10024,uu____10025,uu____10026,uu____10027)
                                                       ->
-                                                      let uu____10062 =
+                                                      let uu____10066 =
                                                         FStar_TypeChecker_Util.maybe_lift
                                                           env br eff_label
                                                           cres1.FStar_TypeChecker_Common.eff_name
                                                           res_t
                                                          in
                                                       (pat, wopt,
-                                                        uu____10062)))
+                                                        uu____10066)))
                                            in
                                         let e =
                                           FStar_Syntax_Syntax.mk
@@ -3238,22 +3241,22 @@ and (tc_match :
                                           FStar_Pervasives_Native.None
                                           e2.FStar_Syntax_Syntax.pos
                                          in
-                                      let uu____10129 =
+                                      let uu____10133 =
                                         FStar_TypeChecker_Util.is_pure_or_ghost_effect
                                           env
                                           c11.FStar_TypeChecker_Common.eff_name
                                          in
-                                      if uu____10129
+                                      if uu____10133
                                       then mk_match e12
                                       else
                                         (let e_match =
-                                           let uu____10137 =
+                                           let uu____10141 =
                                              FStar_Syntax_Syntax.bv_to_name
                                                guard_x
                                               in
-                                           mk_match uu____10137  in
+                                           mk_match uu____10141  in
                                          let lb =
-                                           let uu____10141 =
+                                           let uu____10145 =
                                              FStar_TypeChecker_Env.norm_eff_name
                                                env
                                                c11.FStar_TypeChecker_Common.eff_name
@@ -3261,32 +3264,32 @@ and (tc_match :
                                            FStar_Syntax_Util.mk_letbinding
                                              (FStar_Util.Inl guard_x) []
                                              c11.FStar_TypeChecker_Common.res_typ
-                                             uu____10141 e12 []
+                                             uu____10145 e12 []
                                              e12.FStar_Syntax_Syntax.pos
                                             in
                                          let e =
-                                           let uu____10147 =
-                                             let uu____10154 =
-                                               let uu____10155 =
-                                                 let uu____10169 =
-                                                   let uu____10172 =
-                                                     let uu____10173 =
+                                           let uu____10151 =
+                                             let uu____10158 =
+                                               let uu____10159 =
+                                                 let uu____10173 =
+                                                   let uu____10176 =
+                                                     let uu____10177 =
                                                        FStar_Syntax_Syntax.mk_binder
                                                          guard_x
                                                         in
-                                                     [uu____10173]  in
+                                                     [uu____10177]  in
                                                    FStar_Syntax_Subst.close
-                                                     uu____10172 e_match
+                                                     uu____10176 e_match
                                                     in
-                                                 ((false, [lb]), uu____10169)
+                                                 ((false, [lb]), uu____10173)
                                                   in
                                                FStar_Syntax_Syntax.Tm_let
-                                                 uu____10155
+                                                 uu____10159
                                                 in
                                              FStar_Syntax_Syntax.mk
-                                               uu____10154
+                                               uu____10158
                                               in
-                                           uu____10147
+                                           uu____10151
                                              FStar_Pervasives_Native.None
                                              top.FStar_Syntax_Syntax.pos
                                             in
@@ -3295,34 +3298,34 @@ and (tc_match :
                                            cres1.FStar_TypeChecker_Common.eff_name
                                            cres1.FStar_TypeChecker_Common.res_typ)
                                        in
-                                    ((let uu____10206 =
+                                    ((let uu____10210 =
                                         FStar_TypeChecker_Env.debug env
                                           FStar_Options.Extreme
                                          in
-                                      if uu____10206
+                                      if uu____10210
                                       then
-                                        let uu____10209 =
+                                        let uu____10213 =
                                           FStar_Range.string_of_range
                                             top.FStar_Syntax_Syntax.pos
                                            in
-                                        let uu____10211 =
+                                        let uu____10215 =
                                           FStar_TypeChecker_Common.lcomp_to_string
                                             cres1
                                            in
                                         FStar_Util.print2
                                           "(%s) Typechecked Tm_match, comp type = %s\n"
-                                          uu____10209 uu____10211
+                                          uu____10213 uu____10215
                                       else ());
-                                     (let uu____10216 =
+                                     (let uu____10220 =
                                         FStar_TypeChecker_Env.conj_guard g11
                                           g_branches
                                          in
-                                      (e, cres1, uu____10216)))))))))
-      | uu____10217 ->
-          let uu____10218 =
-            let uu____10220 = FStar_Syntax_Print.tag_of_term top  in
-            FStar_Util.format1 "tc_match called on %s\n" uu____10220  in
-          failwith uu____10218
+                                      (e, cres1, uu____10220)))))))))
+      | uu____10221 ->
+          let uu____10222 =
+            let uu____10224 = FStar_Syntax_Print.tag_of_term top  in
+            FStar_Util.format1 "tc_match called on %s\n" uu____10224  in
+          failwith uu____10222
 
 and (tc_synth :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -3338,87 +3341,87 @@ and (tc_synth :
     fun env  ->
       fun args  ->
         fun rng  ->
-          let uu____10245 =
+          let uu____10249 =
             match args with
             | (tau,FStar_Pervasives_Native.None )::[] ->
                 (tau, FStar_Pervasives_Native.None)
             | (a,FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
-               uu____10284))::(tau,FStar_Pervasives_Native.None )::[] ->
+               uu____10288))::(tau,FStar_Pervasives_Native.None )::[] ->
                 (tau, (FStar_Pervasives_Native.Some a))
-            | uu____10325 ->
+            | uu____10329 ->
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_SynthByTacticError,
                     "synth_by_tactic: bad application") rng
              in
-          match uu____10245 with
+          match uu____10249 with
           | (tau,atyp) ->
               let typ =
                 match atyp with
                 | FStar_Pervasives_Native.Some t -> t
                 | FStar_Pervasives_Native.None  ->
-                    let uu____10358 = FStar_TypeChecker_Env.expected_typ env
+                    let uu____10362 = FStar_TypeChecker_Env.expected_typ env
                        in
-                    (match uu____10358 with
+                    (match uu____10362 with
                      | FStar_Pervasives_Native.Some t -> t
                      | FStar_Pervasives_Native.None  ->
-                         let uu____10362 =
+                         let uu____10366 =
                            FStar_TypeChecker_Env.get_range env  in
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_SynthByTacticError,
                              "synth_by_tactic: need a type annotation when no expected type is present")
-                           uu____10362)
+                           uu____10366)
                  in
-              let uu____10365 =
-                let uu____10372 =
-                  let uu____10373 =
-                    let uu____10374 = FStar_Syntax_Util.type_u ()  in
+              let uu____10369 =
+                let uu____10376 =
+                  let uu____10377 =
+                    let uu____10378 = FStar_Syntax_Util.type_u ()  in
                     FStar_All.pipe_left FStar_Pervasives_Native.fst
-                      uu____10374
+                      uu____10378
                      in
-                  FStar_TypeChecker_Env.set_expected_typ env uu____10373  in
-                tc_term uu____10372 typ  in
-              (match uu____10365 with
-               | (typ1,uu____10390,g1) ->
+                  FStar_TypeChecker_Env.set_expected_typ env uu____10377  in
+                tc_term uu____10376 typ  in
+              (match uu____10369 with
+               | (typ1,uu____10394,g1) ->
                    (FStar_TypeChecker_Rel.force_trivial_guard env g1;
-                    (let uu____10393 =
+                    (let uu____10397 =
                        tc_tactic FStar_Syntax_Syntax.t_unit
                          FStar_Syntax_Syntax.t_unit env tau
                         in
-                     match uu____10393 with
-                     | (tau1,uu____10407,g2) ->
+                     match uu____10397 with
+                     | (tau1,uu____10411,g2) ->
                          (FStar_TypeChecker_Rel.force_trivial_guard env g2;
                           (let t =
                              env.FStar_TypeChecker_Env.synth_hook env typ1
-                               (let uu___1324_10412 = tau1  in
+                               (let uu___1324_10416 = tau1  in
                                 {
                                   FStar_Syntax_Syntax.n =
-                                    (uu___1324_10412.FStar_Syntax_Syntax.n);
+                                    (uu___1324_10416.FStar_Syntax_Syntax.n);
                                   FStar_Syntax_Syntax.pos = rng;
                                   FStar_Syntax_Syntax.vars =
-                                    (uu___1324_10412.FStar_Syntax_Syntax.vars)
+                                    (uu___1324_10416.FStar_Syntax_Syntax.vars)
                                 })
                               in
-                           (let uu____10414 =
+                           (let uu____10418 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "Tac")
                                in
-                            if uu____10414
+                            if uu____10418
                             then
-                              let uu____10419 =
+                              let uu____10423 =
                                 FStar_Syntax_Print.term_to_string t  in
-                              FStar_Util.print1 "Got %s\n" uu____10419
+                              FStar_Util.print1 "Got %s\n" uu____10423
                             else ());
                            FStar_TypeChecker_Util.check_uvars
                              tau1.FStar_Syntax_Syntax.pos t;
-                           (let uu____10425 =
-                              let uu____10426 =
+                           (let uu____10429 =
+                              let uu____10430 =
                                 FStar_Syntax_Syntax.mk_Total typ1  in
                               FStar_All.pipe_left
                                 FStar_TypeChecker_Common.lcomp_of_comp
-                                uu____10426
+                                uu____10430
                                in
-                            (t, uu____10425,
+                            (t, uu____10429,
                               FStar_TypeChecker_Env.trivial_guard)))))))
 
 and (tc_tactic :
@@ -3434,104 +3437,104 @@ and (tc_tactic :
       fun env  ->
         fun tau  ->
           let env1 =
-            let uu___1334_10432 = env  in
+            let uu___1334_10436 = env  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___1334_10432.FStar_TypeChecker_Env.solver);
+                (uu___1334_10436.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___1334_10432.FStar_TypeChecker_Env.range);
+                (uu___1334_10436.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___1334_10432.FStar_TypeChecker_Env.curmodule);
+                (uu___1334_10436.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___1334_10432.FStar_TypeChecker_Env.gamma);
+                (uu___1334_10436.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___1334_10432.FStar_TypeChecker_Env.gamma_sig);
+                (uu___1334_10436.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___1334_10432.FStar_TypeChecker_Env.gamma_cache);
+                (uu___1334_10436.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___1334_10432.FStar_TypeChecker_Env.modules);
+                (uu___1334_10436.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___1334_10432.FStar_TypeChecker_Env.expected_typ);
+                (uu___1334_10436.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___1334_10432.FStar_TypeChecker_Env.sigtab);
+                (uu___1334_10436.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___1334_10432.FStar_TypeChecker_Env.attrtab);
+                (uu___1334_10436.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___1334_10432.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___1334_10436.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___1334_10432.FStar_TypeChecker_Env.effects);
+                (uu___1334_10436.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___1334_10432.FStar_TypeChecker_Env.generalize);
+                (uu___1334_10436.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___1334_10432.FStar_TypeChecker_Env.letrecs);
+                (uu___1334_10436.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___1334_10432.FStar_TypeChecker_Env.top_level);
+                (uu___1334_10436.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___1334_10432.FStar_TypeChecker_Env.check_uvars);
+                (uu___1334_10436.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___1334_10432.FStar_TypeChecker_Env.use_eq);
+                (uu___1334_10436.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___1334_10432.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___1334_10436.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___1334_10432.FStar_TypeChecker_Env.is_iface);
+                (uu___1334_10436.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___1334_10432.FStar_TypeChecker_Env.admit);
+                (uu___1334_10436.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___1334_10432.FStar_TypeChecker_Env.lax);
+                (uu___1334_10436.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___1334_10432.FStar_TypeChecker_Env.lax_universes);
+                (uu___1334_10436.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___1334_10432.FStar_TypeChecker_Env.phase1);
+                (uu___1334_10436.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard = true;
               FStar_TypeChecker_Env.nosynth =
-                (uu___1334_10432.FStar_TypeChecker_Env.nosynth);
+                (uu___1334_10436.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___1334_10432.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___1334_10436.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___1334_10432.FStar_TypeChecker_Env.tc_term);
+                (uu___1334_10436.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___1334_10432.FStar_TypeChecker_Env.type_of);
+                (uu___1334_10436.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___1334_10432.FStar_TypeChecker_Env.universe_of);
+                (uu___1334_10436.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___1334_10432.FStar_TypeChecker_Env.check_type_of);
+                (uu___1334_10436.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___1334_10432.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___1334_10436.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___1334_10432.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___1334_10436.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___1334_10432.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___1334_10436.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___1334_10432.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___1334_10436.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___1334_10432.FStar_TypeChecker_Env.proof_ns);
+                (uu___1334_10436.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___1334_10432.FStar_TypeChecker_Env.synth_hook);
+                (uu___1334_10436.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___1334_10432.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___1334_10436.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___1334_10432.FStar_TypeChecker_Env.splice);
+                (uu___1334_10436.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___1334_10432.FStar_TypeChecker_Env.mpreprocess);
+                (uu___1334_10436.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___1334_10432.FStar_TypeChecker_Env.postprocess);
+                (uu___1334_10436.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.is_native_tactic =
-                (uu___1334_10432.FStar_TypeChecker_Env.is_native_tactic);
+                (uu___1334_10436.FStar_TypeChecker_Env.is_native_tactic);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___1334_10432.FStar_TypeChecker_Env.identifier_info);
+                (uu___1334_10436.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___1334_10432.FStar_TypeChecker_Env.tc_hooks);
+                (uu___1334_10436.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___1334_10432.FStar_TypeChecker_Env.dsenv);
+                (uu___1334_10436.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___1334_10432.FStar_TypeChecker_Env.nbe);
+                (uu___1334_10436.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___1334_10432.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___1334_10436.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___1334_10432.FStar_TypeChecker_Env.erasable_types_tab)
+                (uu___1334_10436.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let uu____10434 = FStar_Syntax_Syntax.t_tac_of a b  in
-          tc_check_tot_or_gtot_term env1 tau uu____10434
+          let uu____10438 = FStar_Syntax_Syntax.t_tac_of a b  in
+          tc_check_tot_or_gtot_term env1 tau uu____10438
 
 and (tc_tactic_opt :
   FStar_TypeChecker_Env.env ->
@@ -3546,12 +3549,12 @@ and (tc_tactic_opt :
       | FStar_Pervasives_Native.None  ->
           (FStar_Pervasives_Native.None, FStar_TypeChecker_Env.trivial_guard)
       | FStar_Pervasives_Native.Some tactic ->
-          let uu____10456 =
+          let uu____10460 =
             tc_tactic FStar_Syntax_Syntax.t_unit FStar_Syntax_Syntax.t_unit
               env tactic
              in
-          (match uu____10456 with
-           | (tactic1,uu____10470,g) ->
+          (match uu____10460 with
+           | (tactic1,uu____10474,g) ->
                ((FStar_Pervasives_Native.Some tactic1), g))
 
 and (tc_value :
@@ -3564,47 +3567,49 @@ and (tc_value :
     fun e  ->
       let check_instantiated_fvar env1 v dc e1 t0 =
         let t = FStar_Syntax_Util.remove_inacc t0  in
-        let uu____10523 = FStar_TypeChecker_Util.maybe_instantiate env1 e1 t
+        let uu____10527 = FStar_TypeChecker_Util.maybe_instantiate env1 e1 t
            in
-        match uu____10523 with
+        match uu____10527 with
         | (e2,t1,implicits) ->
             let tc =
-              let uu____10544 = FStar_TypeChecker_Env.should_verify env1  in
-              if uu____10544
+              let uu____10548 = FStar_TypeChecker_Env.should_verify env1  in
+              if uu____10548
               then FStar_Util.Inl t1
               else
-                (let uu____10553 =
-                   let uu____10554 = FStar_Syntax_Syntax.mk_Total t1  in
+                (let uu____10557 =
+                   let uu____10558 = FStar_Syntax_Syntax.mk_Total t1  in
                    FStar_All.pipe_left FStar_TypeChecker_Common.lcomp_of_comp
-                     uu____10554
+                     uu____10558
                     in
-                 FStar_Util.Inr uu____10553)
+                 FStar_Util.Inr uu____10557)
                in
-            let is_data_ctor uu___4_10563 =
-              match uu___4_10563 with
+            let is_data_ctor uu___4_10567 =
+              match uu___4_10567 with
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor )
                   -> true
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
-                  uu____10568) -> true
-              | uu____10576 -> false  in
-            let uu____10580 =
+                  uu____10572) -> true
+              | uu____10580 -> false  in
+            let uu____10584 =
               (is_data_ctor dc) &&
-                (let uu____10583 =
+                (let uu____10587 =
                    FStar_TypeChecker_Env.is_datacon env1
                      v.FStar_Syntax_Syntax.v
                     in
-                 Prims.op_Negation uu____10583)
+                 Prims.op_Negation uu____10587)
                in
-            if uu____10580
+            if uu____10584
             then
-              let uu____10592 =
-                let uu____10598 =
+              let uu____10596 =
+                let uu____10602 =
+                  let uu____10604 =
+                    FStar_Ident.string_of_lid v.FStar_Syntax_Syntax.v  in
                   FStar_Util.format1 "Expected a data constructor; got %s"
-                    (v.FStar_Syntax_Syntax.v).FStar_Ident.str
+                    uu____10604
                    in
-                (FStar_Errors.Fatal_MissingDataConstructor, uu____10598)  in
-              let uu____10602 = FStar_TypeChecker_Env.get_range env1  in
-              FStar_Errors.raise_error uu____10592 uu____10602
+                (FStar_Errors.Fatal_MissingDataConstructor, uu____10602)  in
+              let uu____10608 = FStar_TypeChecker_Env.get_range env1  in
+              FStar_Errors.raise_error uu____10596 uu____10608
             else value_check_expected_typ env1 e2 tc implicits
          in
       let env1 =
@@ -3612,148 +3617,148 @@ and (tc_value :
       let top = FStar_Syntax_Subst.compress e  in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_bvar x ->
-          let uu____10620 =
-            let uu____10626 =
-              let uu____10628 = FStar_Syntax_Print.term_to_string top  in
+          let uu____10626 =
+            let uu____10632 =
+              let uu____10634 = FStar_Syntax_Print.term_to_string top  in
               FStar_Util.format1
-                "Violation of locally nameless convention: %s" uu____10628
+                "Violation of locally nameless convention: %s" uu____10634
                in
-            (FStar_Errors.Error_IllScopedTerm, uu____10626)  in
-          FStar_Errors.raise_error uu____10620 top.FStar_Syntax_Syntax.pos
+            (FStar_Errors.Error_IllScopedTerm, uu____10632)  in
+          FStar_Errors.raise_error uu____10626 top.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
-          let uu____10656 =
-            let uu____10661 =
+          let uu____10662 =
+            let uu____10667 =
               FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
                in
-            FStar_Util.Inl uu____10661  in
-          value_check_expected_typ env1 e uu____10656
+            FStar_Util.Inl uu____10667  in
+          value_check_expected_typ env1 e uu____10662
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_unknown  ->
           let r = FStar_TypeChecker_Env.get_range env1  in
-          let uu____10663 =
-            let uu____10676 = FStar_TypeChecker_Env.expected_typ env1  in
-            match uu____10676 with
+          let uu____10669 =
+            let uu____10682 = FStar_TypeChecker_Env.expected_typ env1  in
+            match uu____10682 with
             | FStar_Pervasives_Native.None  ->
-                let uu____10691 = FStar_Syntax_Util.type_u ()  in
-                (match uu____10691 with
+                let uu____10697 = FStar_Syntax_Util.type_u ()  in
+                (match uu____10697 with
                  | (k,u) ->
                      FStar_TypeChecker_Util.new_implicit_var
                        "type of user-provided implicit term" r env1 k)
             | FStar_Pervasives_Native.Some t ->
                 (t, [], FStar_TypeChecker_Env.trivial_guard)
              in
-          (match uu____10663 with
-           | (t,uu____10729,g0) ->
-               let uu____10743 =
-                 let uu____10756 =
-                   let uu____10758 = FStar_Range.string_of_range r  in
-                   Prims.op_Hat "user-provided implicit term at " uu____10758
+          (match uu____10669 with
+           | (t,uu____10735,g0) ->
+               let uu____10749 =
+                 let uu____10762 =
+                   let uu____10764 = FStar_Range.string_of_range r  in
+                   Prims.op_Hat "user-provided implicit term at " uu____10764
                     in
-                 FStar_TypeChecker_Util.new_implicit_var uu____10756 r env1 t
+                 FStar_TypeChecker_Util.new_implicit_var uu____10762 r env1 t
                   in
-               (match uu____10743 with
-                | (e1,uu____10768,g1) ->
-                    let uu____10782 =
-                      let uu____10783 = FStar_Syntax_Syntax.mk_Total t  in
-                      FStar_All.pipe_right uu____10783
+               (match uu____10749 with
+                | (e1,uu____10774,g1) ->
+                    let uu____10788 =
+                      let uu____10789 = FStar_Syntax_Syntax.mk_Total t  in
+                      FStar_All.pipe_right uu____10789
                         FStar_TypeChecker_Common.lcomp_of_comp
                        in
-                    let uu____10784 = FStar_TypeChecker_Env.conj_guard g0 g1
+                    let uu____10790 = FStar_TypeChecker_Env.conj_guard g0 g1
                        in
-                    (e1, uu____10782, uu____10784)))
+                    (e1, uu____10788, uu____10790)))
       | FStar_Syntax_Syntax.Tm_name x ->
-          let uu____10786 =
+          let uu____10792 =
             if env1.FStar_TypeChecker_Env.use_bv_sorts
             then
-              let uu____10796 = FStar_Syntax_Syntax.range_of_bv x  in
-              ((x.FStar_Syntax_Syntax.sort), uu____10796)
+              let uu____10802 = FStar_Syntax_Syntax.range_of_bv x  in
+              ((x.FStar_Syntax_Syntax.sort), uu____10802)
             else FStar_TypeChecker_Env.lookup_bv env1 x  in
-          (match uu____10786 with
+          (match uu____10792 with
            | (t,rng) ->
                let x1 =
                  FStar_Syntax_Syntax.set_range_of_bv
-                   (let uu___1400_10810 = x  in
+                   (let uu___1400_10816 = x  in
                     {
                       FStar_Syntax_Syntax.ppname =
-                        (uu___1400_10810.FStar_Syntax_Syntax.ppname);
+                        (uu___1400_10816.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index =
-                        (uu___1400_10810.FStar_Syntax_Syntax.index);
+                        (uu___1400_10816.FStar_Syntax_Syntax.index);
                       FStar_Syntax_Syntax.sort = t
                     }) rng
                   in
                (FStar_TypeChecker_Env.insert_bv_info env1 x1 t;
                 (let e1 = FStar_Syntax_Syntax.bv_to_name x1  in
-                 let uu____10813 =
+                 let uu____10819 =
                    FStar_TypeChecker_Util.maybe_instantiate env1 e1 t  in
-                 match uu____10813 with
+                 match uu____10819 with
                  | (e2,t1,implicits) ->
                      let tc =
-                       let uu____10834 =
+                       let uu____10840 =
                          FStar_TypeChecker_Env.should_verify env1  in
-                       if uu____10834
+                       if uu____10840
                        then FStar_Util.Inl t1
                        else
-                         (let uu____10843 =
-                            let uu____10844 = FStar_Syntax_Syntax.mk_Total t1
+                         (let uu____10849 =
+                            let uu____10850 = FStar_Syntax_Syntax.mk_Total t1
                                in
                             FStar_All.pipe_left
                               FStar_TypeChecker_Common.lcomp_of_comp
-                              uu____10844
+                              uu____10850
                              in
-                          FStar_Util.Inr uu____10843)
+                          FStar_Util.Inr uu____10849)
                         in
                      value_check_expected_typ env1 e2 tc implicits)))
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____10846;
-             FStar_Syntax_Syntax.vars = uu____10847;_},uu____10848)
+             FStar_Syntax_Syntax.pos = uu____10852;
+             FStar_Syntax_Syntax.vars = uu____10853;_},uu____10854)
           when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
           ->
-          let uu____10853 = FStar_TypeChecker_Env.get_range env1  in
+          let uu____10859 = FStar_TypeChecker_Env.get_range env1  in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
-              "Badly instantiated synth_by_tactic") uu____10853
+              "Badly instantiated synth_by_tactic") uu____10859
       | FStar_Syntax_Syntax.Tm_fvar fv when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
           ->
-          let uu____10863 = FStar_TypeChecker_Env.get_range env1  in
+          let uu____10869 = FStar_TypeChecker_Env.get_range env1  in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
-              "Badly instantiated synth_by_tactic") uu____10863
+              "Badly instantiated synth_by_tactic") uu____10869
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____10873;
-             FStar_Syntax_Syntax.vars = uu____10874;_},us)
+             FStar_Syntax_Syntax.pos = uu____10879;
+             FStar_Syntax_Syntax.vars = uu____10880;_},us)
           ->
           let us1 = FStar_List.map (tc_universe env1) us  in
-          let uu____10883 =
+          let uu____10889 =
             FStar_TypeChecker_Env.lookup_lid env1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____10883 with
+          (match uu____10889 with
            | ((us',t),range) ->
                (if (FStar_List.length us1) <> (FStar_List.length us')
                 then
-                  (let uu____10907 =
-                     let uu____10913 =
-                       let uu____10915 = FStar_Syntax_Print.fv_to_string fv
+                  (let uu____10913 =
+                     let uu____10919 =
+                       let uu____10921 = FStar_Syntax_Print.fv_to_string fv
                           in
-                       let uu____10917 =
+                       let uu____10923 =
                          FStar_Util.string_of_int (FStar_List.length us1)  in
-                       let uu____10919 =
+                       let uu____10925 =
                          FStar_Util.string_of_int (FStar_List.length us')  in
                        FStar_Util.format3
                          "Unexpected number of universe instantiations for \"%s\" (%s vs %s)"
-                         uu____10915 uu____10917 uu____10919
+                         uu____10921 uu____10923 uu____10925
                         in
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                       uu____10913)
+                       uu____10919)
                       in
-                   let uu____10923 = FStar_TypeChecker_Env.get_range env1  in
-                   FStar_Errors.raise_error uu____10907 uu____10923)
+                   let uu____10929 = FStar_TypeChecker_Env.get_range env1  in
+                   FStar_Errors.raise_error uu____10913 uu____10929)
                 else
                   FStar_List.iter2
                     (fun u'  ->
@@ -3761,58 +3766,58 @@ and (tc_value :
                          match u' with
                          | FStar_Syntax_Syntax.U_unif u'' ->
                              FStar_Syntax_Unionfind.univ_change u'' u
-                         | uu____10940 -> failwith "Impossible") us' us1;
+                         | uu____10946 -> failwith "Impossible") us' us1;
                 (let fv' = FStar_Syntax_Syntax.set_range_of_fv fv range  in
                  FStar_TypeChecker_Env.insert_fv_info env1 fv' t;
                  (let e1 =
-                    let uu____10945 =
+                    let uu____10951 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_fvar fv')
                         FStar_Pervasives_Native.None
                         e.FStar_Syntax_Syntax.pos
                        in
-                    FStar_Syntax_Syntax.mk_Tm_uinst uu____10945 us1  in
+                    FStar_Syntax_Syntax.mk_Tm_uinst uu____10951 us1  in
                   check_instantiated_fvar env1
                     fv'.FStar_Syntax_Syntax.fv_name
                     fv'.FStar_Syntax_Syntax.fv_qual e1 t))))
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____10947 =
+          let uu____10953 =
             FStar_TypeChecker_Env.lookup_lid env1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____10947 with
+          (match uu____10953 with
            | ((us,t),range) ->
-               ((let uu____10970 =
+               ((let uu____10976 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                      (FStar_Options.Other "Range")
                     in
-                 if uu____10970
+                 if uu____10976
                  then
-                   let uu____10975 =
-                     let uu____10977 = FStar_Syntax_Syntax.lid_of_fv fv  in
-                     FStar_Syntax_Print.lid_to_string uu____10977  in
-                   let uu____10978 =
+                   let uu____10981 =
+                     let uu____10983 = FStar_Syntax_Syntax.lid_of_fv fv  in
+                     FStar_Syntax_Print.lid_to_string uu____10983  in
+                   let uu____10984 =
                      FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos
                       in
-                   let uu____10980 = FStar_Range.string_of_range range  in
-                   let uu____10982 = FStar_Range.string_of_use_range range
+                   let uu____10986 = FStar_Range.string_of_range range  in
+                   let uu____10988 = FStar_Range.string_of_use_range range
                       in
-                   let uu____10984 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____10990 = FStar_Syntax_Print.term_to_string t  in
                    FStar_Util.print5
                      "Lookup up fvar %s at location %s (lid range = defined at %s, used at %s); got universes type %s"
-                     uu____10975 uu____10978 uu____10980 uu____10982
-                     uu____10984
+                     uu____10981 uu____10984 uu____10986 uu____10988
+                     uu____10990
                  else ());
                 (let fv' = FStar_Syntax_Syntax.set_range_of_fv fv range  in
                  FStar_TypeChecker_Env.insert_fv_info env1 fv' t;
                  (let e1 =
-                    let uu____10992 =
+                    let uu____10998 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_fvar fv')
                         FStar_Pervasives_Native.None
                         e.FStar_Syntax_Syntax.pos
                        in
-                    FStar_Syntax_Syntax.mk_Tm_uinst uu____10992 us  in
+                    FStar_Syntax_Syntax.mk_Tm_uinst uu____10998 us  in
                   check_instantiated_fvar env1
                     fv'.FStar_Syntax_Syntax.fv_name
                     fv'.FStar_Syntax_Syntax.fv_qual e1 t))))
@@ -3825,30 +3830,30 @@ and (tc_value :
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____11020 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____11020 with
+          let uu____11026 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____11026 with
            | (bs1,c1) ->
                let env0 = env1  in
-               let uu____11034 =
+               let uu____11040 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____11034 with
-                | (env2,uu____11048) ->
-                    let uu____11053 = tc_binders env2 bs1  in
-                    (match uu____11053 with
+               (match uu____11040 with
+                | (env2,uu____11054) ->
+                    let uu____11059 = tc_binders env2 bs1  in
+                    (match uu____11059 with
                      | (bs2,env3,g,us) ->
-                         let uu____11072 = tc_comp env3 c1  in
-                         (match uu____11072 with
+                         let uu____11078 = tc_comp env3 c1  in
+                         (match uu____11078 with
                           | (c2,uc,f) ->
                               let e1 =
-                                let uu___1480_11091 =
+                                let uu___1480_11097 =
                                   FStar_Syntax_Util.arrow bs2 c2  in
                                 {
                                   FStar_Syntax_Syntax.n =
-                                    (uu___1480_11091.FStar_Syntax_Syntax.n);
+                                    (uu___1480_11097.FStar_Syntax_Syntax.n);
                                   FStar_Syntax_Syntax.pos =
                                     (top.FStar_Syntax_Syntax.pos);
                                   FStar_Syntax_Syntax.vars =
-                                    (uu___1480_11091.FStar_Syntax_Syntax.vars)
+                                    (uu___1480_11097.FStar_Syntax_Syntax.vars)
                                 }  in
                               (check_smt_pat env3 e1 bs2 c2;
                                (let u = FStar_Syntax_Syntax.U_max (uc :: us)
@@ -3860,12 +3865,12 @@ and (tc_value :
                                     top.FStar_Syntax_Syntax.pos
                                    in
                                 let g1 =
-                                  let uu____11102 =
+                                  let uu____11108 =
                                     FStar_TypeChecker_Env.close_guard_univs
                                       us bs2 f
                                      in
                                   FStar_TypeChecker_Env.conj_guard g
-                                    uu____11102
+                                    uu____11108
                                    in
                                 let g2 =
                                   FStar_TypeChecker_Util.close_guard_implicits
@@ -3887,64 +3892,64 @@ and (tc_value :
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
-          let uu____11119 =
-            let uu____11124 =
-              let uu____11125 = FStar_Syntax_Syntax.mk_binder x  in
-              [uu____11125]  in
-            FStar_Syntax_Subst.open_term uu____11124 phi  in
-          (match uu____11119 with
+          let uu____11125 =
+            let uu____11130 =
+              let uu____11131 = FStar_Syntax_Syntax.mk_binder x  in
+              [uu____11131]  in
+            FStar_Syntax_Subst.open_term uu____11130 phi  in
+          (match uu____11125 with
            | (x1,phi1) ->
                let env0 = env1  in
-               let uu____11153 =
+               let uu____11159 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____11153 with
-                | (env2,uu____11167) ->
-                    let uu____11172 =
-                      let uu____11187 = FStar_List.hd x1  in
-                      tc_binder env2 uu____11187  in
-                    (match uu____11172 with
+               (match uu____11159 with
+                | (env2,uu____11173) ->
+                    let uu____11178 =
+                      let uu____11193 = FStar_List.hd x1  in
+                      tc_binder env2 uu____11193  in
+                    (match uu____11178 with
                      | (x2,env3,f1,u) ->
-                         ((let uu____11223 =
+                         ((let uu____11229 =
                              FStar_TypeChecker_Env.debug env3
                                FStar_Options.High
                               in
-                           if uu____11223
+                           if uu____11229
                            then
-                             let uu____11226 =
+                             let uu____11232 =
                                FStar_Range.string_of_range
                                  top.FStar_Syntax_Syntax.pos
                                 in
-                             let uu____11228 =
+                             let uu____11234 =
                                FStar_Syntax_Print.term_to_string phi1  in
-                             let uu____11230 =
+                             let uu____11236 =
                                FStar_Syntax_Print.bv_to_string
                                  (FStar_Pervasives_Native.fst x2)
                                 in
                              FStar_Util.print3
                                "(%s) Checking refinement formula %s; binder is %s\n"
-                               uu____11226 uu____11228 uu____11230
+                               uu____11232 uu____11234 uu____11236
                            else ());
-                          (let uu____11237 = FStar_Syntax_Util.type_u ()  in
-                           match uu____11237 with
-                           | (t_phi,uu____11249) ->
-                               let uu____11250 =
+                          (let uu____11243 = FStar_Syntax_Util.type_u ()  in
+                           match uu____11243 with
+                           | (t_phi,uu____11255) ->
+                               let uu____11256 =
                                  tc_check_tot_or_gtot_term env3 phi1 t_phi
                                   in
-                               (match uu____11250 with
-                                | (phi2,uu____11264,f2) ->
+                               (match uu____11256 with
+                                | (phi2,uu____11270,f2) ->
                                     let e1 =
-                                      let uu___1518_11269 =
+                                      let uu___1518_11275 =
                                         FStar_Syntax_Util.refine
                                           (FStar_Pervasives_Native.fst x2)
                                           phi2
                                          in
                                       {
                                         FStar_Syntax_Syntax.n =
-                                          (uu___1518_11269.FStar_Syntax_Syntax.n);
+                                          (uu___1518_11275.FStar_Syntax_Syntax.n);
                                         FStar_Syntax_Syntax.pos =
                                           (top.FStar_Syntax_Syntax.pos);
                                         FStar_Syntax_Syntax.vars =
-                                          (uu___1518_11269.FStar_Syntax_Syntax.vars)
+                                          (uu___1518_11275.FStar_Syntax_Syntax.vars)
                                       }  in
                                     let t =
                                       FStar_Syntax_Syntax.mk
@@ -3953,12 +3958,12 @@ and (tc_value :
                                         top.FStar_Syntax_Syntax.pos
                                        in
                                     let g =
-                                      let uu____11278 =
+                                      let uu____11284 =
                                         FStar_TypeChecker_Env.close_guard_univs
                                           [u] [x2] f2
                                          in
                                       FStar_TypeChecker_Env.conj_guard f1
-                                        uu____11278
+                                        uu____11284
                                        in
                                     let g1 =
                                       FStar_TypeChecker_Util.close_guard_implicits
@@ -3966,38 +3971,38 @@ and (tc_value :
                                        in
                                     value_check_expected_typ env0 e1
                                       (FStar_Util.Inl t) g1))))))
-      | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____11307) ->
+      | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____11313) ->
           let bs1 = FStar_TypeChecker_Util.maybe_add_implicit_binders env1 bs
              in
-          ((let uu____11334 =
+          ((let uu____11340 =
               FStar_TypeChecker_Env.debug env1 FStar_Options.Medium  in
-            if uu____11334
+            if uu____11340
             then
-              let uu____11337 =
+              let uu____11343 =
                 FStar_Syntax_Print.term_to_string
-                  (let uu___1531_11341 = top  in
+                  (let uu___1531_11347 = top  in
                    {
                      FStar_Syntax_Syntax.n =
                        (FStar_Syntax_Syntax.Tm_abs
                           (bs1, body, FStar_Pervasives_Native.None));
                      FStar_Syntax_Syntax.pos =
-                       (uu___1531_11341.FStar_Syntax_Syntax.pos);
+                       (uu___1531_11347.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
-                       (uu___1531_11341.FStar_Syntax_Syntax.vars)
+                       (uu___1531_11347.FStar_Syntax_Syntax.vars)
                    })
                  in
-              FStar_Util.print1 "Abstraction is: %s\n" uu____11337
+              FStar_Util.print1 "Abstraction is: %s\n" uu____11343
             else ());
-           (let uu____11357 = FStar_Syntax_Subst.open_term bs1 body  in
-            match uu____11357 with | (bs2,body1) -> tc_abs env1 top bs2 body1))
-      | uu____11370 ->
-          let uu____11371 =
-            let uu____11373 = FStar_Syntax_Print.term_to_string top  in
-            let uu____11375 = FStar_Syntax_Print.tag_of_term top  in
-            FStar_Util.format2 "Unexpected value: %s (%s)" uu____11373
-              uu____11375
+           (let uu____11363 = FStar_Syntax_Subst.open_term bs1 body  in
+            match uu____11363 with | (bs2,body1) -> tc_abs env1 top bs2 body1))
+      | uu____11376 ->
+          let uu____11377 =
+            let uu____11379 = FStar_Syntax_Print.term_to_string top  in
+            let uu____11381 = FStar_Syntax_Print.tag_of_term top  in
+            FStar_Util.format2 "Unexpected value: %s (%s)" uu____11379
+              uu____11381
              in
-          failwith uu____11371
+          failwith uu____11377
 
 and (tc_constant :
   FStar_TypeChecker_Env.env ->
@@ -4008,11 +4013,11 @@ and (tc_constant :
       fun c  ->
         match c with
         | FStar_Const.Const_unit  -> FStar_Syntax_Syntax.t_unit
-        | FStar_Const.Const_bool uu____11387 -> FStar_Syntax_Util.t_bool
-        | FStar_Const.Const_int (uu____11389,FStar_Pervasives_Native.None )
+        | FStar_Const.Const_bool uu____11393 -> FStar_Syntax_Util.t_bool
+        | FStar_Const.Const_int (uu____11395,FStar_Pervasives_Native.None )
             -> FStar_Syntax_Syntax.t_int
         | FStar_Const.Const_int
-            (uu____11402,FStar_Pervasives_Native.Some msize) ->
+            (uu____11408,FStar_Pervasives_Native.Some msize) ->
             FStar_Syntax_Syntax.tconst
               (match msize with
                | (FStar_Const.Signed ,FStar_Const.Int8 ) ->
@@ -4031,59 +4036,59 @@ and (tc_constant :
                    FStar_Parser_Const.uint32_lid
                | (FStar_Const.Unsigned ,FStar_Const.Int64 ) ->
                    FStar_Parser_Const.uint64_lid)
-        | FStar_Const.Const_string uu____11420 ->
+        | FStar_Const.Const_string uu____11426 ->
             FStar_Syntax_Syntax.t_string
-        | FStar_Const.Const_real uu____11426 -> FStar_Syntax_Syntax.t_real
-        | FStar_Const.Const_float uu____11428 -> FStar_Syntax_Syntax.t_float
-        | FStar_Const.Const_char uu____11429 ->
-            let uu____11431 =
+        | FStar_Const.Const_real uu____11432 -> FStar_Syntax_Syntax.t_real
+        | FStar_Const.Const_float uu____11434 -> FStar_Syntax_Syntax.t_float
+        | FStar_Const.Const_char uu____11435 ->
+            let uu____11437 =
               FStar_Syntax_DsEnv.try_lookup_lid
                 env.FStar_TypeChecker_Env.dsenv FStar_Parser_Const.char_lid
                in
-            FStar_All.pipe_right uu____11431 FStar_Util.must
+            FStar_All.pipe_right uu____11437 FStar_Util.must
         | FStar_Const.Const_effect  -> FStar_Syntax_Util.ktype0
-        | FStar_Const.Const_range uu____11436 -> FStar_Syntax_Syntax.t_range
+        | FStar_Const.Const_range uu____11442 -> FStar_Syntax_Syntax.t_range
         | FStar_Const.Const_range_of  ->
-            let uu____11437 =
-              let uu____11443 =
-                let uu____11445 = FStar_Parser_Const.const_to_string c  in
+            let uu____11443 =
+              let uu____11449 =
+                let uu____11451 = FStar_Parser_Const.const_to_string c  in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____11445
+                  uu____11451
                  in
-              (FStar_Errors.Fatal_IllTyped, uu____11443)  in
-            FStar_Errors.raise_error uu____11437 r
+              (FStar_Errors.Fatal_IllTyped, uu____11449)  in
+            FStar_Errors.raise_error uu____11443 r
         | FStar_Const.Const_set_range_of  ->
-            let uu____11449 =
-              let uu____11455 =
-                let uu____11457 = FStar_Parser_Const.const_to_string c  in
+            let uu____11455 =
+              let uu____11461 =
+                let uu____11463 = FStar_Parser_Const.const_to_string c  in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____11457
+                  uu____11463
                  in
-              (FStar_Errors.Fatal_IllTyped, uu____11455)  in
-            FStar_Errors.raise_error uu____11449 r
+              (FStar_Errors.Fatal_IllTyped, uu____11461)  in
+            FStar_Errors.raise_error uu____11455 r
         | FStar_Const.Const_reify  ->
-            let uu____11461 =
-              let uu____11467 =
-                let uu____11469 = FStar_Parser_Const.const_to_string c  in
+            let uu____11467 =
+              let uu____11473 =
+                let uu____11475 = FStar_Parser_Const.const_to_string c  in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____11469
+                  uu____11475
                  in
-              (FStar_Errors.Fatal_IllTyped, uu____11467)  in
-            FStar_Errors.raise_error uu____11461 r
-        | FStar_Const.Const_reflect uu____11473 ->
-            let uu____11474 =
-              let uu____11480 =
-                let uu____11482 = FStar_Parser_Const.const_to_string c  in
+              (FStar_Errors.Fatal_IllTyped, uu____11473)  in
+            FStar_Errors.raise_error uu____11467 r
+        | FStar_Const.Const_reflect uu____11479 ->
+            let uu____11480 =
+              let uu____11486 =
+                let uu____11488 = FStar_Parser_Const.const_to_string c  in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____11482
+                  uu____11488
                  in
-              (FStar_Errors.Fatal_IllTyped, uu____11480)  in
-            FStar_Errors.raise_error uu____11474 r
-        | uu____11486 ->
+              (FStar_Errors.Fatal_IllTyped, uu____11486)  in
+            FStar_Errors.raise_error uu____11480 r
+        | uu____11492 ->
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_UnsupportedConstant,
                 "Unsupported constant") r
@@ -4098,30 +4103,30 @@ and (tc_comp :
     fun c  ->
       let c0 = c  in
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total (t,uu____11505) ->
-          let uu____11514 = FStar_Syntax_Util.type_u ()  in
-          (match uu____11514 with
+      | FStar_Syntax_Syntax.Total (t,uu____11511) ->
+          let uu____11520 = FStar_Syntax_Util.type_u ()  in
+          (match uu____11520 with
            | (k,u) ->
-               let uu____11527 = tc_check_tot_or_gtot_term env t k  in
-               (match uu____11527 with
-                | (t1,uu____11541,g) ->
-                    let uu____11543 =
+               let uu____11533 = tc_check_tot_or_gtot_term env t k  in
+               (match uu____11533 with
+                | (t1,uu____11547,g) ->
+                    let uu____11549 =
                       FStar_Syntax_Syntax.mk_Total' t1
                         (FStar_Pervasives_Native.Some u)
                        in
-                    (uu____11543, u, g)))
-      | FStar_Syntax_Syntax.GTotal (t,uu____11545) ->
-          let uu____11554 = FStar_Syntax_Util.type_u ()  in
-          (match uu____11554 with
+                    (uu____11549, u, g)))
+      | FStar_Syntax_Syntax.GTotal (t,uu____11551) ->
+          let uu____11560 = FStar_Syntax_Util.type_u ()  in
+          (match uu____11560 with
            | (k,u) ->
-               let uu____11567 = tc_check_tot_or_gtot_term env t k  in
-               (match uu____11567 with
-                | (t1,uu____11581,g) ->
-                    let uu____11583 =
+               let uu____11573 = tc_check_tot_or_gtot_term env t k  in
+               (match uu____11573 with
+                | (t1,uu____11587,g) ->
+                    let uu____11589 =
                       FStar_Syntax_Syntax.mk_GTotal' t1
                         (FStar_Pervasives_Native.Some u)
                        in
-                    (uu____11583, u, g)))
+                    (uu____11589, u, g)))
       | FStar_Syntax_Syntax.Comp c1 ->
           let head =
             FStar_Syntax_Syntax.fvar c1.FStar_Syntax_Syntax.effect_name
@@ -4136,72 +4141,72 @@ and (tc_comp :
                   FStar_Pervasives_Native.None c0.FStar_Syntax_Syntax.pos
              in
           let tc =
-            let uu____11593 =
-              let uu____11598 =
-                let uu____11599 =
+            let uu____11599 =
+              let uu____11604 =
+                let uu____11605 =
                   FStar_Syntax_Syntax.as_arg
                     c1.FStar_Syntax_Syntax.result_typ
                    in
-                uu____11599 :: (c1.FStar_Syntax_Syntax.effect_args)  in
-              FStar_Syntax_Syntax.mk_Tm_app head1 uu____11598  in
-            uu____11593 FStar_Pervasives_Native.None
+                uu____11605 :: (c1.FStar_Syntax_Syntax.effect_args)  in
+              FStar_Syntax_Syntax.mk_Tm_app head1 uu____11604  in
+            uu____11599 FStar_Pervasives_Native.None
               (c1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos
              in
-          let uu____11616 =
+          let uu____11622 =
             tc_check_tot_or_gtot_term env tc FStar_Syntax_Syntax.teff  in
-          (match uu____11616 with
-           | (tc1,uu____11630,f) ->
-               let uu____11632 = FStar_Syntax_Util.head_and_args tc1  in
-               (match uu____11632 with
+          (match uu____11622 with
+           | (tc1,uu____11636,f) ->
+               let uu____11638 = FStar_Syntax_Util.head_and_args tc1  in
+               (match uu____11638 with
                 | (head2,args) ->
                     let comp_univs =
-                      let uu____11682 =
-                        let uu____11683 = FStar_Syntax_Subst.compress head2
+                      let uu____11688 =
+                        let uu____11689 = FStar_Syntax_Subst.compress head2
                            in
-                        uu____11683.FStar_Syntax_Syntax.n  in
-                      match uu____11682 with
-                      | FStar_Syntax_Syntax.Tm_uinst (uu____11686,us) -> us
-                      | uu____11692 -> []  in
-                    let uu____11693 = FStar_Syntax_Util.head_and_args tc1  in
-                    (match uu____11693 with
-                     | (uu____11716,args1) ->
-                         let uu____11742 =
-                           let uu____11765 = FStar_List.hd args1  in
-                           let uu____11782 = FStar_List.tl args1  in
-                           (uu____11765, uu____11782)  in
-                         (match uu____11742 with
+                        uu____11689.FStar_Syntax_Syntax.n  in
+                      match uu____11688 with
+                      | FStar_Syntax_Syntax.Tm_uinst (uu____11692,us) -> us
+                      | uu____11698 -> []  in
+                    let uu____11699 = FStar_Syntax_Util.head_and_args tc1  in
+                    (match uu____11699 with
+                     | (uu____11722,args1) ->
+                         let uu____11748 =
+                           let uu____11771 = FStar_List.hd args1  in
+                           let uu____11788 = FStar_List.tl args1  in
+                           (uu____11771, uu____11788)  in
+                         (match uu____11748 with
                           | (res,args2) ->
-                              let uu____11863 =
-                                let uu____11872 =
+                              let uu____11869 =
+                                let uu____11878 =
                                   FStar_All.pipe_right
                                     c1.FStar_Syntax_Syntax.flags
                                     (FStar_List.map
-                                       (fun uu___5_11900  ->
-                                          match uu___5_11900 with
+                                       (fun uu___5_11906  ->
+                                          match uu___5_11906 with
                                           | FStar_Syntax_Syntax.DECREASES e
                                               ->
-                                              let uu____11908 =
+                                              let uu____11914 =
                                                 FStar_TypeChecker_Env.clear_expected_typ
                                                   env
                                                  in
-                                              (match uu____11908 with
-                                               | (env1,uu____11920) ->
-                                                   let uu____11925 =
+                                              (match uu____11914 with
+                                               | (env1,uu____11926) ->
+                                                   let uu____11931 =
                                                      tc_tot_or_gtot_term env1
                                                        e
                                                       in
-                                                   (match uu____11925 with
-                                                    | (e1,uu____11937,g) ->
+                                                   (match uu____11931 with
+                                                    | (e1,uu____11943,g) ->
                                                         ((FStar_Syntax_Syntax.DECREASES
                                                             e1), g)))
                                           | f1 ->
                                               (f1,
                                                 FStar_TypeChecker_Env.trivial_guard)))
                                    in
-                                FStar_All.pipe_right uu____11872
+                                FStar_All.pipe_right uu____11878
                                   FStar_List.unzip
                                  in
-                              (match uu____11863 with
+                              (match uu____11869 with
                                | (flags,guards) ->
                                    let u =
                                      env.FStar_TypeChecker_Env.universe_of
@@ -4209,12 +4214,12 @@ and (tc_comp :
                                       in
                                    let c2 =
                                      FStar_Syntax_Syntax.mk_Comp
-                                       (let uu___1660_11978 = c1  in
+                                       (let uu___1660_11984 = c1  in
                                         {
                                           FStar_Syntax_Syntax.comp_univs =
                                             comp_univs;
                                           FStar_Syntax_Syntax.effect_name =
-                                            (uu___1660_11978.FStar_Syntax_Syntax.effect_name);
+                                            (uu___1660_11984.FStar_Syntax_Syntax.effect_name);
                                           FStar_Syntax_Syntax.result_typ =
                                             (FStar_Pervasives_Native.fst res);
                                           FStar_Syntax_Syntax.effect_args =
@@ -4227,12 +4232,12 @@ and (tc_comp :
                                        (FStar_TypeChecker_Util.universe_of_comp
                                           env u)
                                       in
-                                   let uu____11984 =
+                                   let uu____11990 =
                                      FStar_List.fold_left
                                        FStar_TypeChecker_Env.conj_guard f
                                        guards
                                       in
-                                   (c2, u_c, uu____11984))))))
+                                   (c2, u_c, uu____11990))))))
 
 and (tc_universe :
   FStar_TypeChecker_Env.env ->
@@ -4243,40 +4248,40 @@ and (tc_universe :
       let rec aux u1 =
         let u2 = FStar_Syntax_Subst.compress_univ u1  in
         match u2 with
-        | FStar_Syntax_Syntax.U_bvar uu____11994 ->
+        | FStar_Syntax_Syntax.U_bvar uu____12000 ->
             failwith "Impossible: locally nameless"
         | FStar_Syntax_Syntax.U_unknown  -> failwith "Unknown universe"
-        | FStar_Syntax_Syntax.U_unif uu____11998 -> u2
+        | FStar_Syntax_Syntax.U_unif uu____12004 -> u2
         | FStar_Syntax_Syntax.U_zero  -> u2
         | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____12008 = aux u3  in
-            FStar_Syntax_Syntax.U_succ uu____12008
+            let uu____12014 = aux u3  in
+            FStar_Syntax_Syntax.U_succ uu____12014
         | FStar_Syntax_Syntax.U_max us ->
-            let uu____12012 = FStar_List.map aux us  in
-            FStar_Syntax_Syntax.U_max uu____12012
+            let uu____12018 = FStar_List.map aux us  in
+            FStar_Syntax_Syntax.U_max uu____12018
         | FStar_Syntax_Syntax.U_name x ->
-            let uu____12016 =
+            let uu____12022 =
               env.FStar_TypeChecker_Env.use_bv_sorts ||
                 (FStar_TypeChecker_Env.lookup_univ env x)
                in
-            if uu____12016
+            if uu____12022
             then u2
             else
-              (let uu____12021 =
-                 let uu____12023 =
-                   let uu____12025 = FStar_Syntax_Print.univ_to_string u2  in
-                   Prims.op_Hat uu____12025 " not found"  in
-                 Prims.op_Hat "Universe variable " uu____12023  in
-               failwith uu____12021)
+              (let uu____12027 =
+                 let uu____12029 =
+                   let uu____12031 = FStar_Syntax_Print.univ_to_string u2  in
+                   Prims.op_Hat uu____12031 " not found"  in
+                 Prims.op_Hat "Universe variable " uu____12029  in
+               failwith uu____12027)
          in
       if env.FStar_TypeChecker_Env.lax_universes
       then FStar_Syntax_Syntax.U_zero
       else
         (match u with
          | FStar_Syntax_Syntax.U_unknown  ->
-             let uu____12032 = FStar_Syntax_Util.type_u ()  in
-             FStar_All.pipe_right uu____12032 FStar_Pervasives_Native.snd
-         | uu____12041 -> aux u)
+             let uu____12038 = FStar_Syntax_Util.type_u ()  in
+             FStar_All.pipe_right uu____12038 FStar_Pervasives_Native.snd
+         | uu____12047 -> aux u)
 
 and (tc_abs :
   FStar_TypeChecker_Env.env ->
@@ -4291,15 +4296,15 @@ and (tc_abs :
       fun bs  ->
         fun body  ->
           let fail msg t =
-            let uu____12072 =
+            let uu____12078 =
               FStar_TypeChecker_Err.expected_a_term_of_type_t_got_a_function
                 env msg t top
                in
-            FStar_Errors.raise_error uu____12072 top.FStar_Syntax_Syntax.pos
+            FStar_Errors.raise_error uu____12078 top.FStar_Syntax_Syntax.pos
              in
           let check_binders env1 bs1 bs_expected =
-            let rec aux uu____12161 bs2 bs_expected1 =
-              match uu____12161 with
+            let rec aux uu____12167 bs2 bs_expected1 =
+              match uu____12167 with
               | (env2,subst) ->
                   (match (bs2, bs_expected1) with
                    | ([],[]) ->
@@ -4310,102 +4315,102 @@ and (tc_abs :
                            match (q1, q2) with
                            | (FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Meta
-                              uu____12352),FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Meta uu____12353)) -> true
+                              uu____12358),FStar_Pervasives_Native.Some
+                              (FStar_Syntax_Syntax.Meta uu____12359)) -> true
                            | (FStar_Pervasives_Native.None
                               ,FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Equality )) -> true
                            | (FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Implicit
-                              uu____12368),FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Meta uu____12369)) -> true
-                           | uu____12378 -> false  in
-                         let uu____12388 =
+                              uu____12374),FStar_Pervasives_Native.Some
+                              (FStar_Syntax_Syntax.Meta uu____12375)) -> true
+                           | uu____12384 -> false  in
+                         let uu____12394 =
                            (Prims.op_Negation (special imp imp')) &&
-                             (let uu____12391 =
+                             (let uu____12397 =
                                 FStar_Syntax_Util.eq_aqual imp imp'  in
-                              uu____12391 <> FStar_Syntax_Util.Equal)
+                              uu____12397 <> FStar_Syntax_Util.Equal)
                             in
-                         if uu____12388
+                         if uu____12394
                          then
-                           let uu____12393 =
-                             let uu____12399 =
-                               let uu____12401 =
+                           let uu____12399 =
+                             let uu____12405 =
+                               let uu____12407 =
                                  FStar_Syntax_Print.bv_to_string hd  in
                                FStar_Util.format1
                                  "Inconsistent implicit argument annotation on argument %s"
-                                 uu____12401
+                                 uu____12407
                                 in
                              (FStar_Errors.Fatal_InconsistentImplicitArgumentAnnotation,
-                               uu____12399)
+                               uu____12405)
                               in
-                           let uu____12405 =
+                           let uu____12411 =
                              FStar_Syntax_Syntax.range_of_bv hd  in
-                           FStar_Errors.raise_error uu____12393 uu____12405
+                           FStar_Errors.raise_error uu____12399 uu____12411
                          else ());
                         (let expected_t =
                            FStar_Syntax_Subst.subst subst
                              hd_expected.FStar_Syntax_Syntax.sort
                             in
-                         let uu____12409 =
-                           let uu____12416 =
-                             let uu____12417 =
+                         let uu____12415 =
+                           let uu____12422 =
+                             let uu____12423 =
                                FStar_Syntax_Util.unmeta
                                  hd.FStar_Syntax_Syntax.sort
                                 in
-                             uu____12417.FStar_Syntax_Syntax.n  in
-                           match uu____12416 with
+                             uu____12423.FStar_Syntax_Syntax.n  in
+                           match uu____12422 with
                            | FStar_Syntax_Syntax.Tm_unknown  ->
                                (expected_t,
                                  FStar_TypeChecker_Env.trivial_guard)
-                           | uu____12428 ->
-                               ((let uu____12430 =
+                           | uu____12434 ->
+                               ((let uu____12436 =
                                    FStar_TypeChecker_Env.debug env2
                                      FStar_Options.High
                                     in
-                                 if uu____12430
+                                 if uu____12436
                                  then
-                                   let uu____12433 =
+                                   let uu____12439 =
                                      FStar_Syntax_Print.bv_to_string hd  in
                                    FStar_Util.print1 "Checking binder %s\n"
-                                     uu____12433
+                                     uu____12439
                                  else ());
-                                (let uu____12438 =
+                                (let uu____12444 =
                                    tc_tot_or_gtot_term env2
                                      hd.FStar_Syntax_Syntax.sort
                                     in
-                                 match uu____12438 with
-                                 | (t,uu____12452,g1_env) ->
+                                 match uu____12444 with
+                                 | (t,uu____12458,g1_env) ->
                                      let g2_env =
-                                       let uu____12455 =
+                                       let uu____12461 =
                                          FStar_TypeChecker_Rel.teq_nosmt env2
                                            t expected_t
                                           in
-                                       match uu____12455 with
+                                       match uu____12461 with
                                        | FStar_Pervasives_Native.Some g ->
                                            FStar_All.pipe_right g
                                              (FStar_TypeChecker_Rel.resolve_implicits
                                                 env2)
                                        | FStar_Pervasives_Native.None  ->
-                                           let uu____12459 =
+                                           let uu____12465 =
                                              FStar_TypeChecker_Rel.get_subtyping_prop
                                                env2 expected_t t
                                               in
-                                           (match uu____12459 with
+                                           (match uu____12465 with
                                             | FStar_Pervasives_Native.None 
                                                 ->
-                                                let uu____12462 =
+                                                let uu____12468 =
                                                   FStar_TypeChecker_Err.basic_type_error
                                                     env2
                                                     FStar_Pervasives_Native.None
                                                     expected_t t
                                                    in
-                                                let uu____12468 =
+                                                let uu____12474 =
                                                   FStar_TypeChecker_Env.get_range
                                                     env2
                                                    in
                                                 FStar_Errors.raise_error
-                                                  uu____12462 uu____12468
+                                                  uu____12468 uu____12474
                                             | FStar_Pervasives_Native.Some
                                                 g_env ->
                                                 FStar_TypeChecker_Util.label_guard
@@ -4413,45 +4418,45 @@ and (tc_abs :
                                                   "Type annotation on parameter incompatible with the expected type"
                                                   g_env)
                                         in
-                                     let uu____12471 =
+                                     let uu____12477 =
                                        FStar_TypeChecker_Env.conj_guard
                                          g1_env g2_env
                                         in
-                                     (t, uu____12471)))
+                                     (t, uu____12477)))
                             in
-                         match uu____12409 with
+                         match uu____12415 with
                          | (t,g_env) ->
                              let hd1 =
-                               let uu___1760_12497 = hd  in
+                               let uu___1760_12503 = hd  in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1760_12497.FStar_Syntax_Syntax.ppname);
+                                   (uu___1760_12503.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1760_12497.FStar_Syntax_Syntax.index);
+                                   (uu___1760_12503.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = t
                                }  in
                              let b = (hd1, imp)  in
                              let b_expected = (hd_expected, imp')  in
                              let env_b = push_binding env2 b  in
                              let subst1 =
-                               let uu____12520 =
+                               let uu____12526 =
                                  FStar_Syntax_Syntax.bv_to_name hd1  in
                                maybe_extend_subst subst b_expected
-                                 uu____12520
+                                 uu____12526
                                 in
-                             let uu____12523 =
+                             let uu____12529 =
                                aux (env_b, subst1) bs3 bs_expected2  in
-                             (match uu____12523 with
+                             (match uu____12529 with
                               | (env_bs,bs4,rest,g'_env_b,subst2) ->
                                   let g'_env =
                                     FStar_TypeChecker_Env.close_guard env_bs
                                       [b] g'_env_b
                                      in
-                                  let uu____12588 =
+                                  let uu____12594 =
                                     FStar_TypeChecker_Env.conj_guard g_env
                                       g'_env
                                      in
-                                  (env_bs, (b :: bs4), rest, uu____12588,
+                                  (env_bs, (b :: bs4), rest, uu____12594,
                                     subst2))))
                    | (rest,[]) ->
                        (env2, [],
@@ -4468,101 +4473,101 @@ and (tc_abs :
             | FStar_Pervasives_Native.None  ->
                 ((match env1.FStar_TypeChecker_Env.letrecs with
                   | [] -> ()
-                  | uu____12760 ->
+                  | uu____12766 ->
                       failwith
                         "Impossible: Can't have a let rec annotation but no expected type");
-                 (let uu____12770 = tc_binders env1 bs  in
-                  match uu____12770 with
-                  | (bs1,envbody,g_env,uu____12800) ->
+                 (let uu____12776 = tc_binders env1 bs  in
+                  match uu____12776 with
+                  | (bs1,envbody,g_env,uu____12806) ->
                       (FStar_Pervasives_Native.None, bs1, [],
                         FStar_Pervasives_Native.None, envbody, body1, g_env)))
             | FStar_Pervasives_Native.Some t ->
                 let t1 = FStar_Syntax_Subst.compress t  in
                 let rec as_function_typ norm1 t2 =
-                  let uu____12856 =
-                    let uu____12857 = FStar_Syntax_Subst.compress t2  in
-                    uu____12857.FStar_Syntax_Syntax.n  in
-                  match uu____12856 with
-                  | FStar_Syntax_Syntax.Tm_uvar uu____12890 ->
+                  let uu____12862 =
+                    let uu____12863 = FStar_Syntax_Subst.compress t2  in
+                    uu____12863.FStar_Syntax_Syntax.n  in
+                  match uu____12862 with
+                  | FStar_Syntax_Syntax.Tm_uvar uu____12896 ->
                       ((match env1.FStar_TypeChecker_Env.letrecs with
                         | [] -> ()
-                        | uu____12910 -> failwith "Impossible");
-                       (let uu____12920 = tc_binders env1 bs  in
-                        match uu____12920 with
-                        | (bs1,envbody,g_env,uu____12962) ->
-                            let uu____12963 =
+                        | uu____12916 -> failwith "Impossible");
+                       (let uu____12926 = tc_binders env1 bs  in
+                        match uu____12926 with
+                        | (bs1,envbody,g_env,uu____12968) ->
+                            let uu____12969 =
                               FStar_TypeChecker_Env.clear_expected_typ
                                 envbody
                                in
-                            (match uu____12963 with
-                             | (envbody1,uu____13001) ->
+                            (match uu____12969 with
+                             | (envbody1,uu____13007) ->
                                  ((FStar_Pervasives_Native.Some t2), bs1, [],
                                    FStar_Pervasives_Native.None, envbody1,
                                    body1, g_env))))
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                           uu____13022;
-                         FStar_Syntax_Syntax.pos = uu____13023;
-                         FStar_Syntax_Syntax.vars = uu____13024;_},uu____13025)
+                           uu____13028;
+                         FStar_Syntax_Syntax.pos = uu____13029;
+                         FStar_Syntax_Syntax.vars = uu____13030;_},uu____13031)
                       ->
                       ((match env1.FStar_TypeChecker_Env.letrecs with
                         | [] -> ()
-                        | uu____13069 -> failwith "Impossible");
-                       (let uu____13079 = tc_binders env1 bs  in
-                        match uu____13079 with
-                        | (bs1,envbody,g_env,uu____13121) ->
-                            let uu____13122 =
+                        | uu____13075 -> failwith "Impossible");
+                       (let uu____13085 = tc_binders env1 bs  in
+                        match uu____13085 with
+                        | (bs1,envbody,g_env,uu____13127) ->
+                            let uu____13128 =
                               FStar_TypeChecker_Env.clear_expected_typ
                                 envbody
                                in
-                            (match uu____13122 with
-                             | (envbody1,uu____13160) ->
+                            (match uu____13128 with
+                             | (envbody1,uu____13166) ->
                                  ((FStar_Pervasives_Native.Some t2), bs1, [],
                                    FStar_Pervasives_Native.None, envbody1,
                                    body1, g_env))))
-                  | FStar_Syntax_Syntax.Tm_refine (b,uu____13182) ->
-                      let uu____13187 =
+                  | FStar_Syntax_Syntax.Tm_refine (b,uu____13188) ->
+                      let uu____13193 =
                         as_function_typ norm1 b.FStar_Syntax_Syntax.sort  in
-                      (match uu____13187 with
-                       | (uu____13248,bs1,bs',copt,env_body,body2,g_env) ->
+                      (match uu____13193 with
+                       | (uu____13254,bs1,bs',copt,env_body,body2,g_env) ->
                            ((FStar_Pervasives_Native.Some t2), bs1, bs',
                              copt, env_body, body2, g_env))
                   | FStar_Syntax_Syntax.Tm_arrow (bs_expected,c_expected) ->
-                      let uu____13325 =
+                      let uu____13331 =
                         FStar_Syntax_Subst.open_comp bs_expected c_expected
                          in
-                      (match uu____13325 with
+                      (match uu____13331 with
                        | (bs_expected1,c_expected1) ->
                            let check_actuals_against_formals env2 bs1
                              bs_expected2 body2 =
-                             let rec handle_more uu____13470 c_expected2
+                             let rec handle_more uu____13476 c_expected2
                                body3 =
-                               match uu____13470 with
+                               match uu____13476 with
                                | (env_bs,bs2,more,guard_env,subst) ->
                                    (match more with
                                     | FStar_Pervasives_Native.None  ->
-                                        let uu____13584 =
+                                        let uu____13590 =
                                           FStar_Syntax_Subst.subst_comp subst
                                             c_expected2
                                            in
-                                        (env_bs, bs2, guard_env, uu____13584,
+                                        (env_bs, bs2, guard_env, uu____13590,
                                           body3)
                                     | FStar_Pervasives_Native.Some
                                         (FStar_Util.Inr more_bs_expected) ->
                                         let c =
-                                          let uu____13601 =
+                                          let uu____13607 =
                                             FStar_Syntax_Util.arrow
                                               more_bs_expected c_expected2
                                              in
                                           FStar_Syntax_Syntax.mk_Total
-                                            uu____13601
+                                            uu____13607
                                            in
-                                        let uu____13602 =
+                                        let uu____13608 =
                                           FStar_Syntax_Subst.subst_comp subst
                                             c
                                            in
-                                        (env_bs, bs2, guard_env, uu____13602,
+                                        (env_bs, bs2, guard_env, uu____13608,
                                           body3)
                                     | FStar_Pervasives_Native.Some
                                         (FStar_Util.Inl more_bs) ->
@@ -4570,11 +4575,11 @@ and (tc_abs :
                                           FStar_Syntax_Subst.subst_comp subst
                                             c_expected2
                                            in
-                                        let uu____13619 =
+                                        let uu____13625 =
                                           (FStar_Options.ml_ish ()) ||
                                             (FStar_Syntax_Util.is_named_tot c)
                                            in
-                                        if uu____13619
+                                        if uu____13625
                                         then
                                           let t3 =
                                             FStar_TypeChecker_Normalize.unfold_whnf
@@ -4586,18 +4591,18 @@ and (tc_abs :
                                            with
                                            | FStar_Syntax_Syntax.Tm_arrow
                                                (bs_expected3,c_expected3) ->
-                                               let uu____13685 =
+                                               let uu____13691 =
                                                  FStar_Syntax_Subst.open_comp
                                                    bs_expected3 c_expected3
                                                   in
-                                               (match uu____13685 with
+                                               (match uu____13691 with
                                                 | (bs_expected4,c_expected4)
                                                     ->
-                                                    let uu____13712 =
+                                                    let uu____13718 =
                                                       check_binders env_bs
                                                         more_bs bs_expected4
                                                        in
-                                                    (match uu____13712 with
+                                                    (match uu____13718 with
                                                      | (env_bs_bs',bs',more1,guard'_env_bs,subst1)
                                                          ->
                                                          let guard'_env =
@@ -4605,8 +4610,8 @@ and (tc_abs :
                                                              env_bs bs2
                                                              guard'_env_bs
                                                             in
-                                                         let uu____13767 =
-                                                           let uu____13794 =
+                                                         let uu____13773 =
+                                                           let uu____13800 =
                                                              FStar_TypeChecker_Env.conj_guard
                                                                guard_env
                                                                guard'_env
@@ -4615,13 +4620,13 @@ and (tc_abs :
                                                              (FStar_List.append
                                                                 bs2 bs'),
                                                              more1,
-                                                             uu____13794,
+                                                             uu____13800,
                                                              subst1)
                                                             in
                                                          handle_more
-                                                           uu____13767
+                                                           uu____13773
                                                            c_expected4 body3))
-                                           | uu____13817 ->
+                                           | uu____13823 ->
                                                let body4 =
                                                  FStar_Syntax_Util.abs
                                                    more_bs body3
@@ -4637,131 +4642,131 @@ and (tc_abs :
                                               in
                                            (env_bs, bs2, guard_env, c, body4)))
                                 in
-                             let uu____13846 =
+                             let uu____13852 =
                                check_binders env2 bs1 bs_expected2  in
-                             handle_more uu____13846 c_expected1 body2  in
+                             handle_more uu____13852 c_expected1 body2  in
                            let mk_letrec_env envbody bs1 c =
                              let letrecs = guard_letrecs envbody bs1 c  in
                              let envbody1 =
-                               let uu___1886_13911 = envbody  in
+                               let uu___1886_13917 = envbody  in
                                {
                                  FStar_TypeChecker_Env.solver =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.solver);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.solver);
                                  FStar_TypeChecker_Env.range =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.range);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.range);
                                  FStar_TypeChecker_Env.curmodule =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.curmodule);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.curmodule);
                                  FStar_TypeChecker_Env.gamma =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.gamma);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.gamma);
                                  FStar_TypeChecker_Env.gamma_sig =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.gamma_sig);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.gamma_sig);
                                  FStar_TypeChecker_Env.gamma_cache =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.gamma_cache);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.gamma_cache);
                                  FStar_TypeChecker_Env.modules =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.modules);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.modules);
                                  FStar_TypeChecker_Env.expected_typ =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.expected_typ);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.expected_typ);
                                  FStar_TypeChecker_Env.sigtab =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.sigtab);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.sigtab);
                                  FStar_TypeChecker_Env.attrtab =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.attrtab);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.attrtab);
                                  FStar_TypeChecker_Env.instantiate_imp =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.instantiate_imp);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.instantiate_imp);
                                  FStar_TypeChecker_Env.effects =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.effects);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.effects);
                                  FStar_TypeChecker_Env.generalize =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.generalize);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.generalize);
                                  FStar_TypeChecker_Env.letrecs = [];
                                  FStar_TypeChecker_Env.top_level =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.top_level);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.top_level);
                                  FStar_TypeChecker_Env.check_uvars =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.check_uvars);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.check_uvars);
                                  FStar_TypeChecker_Env.use_eq =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.use_eq);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.use_eq);
                                  FStar_TypeChecker_Env.use_eq_strict =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.use_eq_strict);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.use_eq_strict);
                                  FStar_TypeChecker_Env.is_iface =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.is_iface);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.is_iface);
                                  FStar_TypeChecker_Env.admit =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.admit);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.admit);
                                  FStar_TypeChecker_Env.lax =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.lax);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.lax);
                                  FStar_TypeChecker_Env.lax_universes =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.lax_universes);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.lax_universes);
                                  FStar_TypeChecker_Env.phase1 =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.phase1);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.phase1);
                                  FStar_TypeChecker_Env.failhard =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.failhard);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.failhard);
                                  FStar_TypeChecker_Env.nosynth =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.nosynth);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.nosynth);
                                  FStar_TypeChecker_Env.uvar_subtyping =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.uvar_subtyping);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.uvar_subtyping);
                                  FStar_TypeChecker_Env.tc_term =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.tc_term);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.tc_term);
                                  FStar_TypeChecker_Env.type_of =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.type_of);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.type_of);
                                  FStar_TypeChecker_Env.universe_of =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.universe_of);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.universe_of);
                                  FStar_TypeChecker_Env.check_type_of =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.check_type_of);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.check_type_of);
                                  FStar_TypeChecker_Env.use_bv_sorts =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.use_bv_sorts);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.use_bv_sorts);
                                  FStar_TypeChecker_Env.qtbl_name_and_index =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.qtbl_name_and_index);
                                  FStar_TypeChecker_Env.normalized_eff_names =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.normalized_eff_names);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.normalized_eff_names);
                                  FStar_TypeChecker_Env.fv_delta_depths =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.fv_delta_depths);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.fv_delta_depths);
                                  FStar_TypeChecker_Env.proof_ns =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.proof_ns);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.proof_ns);
                                  FStar_TypeChecker_Env.synth_hook =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.synth_hook);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.synth_hook);
                                  FStar_TypeChecker_Env.try_solve_implicits_hook
                                    =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                  FStar_TypeChecker_Env.splice =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.splice);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.splice);
                                  FStar_TypeChecker_Env.mpreprocess =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.mpreprocess);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.mpreprocess);
                                  FStar_TypeChecker_Env.postprocess =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.postprocess);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.postprocess);
                                  FStar_TypeChecker_Env.is_native_tactic =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.is_native_tactic);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.is_native_tactic);
                                  FStar_TypeChecker_Env.identifier_info =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.identifier_info);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.identifier_info);
                                  FStar_TypeChecker_Env.tc_hooks =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.tc_hooks);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.tc_hooks);
                                  FStar_TypeChecker_Env.dsenv =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.dsenv);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.dsenv);
                                  FStar_TypeChecker_Env.nbe =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.nbe);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.nbe);
                                  FStar_TypeChecker_Env.strict_args_tab =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.strict_args_tab);
+                                   (uu___1886_13917.FStar_TypeChecker_Env.strict_args_tab);
                                  FStar_TypeChecker_Env.erasable_types_tab =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.erasable_types_tab)
+                                   (uu___1886_13917.FStar_TypeChecker_Env.erasable_types_tab)
                                }  in
-                             let uu____13918 =
+                             let uu____13924 =
                                FStar_All.pipe_right letrecs
                                  (FStar_List.fold_left
-                                    (fun uu____13984  ->
-                                       fun uu____13985  ->
-                                         match (uu____13984, uu____13985)
+                                    (fun uu____13990  ->
+                                       fun uu____13991  ->
+                                         match (uu____13990, uu____13991)
                                          with
                                          | ((env2,letrec_binders,g),(l,t3,u_names))
                                              ->
-                                             let uu____14076 =
-                                               let uu____14083 =
-                                                 let uu____14084 =
+                                             let uu____14082 =
+                                               let uu____14089 =
+                                                 let uu____14090 =
                                                    FStar_TypeChecker_Env.clear_expected_typ
                                                      env2
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____14084
+                                                   uu____14090
                                                    FStar_Pervasives_Native.fst
                                                   in
-                                               tc_term uu____14083 t3  in
-                                             (match uu____14076 with
-                                              | (t4,uu____14108,g') ->
+                                               tc_term uu____14089 t3  in
+                                             (match uu____14082 with
+                                              | (t4,uu____14114,g') ->
                                                   let env3 =
                                                     FStar_TypeChecker_Env.push_let_binding
                                                       env2 l (u_names, t4)
@@ -4769,84 +4774,84 @@ and (tc_abs :
                                                   let lb =
                                                     match l with
                                                     | FStar_Util.Inl x ->
-                                                        let uu____14121 =
+                                                        let uu____14127 =
                                                           FStar_Syntax_Syntax.mk_binder
-                                                            (let uu___1904_14124
+                                                            (let uu___1904_14130
                                                                = x  in
                                                              {
                                                                FStar_Syntax_Syntax.ppname
                                                                  =
-                                                                 (uu___1904_14124.FStar_Syntax_Syntax.ppname);
+                                                                 (uu___1904_14130.FStar_Syntax_Syntax.ppname);
                                                                FStar_Syntax_Syntax.index
                                                                  =
-                                                                 (uu___1904_14124.FStar_Syntax_Syntax.index);
+                                                                 (uu___1904_14130.FStar_Syntax_Syntax.index);
                                                                FStar_Syntax_Syntax.sort
                                                                  = t4
                                                              })
                                                            in
-                                                        uu____14121 ::
+                                                        uu____14127 ::
                                                           letrec_binders
-                                                    | uu____14125 ->
+                                                    | uu____14131 ->
                                                         letrec_binders
                                                      in
-                                                  let uu____14130 =
+                                                  let uu____14136 =
                                                     FStar_TypeChecker_Env.conj_guard
                                                       g g'
                                                      in
-                                                  (env3, lb, uu____14130)))
+                                                  (env3, lb, uu____14136)))
                                     (envbody1, [],
                                       FStar_TypeChecker_Env.trivial_guard))
                                 in
-                             match uu____13918 with
+                             match uu____13924 with
                              | (envbody2,letrec_binders,g) ->
-                                 let uu____14150 =
+                                 let uu____14156 =
                                    FStar_TypeChecker_Env.close_guard envbody2
                                      bs1 g
                                     in
-                                 (envbody2, letrec_binders, uu____14150)
+                                 (envbody2, letrec_binders, uu____14156)
                               in
-                           let uu____14153 =
+                           let uu____14159 =
                              check_actuals_against_formals env1 bs
                                bs_expected1 body1
                               in
-                           (match uu____14153 with
+                           (match uu____14159 with
                             | (envbody,bs1,g_env,c,body2) ->
-                                let uu____14229 = mk_letrec_env envbody bs1 c
+                                let uu____14235 = mk_letrec_env envbody bs1 c
                                    in
-                                (match uu____14229 with
+                                (match uu____14235 with
                                  | (envbody1,letrecs,g_annots) ->
                                      let envbody2 =
                                        FStar_TypeChecker_Env.set_expected_typ
                                          envbody1
                                          (FStar_Syntax_Util.comp_result c)
                                         in
-                                     let uu____14276 =
+                                     let uu____14282 =
                                        FStar_TypeChecker_Env.conj_guard g_env
                                          g_annots
                                         in
                                      ((FStar_Pervasives_Native.Some t2), bs1,
                                        letrecs,
                                        (FStar_Pervasives_Native.Some c),
-                                       envbody2, body2, uu____14276))))
-                  | uu____14293 ->
+                                       envbody2, body2, uu____14282))))
+                  | uu____14299 ->
                       if Prims.op_Negation norm1
                       then
-                        let uu____14325 =
-                          let uu____14326 =
+                        let uu____14331 =
+                          let uu____14332 =
                             FStar_All.pipe_right t2
                               (FStar_TypeChecker_Normalize.unfold_whnf env1)
                              in
-                          FStar_All.pipe_right uu____14326
+                          FStar_All.pipe_right uu____14332
                             FStar_Syntax_Util.unascribe
                            in
-                        as_function_typ true uu____14325
+                        as_function_typ true uu____14331
                       else
-                        (let uu____14330 =
+                        (let uu____14336 =
                            expected_function_typ env1
                              FStar_Pervasives_Native.None body1
                             in
-                         match uu____14330 with
-                         | (uu____14379,bs1,uu____14381,c_opt,envbody,body2,g_env)
+                         match uu____14336 with
+                         | (uu____14385,bs1,uu____14387,c_opt,envbody,body2,g_env)
                              ->
                              ((FStar_Pervasives_Native.Some t2), bs1, [],
                                c_opt, envbody, body2, g_env))
@@ -4854,14 +4859,14 @@ and (tc_abs :
                 as_function_typ false t1
              in
           let use_eq = env.FStar_TypeChecker_Env.use_eq  in
-          let uu____14413 = FStar_TypeChecker_Env.clear_expected_typ env  in
-          match uu____14413 with
+          let uu____14419 = FStar_TypeChecker_Env.clear_expected_typ env  in
+          match uu____14419 with
           | (env1,topt) ->
-              ((let uu____14433 =
+              ((let uu____14439 =
                   FStar_TypeChecker_Env.debug env1 FStar_Options.High  in
-                if uu____14433
+                if uu____14439
                 then
-                  let uu____14436 =
+                  let uu____14442 =
                     match topt with
                     | FStar_Pervasives_Native.None  -> "None"
                     | FStar_Pervasives_Native.Some t ->
@@ -4869,179 +4874,179 @@ and (tc_abs :
                      in
                   FStar_Util.print2
                     "!!!!!!!!!!!!!!!Expected type is %s, top_level=%s\n"
-                    uu____14436
+                    uu____14442
                     (if env1.FStar_TypeChecker_Env.top_level
                      then "true"
                      else "false")
                 else ());
-               (let uu____14450 = expected_function_typ env1 topt body  in
-                match uu____14450 with
+               (let uu____14456 = expected_function_typ env1 topt body  in
+                match uu____14456 with
                 | (tfun_opt,bs1,letrec_binders,c_opt,envbody,body1,g_env) ->
-                    ((let uu____14491 =
+                    ((let uu____14497 =
                         FStar_TypeChecker_Env.debug env1
                           FStar_Options.Extreme
                          in
-                      if uu____14491
+                      if uu____14497
                       then
-                        let uu____14494 =
+                        let uu____14500 =
                           match tfun_opt with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t
                            in
-                        let uu____14499 =
+                        let uu____14505 =
                           match c_opt with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.comp_to_string t
                            in
-                        let uu____14504 =
-                          let uu____14506 =
+                        let uu____14510 =
+                          let uu____14512 =
                             FStar_TypeChecker_Env.expected_typ envbody  in
-                          match uu____14506 with
+                          match uu____14512 with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t
                            in
                         FStar_Util.print3
                           "After expected_function_typ, tfun_opt: %s, c_opt: %s, and expected type in envbody: %s\n"
-                          uu____14494 uu____14499 uu____14504
+                          uu____14500 uu____14505 uu____14510
                       else ());
-                     (let uu____14516 =
+                     (let uu____14522 =
                         FStar_All.pipe_left
                           (FStar_TypeChecker_Env.debug env1)
                           (FStar_Options.Other "NYC")
                          in
-                      if uu____14516
+                      if uu____14522
                       then
-                        let uu____14521 =
+                        let uu____14527 =
                           FStar_Syntax_Print.binders_to_string ", " bs1  in
-                        let uu____14524 =
+                        let uu____14530 =
                           FStar_TypeChecker_Rel.guard_to_string env1 g_env
                            in
                         FStar_Util.print2
                           "!!!!!!!!!!!!!!!Guard for function with binders %s is %s\n"
-                          uu____14521 uu____14524
+                          uu____14527 uu____14530
                       else ());
                      (let envbody1 =
                         FStar_TypeChecker_Env.set_range envbody
                           body1.FStar_Syntax_Syntax.pos
                          in
-                      let uu____14530 =
+                      let uu____14536 =
                         let should_check_expected_effect =
-                          let uu____14543 =
-                            let uu____14550 =
-                              let uu____14551 =
+                          let uu____14549 =
+                            let uu____14556 =
+                              let uu____14557 =
                                 FStar_Syntax_Subst.compress body1  in
-                              uu____14551.FStar_Syntax_Syntax.n  in
-                            (c_opt, uu____14550)  in
-                          match uu____14543 with
+                              uu____14557.FStar_Syntax_Syntax.n  in
+                            (c_opt, uu____14556)  in
+                          match uu____14549 with
                           | (FStar_Pervasives_Native.None
                              ,FStar_Syntax_Syntax.Tm_ascribed
-                             (uu____14557,(FStar_Util.Inr
-                                           expected_c,uu____14559),uu____14560))
+                             (uu____14563,(FStar_Util.Inr
+                                           expected_c,uu____14565),uu____14566))
                               -> false
-                          | uu____14610 -> true  in
-                        let uu____14618 =
+                          | uu____14616 -> true  in
+                        let uu____14624 =
                           tc_term
-                            (let uu___1977_14627 = envbody1  in
+                            (let uu___1977_14633 = envbody1  in
                              {
                                FStar_TypeChecker_Env.solver =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.solver);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.solver);
                                FStar_TypeChecker_Env.range =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.range);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.range);
                                FStar_TypeChecker_Env.curmodule =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.curmodule);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.curmodule);
                                FStar_TypeChecker_Env.gamma =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.gamma);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.gamma);
                                FStar_TypeChecker_Env.gamma_sig =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.gamma_sig);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.gamma_sig);
                                FStar_TypeChecker_Env.gamma_cache =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.gamma_cache);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.gamma_cache);
                                FStar_TypeChecker_Env.modules =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.modules);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.modules);
                                FStar_TypeChecker_Env.expected_typ =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.expected_typ);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.expected_typ);
                                FStar_TypeChecker_Env.sigtab =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.sigtab);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.sigtab);
                                FStar_TypeChecker_Env.attrtab =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.attrtab);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.attrtab);
                                FStar_TypeChecker_Env.instantiate_imp =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.instantiate_imp);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.instantiate_imp);
                                FStar_TypeChecker_Env.effects =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.effects);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.effects);
                                FStar_TypeChecker_Env.generalize =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.generalize);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.generalize);
                                FStar_TypeChecker_Env.letrecs =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.letrecs);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.letrecs);
                                FStar_TypeChecker_Env.top_level = false;
                                FStar_TypeChecker_Env.check_uvars =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.check_uvars);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.check_uvars);
                                FStar_TypeChecker_Env.use_eq = use_eq;
                                FStar_TypeChecker_Env.use_eq_strict =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.use_eq_strict);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.use_eq_strict);
                                FStar_TypeChecker_Env.is_iface =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.is_iface);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.is_iface);
                                FStar_TypeChecker_Env.admit =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.admit);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.admit);
                                FStar_TypeChecker_Env.lax =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.lax);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.lax);
                                FStar_TypeChecker_Env.lax_universes =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.lax_universes);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.lax_universes);
                                FStar_TypeChecker_Env.phase1 =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.phase1);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.phase1);
                                FStar_TypeChecker_Env.failhard =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.failhard);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.failhard);
                                FStar_TypeChecker_Env.nosynth =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.nosynth);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.nosynth);
                                FStar_TypeChecker_Env.uvar_subtyping =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.uvar_subtyping);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.uvar_subtyping);
                                FStar_TypeChecker_Env.tc_term =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.tc_term);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.tc_term);
                                FStar_TypeChecker_Env.type_of =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.type_of);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.type_of);
                                FStar_TypeChecker_Env.universe_of =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.universe_of);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.universe_of);
                                FStar_TypeChecker_Env.check_type_of =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.check_type_of);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.check_type_of);
                                FStar_TypeChecker_Env.use_bv_sorts =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.use_bv_sorts);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.use_bv_sorts);
                                FStar_TypeChecker_Env.qtbl_name_and_index =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.qtbl_name_and_index);
                                FStar_TypeChecker_Env.normalized_eff_names =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.normalized_eff_names);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.normalized_eff_names);
                                FStar_TypeChecker_Env.fv_delta_depths =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.fv_delta_depths);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.fv_delta_depths);
                                FStar_TypeChecker_Env.proof_ns =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.proof_ns);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.proof_ns);
                                FStar_TypeChecker_Env.synth_hook =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.synth_hook);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.synth_hook);
                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                  =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                FStar_TypeChecker_Env.splice =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.splice);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.splice);
                                FStar_TypeChecker_Env.mpreprocess =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.mpreprocess);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.mpreprocess);
                                FStar_TypeChecker_Env.postprocess =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.postprocess);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.postprocess);
                                FStar_TypeChecker_Env.is_native_tactic =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.is_native_tactic);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.is_native_tactic);
                                FStar_TypeChecker_Env.identifier_info =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.identifier_info);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.identifier_info);
                                FStar_TypeChecker_Env.tc_hooks =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.tc_hooks);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.tc_hooks);
                                FStar_TypeChecker_Env.dsenv =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.dsenv);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.dsenv);
                                FStar_TypeChecker_Env.nbe =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.nbe);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.nbe);
                                FStar_TypeChecker_Env.strict_args_tab =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.strict_args_tab);
+                                 (uu___1977_14633.FStar_TypeChecker_Env.strict_args_tab);
                                FStar_TypeChecker_Env.erasable_types_tab =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.erasable_types_tab)
+                                 (uu___1977_14633.FStar_TypeChecker_Env.erasable_types_tab)
                              }) body1
                            in
-                        match uu____14618 with
+                        match uu____14624 with
                         | (body2,cbody,guard_body) ->
                             let guard_body1 =
                               FStar_TypeChecker_Rel.solve_deferred_constraints
@@ -5049,179 +5054,179 @@ and (tc_abs :
                                in
                             if should_check_expected_effect
                             then
-                              let uu____14654 =
+                              let uu____14660 =
                                 FStar_TypeChecker_Common.lcomp_comp cbody  in
-                              (match uu____14654 with
+                              (match uu____14660 with
                                | (cbody1,g_lc) ->
-                                   let uu____14671 =
+                                   let uu____14677 =
                                      check_expected_effect
-                                       (let uu___1988_14680 = envbody1  in
+                                       (let uu___1988_14686 = envbody1  in
                                         {
                                           FStar_TypeChecker_Env.solver =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.solver);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.solver);
                                           FStar_TypeChecker_Env.range =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.range);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.range);
                                           FStar_TypeChecker_Env.curmodule =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.curmodule);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.curmodule);
                                           FStar_TypeChecker_Env.gamma =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.gamma);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.gamma);
                                           FStar_TypeChecker_Env.gamma_sig =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.gamma_sig);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.gamma_sig);
                                           FStar_TypeChecker_Env.gamma_cache =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.gamma_cache);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.gamma_cache);
                                           FStar_TypeChecker_Env.modules =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.modules);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.modules);
                                           FStar_TypeChecker_Env.expected_typ
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.expected_typ);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.expected_typ);
                                           FStar_TypeChecker_Env.sigtab =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.sigtab);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.sigtab);
                                           FStar_TypeChecker_Env.attrtab =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.attrtab);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.attrtab);
                                           FStar_TypeChecker_Env.instantiate_imp
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.instantiate_imp);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.instantiate_imp);
                                           FStar_TypeChecker_Env.effects =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.effects);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.effects);
                                           FStar_TypeChecker_Env.generalize =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.generalize);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.generalize);
                                           FStar_TypeChecker_Env.letrecs =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.letrecs);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.letrecs);
                                           FStar_TypeChecker_Env.top_level =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.top_level);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.top_level);
                                           FStar_TypeChecker_Env.check_uvars =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.check_uvars);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.check_uvars);
                                           FStar_TypeChecker_Env.use_eq =
                                             use_eq;
                                           FStar_TypeChecker_Env.use_eq_strict
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.use_eq_strict);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.use_eq_strict);
                                           FStar_TypeChecker_Env.is_iface =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.is_iface);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.is_iface);
                                           FStar_TypeChecker_Env.admit =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.admit);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.admit);
                                           FStar_TypeChecker_Env.lax =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.lax);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.lax);
                                           FStar_TypeChecker_Env.lax_universes
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.lax_universes);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.lax_universes);
                                           FStar_TypeChecker_Env.phase1 =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.phase1);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.phase1);
                                           FStar_TypeChecker_Env.failhard =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.failhard);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.failhard);
                                           FStar_TypeChecker_Env.nosynth =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.nosynth);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.nosynth);
                                           FStar_TypeChecker_Env.uvar_subtyping
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.uvar_subtyping);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.uvar_subtyping);
                                           FStar_TypeChecker_Env.tc_term =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.tc_term);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.tc_term);
                                           FStar_TypeChecker_Env.type_of =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.type_of);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.type_of);
                                           FStar_TypeChecker_Env.universe_of =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.universe_of);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.universe_of);
                                           FStar_TypeChecker_Env.check_type_of
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.check_type_of);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.check_type_of);
                                           FStar_TypeChecker_Env.use_bv_sorts
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.use_bv_sorts);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.use_bv_sorts);
                                           FStar_TypeChecker_Env.qtbl_name_and_index
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.qtbl_name_and_index);
                                           FStar_TypeChecker_Env.normalized_eff_names
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.normalized_eff_names);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.normalized_eff_names);
                                           FStar_TypeChecker_Env.fv_delta_depths
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.fv_delta_depths);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.fv_delta_depths);
                                           FStar_TypeChecker_Env.proof_ns =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.proof_ns);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.proof_ns);
                                           FStar_TypeChecker_Env.synth_hook =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.synth_hook);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.synth_hook);
                                           FStar_TypeChecker_Env.try_solve_implicits_hook
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                           FStar_TypeChecker_Env.splice =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.splice);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.splice);
                                           FStar_TypeChecker_Env.mpreprocess =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.mpreprocess);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.mpreprocess);
                                           FStar_TypeChecker_Env.postprocess =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.postprocess);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.postprocess);
                                           FStar_TypeChecker_Env.is_native_tactic
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.is_native_tactic);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.is_native_tactic);
                                           FStar_TypeChecker_Env.identifier_info
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.identifier_info);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.identifier_info);
                                           FStar_TypeChecker_Env.tc_hooks =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.tc_hooks);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.tc_hooks);
                                           FStar_TypeChecker_Env.dsenv =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.dsenv);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.dsenv);
                                           FStar_TypeChecker_Env.nbe =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.nbe);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.nbe);
                                           FStar_TypeChecker_Env.strict_args_tab
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.strict_args_tab);
+                                            (uu___1988_14686.FStar_TypeChecker_Env.strict_args_tab);
                                           FStar_TypeChecker_Env.erasable_types_tab
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.erasable_types_tab)
+                                            (uu___1988_14686.FStar_TypeChecker_Env.erasable_types_tab)
                                         }) c_opt (body2, cbody1)
                                       in
-                                   (match uu____14671 with
+                                   (match uu____14677 with
                                     | (body3,cbody2,guard) ->
-                                        let uu____14694 =
-                                          let uu____14695 =
+                                        let uu____14700 =
+                                          let uu____14701 =
                                             FStar_TypeChecker_Env.conj_guard
                                               g_lc guard
                                              in
                                           FStar_TypeChecker_Env.conj_guard
-                                            guard_body1 uu____14695
+                                            guard_body1 uu____14701
                                            in
-                                        (body3, cbody2, uu____14694)))
+                                        (body3, cbody2, uu____14700)))
                             else
-                              (let uu____14702 =
+                              (let uu____14708 =
                                  FStar_TypeChecker_Common.lcomp_comp cbody
                                   in
-                               match uu____14702 with
+                               match uu____14708 with
                                | (cbody1,g_lc) ->
-                                   let uu____14719 =
+                                   let uu____14725 =
                                      FStar_TypeChecker_Env.conj_guard
                                        guard_body1 g_lc
                                       in
-                                   (body2, cbody1, uu____14719))
+                                   (body2, cbody1, uu____14725))
                          in
-                      match uu____14530 with
+                      match uu____14536 with
                       | (body2,cbody,guard_body) ->
                           let guard =
-                            let uu____14742 =
+                            let uu____14748 =
                               env1.FStar_TypeChecker_Env.top_level ||
-                                (let uu____14745 =
+                                (let uu____14751 =
                                    FStar_TypeChecker_Env.should_verify env1
                                     in
-                                 Prims.op_Negation uu____14745)
+                                 Prims.op_Negation uu____14751)
                                in
-                            if uu____14742
+                            if uu____14748
                             then
-                              let uu____14748 =
+                              let uu____14754 =
                                 FStar_TypeChecker_Rel.discharge_guard env1
                                   g_env
                                  in
-                              let uu____14749 =
+                              let uu____14755 =
                                 FStar_TypeChecker_Rel.discharge_guard
                                   envbody1 guard_body
                                  in
-                              FStar_TypeChecker_Env.conj_guard uu____14748
-                                uu____14749
+                              FStar_TypeChecker_Env.conj_guard uu____14754
+                                uu____14755
                             else
                               (let guard =
-                                 let uu____14753 =
+                                 let uu____14759 =
                                    FStar_TypeChecker_Env.close_guard env1
                                      (FStar_List.append bs1 letrec_binders)
                                      guard_body
                                     in
                                  FStar_TypeChecker_Env.conj_guard g_env
-                                   uu____14753
+                                   uu____14759
                                   in
                                guard)
                              in
@@ -5237,7 +5242,7 @@ and (tc_abs :
                                  (FStar_Syntax_Util.residual_comp_of_comp
                                     (FStar_Util.dflt cbody c_opt)))
                              in
-                          let uu____14768 =
+                          let uu____14774 =
                             match tfun_opt with
                             | FStar_Pervasives_Native.Some t ->
                                 let t1 = FStar_Syntax_Subst.compress t  in
@@ -5249,43 +5254,43 @@ and (tc_abs :
                                         "Impossible! tc_abs: if tfun_computed is Some, expected topt to also be Some"
                                    in
                                 (match t1.FStar_Syntax_Syntax.n with
-                                 | FStar_Syntax_Syntax.Tm_arrow uu____14792
+                                 | FStar_Syntax_Syntax.Tm_arrow uu____14798
                                      -> (e, t_annot, guard1)
-                                 | uu____14807 ->
+                                 | uu____14813 ->
                                      let lc =
-                                       let uu____14809 =
+                                       let uu____14815 =
                                          FStar_Syntax_Syntax.mk_Total
                                            tfun_computed
                                           in
-                                       FStar_All.pipe_right uu____14809
+                                       FStar_All.pipe_right uu____14815
                                          FStar_TypeChecker_Common.lcomp_of_comp
                                         in
-                                     let uu____14810 =
+                                     let uu____14816 =
                                        FStar_TypeChecker_Util.check_has_type
                                          env1 e lc t1
                                         in
-                                     (match uu____14810 with
-                                      | (e1,uu____14824,guard') ->
-                                          let uu____14826 =
+                                     (match uu____14816 with
+                                      | (e1,uu____14830,guard') ->
+                                          let uu____14832 =
                                             FStar_TypeChecker_Env.conj_guard
                                               guard1 guard'
                                              in
-                                          (e1, t_annot, uu____14826)))
+                                          (e1, t_annot, uu____14832)))
                             | FStar_Pervasives_Native.None  ->
                                 (e, tfun_computed, guard1)
                              in
-                          (match uu____14768 with
+                          (match uu____14774 with
                            | (e1,tfun,guard2) ->
                                let c = FStar_Syntax_Syntax.mk_Total tfun  in
-                               let uu____14837 =
-                                 let uu____14842 =
+                               let uu____14843 =
+                                 let uu____14848 =
                                    FStar_TypeChecker_Common.lcomp_of_comp c
                                     in
                                  FStar_TypeChecker_Util.strengthen_precondition
                                    FStar_Pervasives_Native.None env1 e1
-                                   uu____14842 guard2
+                                   uu____14848 guard2
                                   in
-                               (match uu____14837 with
+                               (match uu____14843 with
                                 | (c1,g) -> (e1, c1, g)))))))
 
 and (check_application_args :
@@ -5309,98 +5314,98 @@ and (check_application_args :
               let n_args = FStar_List.length args  in
               let r = FStar_TypeChecker_Env.get_range env  in
               let thead = FStar_Syntax_Util.comp_result chead  in
-              (let uu____14893 =
+              (let uu____14899 =
                  FStar_TypeChecker_Env.debug env FStar_Options.High  in
-               if uu____14893
+               if uu____14899
                then
-                 let uu____14896 =
+                 let uu____14902 =
                    FStar_Range.string_of_range head.FStar_Syntax_Syntax.pos
                     in
-                 let uu____14898 = FStar_Syntax_Print.term_to_string thead
+                 let uu____14904 = FStar_Syntax_Print.term_to_string thead
                     in
-                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____14896
-                   uu____14898
+                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____14902
+                   uu____14904
                else ());
-              (let monadic_application uu____14980 subst arg_comps_rev
+              (let monadic_application uu____14986 subst arg_comps_rev
                  arg_rets_rev guard fvs bs =
-                 match uu____14980 with
+                 match uu____14986 with
                  | (head1,chead1,ghead1,cres) ->
-                     let uu____15049 =
+                     let uu____15055 =
                        check_no_escape (FStar_Pervasives_Native.Some head1)
                          env fvs (FStar_Syntax_Util.comp_result cres)
                         in
-                     (match uu____15049 with
+                     (match uu____15055 with
                       | (rt,g0) ->
                           let cres1 =
                             FStar_Syntax_Util.set_result_typ cres rt  in
-                          let uu____15063 =
+                          let uu____15069 =
                             match bs with
                             | [] ->
                                 let g =
-                                  let uu____15079 =
+                                  let uu____15085 =
                                     FStar_TypeChecker_Env.conj_guard ghead1
                                       guard
                                      in
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.conj_guard g0)
-                                    uu____15079
+                                    uu____15085
                                    in
                                 (cres1, g)
-                            | uu____15080 ->
+                            | uu____15086 ->
                                 let g =
-                                  let uu____15090 =
-                                    let uu____15091 =
+                                  let uu____15096 =
+                                    let uu____15097 =
                                       FStar_TypeChecker_Env.conj_guard ghead1
                                         guard
                                        in
-                                    FStar_All.pipe_right uu____15091
+                                    FStar_All.pipe_right uu____15097
                                       (FStar_TypeChecker_Rel.solve_deferred_constraints
                                          env)
                                      in
                                   FStar_TypeChecker_Env.conj_guard g0
-                                    uu____15090
+                                    uu____15096
                                    in
-                                let uu____15092 =
-                                  let uu____15093 =
+                                let uu____15098 =
+                                  let uu____15099 =
                                     FStar_Syntax_Util.arrow bs cres1  in
-                                  FStar_Syntax_Syntax.mk_Total uu____15093
+                                  FStar_Syntax_Syntax.mk_Total uu____15099
                                    in
-                                (uu____15092, g)
+                                (uu____15098, g)
                              in
-                          (match uu____15063 with
+                          (match uu____15069 with
                            | (cres2,guard1) ->
-                               ((let uu____15103 =
+                               ((let uu____15109 =
                                    FStar_TypeChecker_Env.debug env
                                      FStar_Options.Medium
                                     in
-                                 if uu____15103
+                                 if uu____15109
                                  then
-                                   let uu____15106 =
+                                   let uu____15112 =
                                      FStar_Syntax_Print.comp_to_string cres2
                                       in
                                    FStar_Util.print1
                                      "\t Type of result cres is %s\n"
-                                     uu____15106
+                                     uu____15112
                                  else ());
-                                (let uu____15111 =
-                                   let uu____15116 =
-                                     let uu____15117 =
+                                (let uu____15117 =
+                                   let uu____15122 =
+                                     let uu____15123 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          chead1
                                         in
-                                     FStar_All.pipe_right uu____15117
+                                     FStar_All.pipe_right uu____15123
                                        FStar_TypeChecker_Common.lcomp_of_comp
                                       in
-                                   let uu____15118 =
-                                     let uu____15119 =
+                                   let uu____15124 =
+                                     let uu____15125 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          cres2
                                         in
-                                     FStar_All.pipe_right uu____15119
+                                     FStar_All.pipe_right uu____15125
                                        FStar_TypeChecker_Common.lcomp_of_comp
                                       in
-                                   (uu____15116, uu____15118)  in
-                                 match uu____15111 with
+                                   (uu____15122, uu____15124)  in
+                                 match uu____15117 with
                                  | (chead2,cres3) ->
                                      let cres4 =
                                        let head_is_pure_and_some_arg_is_effectful
@@ -5409,16 +5414,16 @@ and (check_application_args :
                                             chead2)
                                            &&
                                            (FStar_Util.for_some
-                                              (fun uu____15143  ->
-                                                 match uu____15143 with
-                                                 | (uu____15153,uu____15154,lc)
+                                              (fun uu____15149  ->
+                                                 match uu____15149 with
+                                                 | (uu____15159,uu____15160,lc)
                                                      ->
-                                                     (let uu____15162 =
+                                                     (let uu____15168 =
                                                         FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                           lc
                                                          in
                                                       Prims.op_Negation
-                                                        uu____15162)
+                                                        uu____15168)
                                                        ||
                                                        (FStar_TypeChecker_Util.should_not_inline_lc
                                                           lc)) arg_comps_rev)
@@ -5429,61 +5434,61 @@ and (check_application_args :
                                            FStar_Pervasives_Native.None
                                            head1.FStar_Syntax_Syntax.pos
                                           in
-                                       let uu____15175 =
+                                       let uu____15181 =
                                          (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                             cres3)
                                            &&
                                            head_is_pure_and_some_arg_is_effectful
                                           in
-                                       if uu____15175
+                                       if uu____15181
                                        then
-                                         ((let uu____15179 =
+                                         ((let uu____15185 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme
                                               in
-                                           if uu____15179
+                                           if uu____15185
                                            then
-                                             let uu____15182 =
+                                             let uu____15188 =
                                                FStar_Syntax_Print.term_to_string
                                                  term
                                                 in
                                              FStar_Util.print1
                                                "(a) Monadic app: Return inserted in monadic application: %s\n"
-                                               uu____15182
+                                               uu____15188
                                            else ());
                                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                             env term cres3)
                                        else
-                                         ((let uu____15190 =
+                                         ((let uu____15196 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme
                                               in
-                                           if uu____15190
+                                           if uu____15196
                                            then
-                                             let uu____15193 =
+                                             let uu____15199 =
                                                FStar_Syntax_Print.term_to_string
                                                  term
                                                 in
                                              FStar_Util.print1
                                                "(a) Monadic app: No return inserted in monadic application: %s\n"
-                                               uu____15193
+                                               uu____15199
                                            else ());
                                           cres3)
                                         in
                                      let comp =
                                        FStar_List.fold_left
                                          (fun out_c  ->
-                                            fun uu____15224  ->
-                                              match uu____15224 with
+                                            fun uu____15230  ->
+                                              match uu____15230 with
                                               | ((e,q),x,c) ->
-                                                  ((let uu____15266 =
+                                                  ((let uu____15272 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme
                                                        in
-                                                    if uu____15266
+                                                    if uu____15272
                                                     then
-                                                      let uu____15269 =
+                                                      let uu____15275 =
                                                         match x with
                                                         | FStar_Pervasives_Native.None
                                                              -> "_"
@@ -5492,25 +5497,25 @@ and (check_application_args :
                                                             FStar_Syntax_Print.bv_to_string
                                                               x1
                                                          in
-                                                      let uu____15274 =
+                                                      let uu____15280 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e
                                                          in
-                                                      let uu____15276 =
+                                                      let uu____15282 =
                                                         FStar_TypeChecker_Common.lcomp_to_string
                                                           c
                                                          in
                                                       FStar_Util.print3
                                                         "(b) Monadic app: Binding argument %s : %s of type (%s)\n"
-                                                        uu____15269
-                                                        uu____15274
-                                                        uu____15276
+                                                        uu____15275
+                                                        uu____15280
+                                                        uu____15282
                                                     else ());
-                                                   (let uu____15281 =
+                                                   (let uu____15287 =
                                                       FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                         c
                                                        in
-                                                    if uu____15281
+                                                    if uu____15287
                                                     then
                                                       FStar_TypeChecker_Util.bind
                                                         e.FStar_Syntax_Syntax.pos
@@ -5526,25 +5531,25 @@ and (check_application_args :
                                          arg_comps_rev
                                         in
                                      let comp1 =
-                                       (let uu____15292 =
+                                       (let uu____15298 =
                                           FStar_TypeChecker_Env.debug env
                                             FStar_Options.Extreme
                                            in
-                                        if uu____15292
+                                        if uu____15298
                                         then
-                                          let uu____15295 =
+                                          let uu____15301 =
                                             FStar_Syntax_Print.term_to_string
                                               head1
                                              in
                                           FStar_Util.print1
                                             "(c) Monadic app: Binding head %s\n"
-                                            uu____15295
+                                            uu____15301
                                         else ());
-                                       (let uu____15300 =
+                                       (let uu____15306 =
                                           FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                             chead2
                                            in
-                                        if uu____15300
+                                        if uu____15306
                                         then
                                           FStar_TypeChecker_Util.bind
                                             head1.FStar_Syntax_Syntax.pos env
@@ -5561,29 +5566,29 @@ and (check_application_args :
                                               comp))
                                         in
                                      let shortcuts_evaluation_order =
-                                       let uu____15311 =
-                                         let uu____15312 =
+                                       let uu____15317 =
+                                         let uu____15318 =
                                            FStar_Syntax_Subst.compress head1
                                             in
-                                         uu____15312.FStar_Syntax_Syntax.n
+                                         uu____15318.FStar_Syntax_Syntax.n
                                           in
-                                       match uu____15311 with
+                                       match uu____15317 with
                                        | FStar_Syntax_Syntax.Tm_fvar fv ->
                                            (FStar_Syntax_Syntax.fv_eq_lid fv
                                               FStar_Parser_Const.op_And)
                                              ||
                                              (FStar_Syntax_Syntax.fv_eq_lid
                                                 fv FStar_Parser_Const.op_Or)
-                                       | uu____15317 -> false  in
+                                       | uu____15323 -> false  in
                                      let app =
                                        if shortcuts_evaluation_order
                                        then
                                          let args1 =
                                            FStar_List.fold_left
                                              (fun args1  ->
-                                                fun uu____15340  ->
-                                                  match uu____15340 with
-                                                  | (arg,uu____15354,uu____15355)
+                                                fun uu____15346  ->
+                                                  match uu____15346 with
+                                                  | (arg,uu____15360,uu____15361)
                                                       -> arg :: args1) []
                                              arg_comps_rev
                                             in
@@ -5604,42 +5609,42 @@ and (check_application_args :
                                            comp1.FStar_TypeChecker_Common.eff_name
                                            comp1.FStar_TypeChecker_Common.res_typ
                                        else
-                                         (let uu____15366 =
-                                            let map_fun uu____15432 =
-                                              match uu____15432 with
-                                              | ((e,q),uu____15473,c) ->
-                                                  ((let uu____15496 =
+                                         (let uu____15372 =
+                                            let map_fun uu____15438 =
+                                              match uu____15438 with
+                                              | ((e,q),uu____15479,c) ->
+                                                  ((let uu____15502 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme
                                                        in
-                                                    if uu____15496
+                                                    if uu____15502
                                                     then
-                                                      let uu____15499 =
+                                                      let uu____15505 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e
                                                          in
-                                                      let uu____15501 =
+                                                      let uu____15507 =
                                                         FStar_TypeChecker_Common.lcomp_to_string
                                                           c
                                                          in
                                                       FStar_Util.print2
                                                         "For arg e=(%s) c=(%s)... "
-                                                        uu____15499
-                                                        uu____15501
+                                                        uu____15505
+                                                        uu____15507
                                                     else ());
-                                                   (let uu____15506 =
+                                                   (let uu____15512 =
                                                       FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                         c
                                                        in
-                                                    if uu____15506
+                                                    if uu____15512
                                                     then
-                                                      ((let uu____15532 =
+                                                      ((let uu____15538 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme
                                                            in
-                                                        if uu____15532
+                                                        if uu____15538
                                                         then
                                                           FStar_Util.print_string
                                                             "... not lifting\n"
@@ -5653,67 +5658,72 @@ and (check_application_args :
                                                             env
                                                             chead2.FStar_TypeChecker_Common.res_typ)
                                                            &&
-                                                           (let uu____15573 =
-                                                              let uu____15575
+                                                           (let uu____15579 =
+                                                              let uu____15581
                                                                 =
-                                                                let uu____15576
+                                                                let uu____15582
                                                                   =
                                                                   FStar_Syntax_Util.un_uinst
                                                                     head1
                                                                    in
-                                                                uu____15576.FStar_Syntax_Syntax.n
+                                                                uu____15582.FStar_Syntax_Syntax.n
                                                                  in
-                                                              match uu____15575
+                                                              match uu____15581
                                                               with
                                                               | FStar_Syntax_Syntax.Tm_fvar
                                                                   fv ->
-                                                                  let uu____15581
+                                                                  let uu____15587
                                                                     =
                                                                     FStar_Parser_Const.psconst
                                                                     "ignore"
                                                                      in
                                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                                     fv
-                                                                    uu____15581
-                                                              | uu____15583
+                                                                    uu____15587
+                                                              | uu____15589
                                                                   -> true
                                                                in
                                                             Prims.op_Negation
-                                                              uu____15573)
+                                                              uu____15579)
                                                           in
                                                        if warn_effectful_args
                                                        then
-                                                         (let uu____15587 =
-                                                            let uu____15593 =
-                                                              let uu____15595
+                                                         (let uu____15593 =
+                                                            let uu____15599 =
+                                                              let uu____15601
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   e
                                                                  in
-                                                              let uu____15597
+                                                              let uu____15603
+                                                                =
+                                                                FStar_Ident.string_of_lid
+                                                                  c.FStar_TypeChecker_Common.eff_name
+                                                                 in
+                                                              let uu____15605
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   head1
                                                                  in
                                                               FStar_Util.format3
                                                                 "Effectful argument %s (%s) to erased function %s, consider let binding it"
-                                                                uu____15595
-                                                                (c.FStar_TypeChecker_Common.eff_name).FStar_Ident.str
-                                                                uu____15597
+                                                                uu____15601
+                                                                uu____15603
+                                                                uu____15605
                                                                in
                                                             (FStar_Errors.Warning_EffectfulArgumentToErasedFunction,
-                                                              uu____15593)
+                                                              uu____15599)
                                                              in
                                                           FStar_Errors.log_issue
                                                             e.FStar_Syntax_Syntax.pos
-                                                            uu____15587)
+                                                            uu____15593)
                                                        else ();
-                                                       (let uu____15604 =
+                                                       (let uu____15612 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme
                                                            in
-                                                        if uu____15604
+                                                        if uu____15612
                                                         then
                                                           FStar_Util.print_string
                                                             "... lifting!\n"
@@ -5730,62 +5740,62 @@ and (check_application_args :
                                                             comp1.FStar_TypeChecker_Common.eff_name
                                                             c.FStar_TypeChecker_Common.res_typ
                                                            in
-                                                        let uu____15612 =
-                                                          let uu____15621 =
+                                                        let uu____15620 =
+                                                          let uu____15629 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x
                                                              in
-                                                          (uu____15621, q)
+                                                          (uu____15629, q)
                                                            in
                                                         ((FStar_Pervasives_Native.Some
                                                             (x,
                                                               (c.FStar_TypeChecker_Common.eff_name),
                                                               (c.FStar_TypeChecker_Common.res_typ),
                                                               e1)),
-                                                          uu____15612)))))
+                                                          uu____15620)))))
                                                in
-                                            let uu____15650 =
-                                              let uu____15681 =
-                                                let uu____15710 =
-                                                  let uu____15721 =
-                                                    let uu____15730 =
+                                            let uu____15658 =
+                                              let uu____15689 =
+                                                let uu____15718 =
+                                                  let uu____15729 =
+                                                    let uu____15738 =
                                                       FStar_Syntax_Syntax.as_arg
                                                         head1
                                                        in
-                                                    (uu____15730,
+                                                    (uu____15738,
                                                       FStar_Pervasives_Native.None,
                                                       chead2)
                                                      in
-                                                  uu____15721 ::
+                                                  uu____15729 ::
                                                     arg_comps_rev
                                                    in
                                                 FStar_List.map map_fun
-                                                  uu____15710
+                                                  uu____15718
                                                  in
                                               FStar_All.pipe_left
-                                                FStar_List.split uu____15681
+                                                FStar_List.split uu____15689
                                                in
-                                            match uu____15650 with
+                                            match uu____15658 with
                                             | (lifted_args,reverse_args) ->
-                                                let uu____15931 =
-                                                  let uu____15932 =
+                                                let uu____15939 =
+                                                  let uu____15940 =
                                                     FStar_List.hd
                                                       reverse_args
                                                      in
                                                   FStar_Pervasives_Native.fst
-                                                    uu____15932
+                                                    uu____15940
                                                    in
-                                                let uu____15953 =
-                                                  let uu____15954 =
+                                                let uu____15961 =
+                                                  let uu____15962 =
                                                     FStar_List.tl
                                                       reverse_args
                                                      in
-                                                  FStar_List.rev uu____15954
+                                                  FStar_List.rev uu____15962
                                                    in
-                                                (lifted_args, uu____15931,
-                                                  uu____15953)
+                                                (lifted_args, uu____15939,
+                                                  uu____15961)
                                              in
-                                          match uu____15366 with
+                                          match uu____15372 with
                                           | (lifted_args,head2,args1) ->
                                               let app =
                                                 FStar_Syntax_Syntax.mk_Tm_app
@@ -5807,8 +5817,8 @@ and (check_application_args :
                                                   comp1.FStar_TypeChecker_Common.res_typ
                                                  in
                                               let bind_lifted_args e
-                                                uu___6_16065 =
-                                                match uu___6_16065 with
+                                                uu___6_16073 =
+                                                match uu___6_16073 with
                                                 | FStar_Pervasives_Native.None
                                                      -> e
                                                 | FStar_Pervasives_Native.Some
@@ -5820,32 +5830,32 @@ and (check_application_args :
                                                         e1.FStar_Syntax_Syntax.pos
                                                        in
                                                     let letbinding =
-                                                      let uu____16126 =
-                                                        let uu____16133 =
-                                                          let uu____16134 =
-                                                            let uu____16148 =
-                                                              let uu____16151
+                                                      let uu____16134 =
+                                                        let uu____16141 =
+                                                          let uu____16142 =
+                                                            let uu____16156 =
+                                                              let uu____16159
                                                                 =
-                                                                let uu____16152
+                                                                let uu____16160
                                                                   =
                                                                   FStar_Syntax_Syntax.mk_binder
                                                                     x
                                                                    in
-                                                                [uu____16152]
+                                                                [uu____16160]
                                                                  in
                                                               FStar_Syntax_Subst.close
-                                                                uu____16151 e
+                                                                uu____16159 e
                                                                in
                                                             ((false, [lb]),
-                                                              uu____16148)
+                                                              uu____16156)
                                                              in
                                                           FStar_Syntax_Syntax.Tm_let
-                                                            uu____16134
+                                                            uu____16142
                                                            in
                                                         FStar_Syntax_Syntax.mk
-                                                          uu____16133
+                                                          uu____16141
                                                          in
-                                                      uu____16126
+                                                      uu____16134
                                                         FStar_Pervasives_Native.None
                                                         e.FStar_Syntax_Syntax.pos
                                                        in
@@ -5862,210 +5872,210 @@ and (check_application_args :
                                                 bind_lifted_args app2
                                                 lifted_args)
                                         in
-                                     let uu____16204 =
+                                     let uu____16212 =
                                        FStar_TypeChecker_Util.strengthen_precondition
                                          FStar_Pervasives_Native.None env app
                                          comp1 guard1
                                         in
-                                     (match uu____16204 with
+                                     (match uu____16212 with
                                       | (comp2,g) ->
-                                          ((let uu____16222 =
+                                          ((let uu____16230 =
                                               FStar_TypeChecker_Env.debug env
                                                 FStar_Options.Extreme
                                                in
-                                            if uu____16222
+                                            if uu____16230
                                             then
-                                              let uu____16225 =
+                                              let uu____16233 =
                                                 FStar_Syntax_Print.term_to_string
                                                   app
                                                  in
-                                              let uu____16227 =
+                                              let uu____16235 =
                                                 FStar_TypeChecker_Common.lcomp_to_string
                                                   comp2
                                                  in
                                               FStar_Util.print2
                                                 "(d) Monadic app: type of app\n\t(%s)\n\t: %s\n"
-                                                uu____16225 uu____16227
+                                                uu____16233 uu____16235
                                             else ());
                                            (app, comp2, g)))))))
                   in
-               let rec tc_args head_info uu____16308 bs args1 =
-                 match uu____16308 with
+               let rec tc_args head_info uu____16316 bs args1 =
+                 match uu____16316 with
                  | (subst,outargs,arg_rets,g,fvs) ->
                      (match (bs, args1) with
                       | ((x,FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Implicit uu____16447))::rest,
-                         (uu____16449,FStar_Pervasives_Native.None )::uu____16450)
+                          (FStar_Syntax_Syntax.Implicit uu____16455))::rest,
+                         (uu____16457,FStar_Pervasives_Native.None )::uu____16458)
                           ->
                           let t =
                             FStar_Syntax_Subst.subst subst
                               x.FStar_Syntax_Syntax.sort
                              in
-                          let uu____16511 =
+                          let uu____16519 =
                             check_no_escape
                               (FStar_Pervasives_Native.Some head) env fvs t
                              in
-                          (match uu____16511 with
+                          (match uu____16519 with
                            | (t1,g_ex) ->
-                               let uu____16524 =
+                               let uu____16532 =
                                  FStar_TypeChecker_Util.new_implicit_var
                                    "Instantiating implicit argument in application"
                                    head.FStar_Syntax_Syntax.pos env t1
                                   in
-                               (match uu____16524 with
-                                | (varg,uu____16545,implicits) ->
+                               (match uu____16532 with
+                                | (varg,uu____16553,implicits) ->
                                     let subst1 =
                                       (FStar_Syntax_Syntax.NT (x, varg)) ::
                                       subst  in
                                     let arg =
-                                      let uu____16573 =
+                                      let uu____16581 =
                                         FStar_Syntax_Syntax.as_implicit true
                                          in
-                                      (varg, uu____16573)  in
+                                      (varg, uu____16581)  in
                                     let guard =
                                       FStar_List.fold_right
                                         FStar_TypeChecker_Env.conj_guard
                                         [g_ex; g] implicits
                                        in
-                                    let uu____16582 =
-                                      let uu____16617 =
-                                        let uu____16628 =
-                                          let uu____16637 =
-                                            let uu____16638 =
+                                    let uu____16590 =
+                                      let uu____16625 =
+                                        let uu____16636 =
+                                          let uu____16645 =
+                                            let uu____16646 =
                                               FStar_Syntax_Syntax.mk_Total t1
                                                in
-                                            FStar_All.pipe_right uu____16638
+                                            FStar_All.pipe_right uu____16646
                                               FStar_TypeChecker_Common.lcomp_of_comp
                                              in
                                           (arg, FStar_Pervasives_Native.None,
-                                            uu____16637)
+                                            uu____16645)
                                            in
-                                        uu____16628 :: outargs  in
-                                      (subst1, uu____16617, (arg ::
+                                        uu____16636 :: outargs  in
+                                      (subst1, uu____16625, (arg ::
                                         arg_rets), guard, fvs)
                                        in
-                                    tc_args head_info uu____16582 rest args1))
+                                    tc_args head_info uu____16590 rest args1))
                       | ((x,FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta tau))::rest,(uu____16684,FStar_Pervasives_Native.None
-                                                                 )::uu____16685)
+                          (FStar_Syntax_Syntax.Meta tau))::rest,(uu____16692,FStar_Pervasives_Native.None
+                                                                 )::uu____16693)
                           ->
                           let tau1 = FStar_Syntax_Subst.subst subst tau  in
-                          let uu____16747 =
+                          let uu____16755 =
                             tc_tactic FStar_Syntax_Syntax.t_unit
                               FStar_Syntax_Syntax.t_unit env tau1
                              in
-                          (match uu____16747 with
-                           | (tau2,uu____16761,g_tau) ->
+                          (match uu____16755 with
+                           | (tau2,uu____16769,g_tau) ->
                                let t =
                                  FStar_Syntax_Subst.subst subst
                                    x.FStar_Syntax_Syntax.sort
                                   in
-                               let uu____16764 =
+                               let uu____16772 =
                                  check_no_escape
                                    (FStar_Pervasives_Native.Some head) env
                                    fvs t
                                   in
-                               (match uu____16764 with
+                               (match uu____16772 with
                                 | (t1,g_ex) ->
-                                    let uu____16777 =
-                                      let uu____16790 =
-                                        let uu____16797 =
-                                          let uu____16802 =
+                                    let uu____16785 =
+                                      let uu____16798 =
+                                        let uu____16805 =
+                                          let uu____16810 =
                                             FStar_Dyn.mkdyn env  in
-                                          (uu____16802, tau2)  in
+                                          (uu____16810, tau2)  in
                                         FStar_Pervasives_Native.Some
-                                          uu____16797
+                                          uu____16805
                                          in
                                       FStar_TypeChecker_Env.new_implicit_var_aux
                                         "Instantiating meta argument in application"
                                         head.FStar_Syntax_Syntax.pos env t1
                                         FStar_Syntax_Syntax.Strict
-                                        uu____16790
+                                        uu____16798
                                        in
-                                    (match uu____16777 with
-                                     | (varg,uu____16815,implicits) ->
+                                    (match uu____16785 with
+                                     | (varg,uu____16823,implicits) ->
                                          let subst1 =
                                            (FStar_Syntax_Syntax.NT (x, varg))
                                            :: subst  in
                                          let arg =
-                                           let uu____16843 =
+                                           let uu____16851 =
                                              FStar_Syntax_Syntax.as_implicit
                                                true
                                               in
-                                           (varg, uu____16843)  in
+                                           (varg, uu____16851)  in
                                          let guard =
                                            FStar_List.fold_right
                                              FStar_TypeChecker_Env.conj_guard
                                              [g_ex; g; g_tau] implicits
                                             in
-                                         let uu____16852 =
-                                           let uu____16887 =
-                                             let uu____16898 =
-                                               let uu____16907 =
-                                                 let uu____16908 =
+                                         let uu____16860 =
+                                           let uu____16895 =
+                                             let uu____16906 =
+                                               let uu____16915 =
+                                                 let uu____16916 =
                                                    FStar_Syntax_Syntax.mk_Total
                                                      t1
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____16908
+                                                   uu____16916
                                                    FStar_TypeChecker_Common.lcomp_of_comp
                                                   in
                                                (arg,
                                                  FStar_Pervasives_Native.None,
-                                                 uu____16907)
+                                                 uu____16915)
                                                 in
-                                             uu____16898 :: outargs  in
-                                           (subst1, uu____16887, (arg ::
+                                             uu____16906 :: outargs  in
+                                           (subst1, uu____16895, (arg ::
                                              arg_rets), guard, fvs)
                                             in
-                                         tc_args head_info uu____16852 rest
+                                         tc_args head_info uu____16860 rest
                                            args1)))
                       | ((x,aqual)::rest,(e,aq)::rest') ->
                           ((match (aqual, aq) with
-                            | (uu____17024,FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Meta uu____17025)) ->
+                            | (uu____17032,FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Meta uu____17033)) ->
                                 FStar_Errors.raise_error
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                     "Inconsistent implicit qualifier; cannot apply meta arguments, just use #")
                                   e.FStar_Syntax_Syntax.pos
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Meta
-                               uu____17036),FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____17037)) ->
+                               uu____17044),FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____17045)) ->
                                 ()
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Implicit
-                               uu____17045),FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____17046)) ->
+                               uu____17053),FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____17054)) ->
                                 ()
                             | (FStar_Pervasives_Native.None
                                ,FStar_Pervasives_Native.None ) -> ()
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Equality
                                ),FStar_Pervasives_Native.None ) -> ()
-                            | uu____17061 ->
-                                let uu____17070 =
-                                  let uu____17076 =
-                                    let uu____17078 =
+                            | uu____17069 ->
+                                let uu____17078 =
+                                  let uu____17084 =
+                                    let uu____17086 =
                                       FStar_Syntax_Print.aqual_to_string
                                         aqual
                                        in
-                                    let uu____17080 =
+                                    let uu____17088 =
                                       FStar_Syntax_Print.aqual_to_string aq
                                        in
-                                    let uu____17082 =
+                                    let uu____17090 =
                                       FStar_Syntax_Print.bv_to_string x  in
-                                    let uu____17084 =
+                                    let uu____17092 =
                                       FStar_Syntax_Print.term_to_string e  in
                                     FStar_Util.format4
                                       "Inconsistent implicit qualifier; %s vs %s\nfor bvar %s and term %s"
-                                      uu____17078 uu____17080 uu____17082
-                                      uu____17084
+                                      uu____17086 uu____17088 uu____17090
+                                      uu____17092
                                      in
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
-                                    uu____17076)
+                                    uu____17084)
                                    in
-                                FStar_Errors.raise_error uu____17070
+                                FStar_Errors.raise_error uu____17078
                                   e.FStar_Syntax_Syntax.pos);
                            (let targ =
                               FStar_Syntax_Subst.subst subst
@@ -6074,202 +6084,202 @@ and (check_application_args :
                             let aqual1 =
                               FStar_Syntax_Subst.subst_imp subst aqual  in
                             let x1 =
-                              let uu___2267_17091 = x  in
+                              let uu___2267_17099 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___2267_17091.FStar_Syntax_Syntax.ppname);
+                                  (uu___2267_17099.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___2267_17091.FStar_Syntax_Syntax.index);
+                                  (uu___2267_17099.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = targ
                               }  in
-                            (let uu____17093 =
+                            (let uu____17101 =
                                FStar_TypeChecker_Env.debug env
                                  FStar_Options.Extreme
                                 in
-                             if uu____17093
+                             if uu____17101
                              then
-                               let uu____17096 =
+                               let uu____17104 =
                                  FStar_Syntax_Print.bv_to_string x1  in
-                               let uu____17098 =
+                               let uu____17106 =
                                  FStar_Syntax_Print.term_to_string
                                    x1.FStar_Syntax_Syntax.sort
                                   in
-                               let uu____17100 =
+                               let uu____17108 =
                                  FStar_Syntax_Print.term_to_string e  in
-                               let uu____17102 =
+                               let uu____17110 =
                                  FStar_Syntax_Print.subst_to_string subst  in
-                               let uu____17104 =
+                               let uu____17112 =
                                  FStar_Syntax_Print.term_to_string targ  in
                                FStar_Util.print5
                                  "\tFormal is %s : %s\tType of arg %s (after subst %s) = %s\n"
-                                 uu____17096 uu____17098 uu____17100
-                                 uu____17102 uu____17104
+                                 uu____17104 uu____17106 uu____17108
+                                 uu____17110 uu____17112
                              else ());
-                            (let uu____17109 =
+                            (let uu____17117 =
                                check_no_escape
                                  (FStar_Pervasives_Native.Some head) env fvs
                                  targ
                                 in
-                             match uu____17109 with
+                             match uu____17117 with
                              | (targ1,g_ex) ->
                                  let env1 =
                                    FStar_TypeChecker_Env.set_expected_typ env
                                      targ1
                                     in
                                  let env2 =
-                                   let uu___2276_17124 = env1  in
+                                   let uu___2276_17132 = env1  in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.solver);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.range);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.curmodule);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.gamma);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.modules);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.sigtab);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.attrtab);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.effects);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.generalize);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.letrecs);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.letrecs);
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.top_level);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
                                        (is_eq aqual1);
                                      FStar_TypeChecker_Env.use_eq_strict =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.use_eq_strict);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.use_eq_strict);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.is_iface);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.admit);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.lax);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.phase1);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.failhard);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.nosynth);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.tc_term);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.type_of);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.universe_of);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.try_solve_implicits_hook
                                        =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.splice);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.mpreprocess =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.mpreprocess);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.mpreprocess);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.postprocess);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.is_native_tactic =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.is_native_tactic);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.is_native_tactic);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.dsenv);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.nbe);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.strict_args_tab);
+                                       (uu___2276_17132.FStar_TypeChecker_Env.strict_args_tab);
                                      FStar_TypeChecker_Env.erasable_types_tab
                                        =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.erasable_types_tab)
+                                       (uu___2276_17132.FStar_TypeChecker_Env.erasable_types_tab)
                                    }  in
-                                 ((let uu____17126 =
+                                 ((let uu____17134 =
                                      FStar_TypeChecker_Env.debug env2
                                        FStar_Options.High
                                       in
-                                   if uu____17126
+                                   if uu____17134
                                    then
-                                     let uu____17129 =
+                                     let uu____17137 =
                                        FStar_Syntax_Print.tag_of_term e  in
-                                     let uu____17131 =
+                                     let uu____17139 =
                                        FStar_Syntax_Print.term_to_string e
                                         in
-                                     let uu____17133 =
+                                     let uu____17141 =
                                        FStar_Syntax_Print.term_to_string
                                          targ1
                                         in
-                                     let uu____17135 =
+                                     let uu____17143 =
                                        FStar_Util.string_of_bool
                                          env2.FStar_TypeChecker_Env.use_eq
                                         in
                                      FStar_Util.print4
                                        "Checking arg (%s) %s at type %s with use_eq:%s\n"
-                                       uu____17129 uu____17131 uu____17133
-                                       uu____17135
+                                       uu____17137 uu____17139 uu____17141
+                                       uu____17143
                                    else ());
-                                  (let uu____17140 = tc_term env2 e  in
-                                   match uu____17140 with
+                                  (let uu____17148 = tc_term env2 e  in
+                                   match uu____17148 with
                                    | (e1,c,g_e) ->
                                        let g1 =
-                                         let uu____17157 =
+                                         let uu____17165 =
                                            FStar_TypeChecker_Env.conj_guard g
                                              g_e
                                             in
                                          FStar_All.pipe_left
                                            (FStar_TypeChecker_Env.conj_guard
-                                              g_ex) uu____17157
+                                              g_ex) uu____17165
                                           in
                                        let arg = (e1, aq)  in
                                        let xterm =
-                                         let uu____17180 =
-                                           let uu____17183 =
-                                             let uu____17192 =
+                                         let uu____17188 =
+                                           let uu____17191 =
+                                             let uu____17200 =
                                                FStar_Syntax_Syntax.bv_to_name
                                                  x1
                                                 in
                                              FStar_Syntax_Syntax.as_arg
-                                               uu____17192
+                                               uu____17200
                                               in
                                            FStar_Pervasives_Native.fst
-                                             uu____17183
+                                             uu____17191
                                             in
-                                         (uu____17180, aq)  in
-                                       let uu____17201 =
+                                         (uu____17188, aq)  in
+                                       let uu____17209 =
                                          (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                             c)
                                            ||
@@ -6277,13 +6287,13 @@ and (check_application_args :
                                               env2
                                               c.FStar_TypeChecker_Common.eff_name)
                                           in
-                                       if uu____17201
+                                       if uu____17209
                                        then
                                          let subst1 =
-                                           let uu____17211 = FStar_List.hd bs
+                                           let uu____17219 = FStar_List.hd bs
                                               in
                                            maybe_extend_subst subst
-                                             uu____17211 e1
+                                             uu____17219 e1
                                             in
                                          tc_args head_info
                                            (subst1,
@@ -6300,58 +6310,58 @@ and (check_application_args :
                                                    x1), c) :: outargs),
                                              (xterm :: arg_rets), g1, (x1 ::
                                              fvs)) rest rest')))))
-                      | (uu____17310,[]) ->
+                      | (uu____17318,[]) ->
                           monadic_application head_info subst outargs
                             arg_rets g fvs bs
-                      | ([],arg::uu____17346) ->
-                          let uu____17397 =
+                      | ([],arg::uu____17354) ->
+                          let uu____17405 =
                             monadic_application head_info subst outargs
                               arg_rets g fvs []
                              in
-                          (match uu____17397 with
+                          (match uu____17405 with
                            | (head1,chead1,ghead1) ->
-                               let uu____17419 =
-                                 let uu____17424 =
+                               let uu____17427 =
+                                 let uu____17432 =
                                    FStar_TypeChecker_Common.lcomp_comp chead1
                                     in
-                                 FStar_All.pipe_right uu____17424
-                                   (fun uu____17441  ->
-                                      match uu____17441 with
+                                 FStar_All.pipe_right uu____17432
+                                   (fun uu____17449  ->
+                                      match uu____17449 with
                                       | (c,g1) ->
-                                          let uu____17452 =
+                                          let uu____17460 =
                                             FStar_TypeChecker_Env.conj_guard
                                               ghead1 g1
                                              in
-                                          (c, uu____17452))
+                                          (c, uu____17460))
                                   in
-                               (match uu____17419 with
+                               (match uu____17427 with
                                 | (chead2,ghead2) ->
                                     let rec aux norm1 solve ghead3 tres =
                                       let tres1 =
-                                        let uu____17495 =
+                                        let uu____17503 =
                                           FStar_Syntax_Subst.compress tres
                                            in
-                                        FStar_All.pipe_right uu____17495
+                                        FStar_All.pipe_right uu____17503
                                           FStar_Syntax_Util.unrefine
                                          in
                                       match tres1.FStar_Syntax_Syntax.n with
                                       | FStar_Syntax_Syntax.Tm_arrow
                                           (bs1,cres') ->
-                                          let uu____17526 =
+                                          let uu____17534 =
                                             FStar_Syntax_Subst.open_comp bs1
                                               cres'
                                              in
-                                          (match uu____17526 with
+                                          (match uu____17534 with
                                            | (bs2,cres'1) ->
                                                let head_info1 =
                                                  (head1, chead2, ghead3,
                                                    cres'1)
                                                   in
-                                               ((let uu____17549 =
+                                               ((let uu____17557 =
                                                    FStar_TypeChecker_Env.debug
                                                      env FStar_Options.Low
                                                     in
-                                                 if uu____17549
+                                                 if uu____17557
                                                  then
                                                    FStar_Errors.log_issue
                                                      tres1.FStar_Syntax_Syntax.pos
@@ -6362,330 +6372,330 @@ and (check_application_args :
                                                   ([], [], [],
                                                     FStar_TypeChecker_Env.trivial_guard,
                                                     []) bs2 args1))
-                                      | uu____17596 when
+                                      | uu____17604 when
                                           Prims.op_Negation norm1 ->
                                           let rec norm_tres tres2 =
                                             let tres3 =
-                                              let uu____17604 =
+                                              let uu____17612 =
                                                 FStar_All.pipe_right tres2
                                                   (FStar_TypeChecker_Normalize.unfold_whnf
                                                      env)
                                                  in
                                               FStar_All.pipe_right
-                                                uu____17604
+                                                uu____17612
                                                 FStar_Syntax_Util.unascribe
                                                in
-                                            let uu____17605 =
-                                              let uu____17606 =
+                                            let uu____17613 =
+                                              let uu____17614 =
                                                 FStar_Syntax_Subst.compress
                                                   tres3
                                                  in
-                                              uu____17606.FStar_Syntax_Syntax.n
+                                              uu____17614.FStar_Syntax_Syntax.n
                                                in
-                                            match uu____17605 with
+                                            match uu____17613 with
                                             | FStar_Syntax_Syntax.Tm_refine
                                                 ({
                                                    FStar_Syntax_Syntax.ppname
-                                                     = uu____17609;
+                                                     = uu____17617;
                                                    FStar_Syntax_Syntax.index
-                                                     = uu____17610;
+                                                     = uu____17618;
                                                    FStar_Syntax_Syntax.sort =
-                                                     tres4;_},uu____17612)
+                                                     tres4;_},uu____17620)
                                                 -> norm_tres tres4
-                                            | uu____17620 -> tres3  in
-                                          let uu____17621 = norm_tres tres1
+                                            | uu____17628 -> tres3  in
+                                          let uu____17629 = norm_tres tres1
                                              in
-                                          aux true solve ghead3 uu____17621
-                                      | uu____17623 when
+                                          aux true solve ghead3 uu____17629
+                                      | uu____17631 when
                                           Prims.op_Negation solve ->
                                           let ghead4 =
                                             FStar_TypeChecker_Rel.solve_deferred_constraints
                                               env ghead3
                                              in
                                           aux norm1 true ghead4 tres1
-                                      | uu____17626 ->
-                                          let uu____17627 =
-                                            let uu____17633 =
-                                              let uu____17635 =
+                                      | uu____17634 ->
+                                          let uu____17635 =
+                                            let uu____17641 =
+                                              let uu____17643 =
                                                 FStar_TypeChecker_Normalize.term_to_string
                                                   env thead
                                                  in
-                                              let uu____17637 =
+                                              let uu____17645 =
                                                 FStar_Util.string_of_int
                                                   n_args
                                                  in
-                                              let uu____17639 =
+                                              let uu____17647 =
                                                 FStar_Syntax_Print.term_to_string
                                                   tres1
                                                  in
                                               FStar_Util.format3
                                                 "Too many arguments to function of type %s; got %s arguments, remaining type is %s"
-                                                uu____17635 uu____17637
-                                                uu____17639
+                                                uu____17643 uu____17645
+                                                uu____17647
                                                in
                                             (FStar_Errors.Fatal_ToManyArgumentToFunction,
-                                              uu____17633)
+                                              uu____17641)
                                              in
-                                          let uu____17643 =
+                                          let uu____17651 =
                                             FStar_Syntax_Syntax.argpos arg
                                              in
                                           FStar_Errors.raise_error
-                                            uu____17627 uu____17643
+                                            uu____17635 uu____17651
                                        in
                                     aux false false ghead2
                                       (FStar_Syntax_Util.comp_result chead2))))
                   in
                let rec check_function_app tf guard =
-                 let uu____17673 =
-                   let uu____17674 =
+                 let uu____17681 =
+                   let uu____17682 =
                      FStar_TypeChecker_Normalize.unfold_whnf env tf  in
-                   uu____17674.FStar_Syntax_Syntax.n  in
-                 match uu____17673 with
-                 | FStar_Syntax_Syntax.Tm_uvar uu____17683 ->
-                     let uu____17696 =
+                   uu____17682.FStar_Syntax_Syntax.n  in
+                 match uu____17681 with
+                 | FStar_Syntax_Syntax.Tm_uvar uu____17691 ->
+                     let uu____17704 =
                        FStar_List.fold_right
-                         (fun uu____17727  ->
-                            fun uu____17728  ->
-                              match uu____17728 with
+                         (fun uu____17735  ->
+                            fun uu____17736  ->
+                              match uu____17736 with
                               | (bs,guard1) ->
-                                  let uu____17755 =
-                                    let uu____17768 =
-                                      let uu____17769 =
+                                  let uu____17763 =
+                                    let uu____17776 =
+                                      let uu____17777 =
                                         FStar_Syntax_Util.type_u ()  in
-                                      FStar_All.pipe_right uu____17769
+                                      FStar_All.pipe_right uu____17777
                                         FStar_Pervasives_Native.fst
                                        in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env
-                                      uu____17768
+                                      uu____17776
                                      in
-                                  (match uu____17755 with
-                                   | (t,uu____17786,g) ->
-                                       let uu____17800 =
-                                         let uu____17803 =
+                                  (match uu____17763 with
+                                   | (t,uu____17794,g) ->
+                                       let uu____17808 =
+                                         let uu____17811 =
                                            FStar_Syntax_Syntax.null_binder t
                                             in
-                                         uu____17803 :: bs  in
-                                       let uu____17804 =
+                                         uu____17811 :: bs  in
+                                       let uu____17812 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1
                                           in
-                                       (uu____17800, uu____17804))) args
+                                       (uu____17808, uu____17812))) args
                          ([], guard)
                         in
-                     (match uu____17696 with
+                     (match uu____17704 with
                       | (bs,guard1) ->
-                          let uu____17821 =
-                            let uu____17828 =
-                              let uu____17841 =
-                                let uu____17842 = FStar_Syntax_Util.type_u ()
+                          let uu____17829 =
+                            let uu____17836 =
+                              let uu____17849 =
+                                let uu____17850 = FStar_Syntax_Util.type_u ()
                                    in
-                                FStar_All.pipe_right uu____17842
+                                FStar_All.pipe_right uu____17850
                                   FStar_Pervasives_Native.fst
                                  in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____17841
+                                uu____17849
                                in
-                            match uu____17828 with
-                            | (t,uu____17859,g) ->
-                                let uu____17873 = FStar_Options.ml_ish ()  in
-                                if uu____17873
+                            match uu____17836 with
+                            | (t,uu____17867,g) ->
+                                let uu____17881 = FStar_Options.ml_ish ()  in
+                                if uu____17881
                                 then
-                                  let uu____17882 =
+                                  let uu____17890 =
                                     FStar_Syntax_Util.ml_comp t r  in
-                                  let uu____17885 =
+                                  let uu____17893 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g
                                      in
-                                  (uu____17882, uu____17885)
+                                  (uu____17890, uu____17893)
                                 else
-                                  (let uu____17890 =
+                                  (let uu____17898 =
                                      FStar_Syntax_Syntax.mk_Total t  in
-                                   let uu____17893 =
+                                   let uu____17901 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g
                                       in
-                                   (uu____17890, uu____17893))
+                                   (uu____17898, uu____17901))
                              in
-                          (match uu____17821 with
+                          (match uu____17829 with
                            | (cres,guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres
                                   in
-                               ((let uu____17912 =
+                               ((let uu____17920 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme
                                     in
-                                 if uu____17912
+                                 if uu____17920
                                  then
-                                   let uu____17916 =
+                                   let uu____17924 =
                                      FStar_Syntax_Print.term_to_string head
                                       in
-                                   let uu____17918 =
+                                   let uu____17926 =
                                      FStar_Syntax_Print.term_to_string tf  in
-                                   let uu____17920 =
+                                   let uu____17928 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres
                                       in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____17916 uu____17918 uu____17920
+                                     uu____17924 uu____17926 uu____17928
                                  else ());
                                 (let g =
-                                   let uu____17926 =
+                                   let uu____17934 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres
                                       in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____17926
+                                     env uu____17934
                                     in
-                                 let uu____17927 =
+                                 let uu____17935 =
                                    FStar_TypeChecker_Env.conj_guard g guard2
                                     in
-                                 check_function_app bs_cres uu____17927))))
+                                 check_function_app bs_cres uu____17935))))
                  | FStar_Syntax_Syntax.Tm_app
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                          uu____17928;
-                        FStar_Syntax_Syntax.pos = uu____17929;
-                        FStar_Syntax_Syntax.vars = uu____17930;_},uu____17931)
+                          uu____17936;
+                        FStar_Syntax_Syntax.pos = uu____17937;
+                        FStar_Syntax_Syntax.vars = uu____17938;_},uu____17939)
                      ->
-                     let uu____17968 =
+                     let uu____17976 =
                        FStar_List.fold_right
-                         (fun uu____17999  ->
-                            fun uu____18000  ->
-                              match uu____18000 with
+                         (fun uu____18007  ->
+                            fun uu____18008  ->
+                              match uu____18008 with
                               | (bs,guard1) ->
-                                  let uu____18027 =
-                                    let uu____18040 =
-                                      let uu____18041 =
+                                  let uu____18035 =
+                                    let uu____18048 =
+                                      let uu____18049 =
                                         FStar_Syntax_Util.type_u ()  in
-                                      FStar_All.pipe_right uu____18041
+                                      FStar_All.pipe_right uu____18049
                                         FStar_Pervasives_Native.fst
                                        in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env
-                                      uu____18040
+                                      uu____18048
                                      in
-                                  (match uu____18027 with
-                                   | (t,uu____18058,g) ->
-                                       let uu____18072 =
-                                         let uu____18075 =
+                                  (match uu____18035 with
+                                   | (t,uu____18066,g) ->
+                                       let uu____18080 =
+                                         let uu____18083 =
                                            FStar_Syntax_Syntax.null_binder t
                                             in
-                                         uu____18075 :: bs  in
-                                       let uu____18076 =
+                                         uu____18083 :: bs  in
+                                       let uu____18084 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1
                                           in
-                                       (uu____18072, uu____18076))) args
+                                       (uu____18080, uu____18084))) args
                          ([], guard)
                         in
-                     (match uu____17968 with
+                     (match uu____17976 with
                       | (bs,guard1) ->
-                          let uu____18093 =
-                            let uu____18100 =
-                              let uu____18113 =
-                                let uu____18114 = FStar_Syntax_Util.type_u ()
+                          let uu____18101 =
+                            let uu____18108 =
+                              let uu____18121 =
+                                let uu____18122 = FStar_Syntax_Util.type_u ()
                                    in
-                                FStar_All.pipe_right uu____18114
+                                FStar_All.pipe_right uu____18122
                                   FStar_Pervasives_Native.fst
                                  in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____18113
+                                uu____18121
                                in
-                            match uu____18100 with
-                            | (t,uu____18131,g) ->
-                                let uu____18145 = FStar_Options.ml_ish ()  in
-                                if uu____18145
+                            match uu____18108 with
+                            | (t,uu____18139,g) ->
+                                let uu____18153 = FStar_Options.ml_ish ()  in
+                                if uu____18153
                                 then
-                                  let uu____18154 =
+                                  let uu____18162 =
                                     FStar_Syntax_Util.ml_comp t r  in
-                                  let uu____18157 =
+                                  let uu____18165 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g
                                      in
-                                  (uu____18154, uu____18157)
+                                  (uu____18162, uu____18165)
                                 else
-                                  (let uu____18162 =
+                                  (let uu____18170 =
                                      FStar_Syntax_Syntax.mk_Total t  in
-                                   let uu____18165 =
+                                   let uu____18173 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g
                                       in
-                                   (uu____18162, uu____18165))
+                                   (uu____18170, uu____18173))
                              in
-                          (match uu____18093 with
+                          (match uu____18101 with
                            | (cres,guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres
                                   in
-                               ((let uu____18184 =
+                               ((let uu____18192 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme
                                     in
-                                 if uu____18184
+                                 if uu____18192
                                  then
-                                   let uu____18188 =
+                                   let uu____18196 =
                                      FStar_Syntax_Print.term_to_string head
                                       in
-                                   let uu____18190 =
+                                   let uu____18198 =
                                      FStar_Syntax_Print.term_to_string tf  in
-                                   let uu____18192 =
+                                   let uu____18200 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres
                                       in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____18188 uu____18190 uu____18192
+                                     uu____18196 uu____18198 uu____18200
                                  else ());
                                 (let g =
-                                   let uu____18198 =
+                                   let uu____18206 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres
                                       in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____18198
+                                     env uu____18206
                                     in
-                                 let uu____18199 =
+                                 let uu____18207 =
                                    FStar_TypeChecker_Env.conj_guard g guard2
                                     in
-                                 check_function_app bs_cres uu____18199))))
+                                 check_function_app bs_cres uu____18207))))
                  | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                     let uu____18222 = FStar_Syntax_Subst.open_comp bs c  in
-                     (match uu____18222 with
+                     let uu____18230 = FStar_Syntax_Subst.open_comp bs c  in
+                     (match uu____18230 with
                       | (bs1,c1) ->
                           let head_info = (head, chead, ghead, c1)  in
-                          ((let uu____18245 =
+                          ((let uu____18253 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.Extreme
                                in
-                            if uu____18245
+                            if uu____18253
                             then
-                              let uu____18248 =
+                              let uu____18256 =
                                 FStar_Syntax_Print.term_to_string head  in
-                              let uu____18250 =
+                              let uu____18258 =
                                 FStar_Syntax_Print.term_to_string tf  in
-                              let uu____18252 =
+                              let uu____18260 =
                                 FStar_Syntax_Print.binders_to_string ", " bs1
                                  in
-                              let uu____18255 =
+                              let uu____18263 =
                                 FStar_Syntax_Print.comp_to_string c1  in
                               FStar_Util.print4
                                 "######tc_args of head %s @ %s with formals=%s and result type=%s\n"
-                                uu____18248 uu____18250 uu____18252
-                                uu____18255
+                                uu____18256 uu____18258 uu____18260
+                                uu____18263
                             else ());
                            tc_args head_info ([], [], [], guard, []) bs1 args))
-                 | FStar_Syntax_Syntax.Tm_refine (bv,uu____18301) ->
+                 | FStar_Syntax_Syntax.Tm_refine (bv,uu____18309) ->
                      check_function_app bv.FStar_Syntax_Syntax.sort guard
                  | FStar_Syntax_Syntax.Tm_ascribed
-                     (t,uu____18307,uu____18308) ->
+                     (t,uu____18315,uu____18316) ->
                      check_function_app t guard
-                 | uu____18349 ->
-                     let uu____18350 =
+                 | uu____18357 ->
+                     let uu____18358 =
                        FStar_TypeChecker_Err.expected_function_typ env tf  in
-                     FStar_Errors.raise_error uu____18350
+                     FStar_Errors.raise_error uu____18358
                        head.FStar_Syntax_Syntax.pos
                   in
                check_function_app thead FStar_TypeChecker_Env.trivial_guard)
@@ -6719,75 +6729,75 @@ and (check_short_circuit_args :
                     ((FStar_List.length bs) = (FStar_List.length args))
                   ->
                   let res_t = FStar_Syntax_Util.comp_result c  in
-                  let uu____18433 =
+                  let uu____18441 =
                     FStar_List.fold_left2
-                      (fun uu____18502  ->
-                         fun uu____18503  ->
-                           fun uu____18504  ->
-                             match (uu____18502, uu____18503, uu____18504)
+                      (fun uu____18510  ->
+                         fun uu____18511  ->
+                           fun uu____18512  ->
+                             match (uu____18510, uu____18511, uu____18512)
                              with
                              | ((seen,guard,ghost),(e,aq),(b,aq')) ->
-                                 ((let uu____18657 =
-                                     let uu____18659 =
+                                 ((let uu____18665 =
+                                     let uu____18667 =
                                        FStar_Syntax_Util.eq_aqual aq aq'  in
-                                     uu____18659 <> FStar_Syntax_Util.Equal
+                                     uu____18667 <> FStar_Syntax_Util.Equal
                                       in
-                                   if uu____18657
+                                   if uu____18665
                                    then
                                      FStar_Errors.raise_error
                                        (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                          "Inconsistent implicit qualifiers")
                                        e.FStar_Syntax_Syntax.pos
                                    else ());
-                                  (let uu____18665 =
+                                  (let uu____18673 =
                                      tc_check_tot_or_gtot_term env e
                                        b.FStar_Syntax_Syntax.sort
                                       in
-                                   match uu____18665 with
+                                   match uu____18673 with
                                    | (e1,c1,g) ->
                                        let short =
                                          FStar_TypeChecker_Util.short_circuit
                                            head seen
                                           in
                                        let g1 =
-                                         let uu____18694 =
+                                         let uu____18702 =
                                            FStar_TypeChecker_Env.guard_of_guard_formula
                                              short
                                             in
                                          FStar_TypeChecker_Env.imp_guard
-                                           uu____18694 g
+                                           uu____18702 g
                                           in
                                        let ghost1 =
                                          ghost ||
-                                           ((let uu____18699 =
+                                           ((let uu____18707 =
                                                FStar_TypeChecker_Common.is_total_lcomp
                                                  c1
                                                 in
-                                             Prims.op_Negation uu____18699)
+                                             Prims.op_Negation uu____18707)
                                               &&
-                                              (let uu____18702 =
+                                              (let uu____18710 =
                                                  FStar_TypeChecker_Util.is_pure_effect
                                                    env
                                                    c1.FStar_TypeChecker_Common.eff_name
                                                   in
-                                               Prims.op_Negation uu____18702))
+                                               Prims.op_Negation uu____18710))
                                           in
-                                       let uu____18704 =
-                                         let uu____18715 =
-                                           let uu____18726 =
+                                       let uu____18712 =
+                                         let uu____18723 =
+                                           let uu____18734 =
                                              FStar_Syntax_Syntax.as_arg e1
                                               in
-                                           [uu____18726]  in
-                                         FStar_List.append seen uu____18715
+                                           [uu____18734]  in
+                                         FStar_List.append seen uu____18723
                                           in
-                                       let uu____18759 =
+                                       let uu____18767 =
                                          FStar_TypeChecker_Env.conj_guard
                                            guard g1
                                           in
-                                       (uu____18704, uu____18759, ghost1))))
+                                       (uu____18712, uu____18767, ghost1))))
                       ([], g_head, false) args bs
                      in
-                  (match uu____18433 with
+                  (match uu____18441 with
                    | (args1,guard,ghost) ->
                        let e =
                          FStar_Syntax_Syntax.mk_Tm_app head args1
@@ -6796,17 +6806,17 @@ and (check_short_circuit_args :
                        let c1 =
                          if ghost
                          then
-                           let uu____18827 =
+                           let uu____18835 =
                              FStar_Syntax_Syntax.mk_GTotal res_t  in
-                           FStar_All.pipe_right uu____18827
+                           FStar_All.pipe_right uu____18835
                              FStar_TypeChecker_Common.lcomp_of_comp
                          else FStar_TypeChecker_Common.lcomp_of_comp c  in
-                       let uu____18830 =
+                       let uu____18838 =
                          FStar_TypeChecker_Util.strengthen_precondition
                            FStar_Pervasives_Native.None env e c1 guard
                           in
-                       (match uu____18830 with | (c2,g) -> (e, c2, g)))
-              | uu____18847 ->
+                       (match uu____18838 with | (c2,g) -> (e, c2, g)))
+              | uu____18855 ->
                   check_application_args env head chead g_head args
                     expected_topt
 
@@ -6830,25 +6840,25 @@ and (tc_pat :
         let expected_pat_typ env1 pos scrutinee_t =
           let rec aux norm1 t =
             let t1 = FStar_Syntax_Util.unrefine t  in
-            let uu____18945 = FStar_Syntax_Util.head_and_args t1  in
-            match uu____18945 with
+            let uu____18953 = FStar_Syntax_Util.head_and_args t1  in
+            match uu____18953 with
             | (head,args) ->
-                let uu____18988 =
-                  let uu____18989 = FStar_Syntax_Subst.compress head  in
-                  uu____18989.FStar_Syntax_Syntax.n  in
-                (match uu____18988 with
+                let uu____18996 =
+                  let uu____18997 = FStar_Syntax_Subst.compress head  in
+                  uu____18997.FStar_Syntax_Syntax.n  in
+                (match uu____18996 with
                  | FStar_Syntax_Syntax.Tm_uinst
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
-                        FStar_Syntax_Syntax.pos = uu____18993;
-                        FStar_Syntax_Syntax.vars = uu____18994;_},us)
+                        FStar_Syntax_Syntax.pos = uu____19001;
+                        FStar_Syntax_Syntax.vars = uu____19002;_},us)
                      -> unfold_once t1 f us args
                  | FStar_Syntax_Syntax.Tm_fvar f -> unfold_once t1 f [] args
-                 | uu____19001 ->
+                 | uu____19009 ->
                      if norm1
                      then t1
                      else
-                       (let uu____19005 =
+                       (let uu____19013 =
                           FStar_TypeChecker_Normalize.normalize
                             [FStar_TypeChecker_Env.HNF;
                             FStar_TypeChecker_Env.Unmeta;
@@ -6856,30 +6866,30 @@ and (tc_pat :
                             FStar_TypeChecker_Env.UnfoldUntil
                               FStar_Syntax_Syntax.delta_constant] env1 t1
                            in
-                        aux true uu____19005))
+                        aux true uu____19013))
           
           and unfold_once t f us args =
-            let uu____19023 =
+            let uu____19031 =
               FStar_TypeChecker_Env.is_type_constructor env1
                 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                in
-            if uu____19023
+            if uu____19031
             then t
             else
-              (let uu____19028 =
+              (let uu____19036 =
                  FStar_TypeChecker_Env.lookup_definition
                    [FStar_TypeChecker_Env.Unfold
                       FStar_Syntax_Syntax.delta_constant] env1
                    (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                   in
-               match uu____19028 with
+               match uu____19036 with
                | FStar_Pervasives_Native.None  -> t
                | FStar_Pervasives_Native.Some head_def_ts ->
-                   let uu____19048 =
+                   let uu____19056 =
                      FStar_TypeChecker_Env.inst_tscheme_with head_def_ts us
                       in
-                   (match uu____19048 with
-                    | (uu____19053,head_def) ->
+                   (match uu____19056 with
+                    | (uu____19061,head_def) ->
                         let t' =
                           FStar_Syntax_Syntax.mk_Tm_app head_def args
                             FStar_Pervasives_Native.None
@@ -6892,79 +6902,79 @@ and (tc_pat :
                            in
                         aux false t'1))
            in
-          let uu____19060 =
+          let uu____19068 =
             FStar_TypeChecker_Normalize.normalize
               [FStar_TypeChecker_Env.Beta; FStar_TypeChecker_Env.Iota] env1
               scrutinee_t
              in
-          aux false uu____19060  in
+          aux false uu____19068  in
         let pat_typ_ok env1 pat_t1 scrutinee_t =
-          (let uu____19079 =
+          (let uu____19087 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns")
               in
-           if uu____19079
+           if uu____19087
            then
-             let uu____19084 = FStar_Syntax_Print.term_to_string pat_t1  in
-             let uu____19086 = FStar_Syntax_Print.term_to_string scrutinee_t
+             let uu____19092 = FStar_Syntax_Print.term_to_string pat_t1  in
+             let uu____19094 = FStar_Syntax_Print.term_to_string scrutinee_t
                 in
              FStar_Util.print2 "$$$$$$$$$$$$pat_typ_ok? %s vs. %s\n"
-               uu____19084 uu____19086
+               uu____19092 uu____19094
            else ());
           (let fail1 msg =
              let msg1 =
-               let uu____19106 = FStar_Syntax_Print.term_to_string pat_t1  in
-               let uu____19108 =
+               let uu____19114 = FStar_Syntax_Print.term_to_string pat_t1  in
+               let uu____19116 =
                  FStar_Syntax_Print.term_to_string scrutinee_t  in
                FStar_Util.format3
                  "Type of pattern (%s) does not match type of scrutinee (%s)%s"
-                 uu____19106 uu____19108 msg
+                 uu____19114 uu____19116 msg
                 in
              FStar_Errors.raise_error
                (FStar_Errors.Fatal_MismatchedPatternType, msg1)
                p0.FStar_Syntax_Syntax.p
               in
-           let uu____19112 = FStar_Syntax_Util.head_and_args scrutinee_t  in
-           match uu____19112 with
+           let uu____19120 = FStar_Syntax_Util.head_and_args scrutinee_t  in
+           match uu____19120 with
            | (head_s,args_s) ->
                let pat_t2 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env1 pat_t1
                   in
-               let uu____19156 = FStar_Syntax_Util.un_uinst head_s  in
-               (match uu____19156 with
+               let uu____19164 = FStar_Syntax_Util.un_uinst head_s  in
+               (match uu____19164 with
                 | {
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
-                      uu____19157;
-                    FStar_Syntax_Syntax.pos = uu____19158;
-                    FStar_Syntax_Syntax.vars = uu____19159;_} ->
-                    let uu____19162 = FStar_Syntax_Util.head_and_args pat_t2
+                      uu____19165;
+                    FStar_Syntax_Syntax.pos = uu____19166;
+                    FStar_Syntax_Syntax.vars = uu____19167;_} ->
+                    let uu____19170 = FStar_Syntax_Util.head_and_args pat_t2
                        in
-                    (match uu____19162 with
+                    (match uu____19170 with
                      | (head_p,args_p) ->
-                         let uu____19205 =
+                         let uu____19213 =
                            FStar_TypeChecker_Rel.teq_nosmt_force env1 head_p
                              head_s
                             in
-                         if uu____19205
+                         if uu____19213
                          then
-                           let uu____19208 =
-                             let uu____19209 =
+                           let uu____19216 =
+                             let uu____19217 =
                                FStar_Syntax_Util.un_uinst head_p  in
-                             uu____19209.FStar_Syntax_Syntax.n  in
-                           (match uu____19208 with
+                             uu____19217.FStar_Syntax_Syntax.n  in
+                           (match uu____19216 with
                             | FStar_Syntax_Syntax.Tm_fvar f ->
-                                ((let uu____19214 =
-                                    let uu____19216 =
-                                      let uu____19218 =
+                                ((let uu____19222 =
+                                    let uu____19224 =
+                                      let uu____19226 =
                                         FStar_Syntax_Syntax.lid_of_fv f  in
                                       FStar_TypeChecker_Env.is_type_constructor
-                                        env1 uu____19218
+                                        env1 uu____19226
                                        in
                                     FStar_All.pipe_left Prims.op_Negation
-                                      uu____19216
+                                      uu____19224
                                      in
-                                  if uu____19214
+                                  if uu____19222
                                   then
                                     fail1
                                       "Pattern matching a non-inductive type"
@@ -6974,61 +6984,61 @@ and (tc_pat :
                                      (FStar_List.length args_s)
                                  then fail1 ""
                                  else ();
-                                 (let uu____19246 =
-                                    let uu____19271 =
-                                      let uu____19275 =
+                                 (let uu____19254 =
+                                    let uu____19279 =
+                                      let uu____19283 =
                                         FStar_Syntax_Syntax.lid_of_fv f  in
                                       FStar_TypeChecker_Env.num_inductive_ty_params
-                                        env1 uu____19275
+                                        env1 uu____19283
                                        in
-                                    match uu____19271 with
+                                    match uu____19279 with
                                     | FStar_Pervasives_Native.None  ->
                                         (args_p, args_s)
                                     | FStar_Pervasives_Native.Some n ->
-                                        let uu____19324 =
+                                        let uu____19332 =
                                           FStar_Util.first_N n args_p  in
-                                        (match uu____19324 with
-                                         | (params_p,uu____19382) ->
-                                             let uu____19423 =
+                                        (match uu____19332 with
+                                         | (params_p,uu____19390) ->
+                                             let uu____19431 =
                                                FStar_Util.first_N n args_s
                                                 in
-                                             (match uu____19423 with
-                                              | (params_s,uu____19481) ->
+                                             (match uu____19431 with
+                                              | (params_s,uu____19489) ->
                                                   (params_p, params_s)))
                                      in
-                                  match uu____19246 with
+                                  match uu____19254 with
                                   | (params_p,params_s) ->
                                       FStar_List.fold_left2
                                         (fun out  ->
-                                           fun uu____19610  ->
-                                             fun uu____19611  ->
-                                               match (uu____19610,
-                                                       uu____19611)
+                                           fun uu____19618  ->
+                                             fun uu____19619  ->
+                                               match (uu____19618,
+                                                       uu____19619)
                                                with
-                                               | ((p,uu____19645),(s,uu____19647))
+                                               | ((p,uu____19653),(s,uu____19655))
                                                    ->
-                                                   let uu____19680 =
+                                                   let uu____19688 =
                                                      FStar_TypeChecker_Rel.teq_nosmt
                                                        env1 p s
                                                       in
-                                                   (match uu____19680 with
+                                                   (match uu____19688 with
                                                     | FStar_Pervasives_Native.None
                                                          ->
-                                                        let uu____19683 =
-                                                          let uu____19685 =
+                                                        let uu____19691 =
+                                                          let uu____19693 =
                                                             FStar_Syntax_Print.term_to_string
                                                               p
                                                              in
-                                                          let uu____19687 =
+                                                          let uu____19695 =
                                                             FStar_Syntax_Print.term_to_string
                                                               s
                                                              in
                                                           FStar_Util.format2
                                                             "; parameter %s <> parameter %s"
-                                                            uu____19685
-                                                            uu____19687
+                                                            uu____19693
+                                                            uu____19695
                                                            in
-                                                        fail1 uu____19683
+                                                        fail1 uu____19691
                                                     | FStar_Pervasives_Native.Some
                                                         g ->
                                                         let g1 =
@@ -7039,23 +7049,23 @@ and (tc_pat :
                                                           g1 out))
                                         FStar_TypeChecker_Env.trivial_guard
                                         params_p params_s))
-                            | uu____19692 ->
+                            | uu____19700 ->
                                 fail1 "Pattern matching a non-inductive type")
                          else
-                           (let uu____19696 =
-                              let uu____19698 =
+                           (let uu____19704 =
+                              let uu____19706 =
                                 FStar_Syntax_Print.term_to_string head_p  in
-                              let uu____19700 =
+                              let uu____19708 =
                                 FStar_Syntax_Print.term_to_string head_s  in
                               FStar_Util.format2 "; head mismatch %s vs %s"
-                                uu____19698 uu____19700
+                                uu____19706 uu____19708
                                in
-                            fail1 uu____19696))
-                | uu____19703 ->
-                    let uu____19704 =
+                            fail1 uu____19704))
+                | uu____19711 ->
+                    let uu____19712 =
                       FStar_TypeChecker_Rel.teq_nosmt env1 pat_t2 scrutinee_t
                        in
-                    (match uu____19704 with
+                    (match uu____19712 with
                      | FStar_Pervasives_Native.None  -> fail1 ""
                      | FStar_Pervasives_Native.Some g ->
                          let g1 =
@@ -7065,20 +7075,20 @@ and (tc_pat :
                          g1)))
            in
         let type_of_simple_pat env1 e =
-          let uu____19747 = FStar_Syntax_Util.head_and_args e  in
-          match uu____19747 with
+          let uu____19755 = FStar_Syntax_Util.head_and_args e  in
+          match uu____19755 with
           | (head,args) ->
               (match head.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_fvar f ->
-                   let uu____19817 =
+                   let uu____19825 =
                      FStar_TypeChecker_Env.lookup_datacon env1
                        (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                       in
-                   (match uu____19817 with
+                   (match uu____19825 with
                     | (us,t_f) ->
-                        let uu____19837 = FStar_Syntax_Util.arrow_formals t_f
+                        let uu____19845 = FStar_Syntax_Util.arrow_formals t_f
                            in
-                        (match uu____19837 with
+                        (match uu____19845 with
                          | (formals,t) ->
                              let erasable =
                                FStar_TypeChecker_Env.non_informative env1 t
@@ -7090,8 +7100,8 @@ and (tc_pat :
                                 fail
                                   "Pattern is not a fully-applied data constructor"
                               else ();
-                              (let rec aux uu____19950 formals1 args1 =
-                                 match uu____19950 with
+                              (let rec aux uu____19958 formals1 args1 =
+                                 match uu____19958 with
                                  | (subst,args_out,bvs,guard) ->
                                      (match (formals1, args1) with
                                       | ([],[]) ->
@@ -7105,36 +7115,36 @@ and (tc_pat :
                                               FStar_Pervasives_Native.None
                                               e.FStar_Syntax_Syntax.pos
                                              in
-                                          let uu____20101 =
+                                          let uu____20109 =
                                             FStar_Syntax_Subst.subst subst t
                                              in
-                                          (pat_e, uu____20101, bvs, guard,
+                                          (pat_e, uu____20109, bvs, guard,
                                             erasable)
-                                      | ((f1,uu____20108)::formals2,(a,imp_a)::args2)
+                                      | ((f1,uu____20116)::formals2,(a,imp_a)::args2)
                                           ->
                                           let t_f1 =
                                             FStar_Syntax_Subst.subst subst
                                               f1.FStar_Syntax_Syntax.sort
                                              in
-                                          let uu____20166 =
-                                            let uu____20187 =
-                                              let uu____20188 =
+                                          let uu____20174 =
+                                            let uu____20195 =
+                                              let uu____20196 =
                                                 FStar_Syntax_Subst.compress a
                                                  in
-                                              uu____20188.FStar_Syntax_Syntax.n
+                                              uu____20196.FStar_Syntax_Syntax.n
                                                in
-                                            match uu____20187 with
+                                            match uu____20195 with
                                             | FStar_Syntax_Syntax.Tm_name x
                                                 ->
                                                 let x1 =
-                                                  let uu___2583_20213 = x  in
+                                                  let uu___2583_20221 = x  in
                                                   {
                                                     FStar_Syntax_Syntax.ppname
                                                       =
-                                                      (uu___2583_20213.FStar_Syntax_Syntax.ppname);
+                                                      (uu___2583_20221.FStar_Syntax_Syntax.ppname);
                                                     FStar_Syntax_Syntax.index
                                                       =
-                                                      (uu___2583_20213.FStar_Syntax_Syntax.index);
+                                                      (uu___2583_20221.FStar_Syntax_Syntax.index);
                                                     FStar_Syntax_Syntax.sort
                                                       = t_f1
                                                   }  in
@@ -7150,16 +7160,16 @@ and (tc_pat :
                                                   (FStar_List.append bvs [x1]),
                                                   FStar_TypeChecker_Env.trivial_guard)
                                             | FStar_Syntax_Syntax.Tm_uvar
-                                                uu____20236 ->
+                                                uu____20244 ->
                                                 let env2 =
                                                   FStar_TypeChecker_Env.set_expected_typ
                                                     env1 t_f1
                                                    in
-                                                let uu____20250 =
+                                                let uu____20258 =
                                                   tc_tot_or_gtot_term env2 a
                                                    in
-                                                (match uu____20250 with
-                                                 | (a1,uu____20278,g) ->
+                                                (match uu____20258 with
+                                                 | (a1,uu____20286,g) ->
                                                      let g1 =
                                                        FStar_TypeChecker_Rel.discharge_guard_no_smt
                                                          env2 g
@@ -7170,42 +7180,42 @@ and (tc_pat :
                                                        :: subst  in
                                                      ((a1, imp_a), subst1,
                                                        bvs, g1))
-                                            | uu____20302 ->
+                                            | uu____20310 ->
                                                 fail "Not a simple pattern"
                                              in
-                                          (match uu____20166 with
+                                          (match uu____20174 with
                                            | (a1,subst1,bvs1,g) ->
-                                               let uu____20367 =
-                                                 let uu____20390 =
+                                               let uu____20375 =
+                                                 let uu____20398 =
                                                    FStar_TypeChecker_Env.conj_guard
                                                      g guard
                                                     in
                                                  (subst1,
                                                    (FStar_List.append
                                                       args_out [a1]), bvs1,
-                                                   uu____20390)
+                                                   uu____20398)
                                                   in
-                                               aux uu____20367 formals2 args2)
-                                      | uu____20429 ->
+                                               aux uu____20375 formals2 args2)
+                                      | uu____20437 ->
                                           fail "Not a fully applued pattern")
                                   in
                                aux
                                  ([], [], [],
                                    FStar_TypeChecker_Env.trivial_guard)
                                  formals args))))
-               | uu____20488 -> fail "Not a simple pattern")
+               | uu____20496 -> fail "Not a simple pattern")
            in
         let rec check_nested_pattern env1 p t =
-          (let uu____20554 =
+          (let uu____20562 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns")
               in
-           if uu____20554
+           if uu____20562
            then
-             let uu____20559 = FStar_Syntax_Print.pat_to_string p  in
-             let uu____20561 = FStar_Syntax_Print.term_to_string t  in
-             FStar_Util.print2 "Checking pattern %s at type %s\n" uu____20559
-               uu____20561
+             let uu____20567 = FStar_Syntax_Print.pat_to_string p  in
+             let uu____20569 = FStar_Syntax_Print.term_to_string t  in
+             FStar_Util.print2 "Checking pattern %s at type %s\n" uu____20567
+               uu____20569
            else ());
           (let id =
              FStar_Syntax_Syntax.fvar FStar_Parser_Const.id_lid
@@ -7214,122 +7224,122 @@ and (tc_pat :
               in
            let mk_disc_t disc inner_t =
              let x_b =
-               let uu____20586 =
+               let uu____20594 =
                  FStar_Syntax_Syntax.gen_bv "x" FStar_Pervasives_Native.None
                    t
                   in
-               FStar_All.pipe_right uu____20586 FStar_Syntax_Syntax.mk_binder
+               FStar_All.pipe_right uu____20594 FStar_Syntax_Syntax.mk_binder
                 in
              let tm =
-               let uu____20597 =
-                 let uu____20602 =
-                   let uu____20603 =
-                     let uu____20612 =
-                       let uu____20613 =
+               let uu____20605 =
+                 let uu____20610 =
+                   let uu____20611 =
+                     let uu____20620 =
+                       let uu____20621 =
                          FStar_All.pipe_right x_b FStar_Pervasives_Native.fst
                           in
-                       FStar_All.pipe_right uu____20613
+                       FStar_All.pipe_right uu____20621
                          FStar_Syntax_Syntax.bv_to_name
                         in
-                     FStar_All.pipe_right uu____20612
+                     FStar_All.pipe_right uu____20620
                        FStar_Syntax_Syntax.as_arg
                       in
-                   [uu____20603]  in
-                 FStar_Syntax_Syntax.mk_Tm_app disc uu____20602  in
-               uu____20597 FStar_Pervasives_Native.None
+                   [uu____20611]  in
+                 FStar_Syntax_Syntax.mk_Tm_app disc uu____20610  in
+               uu____20605 FStar_Pervasives_Native.None
                  FStar_Range.dummyRange
                 in
              let tm1 =
-               let uu____20649 =
-                 let uu____20654 =
-                   let uu____20655 =
+               let uu____20657 =
+                 let uu____20662 =
+                   let uu____20663 =
                      FStar_All.pipe_right tm FStar_Syntax_Syntax.as_arg  in
-                   [uu____20655]  in
-                 FStar_Syntax_Syntax.mk_Tm_app inner_t uu____20654  in
-               uu____20649 FStar_Pervasives_Native.None
+                   [uu____20663]  in
+                 FStar_Syntax_Syntax.mk_Tm_app inner_t uu____20662  in
+               uu____20657 FStar_Pervasives_Native.None
                  FStar_Range.dummyRange
                 in
              FStar_Syntax_Util.abs [x_b] tm1 FStar_Pervasives_Native.None  in
            match p.FStar_Syntax_Syntax.v with
-           | FStar_Syntax_Syntax.Pat_dot_term uu____20717 ->
-               let uu____20724 =
-                 let uu____20726 = FStar_Syntax_Print.pat_to_string p  in
+           | FStar_Syntax_Syntax.Pat_dot_term uu____20725 ->
+               let uu____20732 =
+                 let uu____20734 = FStar_Syntax_Print.pat_to_string p  in
                  FStar_Util.format1
                    "Impossible: Expected an undecorated pattern, got %s"
-                   uu____20726
+                   uu____20734
                   in
-               failwith uu____20724
+               failwith uu____20732
            | FStar_Syntax_Syntax.Pat_wild x ->
                let x1 =
-                 let uu___2622_20748 = x  in
+                 let uu___2622_20756 = x  in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2622_20748.FStar_Syntax_Syntax.ppname);
+                     (uu___2622_20756.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2622_20748.FStar_Syntax_Syntax.index);
+                     (uu___2622_20756.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  }  in
-               let uu____20749 = FStar_Syntax_Syntax.bv_to_name x1  in
-               ([x1], [id], uu____20749,
-                 (let uu___2625_20756 = p  in
+               let uu____20757 = FStar_Syntax_Syntax.bv_to_name x1  in
+               ([x1], [id], uu____20757,
+                 (let uu___2625_20764 = p  in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
                     FStar_Syntax_Syntax.p =
-                      (uu___2625_20756.FStar_Syntax_Syntax.p)
+                      (uu___2625_20764.FStar_Syntax_Syntax.p)
                   }), FStar_TypeChecker_Env.trivial_guard, false)
            | FStar_Syntax_Syntax.Pat_var x ->
                let x1 =
-                 let uu___2629_20760 = x  in
+                 let uu___2629_20768 = x  in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2629_20760.FStar_Syntax_Syntax.ppname);
+                     (uu___2629_20768.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2629_20760.FStar_Syntax_Syntax.index);
+                     (uu___2629_20768.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  }  in
-               let uu____20761 = FStar_Syntax_Syntax.bv_to_name x1  in
-               ([x1], [id], uu____20761,
-                 (let uu___2632_20768 = p  in
+               let uu____20769 = FStar_Syntax_Syntax.bv_to_name x1  in
+               ([x1], [id], uu____20769,
+                 (let uu___2632_20776 = p  in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
                     FStar_Syntax_Syntax.p =
-                      (uu___2632_20768.FStar_Syntax_Syntax.p)
+                      (uu___2632_20776.FStar_Syntax_Syntax.p)
                   }), FStar_TypeChecker_Env.trivial_guard, false)
-           | FStar_Syntax_Syntax.Pat_constant uu____20770 ->
-               let uu____20771 =
+           | FStar_Syntax_Syntax.Pat_constant uu____20778 ->
+               let uu____20779 =
                  FStar_TypeChecker_PatternUtils.pat_as_exp false env1 p  in
-               (match uu____20771 with
-                | (uu____20800,e_c,uu____20802,uu____20803) ->
-                    let uu____20808 = tc_tot_or_gtot_term env1 e_c  in
-                    (match uu____20808 with
+               (match uu____20779 with
+                | (uu____20808,e_c,uu____20810,uu____20811) ->
+                    let uu____20816 = tc_tot_or_gtot_term env1 e_c  in
+                    (match uu____20816 with
                      | (e_c1,lc,g) ->
                          (FStar_TypeChecker_Rel.force_trivial_guard env1 g;
                           (let expected_t =
                              expected_pat_typ env1 p0.FStar_Syntax_Syntax.p t
                               in
-                           (let uu____20838 =
-                              let uu____20840 =
+                           (let uu____20846 =
+                              let uu____20848 =
                                 FStar_TypeChecker_Rel.teq_nosmt_force env1
                                   lc.FStar_TypeChecker_Common.res_typ
                                   expected_t
                                  in
-                              Prims.op_Negation uu____20840  in
-                            if uu____20838
+                              Prims.op_Negation uu____20848  in
+                            if uu____20846
                             then
-                              let uu____20843 =
-                                let uu____20845 =
+                              let uu____20851 =
+                                let uu____20853 =
                                   FStar_Syntax_Print.term_to_string
                                     lc.FStar_TypeChecker_Common.res_typ
                                    in
-                                let uu____20847 =
+                                let uu____20855 =
                                   FStar_Syntax_Print.term_to_string
                                     expected_t
                                    in
                                 FStar_Util.format2
                                   "Type of pattern (%s) does not match type of scrutinee (%s)"
-                                  uu____20845 uu____20847
+                                  uu____20853 uu____20855
                                  in
-                              fail uu____20843
+                              fail uu____20851
                             else ());
                            ([], [], e_c1, p,
                              FStar_TypeChecker_Env.trivial_guard, false)))))
@@ -7337,165 +7347,165 @@ and (tc_pat :
                let simple_pat =
                  let simple_sub_pats =
                    FStar_List.map
-                     (fun uu____20909  ->
-                        match uu____20909 with
+                     (fun uu____20917  ->
+                        match uu____20917 with
                         | (p1,b) ->
                             (match p1.FStar_Syntax_Syntax.v with
-                             | FStar_Syntax_Syntax.Pat_dot_term uu____20939
+                             | FStar_Syntax_Syntax.Pat_dot_term uu____20947
                                  -> (p1, b)
-                             | uu____20949 ->
-                                 let uu____20950 =
-                                   let uu____20953 =
-                                     let uu____20954 =
+                             | uu____20957 ->
+                                 let uu____20958 =
+                                   let uu____20961 =
+                                     let uu____20962 =
                                        FStar_Syntax_Syntax.new_bv
                                          (FStar_Pervasives_Native.Some
                                             (p1.FStar_Syntax_Syntax.p))
                                          FStar_Syntax_Syntax.tun
                                         in
-                                     FStar_Syntax_Syntax.Pat_var uu____20954
+                                     FStar_Syntax_Syntax.Pat_var uu____20962
                                       in
-                                   FStar_Syntax_Syntax.withinfo uu____20953
+                                   FStar_Syntax_Syntax.withinfo uu____20961
                                      p1.FStar_Syntax_Syntax.p
                                     in
-                                 (uu____20950, b))) sub_pats
+                                 (uu____20958, b))) sub_pats
                     in
-                 let uu___2660_20958 = p  in
+                 let uu___2660_20966 = p  in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons (fv, simple_sub_pats));
                    FStar_Syntax_Syntax.p =
-                     (uu___2660_20958.FStar_Syntax_Syntax.p)
+                     (uu___2660_20966.FStar_Syntax_Syntax.p)
                  }  in
                let sub_pats1 =
                  FStar_All.pipe_right sub_pats
                    (FStar_List.filter
-                      (fun uu____21003  ->
-                         match uu____21003 with
-                         | (x,uu____21013) ->
+                      (fun uu____21011  ->
+                         match uu____21011 with
+                         | (x,uu____21021) ->
                              (match x.FStar_Syntax_Syntax.v with
-                              | FStar_Syntax_Syntax.Pat_dot_term uu____21021
+                              | FStar_Syntax_Syntax.Pat_dot_term uu____21029
                                   -> false
-                              | uu____21029 -> true)))
+                              | uu____21037 -> true)))
                   in
-               let uu____21031 =
+               let uu____21039 =
                  FStar_TypeChecker_PatternUtils.pat_as_exp false env1
                    simple_pat
                   in
-               (match uu____21031 with
+               (match uu____21039 with
                 | (simple_bvs,simple_pat_e,g0,simple_pat_elab) ->
                     (if
                        (FStar_List.length simple_bvs) <>
                          (FStar_List.length sub_pats1)
                      then
-                       (let uu____21075 =
-                          let uu____21077 =
+                       (let uu____21083 =
+                          let uu____21085 =
                             FStar_Range.string_of_range
                               p.FStar_Syntax_Syntax.p
                              in
-                          let uu____21079 =
+                          let uu____21087 =
                             FStar_Syntax_Print.pat_to_string simple_pat  in
-                          let uu____21081 =
+                          let uu____21089 =
                             FStar_Util.string_of_int
                               (FStar_List.length sub_pats1)
                              in
-                          let uu____21088 =
+                          let uu____21096 =
                             FStar_Util.string_of_int
                               (FStar_List.length simple_bvs)
                              in
                           FStar_Util.format4
                             "(%s) Impossible: pattern bvar mismatch: %s; expected %s sub pats; got %s"
-                            uu____21077 uu____21079 uu____21081 uu____21088
+                            uu____21085 uu____21087 uu____21089 uu____21096
                            in
-                        failwith uu____21075)
+                        failwith uu____21083)
                      else ();
-                     (let uu____21093 =
-                        let uu____21105 =
+                     (let uu____21101 =
+                        let uu____21113 =
                           type_of_simple_pat env1 simple_pat_e  in
-                        match uu____21105 with
+                        match uu____21113 with
                         | (simple_pat_e1,simple_pat_t,simple_bvs1,guard,erasable)
                             ->
                             let g' =
-                              let uu____21142 =
+                              let uu____21150 =
                                 expected_pat_typ env1
                                   p0.FStar_Syntax_Syntax.p t
                                  in
-                              pat_typ_ok env1 simple_pat_t uu____21142  in
+                              pat_typ_ok env1 simple_pat_t uu____21150  in
                             let guard1 =
                               FStar_TypeChecker_Env.conj_guard guard g'  in
-                            ((let uu____21145 =
+                            ((let uu____21153 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env1)
                                   (FStar_Options.Other "Patterns")
                                  in
-                              if uu____21145
+                              if uu____21153
                               then
-                                let uu____21150 =
+                                let uu____21158 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_e1
                                    in
-                                let uu____21152 =
+                                let uu____21160 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_t
                                    in
-                                let uu____21154 =
-                                  let uu____21156 =
+                                let uu____21162 =
+                                  let uu____21164 =
                                     FStar_List.map
                                       (fun x  ->
-                                         let uu____21164 =
-                                           let uu____21166 =
+                                         let uu____21172 =
+                                           let uu____21174 =
                                              FStar_Syntax_Print.bv_to_string
                                                x
                                               in
-                                           let uu____21168 =
-                                             let uu____21170 =
-                                               let uu____21172 =
+                                           let uu____21176 =
+                                             let uu____21178 =
+                                               let uu____21180 =
                                                  FStar_Syntax_Print.term_to_string
                                                    x.FStar_Syntax_Syntax.sort
                                                   in
-                                               Prims.op_Hat uu____21172 ")"
+                                               Prims.op_Hat uu____21180 ")"
                                                 in
-                                             Prims.op_Hat " : " uu____21170
+                                             Prims.op_Hat " : " uu____21178
                                               in
-                                           Prims.op_Hat uu____21166
-                                             uu____21168
+                                           Prims.op_Hat uu____21174
+                                             uu____21176
                                             in
-                                         Prims.op_Hat "(" uu____21164)
+                                         Prims.op_Hat "(" uu____21172)
                                       simple_bvs1
                                      in
-                                  FStar_All.pipe_right uu____21156
+                                  FStar_All.pipe_right uu____21164
                                     (FStar_String.concat " ")
                                    in
                                 FStar_Util.print3
                                   "$$$$$$$$$$$$Checked simple pattern %s at type %s with bvs=%s\n"
-                                  uu____21150 uu____21152 uu____21154
+                                  uu____21158 uu____21160 uu____21162
                               else ());
                              (simple_pat_e1, simple_bvs1, guard1, erasable))
                          in
-                      match uu____21093 with
+                      match uu____21101 with
                       | (simple_pat_e1,simple_bvs1,g1,erasable) ->
-                          let uu____21215 =
-                            let uu____21247 =
-                              let uu____21279 =
+                          let uu____21223 =
+                            let uu____21255 =
+                              let uu____21287 =
                                 FStar_TypeChecker_Env.conj_guard g0 g1  in
-                              (env1, [], [], [], [], uu____21279, erasable,
+                              (env1, [], [], [], [], uu____21287, erasable,
                                 Prims.int_zero)
                                in
                             FStar_List.fold_left2
-                              (fun uu____21361  ->
-                                 fun uu____21362  ->
+                              (fun uu____21369  ->
+                                 fun uu____21370  ->
                                    fun x  ->
-                                     match (uu____21361, uu____21362) with
+                                     match (uu____21369, uu____21370) with
                                      | ((env2,bvs,tms,pats,subst,g,erasable1,i),
                                         (p1,b)) ->
                                          let expected_t =
                                            FStar_Syntax_Subst.subst subst
                                              x.FStar_Syntax_Syntax.sort
                                             in
-                                         let uu____21546 =
+                                         let uu____21554 =
                                            check_nested_pattern env2 p1
                                              expected_t
                                             in
-                                         (match uu____21546 with
+                                         (match uu____21554 with
                                           | (bvs_p,tms_p,e_p,p2,g',erasable_p)
                                               ->
                                               let env3 =
@@ -7504,29 +7514,29 @@ and (tc_pat :
                                                  in
                                               let tms_p1 =
                                                 let disc_tm =
-                                                  let uu____21616 =
+                                                  let uu____21624 =
                                                     FStar_Syntax_Syntax.lid_of_fv
                                                       fv
                                                      in
                                                   FStar_TypeChecker_Util.get_field_projector_name
-                                                    env3 uu____21616 i
+                                                    env3 uu____21624 i
                                                    in
-                                                let uu____21617 =
-                                                  let uu____21626 =
-                                                    let uu____21631 =
+                                                let uu____21625 =
+                                                  let uu____21634 =
+                                                    let uu____21639 =
                                                       FStar_Syntax_Syntax.fvar
                                                         disc_tm
                                                         (FStar_Syntax_Syntax.Delta_constant_at_level
                                                            Prims.int_one)
                                                         FStar_Pervasives_Native.None
                                                        in
-                                                    mk_disc_t uu____21631  in
-                                                  FStar_List.map uu____21626
+                                                    mk_disc_t uu____21639  in
+                                                  FStar_List.map uu____21634
                                                    in
                                                 FStar_All.pipe_right tms_p
-                                                  uu____21617
+                                                  uu____21625
                                                  in
-                                              let uu____21637 =
+                                              let uu____21645 =
                                                 FStar_TypeChecker_Env.conj_guard
                                                   g g'
                                                  in
@@ -7537,13 +7547,13 @@ and (tc_pat :
                                                    [(p2, b)]),
                                                 ((FStar_Syntax_Syntax.NT
                                                     (x, e_p)) :: subst),
-                                                uu____21637,
+                                                uu____21645,
                                                 (erasable1 || erasable_p),
                                                 (i + Prims.int_one))))
-                              uu____21247 sub_pats1 simple_bvs1
+                              uu____21255 sub_pats1 simple_bvs1
                              in
-                          (match uu____21215 with
-                           | (_env,bvs,tms,checked_sub_pats,subst,g,erasable1,uu____21696)
+                          (match uu____21223 with
+                           | (_env,bvs,tms,checked_sub_pats,subst,g,erasable1,uu____21704)
                                ->
                                let pat_e =
                                  FStar_Syntax_Subst.subst subst simple_pat_e1
@@ -7561,34 +7571,34 @@ and (tc_pat :
                                                 e
                                                in
                                             let hd1 =
-                                              let uu___2744_21872 = hd  in
+                                              let uu___2744_21880 = hd  in
                                               {
                                                 FStar_Syntax_Syntax.v =
                                                   (FStar_Syntax_Syntax.Pat_dot_term
                                                      (x, e1));
                                                 FStar_Syntax_Syntax.p =
-                                                  (uu___2744_21872.FStar_Syntax_Syntax.p)
+                                                  (uu___2744_21880.FStar_Syntax_Syntax.p)
                                               }  in
-                                            let uu____21877 =
+                                            let uu____21885 =
                                               aux simple_pats1 bvs1 sub_pats2
                                                in
-                                            (hd1, b) :: uu____21877
+                                            (hd1, b) :: uu____21885
                                         | FStar_Syntax_Syntax.Pat_var x ->
                                             (match (bvs1, sub_pats2) with
-                                             | (x'::bvs2,(hd1,uu____21921)::sub_pats3)
+                                             | (x'::bvs2,(hd1,uu____21929)::sub_pats3)
                                                  when
                                                  FStar_Syntax_Syntax.bv_eq x
                                                    x'
                                                  ->
-                                                 let uu____21958 =
+                                                 let uu____21966 =
                                                    aux simple_pats1 bvs2
                                                      sub_pats3
                                                     in
-                                                 (hd1, b) :: uu____21958
-                                             | uu____21978 ->
+                                                 (hd1, b) :: uu____21966
+                                             | uu____21986 ->
                                                  failwith
                                                    "Impossible: simple pat variable mismatch")
-                                        | uu____22004 ->
+                                        | uu____22012 ->
                                             failwith
                                               "Impossible: expected a simple pattern")
                                     in
@@ -7599,154 +7609,154 @@ and (tc_pat :
                                        aux simple_pats simple_bvs1
                                          checked_sub_pats
                                         in
-                                     let uu___2765_22047 = pat  in
+                                     let uu___2765_22055 = pat  in
                                      {
                                        FStar_Syntax_Syntax.v =
                                          (FStar_Syntax_Syntax.Pat_cons
                                             (fv1, nested_pats));
                                        FStar_Syntax_Syntax.p =
-                                         (uu___2765_22047.FStar_Syntax_Syntax.p)
+                                         (uu___2765_22055.FStar_Syntax_Syntax.p)
                                      }
-                                 | uu____22059 -> failwith "Impossible"  in
-                               let uu____22063 =
+                                 | uu____22067 -> failwith "Impossible"  in
+                               let uu____22071 =
                                  reconstruct_nested_pat simple_pat_elab  in
-                               (bvs, tms, pat_e, uu____22063, g, erasable1))))))
+                               (bvs, tms, pat_e, uu____22071, g, erasable1))))))
            in
-        (let uu____22070 =
+        (let uu____22078 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Patterns")
             in
-         if uu____22070
+         if uu____22078
          then
-           let uu____22075 = FStar_Syntax_Print.pat_to_string p0  in
-           FStar_Util.print1 "Checking pattern: %s\n" uu____22075
+           let uu____22083 = FStar_Syntax_Print.pat_to_string p0  in
+           FStar_Util.print1 "Checking pattern: %s\n" uu____22083
          else ());
-        (let uu____22080 =
-           let uu____22098 =
-             let uu___2770_22099 =
-               let uu____22100 = FStar_TypeChecker_Env.clear_expected_typ env
+        (let uu____22088 =
+           let uu____22106 =
+             let uu___2770_22107 =
+               let uu____22108 = FStar_TypeChecker_Env.clear_expected_typ env
                   in
-               FStar_All.pipe_right uu____22100 FStar_Pervasives_Native.fst
+               FStar_All.pipe_right uu____22108 FStar_Pervasives_Native.fst
                 in
              {
                FStar_TypeChecker_Env.solver =
-                 (uu___2770_22099.FStar_TypeChecker_Env.solver);
+                 (uu___2770_22107.FStar_TypeChecker_Env.solver);
                FStar_TypeChecker_Env.range =
-                 (uu___2770_22099.FStar_TypeChecker_Env.range);
+                 (uu___2770_22107.FStar_TypeChecker_Env.range);
                FStar_TypeChecker_Env.curmodule =
-                 (uu___2770_22099.FStar_TypeChecker_Env.curmodule);
+                 (uu___2770_22107.FStar_TypeChecker_Env.curmodule);
                FStar_TypeChecker_Env.gamma =
-                 (uu___2770_22099.FStar_TypeChecker_Env.gamma);
+                 (uu___2770_22107.FStar_TypeChecker_Env.gamma);
                FStar_TypeChecker_Env.gamma_sig =
-                 (uu___2770_22099.FStar_TypeChecker_Env.gamma_sig);
+                 (uu___2770_22107.FStar_TypeChecker_Env.gamma_sig);
                FStar_TypeChecker_Env.gamma_cache =
-                 (uu___2770_22099.FStar_TypeChecker_Env.gamma_cache);
+                 (uu___2770_22107.FStar_TypeChecker_Env.gamma_cache);
                FStar_TypeChecker_Env.modules =
-                 (uu___2770_22099.FStar_TypeChecker_Env.modules);
+                 (uu___2770_22107.FStar_TypeChecker_Env.modules);
                FStar_TypeChecker_Env.expected_typ =
-                 (uu___2770_22099.FStar_TypeChecker_Env.expected_typ);
+                 (uu___2770_22107.FStar_TypeChecker_Env.expected_typ);
                FStar_TypeChecker_Env.sigtab =
-                 (uu___2770_22099.FStar_TypeChecker_Env.sigtab);
+                 (uu___2770_22107.FStar_TypeChecker_Env.sigtab);
                FStar_TypeChecker_Env.attrtab =
-                 (uu___2770_22099.FStar_TypeChecker_Env.attrtab);
+                 (uu___2770_22107.FStar_TypeChecker_Env.attrtab);
                FStar_TypeChecker_Env.instantiate_imp =
-                 (uu___2770_22099.FStar_TypeChecker_Env.instantiate_imp);
+                 (uu___2770_22107.FStar_TypeChecker_Env.instantiate_imp);
                FStar_TypeChecker_Env.effects =
-                 (uu___2770_22099.FStar_TypeChecker_Env.effects);
+                 (uu___2770_22107.FStar_TypeChecker_Env.effects);
                FStar_TypeChecker_Env.generalize =
-                 (uu___2770_22099.FStar_TypeChecker_Env.generalize);
+                 (uu___2770_22107.FStar_TypeChecker_Env.generalize);
                FStar_TypeChecker_Env.letrecs =
-                 (uu___2770_22099.FStar_TypeChecker_Env.letrecs);
+                 (uu___2770_22107.FStar_TypeChecker_Env.letrecs);
                FStar_TypeChecker_Env.top_level =
-                 (uu___2770_22099.FStar_TypeChecker_Env.top_level);
+                 (uu___2770_22107.FStar_TypeChecker_Env.top_level);
                FStar_TypeChecker_Env.check_uvars =
-                 (uu___2770_22099.FStar_TypeChecker_Env.check_uvars);
+                 (uu___2770_22107.FStar_TypeChecker_Env.check_uvars);
                FStar_TypeChecker_Env.use_eq = true;
                FStar_TypeChecker_Env.use_eq_strict =
-                 (uu___2770_22099.FStar_TypeChecker_Env.use_eq_strict);
+                 (uu___2770_22107.FStar_TypeChecker_Env.use_eq_strict);
                FStar_TypeChecker_Env.is_iface =
-                 (uu___2770_22099.FStar_TypeChecker_Env.is_iface);
+                 (uu___2770_22107.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit =
-                 (uu___2770_22099.FStar_TypeChecker_Env.admit);
+                 (uu___2770_22107.FStar_TypeChecker_Env.admit);
                FStar_TypeChecker_Env.lax =
-                 (uu___2770_22099.FStar_TypeChecker_Env.lax);
+                 (uu___2770_22107.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
-                 (uu___2770_22099.FStar_TypeChecker_Env.lax_universes);
+                 (uu___2770_22107.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =
-                 (uu___2770_22099.FStar_TypeChecker_Env.phase1);
+                 (uu___2770_22107.FStar_TypeChecker_Env.phase1);
                FStar_TypeChecker_Env.failhard =
-                 (uu___2770_22099.FStar_TypeChecker_Env.failhard);
+                 (uu___2770_22107.FStar_TypeChecker_Env.failhard);
                FStar_TypeChecker_Env.nosynth =
-                 (uu___2770_22099.FStar_TypeChecker_Env.nosynth);
+                 (uu___2770_22107.FStar_TypeChecker_Env.nosynth);
                FStar_TypeChecker_Env.uvar_subtyping =
-                 (uu___2770_22099.FStar_TypeChecker_Env.uvar_subtyping);
+                 (uu___2770_22107.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.tc_term =
-                 (uu___2770_22099.FStar_TypeChecker_Env.tc_term);
+                 (uu___2770_22107.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.type_of =
-                 (uu___2770_22099.FStar_TypeChecker_Env.type_of);
+                 (uu___2770_22107.FStar_TypeChecker_Env.type_of);
                FStar_TypeChecker_Env.universe_of =
-                 (uu___2770_22099.FStar_TypeChecker_Env.universe_of);
+                 (uu___2770_22107.FStar_TypeChecker_Env.universe_of);
                FStar_TypeChecker_Env.check_type_of =
-                 (uu___2770_22099.FStar_TypeChecker_Env.check_type_of);
+                 (uu___2770_22107.FStar_TypeChecker_Env.check_type_of);
                FStar_TypeChecker_Env.use_bv_sorts =
-                 (uu___2770_22099.FStar_TypeChecker_Env.use_bv_sorts);
+                 (uu___2770_22107.FStar_TypeChecker_Env.use_bv_sorts);
                FStar_TypeChecker_Env.qtbl_name_and_index =
-                 (uu___2770_22099.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 (uu___2770_22107.FStar_TypeChecker_Env.qtbl_name_and_index);
                FStar_TypeChecker_Env.normalized_eff_names =
-                 (uu___2770_22099.FStar_TypeChecker_Env.normalized_eff_names);
+                 (uu___2770_22107.FStar_TypeChecker_Env.normalized_eff_names);
                FStar_TypeChecker_Env.fv_delta_depths =
-                 (uu___2770_22099.FStar_TypeChecker_Env.fv_delta_depths);
+                 (uu___2770_22107.FStar_TypeChecker_Env.fv_delta_depths);
                FStar_TypeChecker_Env.proof_ns =
-                 (uu___2770_22099.FStar_TypeChecker_Env.proof_ns);
+                 (uu___2770_22107.FStar_TypeChecker_Env.proof_ns);
                FStar_TypeChecker_Env.synth_hook =
-                 (uu___2770_22099.FStar_TypeChecker_Env.synth_hook);
+                 (uu___2770_22107.FStar_TypeChecker_Env.synth_hook);
                FStar_TypeChecker_Env.try_solve_implicits_hook =
-                 (uu___2770_22099.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                 (uu___2770_22107.FStar_TypeChecker_Env.try_solve_implicits_hook);
                FStar_TypeChecker_Env.splice =
-                 (uu___2770_22099.FStar_TypeChecker_Env.splice);
+                 (uu___2770_22107.FStar_TypeChecker_Env.splice);
                FStar_TypeChecker_Env.mpreprocess =
-                 (uu___2770_22099.FStar_TypeChecker_Env.mpreprocess);
+                 (uu___2770_22107.FStar_TypeChecker_Env.mpreprocess);
                FStar_TypeChecker_Env.postprocess =
-                 (uu___2770_22099.FStar_TypeChecker_Env.postprocess);
+                 (uu___2770_22107.FStar_TypeChecker_Env.postprocess);
                FStar_TypeChecker_Env.is_native_tactic =
-                 (uu___2770_22099.FStar_TypeChecker_Env.is_native_tactic);
+                 (uu___2770_22107.FStar_TypeChecker_Env.is_native_tactic);
                FStar_TypeChecker_Env.identifier_info =
-                 (uu___2770_22099.FStar_TypeChecker_Env.identifier_info);
+                 (uu___2770_22107.FStar_TypeChecker_Env.identifier_info);
                FStar_TypeChecker_Env.tc_hooks =
-                 (uu___2770_22099.FStar_TypeChecker_Env.tc_hooks);
+                 (uu___2770_22107.FStar_TypeChecker_Env.tc_hooks);
                FStar_TypeChecker_Env.dsenv =
-                 (uu___2770_22099.FStar_TypeChecker_Env.dsenv);
+                 (uu___2770_22107.FStar_TypeChecker_Env.dsenv);
                FStar_TypeChecker_Env.nbe =
-                 (uu___2770_22099.FStar_TypeChecker_Env.nbe);
+                 (uu___2770_22107.FStar_TypeChecker_Env.nbe);
                FStar_TypeChecker_Env.strict_args_tab =
-                 (uu___2770_22099.FStar_TypeChecker_Env.strict_args_tab);
+                 (uu___2770_22107.FStar_TypeChecker_Env.strict_args_tab);
                FStar_TypeChecker_Env.erasable_types_tab =
-                 (uu___2770_22099.FStar_TypeChecker_Env.erasable_types_tab)
+                 (uu___2770_22107.FStar_TypeChecker_Env.erasable_types_tab)
              }  in
-           let uu____22116 =
+           let uu____22124 =
              FStar_TypeChecker_PatternUtils.elaborate_pat env p0  in
-           check_nested_pattern uu____22098 uu____22116 pat_t  in
-         match uu____22080 with
+           check_nested_pattern uu____22106 uu____22124 pat_t  in
+         match uu____22088 with
          | (bvs,tms,pat_e,pat,g,erasable) ->
-             ((let uu____22155 =
+             ((let uu____22163 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Patterns")
                   in
-               if uu____22155
+               if uu____22163
                then
-                 let uu____22160 = FStar_Syntax_Print.pat_to_string pat  in
-                 let uu____22162 = FStar_Syntax_Print.term_to_string pat_e
+                 let uu____22168 = FStar_Syntax_Print.pat_to_string pat  in
+                 let uu____22170 = FStar_Syntax_Print.term_to_string pat_e
                     in
                  FStar_Util.print2
-                   "Done checking pattern %s as expression %s\n" uu____22160
-                   uu____22162
+                   "Done checking pattern %s as expression %s\n" uu____22168
+                   uu____22170
                else ());
-              (let uu____22167 = FStar_TypeChecker_Env.push_bvs env bvs  in
-               let uu____22168 =
+              (let uu____22175 = FStar_TypeChecker_Env.push_bvs env bvs  in
+               let uu____22176 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env pat_e
                   in
-               (pat, bvs, tms, uu____22167, pat_e, uu____22168, g, erasable))))
+               (pat, bvs, tms, uu____22175, pat_e, uu____22176, g, erasable))))
 
 and (tc_eqn :
   FStar_Syntax_Syntax.bv ->
@@ -7762,89 +7772,89 @@ and (tc_eqn :
   fun scrutinee  ->
     fun env  ->
       fun branch  ->
-        let uu____22206 = FStar_Syntax_Subst.open_branch branch  in
-        match uu____22206 with
+        let uu____22214 = FStar_Syntax_Subst.open_branch branch  in
+        match uu____22214 with
         | (pattern,when_clause,branch_exp) ->
-            let uu____22255 = branch  in
-            (match uu____22255 with
-             | (cpat,uu____22286,cbr) ->
+            let uu____22263 = branch  in
+            (match uu____22263 with
+             | (cpat,uu____22294,cbr) ->
                  let pat_t = scrutinee.FStar_Syntax_Syntax.sort  in
                  let scrutinee_tm = FStar_Syntax_Syntax.bv_to_name scrutinee
                     in
-                 let uu____22308 =
-                   let uu____22315 =
+                 let uu____22316 =
+                   let uu____22323 =
                      FStar_TypeChecker_Env.push_bv env scrutinee  in
-                   FStar_All.pipe_right uu____22315
+                   FStar_All.pipe_right uu____22323
                      FStar_TypeChecker_Env.clear_expected_typ
                     in
-                 (match uu____22308 with
-                  | (scrutinee_env,uu____22352) ->
-                      let uu____22357 = tc_pat env pat_t pattern  in
-                      (match uu____22357 with
+                 (match uu____22316 with
+                  | (scrutinee_env,uu____22360) ->
+                      let uu____22365 = tc_pat env pat_t pattern  in
+                      (match uu____22365 with
                        | (pattern1,pat_bvs,pat_bv_tms,pat_env,pat_exp,norm_pat_exp,guard_pat,erasable)
                            ->
-                           ((let uu____22427 =
+                           ((let uu____22435 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug env)
                                  FStar_Options.Extreme
                                 in
-                             if uu____22427
+                             if uu____22435
                              then
-                               let uu____22431 =
+                               let uu____22439 =
                                  FStar_Syntax_Print.pat_to_string pattern1
                                   in
-                               let uu____22433 =
+                               let uu____22441 =
                                  FStar_Syntax_Print.bvs_to_string ";" pat_bvs
                                   in
-                               let uu____22436 =
+                               let uu____22444 =
                                  FStar_List.fold_left
                                    (fun s  ->
                                       fun t  ->
-                                        let uu____22445 =
-                                          let uu____22447 =
+                                        let uu____22453 =
+                                          let uu____22455 =
                                             FStar_Syntax_Print.term_to_string
                                               t
                                              in
-                                          Prims.op_Hat ";" uu____22447  in
-                                        Prims.op_Hat s uu____22445) ""
+                                          Prims.op_Hat ";" uu____22455  in
+                                        Prims.op_Hat s uu____22453) ""
                                    pat_bv_tms
                                   in
                                FStar_Util.print3
                                  "tc_eqn: typechecked pattern %s with bvs %s and pat_bv_tms %s"
-                                 uu____22431 uu____22433 uu____22436
+                                 uu____22439 uu____22441 uu____22444
                              else ());
-                            (let uu____22454 =
+                            (let uu____22462 =
                                match when_clause with
                                | FStar_Pervasives_Native.None  ->
                                    (FStar_Pervasives_Native.None,
                                      FStar_TypeChecker_Env.trivial_guard)
                                | FStar_Pervasives_Native.Some e ->
-                                   let uu____22484 =
+                                   let uu____22492 =
                                      FStar_TypeChecker_Env.should_verify env
                                       in
-                                   if uu____22484
+                                   if uu____22492
                                    then
                                      FStar_Errors.raise_error
                                        (FStar_Errors.Fatal_WhenClauseNotSupported,
                                          "When clauses are not yet supported in --verify mode; they will be some day")
                                        e.FStar_Syntax_Syntax.pos
                                    else
-                                     (let uu____22507 =
-                                        let uu____22514 =
+                                     (let uu____22515 =
+                                        let uu____22522 =
                                           FStar_TypeChecker_Env.set_expected_typ
                                             pat_env FStar_Syntax_Util.t_bool
                                            in
-                                        tc_term uu____22514 e  in
-                                      match uu____22507 with
+                                        tc_term uu____22522 e  in
+                                      match uu____22515 with
                                       | (e1,c,g) ->
                                           ((FStar_Pervasives_Native.Some e1),
                                             g))
                                 in
-                             match uu____22454 with
+                             match uu____22462 with
                              | (when_clause1,g_when) ->
-                                 let uu____22571 = tc_term pat_env branch_exp
+                                 let uu____22579 = tc_term pat_env branch_exp
                                     in
-                                 (match uu____22571 with
+                                 (match uu____22579 with
                                   | (branch_exp1,c,g_branch) ->
                                       (FStar_TypeChecker_Env.def_check_guard_wf
                                          cbr.FStar_Syntax_Syntax.pos
@@ -7854,25 +7864,25 @@ and (tc_eqn :
                                           | FStar_Pervasives_Native.None  ->
                                               FStar_Pervasives_Native.None
                                           | FStar_Pervasives_Native.Some w ->
-                                              let uu____22630 =
+                                              let uu____22638 =
                                                 FStar_Syntax_Util.mk_eq2
                                                   FStar_Syntax_Syntax.U_zero
                                                   FStar_Syntax_Util.t_bool w
                                                   FStar_Syntax_Util.exp_true_bool
                                                  in
                                               FStar_All.pipe_left
-                                                (fun uu____22641  ->
+                                                (fun uu____22649  ->
                                                    FStar_Pervasives_Native.Some
-                                                     uu____22641) uu____22630
+                                                     uu____22649) uu____22638
                                            in
                                         let branch_guard =
-                                          let uu____22645 =
-                                            let uu____22647 =
+                                          let uu____22653 =
+                                            let uu____22655 =
                                               FStar_TypeChecker_Env.should_verify
                                                 env
                                                in
-                                            Prims.op_Negation uu____22647  in
-                                          if uu____22645
+                                            Prims.op_Negation uu____22655  in
+                                          if uu____22653
                                           then FStar_Syntax_Util.t_true
                                           else
                                             (let rec build_branch_guard
@@ -7880,16 +7890,16 @@ and (tc_eqn :
                                                pat_exp1 =
                                                let discriminate scrutinee_tm2
                                                  f =
-                                                 let uu____22703 =
-                                                   let uu____22711 =
+                                                 let uu____22711 =
+                                                   let uu____22719 =
                                                      FStar_TypeChecker_Env.typ_of_datacon
                                                        env
                                                        f.FStar_Syntax_Syntax.v
                                                       in
                                                    FStar_TypeChecker_Env.datacons_of_typ
-                                                     env uu____22711
+                                                     env uu____22719
                                                     in
-                                                 match uu____22703 with
+                                                 match uu____22711 with
                                                  | (is_induc,datacons) ->
                                                      if
                                                        (Prims.op_Negation
@@ -7903,15 +7913,15 @@ and (tc_eqn :
                                                          FStar_Syntax_Util.mk_discriminator
                                                            f.FStar_Syntax_Syntax.v
                                                           in
-                                                       let uu____22727 =
+                                                       let uu____22735 =
                                                          FStar_TypeChecker_Env.try_lookup_lid
                                                            env discriminator
                                                           in
-                                                       (match uu____22727
+                                                       (match uu____22735
                                                         with
                                                         | FStar_Pervasives_Native.None
                                                              -> []
-                                                        | uu____22748 ->
+                                                        | uu____22756 ->
                                                             let disc =
                                                               FStar_Syntax_Syntax.fvar
                                                                 discriminator
@@ -7920,55 +7930,55 @@ and (tc_eqn :
                                                                 FStar_Pervasives_Native.None
                                                                in
                                                             let disc1 =
-                                                              let uu____22764
+                                                              let uu____22772
                                                                 =
-                                                                let uu____22769
+                                                                let uu____22777
                                                                   =
-                                                                  let uu____22770
+                                                                  let uu____22778
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     scrutinee_tm2
                                                                      in
-                                                                  [uu____22770]
+                                                                  [uu____22778]
                                                                    in
                                                                 FStar_Syntax_Syntax.mk_Tm_app
                                                                   disc
-                                                                  uu____22769
+                                                                  uu____22777
                                                                  in
-                                                              uu____22764
+                                                              uu____22772
                                                                 FStar_Pervasives_Native.None
                                                                 scrutinee_tm2.FStar_Syntax_Syntax.pos
                                                                in
-                                                            let uu____22795 =
+                                                            let uu____22803 =
                                                               FStar_Syntax_Util.mk_eq2
                                                                 FStar_Syntax_Syntax.U_zero
                                                                 FStar_Syntax_Util.t_bool
                                                                 disc1
                                                                 FStar_Syntax_Util.exp_true_bool
                                                                in
-                                                            [uu____22795])
+                                                            [uu____22803])
                                                      else []
                                                   in
-                                               let fail uu____22803 =
-                                                 let uu____22804 =
-                                                   let uu____22806 =
+                                               let fail uu____22811 =
+                                                 let uu____22812 =
+                                                   let uu____22814 =
                                                      FStar_Range.string_of_range
                                                        pat_exp1.FStar_Syntax_Syntax.pos
                                                       in
-                                                   let uu____22808 =
+                                                   let uu____22816 =
                                                      FStar_Syntax_Print.term_to_string
                                                        pat_exp1
                                                       in
-                                                   let uu____22810 =
+                                                   let uu____22818 =
                                                      FStar_Syntax_Print.tag_of_term
                                                        pat_exp1
                                                       in
                                                    FStar_Util.format3
                                                      "tc_eqn: Impossible (%s) %s (%s)"
-                                                     uu____22806 uu____22808
-                                                     uu____22810
+                                                     uu____22814 uu____22816
+                                                     uu____22818
                                                     in
-                                                 failwith uu____22804  in
+                                                 failwith uu____22812  in
                                                let rec head_constructor t =
                                                  match t.FStar_Syntax_Syntax.n
                                                  with
@@ -7976,171 +7986,171 @@ and (tc_eqn :
                                                      fv ->
                                                      fv.FStar_Syntax_Syntax.fv_name
                                                  | FStar_Syntax_Syntax.Tm_uinst
-                                                     (t1,uu____22825) ->
+                                                     (t1,uu____22833) ->
                                                      head_constructor t1
-                                                 | uu____22830 -> fail ()  in
+                                                 | uu____22838 -> fail ()  in
                                                let force_scrutinee
-                                                 uu____22836 =
+                                                 uu____22844 =
                                                  match scrutinee_tm1 with
                                                  | FStar_Pervasives_Native.None
                                                       ->
-                                                     let uu____22837 =
-                                                       let uu____22839 =
+                                                     let uu____22845 =
+                                                       let uu____22847 =
                                                          FStar_Range.string_of_range
                                                            pattern2.FStar_Syntax_Syntax.p
                                                           in
-                                                       let uu____22841 =
+                                                       let uu____22849 =
                                                          FStar_Syntax_Print.pat_to_string
                                                            pattern2
                                                           in
                                                        FStar_Util.format2
                                                          "Impossible (%s): scrutinee of match is not defined %s"
-                                                         uu____22839
-                                                         uu____22841
+                                                         uu____22847
+                                                         uu____22849
                                                         in
-                                                     failwith uu____22837
+                                                     failwith uu____22845
                                                  | FStar_Pervasives_Native.Some
                                                      t -> t
                                                   in
                                                let pat_exp2 =
-                                                 let uu____22848 =
+                                                 let uu____22856 =
                                                    FStar_Syntax_Subst.compress
                                                      pat_exp1
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____22848
+                                                   uu____22856
                                                    FStar_Syntax_Util.unmeta
                                                   in
                                                match ((pattern2.FStar_Syntax_Syntax.v),
                                                        (pat_exp2.FStar_Syntax_Syntax.n))
                                                with
-                                               | (uu____22853,FStar_Syntax_Syntax.Tm_name
-                                                  uu____22854) -> []
-                                               | (uu____22855,FStar_Syntax_Syntax.Tm_constant
+                                               | (uu____22861,FStar_Syntax_Syntax.Tm_name
+                                                  uu____22862) -> []
+                                               | (uu____22863,FStar_Syntax_Syntax.Tm_constant
                                                   (FStar_Const.Const_unit ))
                                                    -> []
                                                | (FStar_Syntax_Syntax.Pat_constant
                                                   _c,FStar_Syntax_Syntax.Tm_constant
                                                   c1) ->
-                                                   let uu____22858 =
-                                                     let uu____22859 =
+                                                   let uu____22866 =
+                                                     let uu____22867 =
                                                        tc_constant env
                                                          pat_exp2.FStar_Syntax_Syntax.pos
                                                          c1
                                                         in
-                                                     let uu____22860 =
+                                                     let uu____22868 =
                                                        force_scrutinee ()  in
                                                      FStar_Syntax_Util.mk_eq2
                                                        FStar_Syntax_Syntax.U_zero
-                                                       uu____22859
-                                                       uu____22860 pat_exp2
+                                                       uu____22867
+                                                       uu____22868 pat_exp2
                                                       in
-                                                   [uu____22858]
+                                                   [uu____22866]
                                                | (FStar_Syntax_Syntax.Pat_constant
                                                   (FStar_Const.Const_int
-                                                  (uu____22861,FStar_Pervasives_Native.Some
-                                                   uu____22862)),uu____22863)
+                                                  (uu____22869,FStar_Pervasives_Native.Some
+                                                   uu____22870)),uu____22871)
                                                    ->
-                                                   let uu____22880 =
-                                                     let uu____22887 =
+                                                   let uu____22888 =
+                                                     let uu____22895 =
                                                        FStar_TypeChecker_Env.clear_expected_typ
                                                          env
                                                         in
-                                                     match uu____22887 with
-                                                     | (env1,uu____22901) ->
+                                                     match uu____22895 with
+                                                     | (env1,uu____22909) ->
                                                          env1.FStar_TypeChecker_Env.type_of
                                                            env1 pat_exp2
                                                       in
-                                                   (match uu____22880 with
-                                                    | (uu____22908,t,uu____22910)
+                                                   (match uu____22888 with
+                                                    | (uu____22916,t,uu____22918)
                                                         ->
-                                                        let uu____22911 =
-                                                          let uu____22912 =
+                                                        let uu____22919 =
+                                                          let uu____22920 =
                                                             force_scrutinee
                                                               ()
                                                              in
                                                           FStar_Syntax_Util.mk_eq2
                                                             FStar_Syntax_Syntax.U_zero
-                                                            t uu____22912
+                                                            t uu____22920
                                                             pat_exp2
                                                            in
-                                                        [uu____22911])
+                                                        [uu____22919])
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22913,[]),FStar_Syntax_Syntax.Tm_uinst
-                                                  uu____22914) ->
+                                                  (uu____22921,[]),FStar_Syntax_Syntax.Tm_uinst
+                                                  uu____22922) ->
                                                    let f =
                                                      head_constructor
                                                        pat_exp2
                                                       in
-                                                   let uu____22938 =
-                                                     let uu____22940 =
+                                                   let uu____22946 =
+                                                     let uu____22948 =
                                                        FStar_TypeChecker_Env.is_datacon
                                                          env
                                                          f.FStar_Syntax_Syntax.v
                                                         in
                                                      Prims.op_Negation
-                                                       uu____22940
+                                                       uu____22948
                                                       in
-                                                   if uu____22938
+                                                   if uu____22946
                                                    then
                                                      failwith
                                                        "Impossible: nullary patterns must be data constructors"
                                                    else
-                                                     (let uu____22950 =
+                                                     (let uu____22958 =
                                                         force_scrutinee ()
                                                          in
-                                                      let uu____22953 =
+                                                      let uu____22961 =
                                                         head_constructor
                                                           pat_exp2
                                                          in
                                                       discriminate
-                                                        uu____22950
-                                                        uu____22953)
+                                                        uu____22958
+                                                        uu____22961)
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22956,[]),FStar_Syntax_Syntax.Tm_fvar
-                                                  uu____22957) ->
+                                                  (uu____22964,[]),FStar_Syntax_Syntax.Tm_fvar
+                                                  uu____22965) ->
                                                    let f =
                                                      head_constructor
                                                        pat_exp2
                                                       in
-                                                   let uu____22975 =
-                                                     let uu____22977 =
+                                                   let uu____22983 =
+                                                     let uu____22985 =
                                                        FStar_TypeChecker_Env.is_datacon
                                                          env
                                                          f.FStar_Syntax_Syntax.v
                                                         in
                                                      Prims.op_Negation
-                                                       uu____22977
+                                                       uu____22985
                                                       in
-                                                   if uu____22975
+                                                   if uu____22983
                                                    then
                                                      failwith
                                                        "Impossible: nullary patterns must be data constructors"
                                                    else
-                                                     (let uu____22987 =
+                                                     (let uu____22995 =
                                                         force_scrutinee ()
                                                          in
-                                                      let uu____22990 =
+                                                      let uu____22998 =
                                                         head_constructor
                                                           pat_exp2
                                                          in
                                                       discriminate
-                                                        uu____22987
-                                                        uu____22990)
+                                                        uu____22995
+                                                        uu____22998)
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22993,pat_args),FStar_Syntax_Syntax.Tm_app
+                                                  (uu____23001,pat_args),FStar_Syntax_Syntax.Tm_app
                                                   (head,args)) ->
                                                    let f =
                                                      head_constructor head
                                                       in
-                                                   let uu____23040 =
-                                                     (let uu____23044 =
+                                                   let uu____23048 =
+                                                     (let uu____23052 =
                                                         FStar_TypeChecker_Env.is_datacon
                                                           env
                                                           f.FStar_Syntax_Syntax.v
                                                          in
                                                       Prims.op_Negation
-                                                        uu____23044)
+                                                        uu____23052)
                                                        ||
                                                        ((FStar_List.length
                                                            pat_args)
@@ -8148,29 +8158,29 @@ and (tc_eqn :
                                                           (FStar_List.length
                                                              args))
                                                       in
-                                                   if uu____23040
+                                                   if uu____23048
                                                    then
                                                      failwith
                                                        "Impossible: application patterns must be fully-applied data constructors"
                                                    else
                                                      (let sub_term_guards =
-                                                        let uu____23072 =
-                                                          let uu____23077 =
+                                                        let uu____23080 =
+                                                          let uu____23085 =
                                                             FStar_List.zip
                                                               pat_args args
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____23077
+                                                            uu____23085
                                                             (FStar_List.mapi
                                                                (fun i  ->
                                                                   fun
-                                                                    uu____23163
+                                                                    uu____23171
                                                                      ->
-                                                                    match uu____23163
+                                                                    match uu____23171
                                                                     with
                                                                     | 
-                                                                    ((pi,uu____23185),
-                                                                    (ei,uu____23187))
+                                                                    ((pi,uu____23193),
+                                                                    (ei,uu____23195))
                                                                     ->
                                                                     let projector
                                                                     =
@@ -8180,139 +8190,139 @@ and (tc_eqn :
                                                                     i  in
                                                                     let scrutinee_tm2
                                                                     =
-                                                                    let uu____23215
+                                                                    let uu____23223
                                                                     =
                                                                     FStar_TypeChecker_Env.try_lookup_lid
                                                                     env
                                                                     projector
                                                                      in
-                                                                    match uu____23215
+                                                                    match uu____23223
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
                                                                      ->
                                                                     FStar_Pervasives_Native.None
                                                                     | 
-                                                                    uu____23236
+                                                                    uu____23244
                                                                     ->
                                                                     let proj
                                                                     =
-                                                                    let uu____23248
+                                                                    let uu____23256
                                                                     =
                                                                     FStar_Ident.set_lid_range
                                                                     projector
                                                                     f.FStar_Syntax_Syntax.p
                                                                      in
                                                                     FStar_Syntax_Syntax.fvar
-                                                                    uu____23248
+                                                                    uu____23256
                                                                     (FStar_Syntax_Syntax.Delta_equational_at_level
                                                                     Prims.int_one)
                                                                     FStar_Pervasives_Native.None
                                                                      in
-                                                                    let uu____23250
+                                                                    let uu____23258
                                                                     =
-                                                                    let uu____23251
+                                                                    let uu____23259
                                                                     =
-                                                                    let uu____23256
+                                                                    let uu____23264
                                                                     =
-                                                                    let uu____23257
+                                                                    let uu____23265
                                                                     =
-                                                                    let uu____23266
+                                                                    let uu____23274
                                                                     =
                                                                     force_scrutinee
                                                                     ()  in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu____23266
+                                                                    uu____23274
                                                                      in
-                                                                    [uu____23257]
+                                                                    [uu____23265]
                                                                      in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     proj
-                                                                    uu____23256
+                                                                    uu____23264
                                                                      in
-                                                                    uu____23251
+                                                                    uu____23259
                                                                     FStar_Pervasives_Native.None
                                                                     f.FStar_Syntax_Syntax.p
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____23250
+                                                                    uu____23258
                                                                      in
                                                                     build_branch_guard
                                                                     scrutinee_tm2
                                                                     pi ei))
                                                            in
                                                         FStar_All.pipe_right
-                                                          uu____23072
+                                                          uu____23080
                                                           FStar_List.flatten
                                                          in
-                                                      let uu____23289 =
-                                                        let uu____23292 =
+                                                      let uu____23297 =
+                                                        let uu____23300 =
                                                           force_scrutinee ()
                                                            in
                                                         discriminate
-                                                          uu____23292 f
+                                                          uu____23300 f
                                                          in
                                                       FStar_List.append
-                                                        uu____23289
+                                                        uu____23297
                                                         sub_term_guards)
                                                | (FStar_Syntax_Syntax.Pat_dot_term
-                                                  uu____23295,uu____23296) ->
+                                                  uu____23303,uu____23304) ->
                                                    []
-                                               | uu____23303 ->
-                                                   let uu____23308 =
-                                                     let uu____23310 =
+                                               | uu____23311 ->
+                                                   let uu____23316 =
+                                                     let uu____23318 =
                                                        FStar_Syntax_Print.pat_to_string
                                                          pattern2
                                                         in
-                                                     let uu____23312 =
+                                                     let uu____23320 =
                                                        FStar_Syntax_Print.term_to_string
                                                          pat_exp2
                                                         in
                                                      FStar_Util.format2
                                                        "Internal error: unexpected elaborated pattern: %s and pattern expression %s"
-                                                       uu____23310
-                                                       uu____23312
+                                                       uu____23318
+                                                       uu____23320
                                                       in
-                                                   failwith uu____23308
+                                                   failwith uu____23316
                                                 in
                                              let build_and_check_branch_guard
                                                scrutinee_tm1 pattern2 pat =
-                                               let uu____23341 =
-                                                 let uu____23343 =
+                                               let uu____23349 =
+                                                 let uu____23351 =
                                                    FStar_TypeChecker_Env.should_verify
                                                      env
                                                     in
                                                  Prims.op_Negation
-                                                   uu____23343
+                                                   uu____23351
                                                   in
-                                               if uu____23341
+                                               if uu____23349
                                                then
                                                  FStar_TypeChecker_Util.fvar_const
                                                    env
                                                    FStar_Parser_Const.true_lid
                                                else
                                                  (let t =
-                                                    let uu____23349 =
+                                                    let uu____23357 =
                                                       build_branch_guard
                                                         scrutinee_tm1
                                                         pattern2 pat
                                                        in
                                                     FStar_All.pipe_left
                                                       FStar_Syntax_Util.mk_conj_l
-                                                      uu____23349
+                                                      uu____23357
                                                      in
-                                                  let uu____23358 =
+                                                  let uu____23366 =
                                                     FStar_Syntax_Util.type_u
                                                       ()
                                                      in
-                                                  match uu____23358 with
-                                                  | (k,uu____23364) ->
-                                                      let uu____23365 =
+                                                  match uu____23366 with
+                                                  | (k,uu____23372) ->
+                                                      let uu____23373 =
                                                         tc_check_tot_or_gtot_term
                                                           scrutinee_env t k
                                                          in
-                                                      (match uu____23365 with
-                                                       | (t1,uu____23373,uu____23374)
+                                                      (match uu____23373 with
+                                                       | (t1,uu____23381,uu____23382)
                                                            -> t1))
                                                 in
                                              let branch_guard =
@@ -8332,16 +8342,16 @@ and (tc_eqn :
                                                 in
                                              branch_guard1)
                                            in
-                                        let uu____23388 =
+                                        let uu____23396 =
                                           let eqs =
-                                            let uu____23408 =
-                                              let uu____23410 =
+                                            let uu____23416 =
+                                              let uu____23418 =
                                                 FStar_TypeChecker_Env.should_verify
                                                   env
                                                  in
-                                              Prims.op_Negation uu____23410
+                                              Prims.op_Negation uu____23418
                                                in
-                                            if uu____23408
+                                            if uu____23416
                                             then FStar_Pervasives_Native.None
                                             else
                                               (let e =
@@ -8351,56 +8361,56 @@ and (tc_eqn :
                                                match e.FStar_Syntax_Syntax.n
                                                with
                                                | FStar_Syntax_Syntax.Tm_uvar
-                                                   uu____23420 ->
+                                                   uu____23428 ->
                                                    FStar_Pervasives_Native.None
                                                | FStar_Syntax_Syntax.Tm_constant
-                                                   uu____23433 ->
+                                                   uu____23441 ->
                                                    FStar_Pervasives_Native.None
                                                | FStar_Syntax_Syntax.Tm_fvar
-                                                   uu____23434 ->
+                                                   uu____23442 ->
                                                    FStar_Pervasives_Native.None
-                                               | uu____23435 ->
-                                                   let uu____23436 =
-                                                     let uu____23437 =
+                                               | uu____23443 ->
+                                                   let uu____23444 =
+                                                     let uu____23445 =
                                                        env.FStar_TypeChecker_Env.universe_of
                                                          env pat_t
                                                         in
                                                      FStar_Syntax_Util.mk_eq2
-                                                       uu____23437 pat_t
+                                                       uu____23445 pat_t
                                                        scrutinee_tm e
                                                       in
                                                    FStar_Pervasives_Native.Some
-                                                     uu____23436)
+                                                     uu____23444)
                                              in
-                                          let uu____23438 =
+                                          let uu____23446 =
                                             FStar_TypeChecker_Util.strengthen_precondition
                                               FStar_Pervasives_Native.None
                                               env branch_exp1 c g_branch
                                              in
-                                          match uu____23438 with
+                                          match uu____23446 with
                                           | (c1,g_branch1) ->
                                               let branch_has_layered_effect =
-                                                let uu____23467 =
+                                                let uu____23475 =
                                                   FStar_All.pipe_right
                                                     c1.FStar_TypeChecker_Common.eff_name
                                                     (FStar_TypeChecker_Env.norm_eff_name
                                                        env)
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____23467
+                                                  uu____23475
                                                   (FStar_TypeChecker_Env.is_layered_effect
                                                      env)
                                                  in
-                                              let uu____23469 =
+                                              let uu____23477 =
                                                 let env1 =
-                                                  let uu____23475 =
+                                                  let uu____23483 =
                                                     FStar_All.pipe_right
                                                       pat_bvs
                                                       (FStar_List.map
                                                          FStar_Syntax_Syntax.mk_binder)
                                                      in
                                                   FStar_TypeChecker_Env.push_binders
-                                                    scrutinee_env uu____23475
+                                                    scrutinee_env uu____23483
                                                    in
                                                 if branch_has_layered_effect
                                                 then
@@ -8416,13 +8426,13 @@ and (tc_eqn :
                                                   (match (eqs,
                                                            when_condition)
                                                    with
-                                                   | uu____23496 when
-                                                       let uu____23507 =
+                                                   | uu____23504 when
+                                                       let uu____23515 =
                                                          FStar_TypeChecker_Env.should_verify
                                                            env1
                                                           in
                                                        Prims.op_Negation
-                                                         uu____23507
+                                                         uu____23515
                                                        -> (c1, g_when)
                                                    | (FStar_Pervasives_Native.None
                                                       ,FStar_Pervasives_Native.None
@@ -8438,16 +8448,16 @@ and (tc_eqn :
                                                          FStar_TypeChecker_Env.guard_of_guard_formula
                                                            gf
                                                           in
-                                                       let uu____23528 =
+                                                       let uu____23536 =
                                                          FStar_TypeChecker_Util.weaken_precondition
                                                            env1 c1 gf
                                                           in
-                                                       let uu____23529 =
+                                                       let uu____23537 =
                                                          FStar_TypeChecker_Env.imp_guard
                                                            g g_when
                                                           in
-                                                       (uu____23528,
-                                                         uu____23529)
+                                                       (uu____23536,
+                                                         uu____23537)
                                                    | (FStar_Pervasives_Native.Some
                                                       f,FStar_Pervasives_Native.Some
                                                       w) ->
@@ -8456,27 +8466,27 @@ and (tc_eqn :
                                                            f
                                                           in
                                                        let g_fw =
-                                                         let uu____23544 =
+                                                         let uu____23552 =
                                                            FStar_Syntax_Util.mk_conj
                                                              f w
                                                             in
                                                          FStar_TypeChecker_Common.NonTrivial
-                                                           uu____23544
+                                                           uu____23552
                                                           in
-                                                       let uu____23545 =
+                                                       let uu____23553 =
                                                          FStar_TypeChecker_Util.weaken_precondition
                                                            env1 c1 g_fw
                                                           in
-                                                       let uu____23546 =
-                                                         let uu____23547 =
+                                                       let uu____23554 =
+                                                         let uu____23555 =
                                                            FStar_TypeChecker_Env.guard_of_guard_formula
                                                              g_f
                                                             in
                                                          FStar_TypeChecker_Env.imp_guard
-                                                           uu____23547 g_when
+                                                           uu____23555 g_when
                                                           in
-                                                       (uu____23545,
-                                                         uu____23546)
+                                                       (uu____23553,
+                                                         uu____23554)
                                                    | (FStar_Pervasives_Native.None
                                                       ,FStar_Pervasives_Native.Some
                                                       w) ->
@@ -8488,13 +8498,13 @@ and (tc_eqn :
                                                          FStar_TypeChecker_Env.guard_of_guard_formula
                                                            g_w
                                                           in
-                                                       let uu____23561 =
+                                                       let uu____23569 =
                                                          FStar_TypeChecker_Util.weaken_precondition
                                                            env1 c1 g_w
                                                           in
-                                                       (uu____23561, g_when))
+                                                       (uu____23569, g_when))
                                                  in
-                                              (match uu____23469 with
+                                              (match uu____23477 with
                                                | (c_weak,g_when_weak) ->
                                                    let binders =
                                                      FStar_List.map
@@ -8504,12 +8514,12 @@ and (tc_eqn :
                                                    let maybe_return_c_weak
                                                      should_return =
                                                      let c_weak1 =
-                                                       let uu____23604 =
+                                                       let uu____23612 =
                                                          should_return &&
                                                            (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                               c_weak)
                                                           in
-                                                       if uu____23604
+                                                       if uu____23612
                                                        then
                                                          FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                                            env branch_exp1
@@ -8518,14 +8528,14 @@ and (tc_eqn :
                                                      if
                                                        branch_has_layered_effect
                                                      then
-                                                       ((let uu____23611 =
+                                                       ((let uu____23619 =
                                                            FStar_All.pipe_left
                                                              (FStar_TypeChecker_Env.debug
                                                                 env)
                                                              (FStar_Options.Other
                                                                 "LayeredEffects")
                                                             in
-                                                         if uu____23611
+                                                         if uu____23619
                                                          then
                                                            FStar_Util.print_string
                                                              "Typechecking pat_bv_tms ...\n"
@@ -8537,29 +8547,29 @@ and (tc_eqn :
                                                                 (fun
                                                                    pat_bv_tm 
                                                                    ->
-                                                                   let uu____23631
+                                                                   let uu____23639
                                                                     =
-                                                                    let uu____23636
+                                                                    let uu____23644
                                                                     =
-                                                                    let uu____23637
+                                                                    let uu____23645
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     scrutinee_tm
                                                                     FStar_Syntax_Syntax.as_arg
                                                                      in
-                                                                    [uu____23637]
+                                                                    [uu____23645]
                                                                      in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     pat_bv_tm
-                                                                    uu____23636
+                                                                    uu____23644
                                                                      in
-                                                                   uu____23631
+                                                                   uu____23639
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Range.dummyRange))
                                                             in
                                                          let pat_bv_tms2 =
                                                            let env1 =
-                                                             let uu___3010_23674
+                                                             let uu___3010_23682
                                                                =
                                                                FStar_TypeChecker_Env.push_bv
                                                                  env
@@ -8568,158 +8578,158 @@ and (tc_eqn :
                                                              {
                                                                FStar_TypeChecker_Env.solver
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.solver);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.solver);
                                                                FStar_TypeChecker_Env.range
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.range);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.range);
                                                                FStar_TypeChecker_Env.curmodule
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.curmodule);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.curmodule);
                                                                FStar_TypeChecker_Env.gamma
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.gamma);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.gamma);
                                                                FStar_TypeChecker_Env.gamma_sig
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.gamma_sig);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.gamma_sig);
                                                                FStar_TypeChecker_Env.gamma_cache
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.gamma_cache);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.gamma_cache);
                                                                FStar_TypeChecker_Env.modules
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.modules);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.modules);
                                                                FStar_TypeChecker_Env.expected_typ
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.expected_typ);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.expected_typ);
                                                                FStar_TypeChecker_Env.sigtab
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.sigtab);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.sigtab);
                                                                FStar_TypeChecker_Env.attrtab
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.attrtab);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.attrtab);
                                                                FStar_TypeChecker_Env.instantiate_imp
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.instantiate_imp);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.instantiate_imp);
                                                                FStar_TypeChecker_Env.effects
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.effects);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.effects);
                                                                FStar_TypeChecker_Env.generalize
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.generalize);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.generalize);
                                                                FStar_TypeChecker_Env.letrecs
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.letrecs);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.letrecs);
                                                                FStar_TypeChecker_Env.top_level
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.top_level);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.top_level);
                                                                FStar_TypeChecker_Env.check_uvars
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.check_uvars);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.check_uvars);
                                                                FStar_TypeChecker_Env.use_eq
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.use_eq);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.use_eq);
                                                                FStar_TypeChecker_Env.use_eq_strict
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.use_eq_strict);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.use_eq_strict);
                                                                FStar_TypeChecker_Env.is_iface
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.is_iface);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.is_iface);
                                                                FStar_TypeChecker_Env.admit
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.admit);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.admit);
                                                                FStar_TypeChecker_Env.lax
                                                                  = true;
                                                                FStar_TypeChecker_Env.lax_universes
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.lax_universes);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.lax_universes);
                                                                FStar_TypeChecker_Env.phase1
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.phase1);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.phase1);
                                                                FStar_TypeChecker_Env.failhard
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.failhard);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.failhard);
                                                                FStar_TypeChecker_Env.nosynth
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.nosynth);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.nosynth);
                                                                FStar_TypeChecker_Env.uvar_subtyping
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.uvar_subtyping);
                                                                FStar_TypeChecker_Env.tc_term
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.tc_term);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.tc_term);
                                                                FStar_TypeChecker_Env.type_of
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.type_of);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.type_of);
                                                                FStar_TypeChecker_Env.universe_of
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.universe_of);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.universe_of);
                                                                FStar_TypeChecker_Env.check_type_of
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.check_type_of);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.check_type_of);
                                                                FStar_TypeChecker_Env.use_bv_sorts
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.use_bv_sorts);
                                                                FStar_TypeChecker_Env.qtbl_name_and_index
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                FStar_TypeChecker_Env.normalized_eff_names
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.normalized_eff_names);
                                                                FStar_TypeChecker_Env.fv_delta_depths
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.fv_delta_depths);
                                                                FStar_TypeChecker_Env.proof_ns
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.proof_ns);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.proof_ns);
                                                                FStar_TypeChecker_Env.synth_hook
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.synth_hook);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.synth_hook);
                                                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                FStar_TypeChecker_Env.splice
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.splice);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.splice);
                                                                FStar_TypeChecker_Env.mpreprocess
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.mpreprocess);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.mpreprocess);
                                                                FStar_TypeChecker_Env.postprocess
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.postprocess);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.postprocess);
                                                                FStar_TypeChecker_Env.is_native_tactic
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.is_native_tactic);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.is_native_tactic);
                                                                FStar_TypeChecker_Env.identifier_info
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.identifier_info);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.identifier_info);
                                                                FStar_TypeChecker_Env.tc_hooks
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.tc_hooks);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.tc_hooks);
                                                                FStar_TypeChecker_Env.dsenv
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.dsenv);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.dsenv);
                                                                FStar_TypeChecker_Env.nbe
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.nbe);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.nbe);
                                                                FStar_TypeChecker_Env.strict_args_tab
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.strict_args_tab);
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.strict_args_tab);
                                                                FStar_TypeChecker_Env.erasable_types_tab
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.erasable_types_tab)
+                                                                 (uu___3010_23682.FStar_TypeChecker_Env.erasable_types_tab)
                                                              }  in
-                                                           let uu____23676 =
-                                                             let uu____23679
+                                                           let uu____23684 =
+                                                             let uu____23687
                                                                =
                                                                FStar_List.fold_left2
                                                                  (fun
-                                                                    uu____23707
+                                                                    uu____23715
                                                                      ->
                                                                     fun
                                                                     pat_bv_tm
                                                                      ->
                                                                     fun bv 
                                                                     ->
-                                                                    match uu____23707
+                                                                    match uu____23715
                                                                     with
                                                                     | 
                                                                     (substs,acc)
@@ -8732,32 +8742,32 @@ and (tc_eqn :
                                                                      in
                                                                     let pat_bv_tm1
                                                                     =
-                                                                    let uu____23748
+                                                                    let uu____23756
                                                                     =
-                                                                    let uu____23755
+                                                                    let uu____23763
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     pat_bv_tm
                                                                     (FStar_Syntax_Subst.subst
                                                                     substs)
                                                                      in
-                                                                    let uu____23756
+                                                                    let uu____23764
                                                                     =
-                                                                    let uu____23767
+                                                                    let uu____23775
                                                                     =
                                                                     FStar_TypeChecker_Env.set_expected_typ
                                                                     env1
                                                                     expected_t
                                                                      in
                                                                     tc_trivial_guard
-                                                                    uu____23767
+                                                                    uu____23775
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____23755
+                                                                    uu____23763
+                                                                    uu____23764
+                                                                     in
+                                                                    FStar_All.pipe_right
                                                                     uu____23756
-                                                                     in
-                                                                    FStar_All.pipe_right
-                                                                    uu____23748
                                                                     FStar_Pervasives_Native.fst
                                                                      in
                                                                     ((FStar_List.append
@@ -8774,70 +8784,70 @@ and (tc_eqn :
                                                                  pat_bvs
                                                                 in
                                                              FStar_All.pipe_right
-                                                               uu____23679
+                                                               uu____23687
                                                                FStar_Pervasives_Native.snd
                                                               in
                                                            FStar_All.pipe_right
-                                                             uu____23676
+                                                             uu____23684
                                                              (FStar_List.map
                                                                 (FStar_TypeChecker_Normalize.normalize
                                                                    [FStar_TypeChecker_Env.Beta]
                                                                    env1))
                                                             in
-                                                         (let uu____23829 =
+                                                         (let uu____23837 =
                                                             FStar_All.pipe_left
                                                               (FStar_TypeChecker_Env.debug
                                                                  env)
                                                               (FStar_Options.Other
                                                                  "LayeredEffects")
                                                              in
-                                                          if uu____23829
+                                                          if uu____23837
                                                           then
-                                                            let uu____23834 =
+                                                            let uu____23842 =
                                                               FStar_List.fold_left
                                                                 (fun s  ->
                                                                    fun t  ->
-                                                                    let uu____23843
+                                                                    let uu____23851
                                                                     =
-                                                                    let uu____23845
+                                                                    let uu____23853
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t  in
                                                                     Prims.op_Hat
                                                                     ";"
-                                                                    uu____23845
+                                                                    uu____23853
                                                                      in
                                                                     Prims.op_Hat
                                                                     s
-                                                                    uu____23843)
+                                                                    uu____23851)
                                                                 ""
                                                                 pat_bv_tms2
                                                                in
-                                                            let uu____23849 =
+                                                            let uu____23857 =
                                                               FStar_List.fold_left
                                                                 (fun s  ->
                                                                    fun t  ->
-                                                                    let uu____23858
+                                                                    let uu____23866
                                                                     =
-                                                                    let uu____23860
+                                                                    let uu____23868
                                                                     =
                                                                     FStar_Syntax_Print.bv_to_string
                                                                     t  in
                                                                     Prims.op_Hat
                                                                     ";"
-                                                                    uu____23860
+                                                                    uu____23868
                                                                      in
                                                                     Prims.op_Hat
                                                                     s
-                                                                    uu____23858)
+                                                                    uu____23866)
                                                                 "" pat_bvs
                                                                in
                                                             FStar_Util.print2
                                                               "tc_eqn: typechecked pat_bv_tms %s (pat_bvs : %s)\n"
-                                                              uu____23834
-                                                              uu____23849
+                                                              uu____23842
+                                                              uu____23857
                                                           else ());
-                                                         (let uu____23867 =
+                                                         (let uu____23875 =
                                                             FStar_All.pipe_right
                                                               c_weak1
                                                               (FStar_TypeChecker_Common.apply_lcomp
@@ -8855,77 +8865,77 @@ and (tc_eqn :
                                                                     FStar_TypeChecker_Common.weaken_guard_formula
                                                                     g eqs1))
                                                              in
-                                                          let uu____23874 =
-                                                            let uu____23879 =
+                                                          let uu____23882 =
+                                                            let uu____23887 =
                                                               FStar_TypeChecker_Env.push_bv
                                                                 env scrutinee
                                                                in
                                                             FStar_TypeChecker_Util.close_layered_lcomp
-                                                              uu____23879
+                                                              uu____23887
                                                               pat_bvs
                                                               pat_bv_tms2
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____23867
-                                                            uu____23874)))
+                                                            uu____23875
+                                                            uu____23882)))
                                                      else
                                                        FStar_TypeChecker_Util.close_wp_lcomp
                                                          env pat_bvs c_weak1
                                                       in
-                                                   let uu____23882 =
+                                                   let uu____23890 =
                                                      FStar_TypeChecker_Env.close_guard
                                                        env binders
                                                        g_when_weak
                                                       in
-                                                   let uu____23883 =
+                                                   let uu____23891 =
                                                      FStar_TypeChecker_Env.conj_guard
                                                        guard_pat g_branch1
                                                       in
                                                    ((c_weak.FStar_TypeChecker_Common.eff_name),
                                                      (c_weak.FStar_TypeChecker_Common.cflags),
                                                      maybe_return_c_weak,
-                                                     uu____23882,
-                                                     uu____23883))
+                                                     uu____23890,
+                                                     uu____23891))
                                            in
-                                        match uu____23388 with
+                                        match uu____23396 with
                                         | (effect_label,cflags,maybe_return_c,g_when1,g_branch1)
                                             ->
                                             let guard =
                                               FStar_TypeChecker_Env.conj_guard
                                                 g_when1 g_branch1
                                                in
-                                            ((let uu____23938 =
+                                            ((let uu____23946 =
                                                 FStar_TypeChecker_Env.debug
                                                   env FStar_Options.High
                                                  in
-                                              if uu____23938
+                                              if uu____23946
                                               then
-                                                let uu____23941 =
+                                                let uu____23949 =
                                                   FStar_TypeChecker_Rel.guard_to_string
                                                     env guard
                                                    in
                                                 FStar_All.pipe_left
                                                   (FStar_Util.print1
                                                      "Carrying guard from match: %s\n")
-                                                  uu____23941
+                                                  uu____23949
                                               else ());
-                                             (let uu____23947 =
+                                             (let uu____23955 =
                                                 FStar_Syntax_Subst.close_branch
                                                   (pattern1, when_clause1,
                                                     branch_exp1)
                                                  in
-                                              let uu____23964 =
-                                                let uu____23965 =
+                                              let uu____23972 =
+                                                let uu____23973 =
                                                   FStar_List.map
                                                     FStar_Syntax_Syntax.mk_binder
                                                     pat_bvs
                                                    in
                                                 FStar_TypeChecker_Util.close_guard_implicits
-                                                  env false uu____23965 guard
+                                                  env false uu____23973 guard
                                                  in
-                                              (uu____23947, branch_guard,
+                                              (uu____23955, branch_guard,
                                                 effect_label, cflags,
-                                                maybe_return_c, uu____23964,
+                                                maybe_return_c, uu____23972,
                                                 erasable)))))))))))
 
 and (check_top_level_let :
@@ -8939,42 +8949,42 @@ and (check_top_level_let :
       let env1 = instantiate_both env  in
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
-          let uu____24014 = check_let_bound_def true env1 lb  in
-          (match uu____24014 with
+          let uu____24022 = check_let_bound_def true env1 lb  in
+          (match uu____24022 with
            | (e1,univ_vars,c1,g1,annotated) ->
-               let uu____24040 =
+               let uu____24048 =
                  if
                    annotated &&
                      (Prims.op_Negation env1.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____24062 =
+                   let uu____24070 =
                      FStar_TypeChecker_Normalize.reduce_uvar_solutions env1
                        e1
                       in
-                   (g1, uu____24062, univ_vars, c1)
+                   (g1, uu____24070, univ_vars, c1)
                  else
                    (let g11 =
-                      let uu____24068 =
+                      let uu____24076 =
                         FStar_TypeChecker_Rel.solve_deferred_constraints env1
                           g1
                          in
-                      FStar_All.pipe_right uu____24068
+                      FStar_All.pipe_right uu____24076
                         (FStar_TypeChecker_Rel.resolve_implicits env1)
                        in
-                    let uu____24069 = FStar_TypeChecker_Common.lcomp_comp c1
+                    let uu____24077 = FStar_TypeChecker_Common.lcomp_comp c1
                        in
-                    match uu____24069 with
+                    match uu____24077 with
                     | (comp1,g_comp1) ->
                         let g12 =
                           FStar_TypeChecker_Env.conj_guard g11 g_comp1  in
-                        let uu____24087 =
-                          let uu____24100 =
+                        let uu____24095 =
+                          let uu____24108 =
                             FStar_TypeChecker_Util.generalize env1 false
                               [((lb.FStar_Syntax_Syntax.lbname), e1, comp1)]
                              in
-                          FStar_List.hd uu____24100  in
-                        (match uu____24087 with
-                         | (uu____24150,univs,e11,c11,gvs) ->
+                          FStar_List.hd uu____24108  in
+                        (match uu____24095 with
+                         | (uu____24158,univs,e11,c11,gvs) ->
                              let g13 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.map_guard g12)
@@ -8989,30 +8999,30 @@ and (check_top_level_let :
                              let g14 =
                                FStar_TypeChecker_Env.abstract_guard_n gvs g13
                                 in
-                             let uu____24164 =
+                             let uu____24172 =
                                FStar_TypeChecker_Common.lcomp_of_comp c11  in
-                             (g14, e11, univs, uu____24164)))
+                             (g14, e11, univs, uu____24172)))
                   in
-               (match uu____24040 with
+               (match uu____24048 with
                 | (g11,e11,univ_vars1,c11) ->
-                    let uu____24181 =
-                      let uu____24190 =
+                    let uu____24189 =
+                      let uu____24198 =
                         FStar_TypeChecker_Env.should_verify env1  in
-                      if uu____24190
+                      if uu____24198
                       then
-                        let uu____24201 =
+                        let uu____24209 =
                           FStar_TypeChecker_Util.check_top_level env1 g11 c11
                            in
-                        match uu____24201 with
+                        match uu____24209 with
                         | (ok,c12) ->
                             (if ok
                              then (e2, c12)
                              else
-                               ((let uu____24235 =
+                               ((let uu____24243 =
                                    FStar_TypeChecker_Env.get_range env1  in
-                                 FStar_Errors.log_issue uu____24235
+                                 FStar_Errors.log_issue uu____24243
                                    FStar_TypeChecker_Err.top_level_effect);
-                                (let uu____24236 =
+                                (let uu____24244 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_meta
                                         (e2,
@@ -9021,12 +9031,12 @@ and (check_top_level_let :
                                      FStar_Pervasives_Native.None
                                      e2.FStar_Syntax_Syntax.pos
                                     in
-                                 (uu____24236, c12))))
+                                 (uu____24244, c12))))
                       else
                         (FStar_TypeChecker_Rel.force_trivial_guard env1 g11;
-                         (let uu____24248 =
+                         (let uu____24256 =
                             FStar_TypeChecker_Common.lcomp_comp c11  in
-                          match uu____24248 with
+                          match uu____24256 with
                           | (comp1,g_comp1) ->
                               (FStar_TypeChecker_Rel.force_trivial_guard env1
                                  g_comp1;
@@ -9039,15 +9049,15 @@ and (check_top_level_let :
                                        env1)
                                    in
                                 let e21 =
-                                  let uu____24272 =
+                                  let uu____24280 =
                                     FStar_Syntax_Util.is_pure_comp c  in
-                                  if uu____24272
+                                  if uu____24280
                                   then e2
                                   else
-                                    ((let uu____24280 =
+                                    ((let uu____24288 =
                                         FStar_TypeChecker_Env.get_range env1
                                          in
-                                      FStar_Errors.log_issue uu____24280
+                                      FStar_Errors.log_issue uu____24288
                                         FStar_TypeChecker_Err.top_level_effect);
                                      FStar_Syntax_Syntax.mk
                                        (FStar_Syntax_Syntax.Tm_meta
@@ -9059,22 +9069,22 @@ and (check_top_level_let :
                                    in
                                 (e21, c)))))
                        in
-                    (match uu____24181 with
+                    (match uu____24189 with
                      | (e21,c12) ->
-                         ((let uu____24304 =
+                         ((let uu____24312 =
                              FStar_TypeChecker_Env.debug env1
                                FStar_Options.Medium
                               in
-                           if uu____24304
+                           if uu____24312
                            then
-                             let uu____24307 =
+                             let uu____24315 =
                                FStar_Syntax_Print.term_to_string e11  in
                              FStar_Util.print1
-                               "Let binding BEFORE tcnorm: %s\n" uu____24307
+                               "Let binding BEFORE tcnorm: %s\n" uu____24315
                            else ());
                           (let e12 =
-                             let uu____24313 = FStar_Options.tcnorm ()  in
-                             if uu____24313
+                             let uu____24321 = FStar_Options.tcnorm ()  in
+                             if uu____24321
                              then
                                FStar_TypeChecker_Normalize.normalize
                                  [FStar_TypeChecker_Env.UnfoldAttr
@@ -9087,22 +9097,22 @@ and (check_top_level_let :
                                  FStar_TypeChecker_Env.DoNotUnfoldPureLets]
                                  env1 e11
                              else e11  in
-                           (let uu____24319 =
+                           (let uu____24327 =
                               FStar_TypeChecker_Env.debug env1
                                 FStar_Options.Medium
                                in
-                            if uu____24319
+                            if uu____24327
                             then
-                              let uu____24322 =
+                              let uu____24330 =
                                 FStar_Syntax_Print.term_to_string e12  in
                               FStar_Util.print1
-                                "Let binding AFTER tcnorm: %s\n" uu____24322
+                                "Let binding AFTER tcnorm: %s\n" uu____24330
                             else ());
                            (let cres =
-                              let uu____24328 =
+                              let uu____24336 =
                                 FStar_Syntax_Util.is_pure_or_ghost_comp c12
                                  in
-                              if uu____24328
+                              if uu____24336
                               then
                                 FStar_Syntax_Syntax.mk_Total'
                                   FStar_Syntax_Syntax.t_unit
@@ -9117,8 +9127,8 @@ and (check_top_level_let :
                                  let c1_wp =
                                    match c1_comp_typ.FStar_Syntax_Syntax.effect_args
                                    with
-                                   | (wp,uu____24336)::[] -> wp
-                                   | uu____24361 ->
+                                   | (wp,uu____24344)::[] -> wp
+                                   | uu____24369 ->
                                        failwith
                                          "Impossible! check_top_level_let: got unexpected effect args"
                                     in
@@ -9131,28 +9141,28 @@ and (check_top_level_let :
                                      FStar_All.pipe_right c1_eff_decl
                                        FStar_Syntax_Util.get_return_vc_combinator
                                       in
-                                   let uu____24378 =
-                                     let uu____24383 =
+                                   let uu____24386 =
+                                     let uu____24391 =
                                        FStar_TypeChecker_Env.inst_effect_fun_with
                                          [FStar_Syntax_Syntax.U_zero] env1
                                          c1_eff_decl ret
                                         in
-                                     let uu____24384 =
-                                       let uu____24385 =
+                                     let uu____24392 =
+                                       let uu____24393 =
                                          FStar_Syntax_Syntax.as_arg
                                            FStar_Syntax_Syntax.t_unit
                                           in
-                                       let uu____24394 =
-                                         let uu____24405 =
+                                       let uu____24402 =
+                                         let uu____24413 =
                                            FStar_Syntax_Syntax.as_arg
                                              FStar_Syntax_Syntax.unit_const
                                             in
-                                         [uu____24405]  in
-                                       uu____24385 :: uu____24394  in
+                                         [uu____24413]  in
+                                       uu____24393 :: uu____24402  in
                                      FStar_Syntax_Syntax.mk_Tm_app
-                                       uu____24383 uu____24384
+                                       uu____24391 uu____24392
                                       in
-                                   uu____24378 FStar_Pervasives_Native.None
+                                   uu____24386 FStar_Pervasives_Native.None
                                      e21.FStar_Syntax_Syntax.pos
                                     in
                                  let wp =
@@ -9160,17 +9170,17 @@ and (check_top_level_let :
                                      FStar_All.pipe_right c1_eff_decl
                                        FStar_Syntax_Util.get_bind_vc_combinator
                                       in
-                                   let uu____24442 =
-                                     let uu____24447 =
+                                   let uu____24450 =
+                                     let uu____24455 =
                                        FStar_TypeChecker_Env.inst_effect_fun_with
                                          (FStar_List.append
                                             c1_comp_typ.FStar_Syntax_Syntax.comp_univs
                                             [FStar_Syntax_Syntax.U_zero])
                                          env1 c1_eff_decl bind
                                         in
-                                     let uu____24448 =
-                                       let uu____24449 =
-                                         let uu____24458 =
+                                     let uu____24456 =
+                                       let uu____24457 =
+                                         let uu____24466 =
                                            FStar_Syntax_Syntax.mk
                                              (FStar_Syntax_Syntax.Tm_constant
                                                 (FStar_Const.Const_range
@@ -9180,35 +9190,35 @@ and (check_top_level_let :
                                             in
                                          FStar_All.pipe_left
                                            FStar_Syntax_Syntax.as_arg
-                                           uu____24458
+                                           uu____24466
                                           in
-                                       let uu____24467 =
-                                         let uu____24478 =
+                                       let uu____24475 =
+                                         let uu____24486 =
                                            FStar_All.pipe_left
                                              FStar_Syntax_Syntax.as_arg
                                              c1_comp_typ.FStar_Syntax_Syntax.result_typ
                                             in
-                                         let uu____24495 =
-                                           let uu____24506 =
+                                         let uu____24503 =
+                                           let uu____24514 =
                                              FStar_Syntax_Syntax.as_arg
                                                FStar_Syntax_Syntax.t_unit
                                               in
-                                           let uu____24515 =
-                                             let uu____24526 =
+                                           let uu____24523 =
+                                             let uu____24534 =
                                                FStar_Syntax_Syntax.as_arg
                                                  c1_wp
                                                 in
-                                             let uu____24535 =
-                                               let uu____24546 =
-                                                 let uu____24555 =
-                                                   let uu____24556 =
-                                                     let uu____24557 =
+                                             let uu____24543 =
+                                               let uu____24554 =
+                                                 let uu____24563 =
+                                                   let uu____24564 =
+                                                     let uu____24565 =
                                                        FStar_Syntax_Syntax.null_binder
                                                          c1_comp_typ.FStar_Syntax_Syntax.result_typ
                                                         in
-                                                     [uu____24557]  in
+                                                     [uu____24565]  in
                                                    FStar_Syntax_Util.abs
-                                                     uu____24556 wp2
+                                                     uu____24564 wp2
                                                      (FStar_Pervasives_Native.Some
                                                         (FStar_Syntax_Util.mk_residual_comp
                                                            FStar_Parser_Const.effect_Tot_lid
@@ -9217,24 +9227,24 @@ and (check_top_level_let :
                                                     in
                                                  FStar_All.pipe_left
                                                    FStar_Syntax_Syntax.as_arg
-                                                   uu____24555
+                                                   uu____24563
                                                   in
-                                               [uu____24546]  in
-                                             uu____24526 :: uu____24535  in
-                                           uu____24506 :: uu____24515  in
-                                         uu____24478 :: uu____24495  in
-                                       uu____24449 :: uu____24467  in
+                                               [uu____24554]  in
+                                             uu____24534 :: uu____24543  in
+                                           uu____24514 :: uu____24523  in
+                                         uu____24486 :: uu____24503  in
+                                       uu____24457 :: uu____24475  in
                                      FStar_Syntax_Syntax.mk_Tm_app
-                                       uu____24447 uu____24448
+                                       uu____24455 uu____24456
                                       in
-                                   uu____24442 FStar_Pervasives_Native.None
+                                   uu____24450 FStar_Pervasives_Native.None
                                      lb.FStar_Syntax_Syntax.lbpos
                                     in
-                                 let uu____24634 =
-                                   let uu____24635 =
-                                     let uu____24646 =
+                                 let uu____24642 =
+                                   let uu____24643 =
+                                     let uu____24654 =
                                        FStar_Syntax_Syntax.as_arg wp  in
-                                     [uu____24646]  in
+                                     [uu____24654]  in
                                    {
                                      FStar_Syntax_Syntax.comp_univs =
                                        [FStar_Syntax_Syntax.U_zero];
@@ -9243,10 +9253,10 @@ and (check_top_level_let :
                                      FStar_Syntax_Syntax.result_typ =
                                        FStar_Syntax_Syntax.t_unit;
                                      FStar_Syntax_Syntax.effect_args =
-                                       uu____24635;
+                                       uu____24643;
                                      FStar_Syntax_Syntax.flags = []
                                    }  in
-                                 FStar_Syntax_Syntax.mk_Comp uu____24634)
+                                 FStar_Syntax_Syntax.mk_Comp uu____24642)
                                in
                             let lb1 =
                               FStar_Syntax_Util.close_univs_and_mk_letbinding
@@ -9257,18 +9267,18 @@ and (check_top_level_let :
                                 lb.FStar_Syntax_Syntax.lbattrs
                                 lb.FStar_Syntax_Syntax.lbpos
                                in
-                            let uu____24674 =
+                            let uu____24682 =
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_let
                                    ((false, [lb1]), e21))
                                 FStar_Pervasives_Native.None
                                 e.FStar_Syntax_Syntax.pos
                                in
-                            let uu____24688 =
+                            let uu____24696 =
                               FStar_TypeChecker_Common.lcomp_of_comp cres  in
-                            (uu____24674, uu____24688,
+                            (uu____24682, uu____24696,
                               FStar_TypeChecker_Env.trivial_guard)))))))
-      | uu____24689 -> failwith "Impossible"
+      | uu____24697 -> failwith "Impossible"
 
 and (maybe_intro_smt_lemma :
   FStar_TypeChecker_Env.env ->
@@ -9278,15 +9288,15 @@ and (maybe_intro_smt_lemma :
   fun env  ->
     fun lem_typ  ->
       fun c2  ->
-        let uu____24700 = FStar_Syntax_Util.is_smt_lemma lem_typ  in
-        if uu____24700
+        let uu____24708 = FStar_Syntax_Util.is_smt_lemma lem_typ  in
+        if uu____24708
         then
           let universe_of_binders bs =
-            let uu____24727 =
+            let uu____24735 =
               FStar_List.fold_left
-                (fun uu____24752  ->
+                (fun uu____24760  ->
                    fun b  ->
-                     match uu____24752 with
+                     match uu____24760 with
                      | (env1,us) ->
                          let u =
                            env1.FStar_TypeChecker_Env.universe_of env1
@@ -9296,7 +9306,7 @@ and (maybe_intro_smt_lemma :
                            FStar_TypeChecker_Env.push_binders env1 [b]  in
                          (env2, (u :: us))) (env, []) bs
                in
-            match uu____24727 with | (uu____24800,us) -> FStar_List.rev us
+            match uu____24735 with | (uu____24808,us) -> FStar_List.rev us
              in
           let quant =
             FStar_Syntax_Util.smt_lemma_as_forall lem_typ universe_of_binders
@@ -9317,111 +9327,111 @@ and (check_inner_let :
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
           let env2 =
-            let uu___3142_24836 = env1  in
+            let uu___3142_24844 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___3142_24836.FStar_TypeChecker_Env.solver);
+                (uu___3142_24844.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___3142_24836.FStar_TypeChecker_Env.range);
+                (uu___3142_24844.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___3142_24836.FStar_TypeChecker_Env.curmodule);
+                (uu___3142_24844.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___3142_24836.FStar_TypeChecker_Env.gamma);
+                (uu___3142_24844.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___3142_24836.FStar_TypeChecker_Env.gamma_sig);
+                (uu___3142_24844.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___3142_24836.FStar_TypeChecker_Env.gamma_cache);
+                (uu___3142_24844.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___3142_24836.FStar_TypeChecker_Env.modules);
+                (uu___3142_24844.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___3142_24836.FStar_TypeChecker_Env.expected_typ);
+                (uu___3142_24844.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___3142_24836.FStar_TypeChecker_Env.sigtab);
+                (uu___3142_24844.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___3142_24836.FStar_TypeChecker_Env.attrtab);
+                (uu___3142_24844.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___3142_24836.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___3142_24844.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___3142_24836.FStar_TypeChecker_Env.effects);
+                (uu___3142_24844.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___3142_24836.FStar_TypeChecker_Env.generalize);
+                (uu___3142_24844.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___3142_24836.FStar_TypeChecker_Env.letrecs);
+                (uu___3142_24844.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level = false;
               FStar_TypeChecker_Env.check_uvars =
-                (uu___3142_24836.FStar_TypeChecker_Env.check_uvars);
+                (uu___3142_24844.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___3142_24836.FStar_TypeChecker_Env.use_eq);
+                (uu___3142_24844.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___3142_24836.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___3142_24844.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___3142_24836.FStar_TypeChecker_Env.is_iface);
+                (uu___3142_24844.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___3142_24836.FStar_TypeChecker_Env.admit);
+                (uu___3142_24844.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___3142_24836.FStar_TypeChecker_Env.lax);
+                (uu___3142_24844.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___3142_24836.FStar_TypeChecker_Env.lax_universes);
+                (uu___3142_24844.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___3142_24836.FStar_TypeChecker_Env.phase1);
+                (uu___3142_24844.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___3142_24836.FStar_TypeChecker_Env.failhard);
+                (uu___3142_24844.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___3142_24836.FStar_TypeChecker_Env.nosynth);
+                (uu___3142_24844.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___3142_24836.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___3142_24844.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___3142_24836.FStar_TypeChecker_Env.tc_term);
+                (uu___3142_24844.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___3142_24836.FStar_TypeChecker_Env.type_of);
+                (uu___3142_24844.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___3142_24836.FStar_TypeChecker_Env.universe_of);
+                (uu___3142_24844.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___3142_24836.FStar_TypeChecker_Env.check_type_of);
+                (uu___3142_24844.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___3142_24836.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___3142_24844.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___3142_24836.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___3142_24844.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___3142_24836.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___3142_24844.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___3142_24836.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___3142_24844.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___3142_24836.FStar_TypeChecker_Env.proof_ns);
+                (uu___3142_24844.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___3142_24836.FStar_TypeChecker_Env.synth_hook);
+                (uu___3142_24844.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___3142_24836.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___3142_24844.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___3142_24836.FStar_TypeChecker_Env.splice);
+                (uu___3142_24844.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___3142_24836.FStar_TypeChecker_Env.mpreprocess);
+                (uu___3142_24844.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___3142_24836.FStar_TypeChecker_Env.postprocess);
+                (uu___3142_24844.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.is_native_tactic =
-                (uu___3142_24836.FStar_TypeChecker_Env.is_native_tactic);
+                (uu___3142_24844.FStar_TypeChecker_Env.is_native_tactic);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___3142_24836.FStar_TypeChecker_Env.identifier_info);
+                (uu___3142_24844.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___3142_24836.FStar_TypeChecker_Env.tc_hooks);
+                (uu___3142_24844.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___3142_24836.FStar_TypeChecker_Env.dsenv);
+                (uu___3142_24844.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___3142_24836.FStar_TypeChecker_Env.nbe);
+                (uu___3142_24844.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___3142_24836.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___3142_24844.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___3142_24836.FStar_TypeChecker_Env.erasable_types_tab)
+                (uu___3142_24844.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let uu____24838 =
-            let uu____24850 =
-              let uu____24851 = FStar_TypeChecker_Env.clear_expected_typ env2
+          let uu____24846 =
+            let uu____24858 =
+              let uu____24859 = FStar_TypeChecker_Env.clear_expected_typ env2
                  in
-              FStar_All.pipe_right uu____24851 FStar_Pervasives_Native.fst
+              FStar_All.pipe_right uu____24859 FStar_Pervasives_Native.fst
                in
-            check_let_bound_def false uu____24850 lb  in
-          (match uu____24838 with
-           | (e1,uu____24874,c1,g1,annotated) ->
+            check_let_bound_def false uu____24858 lb  in
+          (match uu____24846 with
+           | (e1,uu____24882,c1,g1,annotated) ->
                let pure_or_ghost =
                  FStar_TypeChecker_Common.is_pure_or_ghost_lcomp c1  in
                let is_inline_let =
@@ -9432,76 +9442,76 @@ and (check_inner_let :
                   in
                (if is_inline_let && (Prims.op_Negation pure_or_ghost)
                 then
-                  (let uu____24888 =
-                     let uu____24894 =
-                       let uu____24896 = FStar_Syntax_Print.term_to_string e1
+                  (let uu____24896 =
+                     let uu____24902 =
+                       let uu____24904 = FStar_Syntax_Print.term_to_string e1
                           in
-                       let uu____24898 =
+                       let uu____24906 =
                          FStar_Syntax_Print.lid_to_string
                            c1.FStar_TypeChecker_Common.eff_name
                           in
                        FStar_Util.format2
                          "Definitions marked @inline_let are expected to be pure or ghost; got an expression \"%s\" with effect \"%s\""
-                         uu____24896 uu____24898
+                         uu____24904 uu____24906
                         in
-                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____24894)
+                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____24902)
                       in
-                   FStar_Errors.raise_error uu____24888
+                   FStar_Errors.raise_error uu____24896
                      e1.FStar_Syntax_Syntax.pos)
                 else ();
                 (let attrs =
-                   let uu____24909 =
+                   let uu____24917 =
                      (pure_or_ghost && (Prims.op_Negation is_inline_let)) &&
                        (FStar_Syntax_Util.is_unit
                           c1.FStar_TypeChecker_Common.res_typ)
                       in
-                   if uu____24909
+                   if uu____24917
                    then FStar_Syntax_Util.inline_let_attr ::
                      (lb.FStar_Syntax_Syntax.lbattrs)
                    else lb.FStar_Syntax_Syntax.lbattrs  in
                  let x =
-                   let uu___3157_24921 =
+                   let uu___3157_24929 =
                      FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
                    {
                      FStar_Syntax_Syntax.ppname =
-                       (uu___3157_24921.FStar_Syntax_Syntax.ppname);
+                       (uu___3157_24929.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
-                       (uu___3157_24921.FStar_Syntax_Syntax.index);
+                       (uu___3157_24929.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort =
                        (c1.FStar_TypeChecker_Common.res_typ)
                    }  in
-                 let uu____24922 =
-                   let uu____24927 =
-                     let uu____24928 = FStar_Syntax_Syntax.mk_binder x  in
-                     [uu____24928]  in
-                   FStar_Syntax_Subst.open_term uu____24927 e2  in
-                 match uu____24922 with
+                 let uu____24930 =
+                   let uu____24935 =
+                     let uu____24936 = FStar_Syntax_Syntax.mk_binder x  in
+                     [uu____24936]  in
+                   FStar_Syntax_Subst.open_term uu____24935 e2  in
+                 match uu____24930 with
                  | (xb,e21) ->
                      let xbinder = FStar_List.hd xb  in
                      let x1 = FStar_Pervasives_Native.fst xbinder  in
                      let env_x = FStar_TypeChecker_Env.push_bv env2 x1  in
-                     let uu____24972 =
-                       let uu____24979 = tc_term env_x e21  in
-                       FStar_All.pipe_right uu____24979
-                         (fun uu____25005  ->
-                            match uu____25005 with
+                     let uu____24980 =
+                       let uu____24987 = tc_term env_x e21  in
+                       FStar_All.pipe_right uu____24987
+                         (fun uu____25013  ->
+                            match uu____25013 with
                             | (e22,c2,g2) ->
-                                let uu____25021 =
-                                  let uu____25026 =
+                                let uu____25029 =
+                                  let uu____25034 =
                                     FStar_All.pipe_right
-                                      (fun uu____25044  ->
+                                      (fun uu____25052  ->
                                          "folding guard g2 of e2 in the lcomp")
-                                      (fun uu____25050  ->
+                                      (fun uu____25058  ->
                                          FStar_Pervasives_Native.Some
-                                           uu____25050)
+                                           uu____25058)
                                      in
                                   FStar_TypeChecker_Util.strengthen_precondition
-                                    uu____25026 env_x e22 c2 g2
+                                    uu____25034 env_x e22 c2 g2
                                    in
-                                (match uu____25021 with
+                                (match uu____25029 with
                                  | (c21,g21) -> (e22, c21, g21)))
                         in
-                     (match uu____24972 with
+                     (match uu____24980 with
                       | (e22,c2,g2) ->
                           let c21 =
                             maybe_intro_smt_lemma env_x
@@ -9533,15 +9543,15 @@ and (check_inner_let :
                               attrs lb.FStar_Syntax_Syntax.lbpos
                              in
                           let e3 =
-                            let uu____25078 =
-                              let uu____25085 =
-                                let uu____25086 =
-                                  let uu____25100 =
+                            let uu____25086 =
+                              let uu____25093 =
+                                let uu____25094 =
+                                  let uu____25108 =
                                     FStar_Syntax_Subst.close xb e23  in
-                                  ((false, [lb1]), uu____25100)  in
-                                FStar_Syntax_Syntax.Tm_let uu____25086  in
-                              FStar_Syntax_Syntax.mk uu____25085  in
-                            uu____25078 FStar_Pervasives_Native.None
+                                  ((false, [lb1]), uu____25108)  in
+                                FStar_Syntax_Syntax.Tm_let uu____25094  in
+                              FStar_Syntax_Syntax.mk uu____25093  in
+                            uu____25086 FStar_Pervasives_Native.None
                               e.FStar_Syntax_Syntax.pos
                              in
                           let e4 =
@@ -9550,92 +9560,92 @@ and (check_inner_let :
                               cres.FStar_TypeChecker_Common.res_typ
                              in
                           let g21 =
-                            let uu____25118 =
-                              let uu____25120 =
+                            let uu____25126 =
+                              let uu____25128 =
                                 FStar_All.pipe_right
                                   cres.FStar_TypeChecker_Common.eff_name
                                   (FStar_TypeChecker_Env.norm_eff_name env2)
                                  in
-                              FStar_All.pipe_right uu____25120
+                              FStar_All.pipe_right uu____25128
                                 (FStar_TypeChecker_Env.is_layered_effect env2)
                                in
                             FStar_TypeChecker_Util.close_guard_implicits env2
-                              uu____25118 xb g2
+                              uu____25126 xb g2
                              in
                           let guard = FStar_TypeChecker_Env.conj_guard g1 g21
                              in
-                          let uu____25123 =
-                            let uu____25125 =
+                          let uu____25131 =
+                            let uu____25133 =
                               FStar_TypeChecker_Env.expected_typ env2  in
-                            FStar_Option.isSome uu____25125  in
-                          if uu____25123
+                            FStar_Option.isSome uu____25133  in
+                          if uu____25131
                           then
                             let tt =
-                              let uu____25136 =
+                              let uu____25144 =
                                 FStar_TypeChecker_Env.expected_typ env2  in
-                              FStar_All.pipe_right uu____25136
+                              FStar_All.pipe_right uu____25144
                                 FStar_Option.get
                                in
-                            ((let uu____25142 =
+                            ((let uu____25150 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env2)
                                   (FStar_Options.Other "Exports")
                                  in
-                              if uu____25142
+                              if uu____25150
                               then
-                                let uu____25147 =
+                                let uu____25155 =
                                   FStar_Syntax_Print.term_to_string tt  in
-                                let uu____25149 =
+                                let uu____25157 =
                                   FStar_Syntax_Print.term_to_string
                                     cres.FStar_TypeChecker_Common.res_typ
                                    in
                                 FStar_Util.print2
                                   "Got expected type from env %s\ncres.res_typ=%s\n"
-                                  uu____25147 uu____25149
+                                  uu____25155 uu____25157
                               else ());
                              (e4, cres, guard))
                           else
-                            (let uu____25156 =
+                            (let uu____25164 =
                                check_no_escape FStar_Pervasives_Native.None
                                  env2 [x1]
                                  cres.FStar_TypeChecker_Common.res_typ
                                 in
-                             match uu____25156 with
+                             match uu____25164 with
                              | (t,g_ex) ->
-                                 ((let uu____25170 =
+                                 ((let uu____25178 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env2)
                                        (FStar_Options.Other "Exports")
                                       in
-                                   if uu____25170
+                                   if uu____25178
                                    then
-                                     let uu____25175 =
+                                     let uu____25183 =
                                        FStar_Syntax_Print.term_to_string
                                          cres.FStar_TypeChecker_Common.res_typ
                                         in
-                                     let uu____25177 =
+                                     let uu____25185 =
                                        FStar_Syntax_Print.term_to_string t
                                         in
                                      FStar_Util.print2
                                        "Checked %s has no escaping types; normalized to %s\n"
-                                       uu____25175 uu____25177
+                                       uu____25183 uu____25185
                                    else ());
-                                  (let uu____25182 =
+                                  (let uu____25190 =
                                      FStar_TypeChecker_Env.conj_guard g_ex
                                        guard
                                       in
                                    (e4,
-                                     (let uu___3196_25184 = cres  in
+                                     (let uu___3196_25192 = cres  in
                                       {
                                         FStar_TypeChecker_Common.eff_name =
-                                          (uu___3196_25184.FStar_TypeChecker_Common.eff_name);
+                                          (uu___3196_25192.FStar_TypeChecker_Common.eff_name);
                                         FStar_TypeChecker_Common.res_typ = t;
                                         FStar_TypeChecker_Common.cflags =
-                                          (uu___3196_25184.FStar_TypeChecker_Common.cflags);
+                                          (uu___3196_25192.FStar_TypeChecker_Common.cflags);
                                         FStar_TypeChecker_Common.comp_thunk =
-                                          (uu___3196_25184.FStar_TypeChecker_Common.comp_thunk)
-                                      }), uu____25182))))))))
-      | uu____25185 ->
+                                          (uu___3196_25192.FStar_TypeChecker_Common.comp_thunk)
+                                      }), uu____25190))))))))
+      | uu____25193 ->
           failwith "Impossible (inner let with more than one lb)"
 
 and (check_top_level_let_rec :
@@ -9649,44 +9659,44 @@ and (check_top_level_let_rec :
       let env1 = instantiate_both env  in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____25221 = FStar_Syntax_Subst.open_let_rec lbs e2  in
-          (match uu____25221 with
+          let uu____25229 = FStar_Syntax_Subst.open_let_rec lbs e2  in
+          (match uu____25229 with
            | (lbs1,e21) ->
-               let uu____25240 =
+               let uu____25248 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____25240 with
+               (match uu____25248 with
                 | (env0,topt) ->
-                    let uu____25259 = build_let_rec_env true env0 lbs1  in
-                    (match uu____25259 with
+                    let uu____25267 = build_let_rec_env true env0 lbs1  in
+                    (match uu____25267 with
                      | (lbs2,rec_env,g_t) ->
-                         let uu____25282 = check_let_recs rec_env lbs2  in
-                         (match uu____25282 with
+                         let uu____25290 = check_let_recs rec_env lbs2  in
+                         (match uu____25290 with
                           | (lbs3,g_lbs) ->
                               let g_lbs1 =
-                                let uu____25302 =
-                                  let uu____25303 =
+                                let uu____25310 =
+                                  let uu____25311 =
                                     FStar_TypeChecker_Env.conj_guard g_t
                                       g_lbs
                                      in
-                                  FStar_All.pipe_right uu____25303
+                                  FStar_All.pipe_right uu____25311
                                     (FStar_TypeChecker_Rel.solve_deferred_constraints
                                        env1)
                                    in
-                                FStar_All.pipe_right uu____25302
+                                FStar_All.pipe_right uu____25310
                                   (FStar_TypeChecker_Rel.resolve_implicits
                                      env1)
                                  in
                               let all_lb_names =
-                                let uu____25309 =
+                                let uu____25317 =
                                   FStar_All.pipe_right lbs3
                                     (FStar_List.map
                                        (fun lb  ->
                                           FStar_Util.right
                                             lb.FStar_Syntax_Syntax.lbname))
                                    in
-                                FStar_All.pipe_right uu____25309
-                                  (fun uu____25326  ->
-                                     FStar_Pervasives_Native.Some uu____25326)
+                                FStar_All.pipe_right uu____25317
+                                  (fun uu____25334  ->
+                                     FStar_Pervasives_Native.Some uu____25334)
                                  in
                               let lbs4 =
                                 if
@@ -9717,25 +9727,25 @@ and (check_top_level_let_rec :
                                               lb.FStar_Syntax_Syntax.lbpos))
                                 else
                                   (let ecs =
-                                     let uu____25363 =
+                                     let uu____25371 =
                                        FStar_All.pipe_right lbs3
                                          (FStar_List.map
                                             (fun lb  ->
-                                               let uu____25397 =
+                                               let uu____25405 =
                                                  FStar_Syntax_Syntax.mk_Total
                                                    lb.FStar_Syntax_Syntax.lbtyp
                                                   in
                                                ((lb.FStar_Syntax_Syntax.lbname),
                                                  (lb.FStar_Syntax_Syntax.lbdef),
-                                                 uu____25397)))
+                                                 uu____25405)))
                                         in
                                      FStar_TypeChecker_Util.generalize env1
-                                       true uu____25363
+                                       true uu____25371
                                       in
                                    FStar_List.map2
-                                     (fun uu____25432  ->
+                                     (fun uu____25440  ->
                                         fun lb  ->
-                                          match uu____25432 with
+                                          match uu____25440 with
                                           | (x,uvs,e,c,gvs) ->
                                               FStar_Syntax_Util.close_univs_and_mk_letbinding
                                                 all_lb_names x uvs
@@ -9748,35 +9758,35 @@ and (check_top_level_let_rec :
                                      ecs lbs3)
                                  in
                               let cres =
-                                let uu____25480 =
+                                let uu____25488 =
                                   FStar_Syntax_Syntax.mk_Total
                                     FStar_Syntax_Syntax.t_unit
                                    in
                                 FStar_All.pipe_left
                                   FStar_TypeChecker_Common.lcomp_of_comp
-                                  uu____25480
+                                  uu____25488
                                  in
-                              let uu____25481 =
+                              let uu____25489 =
                                 FStar_Syntax_Subst.close_let_rec lbs4 e21  in
-                              (match uu____25481 with
+                              (match uu____25489 with
                                | (lbs5,e22) ->
-                                   ((let uu____25501 =
+                                   ((let uu____25509 =
                                        FStar_TypeChecker_Rel.discharge_guard
                                          env1 g_lbs1
                                         in
-                                     FStar_All.pipe_right uu____25501
+                                     FStar_All.pipe_right uu____25509
                                        (FStar_TypeChecker_Rel.force_trivial_guard
                                           env1));
-                                    (let uu____25502 =
+                                    (let uu____25510 =
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_let
                                             ((true, lbs5), e22))
                                          FStar_Pervasives_Native.None
                                          top.FStar_Syntax_Syntax.pos
                                         in
-                                     (uu____25502, cres,
+                                     (uu____25510, cres,
                                        FStar_TypeChecker_Env.trivial_guard))))))))
-      | uu____25516 -> failwith "Impossible"
+      | uu____25524 -> failwith "Impossible"
 
 and (check_inner_let_rec :
   FStar_TypeChecker_Env.env ->
@@ -9789,64 +9799,64 @@ and (check_inner_let_rec :
       let env1 = instantiate_both env  in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____25552 = FStar_Syntax_Subst.open_let_rec lbs e2  in
-          (match uu____25552 with
+          let uu____25560 = FStar_Syntax_Subst.open_let_rec lbs e2  in
+          (match uu____25560 with
            | (lbs1,e21) ->
-               let uu____25571 =
+               let uu____25579 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____25571 with
+               (match uu____25579 with
                 | (env0,topt) ->
-                    let uu____25590 = build_let_rec_env false env0 lbs1  in
-                    (match uu____25590 with
+                    let uu____25598 = build_let_rec_env false env0 lbs1  in
+                    (match uu____25598 with
                      | (lbs2,rec_env,g_t) ->
-                         let uu____25613 =
-                           let uu____25620 = check_let_recs rec_env lbs2  in
-                           FStar_All.pipe_right uu____25620
-                             (fun uu____25643  ->
-                                match uu____25643 with
+                         let uu____25621 =
+                           let uu____25628 = check_let_recs rec_env lbs2  in
+                           FStar_All.pipe_right uu____25628
+                             (fun uu____25651  ->
+                                match uu____25651 with
                                 | (lbs3,g) ->
-                                    let uu____25662 =
+                                    let uu____25670 =
                                       FStar_TypeChecker_Env.conj_guard g_t g
                                        in
-                                    (lbs3, uu____25662))
+                                    (lbs3, uu____25670))
                             in
-                         (match uu____25613 with
+                         (match uu____25621 with
                           | (lbs3,g_lbs) ->
-                              let uu____25677 =
+                              let uu____25685 =
                                 FStar_All.pipe_right lbs3
                                   (FStar_Util.fold_map
                                      (fun env2  ->
                                         fun lb  ->
                                           let x =
-                                            let uu___3271_25700 =
+                                            let uu___3271_25708 =
                                               FStar_Util.left
                                                 lb.FStar_Syntax_Syntax.lbname
                                                in
                                             {
                                               FStar_Syntax_Syntax.ppname =
-                                                (uu___3271_25700.FStar_Syntax_Syntax.ppname);
+                                                (uu___3271_25708.FStar_Syntax_Syntax.ppname);
                                               FStar_Syntax_Syntax.index =
-                                                (uu___3271_25700.FStar_Syntax_Syntax.index);
+                                                (uu___3271_25708.FStar_Syntax_Syntax.index);
                                               FStar_Syntax_Syntax.sort =
                                                 (lb.FStar_Syntax_Syntax.lbtyp)
                                             }  in
                                           let lb1 =
-                                            let uu___3274_25702 = lb  in
+                                            let uu___3274_25710 = lb  in
                                             {
                                               FStar_Syntax_Syntax.lbname =
                                                 (FStar_Util.Inl x);
                                               FStar_Syntax_Syntax.lbunivs =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbunivs);
+                                                (uu___3274_25710.FStar_Syntax_Syntax.lbunivs);
                                               FStar_Syntax_Syntax.lbtyp =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbtyp);
+                                                (uu___3274_25710.FStar_Syntax_Syntax.lbtyp);
                                               FStar_Syntax_Syntax.lbeff =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbeff);
+                                                (uu___3274_25710.FStar_Syntax_Syntax.lbeff);
                                               FStar_Syntax_Syntax.lbdef =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbdef);
+                                                (uu___3274_25710.FStar_Syntax_Syntax.lbdef);
                                               FStar_Syntax_Syntax.lbattrs =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbattrs);
+                                                (uu___3274_25710.FStar_Syntax_Syntax.lbattrs);
                                               FStar_Syntax_Syntax.lbpos =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbpos)
+                                                (uu___3274_25710.FStar_Syntax_Syntax.lbpos)
                                             }  in
                                           let env3 =
                                             FStar_TypeChecker_Env.push_let_binding
@@ -9857,7 +9867,7 @@ and (check_inner_let_rec :
                                              in
                                           (env3, lb1)) env1)
                                  in
-                              (match uu____25677 with
+                              (match uu____25685 with
                                | (env2,lbs4) ->
                                    let bvs =
                                      FStar_All.pipe_right lbs4
@@ -9866,8 +9876,8 @@ and (check_inner_let_rec :
                                              FStar_Util.left
                                                lb.FStar_Syntax_Syntax.lbname))
                                       in
-                                   let uu____25729 = tc_term env2 e21  in
-                                   (match uu____25729 with
+                                   let uu____25737 = tc_term env2 e21  in
+                                   (match uu____25737 with
                                     | (e22,cres,g2) ->
                                         let cres1 =
                                           FStar_List.fold_right
@@ -9887,17 +9897,17 @@ and (check_inner_let_rec :
                                             [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
                                            in
                                         let guard =
-                                          let uu____25753 =
-                                            let uu____25754 =
+                                          let uu____25761 =
+                                            let uu____25762 =
                                               FStar_List.map
                                                 FStar_Syntax_Syntax.mk_binder
                                                 bvs
                                                in
                                             FStar_TypeChecker_Env.close_guard
-                                              env2 uu____25754 g2
+                                              env2 uu____25762 g2
                                              in
                                           FStar_TypeChecker_Env.conj_guard
-                                            g_lbs uu____25753
+                                            g_lbs uu____25761
                                            in
                                         let cres4 =
                                           FStar_TypeChecker_Util.close_wp_lcomp
@@ -9908,39 +9918,39 @@ and (check_inner_let_rec :
                                             cres4.FStar_TypeChecker_Common.res_typ
                                            in
                                         let cres5 =
-                                          let uu___3295_25764 = cres4  in
+                                          let uu___3295_25772 = cres4  in
                                           {
                                             FStar_TypeChecker_Common.eff_name
                                               =
-                                              (uu___3295_25764.FStar_TypeChecker_Common.eff_name);
+                                              (uu___3295_25772.FStar_TypeChecker_Common.eff_name);
                                             FStar_TypeChecker_Common.res_typ
                                               = tres;
                                             FStar_TypeChecker_Common.cflags =
-                                              (uu___3295_25764.FStar_TypeChecker_Common.cflags);
+                                              (uu___3295_25772.FStar_TypeChecker_Common.cflags);
                                             FStar_TypeChecker_Common.comp_thunk
                                               =
-                                              (uu___3295_25764.FStar_TypeChecker_Common.comp_thunk)
+                                              (uu___3295_25772.FStar_TypeChecker_Common.comp_thunk)
                                           }  in
                                         let guard1 =
                                           let bs =
                                             FStar_All.pipe_right lbs4
                                               (FStar_List.map
                                                  (fun lb  ->
-                                                    let uu____25772 =
+                                                    let uu____25780 =
                                                       FStar_Util.left
                                                         lb.FStar_Syntax_Syntax.lbname
                                                        in
                                                     FStar_Syntax_Syntax.mk_binder
-                                                      uu____25772))
+                                                      uu____25780))
                                              in
                                           FStar_TypeChecker_Util.close_guard_implicits
                                             env2 false bs guard
                                            in
-                                        let uu____25774 =
+                                        let uu____25782 =
                                           FStar_Syntax_Subst.close_let_rec
                                             lbs4 e22
                                            in
-                                        (match uu____25774 with
+                                        (match uu____25782 with
                                          | (lbs5,e23) ->
                                              let e =
                                                FStar_Syntax_Syntax.mk
@@ -9951,40 +9961,40 @@ and (check_inner_let_rec :
                                                 in
                                              (match topt with
                                               | FStar_Pervasives_Native.Some
-                                                  uu____25815 ->
+                                                  uu____25823 ->
                                                   (e, cres5, guard1)
                                               | FStar_Pervasives_Native.None 
                                                   ->
-                                                  let uu____25816 =
+                                                  let uu____25824 =
                                                     check_no_escape
                                                       FStar_Pervasives_Native.None
                                                       env2 bvs tres
                                                      in
-                                                  (match uu____25816 with
+                                                  (match uu____25824 with
                                                    | (tres1,g_ex) ->
                                                        let cres6 =
-                                                         let uu___3311_25830
+                                                         let uu___3311_25838
                                                            = cres5  in
                                                          {
                                                            FStar_TypeChecker_Common.eff_name
                                                              =
-                                                             (uu___3311_25830.FStar_TypeChecker_Common.eff_name);
+                                                             (uu___3311_25838.FStar_TypeChecker_Common.eff_name);
                                                            FStar_TypeChecker_Common.res_typ
                                                              = tres1;
                                                            FStar_TypeChecker_Common.cflags
                                                              =
-                                                             (uu___3311_25830.FStar_TypeChecker_Common.cflags);
+                                                             (uu___3311_25838.FStar_TypeChecker_Common.cflags);
                                                            FStar_TypeChecker_Common.comp_thunk
                                                              =
-                                                             (uu___3311_25830.FStar_TypeChecker_Common.comp_thunk)
+                                                             (uu___3311_25838.FStar_TypeChecker_Common.comp_thunk)
                                                          }  in
-                                                       let uu____25831 =
+                                                       let uu____25839 =
                                                          FStar_TypeChecker_Env.conj_guard
                                                            g_ex guard1
                                                           in
                                                        (e, cres6,
-                                                         uu____25831))))))))))
-      | uu____25832 -> failwith "Impossible"
+                                                         uu____25839))))))))))
+      | uu____25840 -> failwith "Impossible"
 
 and (build_let_rec_env :
   Prims.bool ->
@@ -9998,43 +10008,43 @@ and (build_let_rec_env :
       fun lbs  ->
         let env0 = env  in
         let termination_check_enabled lbname lbdef lbtyp =
-          let uu____25880 = FStar_Options.ml_ish ()  in
-          if uu____25880
+          let uu____25888 = FStar_Options.ml_ish ()  in
+          if uu____25888
           then false
           else
             (let t = FStar_TypeChecker_Normalize.unfold_whnf env lbtyp  in
-             let uu____25888 = FStar_Syntax_Util.arrow_formals_comp t  in
-             match uu____25888 with
+             let uu____25896 = FStar_Syntax_Util.arrow_formals_comp t  in
+             match uu____25896 with
              | (formals,c) ->
-                 let uu____25896 = FStar_Syntax_Util.abs_formals lbdef  in
-                 (match uu____25896 with
-                  | (actuals,uu____25907,uu____25908) ->
+                 let uu____25904 = FStar_Syntax_Util.abs_formals lbdef  in
+                 (match uu____25904 with
+                  | (actuals,uu____25915,uu____25916) ->
                       if
                         ((FStar_List.length formals) < Prims.int_one) ||
                           ((FStar_List.length actuals) < Prims.int_one)
                       then
-                        let uu____25929 =
-                          let uu____25935 =
-                            let uu____25937 =
+                        let uu____25937 =
+                          let uu____25943 =
+                            let uu____25945 =
                               FStar_Syntax_Print.term_to_string lbdef  in
-                            let uu____25939 =
+                            let uu____25947 =
                               FStar_Syntax_Print.term_to_string lbtyp  in
                             FStar_Util.format2
                               "Only function literals with arrow types can be defined recursively; got %s : %s"
-                              uu____25937 uu____25939
+                              uu____25945 uu____25947
                              in
                           (FStar_Errors.Fatal_RecursiveFunctionLiteral,
-                            uu____25935)
+                            uu____25943)
                            in
-                        FStar_Errors.raise_error uu____25929
+                        FStar_Errors.raise_error uu____25937
                           lbtyp.FStar_Syntax_Syntax.pos
                       else
                         (let actuals1 =
-                           let uu____25947 =
+                           let uu____25955 =
                              FStar_TypeChecker_Env.set_expected_typ env lbtyp
                               in
                            FStar_TypeChecker_Util.maybe_add_implicit_binders
-                             uu____25947 actuals
+                             uu____25955 actuals
                             in
                          if
                            (FStar_List.length formals) <>
@@ -10045,30 +10055,30 @@ and (build_let_rec_env :
                               if n = Prims.int_one
                               then "1 argument was found"
                               else
-                                (let uu____25978 = FStar_Util.string_of_int n
+                                (let uu____25986 = FStar_Util.string_of_int n
                                     in
                                  FStar_Util.format1 "%s arguments were found"
-                                   uu____25978)
+                                   uu____25986)
                                in
                             let formals_msg =
                               let n = FStar_List.length formals  in
                               if n = Prims.int_one
                               then "1 argument"
                               else
-                                (let uu____25997 = FStar_Util.string_of_int n
+                                (let uu____26005 = FStar_Util.string_of_int n
                                     in
                                  FStar_Util.format1 "%s arguments"
-                                   uu____25997)
+                                   uu____26005)
                                in
                             let msg =
-                              let uu____26002 =
+                              let uu____26010 =
                                 FStar_Syntax_Print.term_to_string lbtyp  in
-                              let uu____26004 =
+                              let uu____26012 =
                                 FStar_Syntax_Print.lbname_to_string lbname
                                  in
                               FStar_Util.format4
                                 "From its type %s, the definition of `let rec %s` expects a function with %s, but %s"
-                                uu____26002 uu____26004 formals_msg
+                                uu____26010 uu____26012 formals_msg
                                 actuals_msg
                                in
                             FStar_Errors.raise_error
@@ -10083,17 +10093,17 @@ and (build_let_rec_env :
                             (FStar_List.contains
                                FStar_Syntax_Syntax.TotalEffect)))))
            in
-        let uu____26016 =
+        let uu____26024 =
           FStar_List.fold_left
-            (fun uu____26049  ->
+            (fun uu____26057  ->
                fun lb  ->
-                 match uu____26049 with
+                 match uu____26057 with
                  | (lbs1,env1,g_acc) ->
-                     let uu____26074 =
+                     let uu____26082 =
                        FStar_TypeChecker_Util.extract_let_rec_annotation env1
                          lb
                         in
-                     (match uu____26074 with
+                     (match uu____26082 with
                       | (univ_vars,t,check_t) ->
                           let env2 =
                             FStar_TypeChecker_Env.push_univ_vars env1
@@ -10103,7 +10113,7 @@ and (build_let_rec_env :
                             FStar_Syntax_Util.unascribe
                               lb.FStar_Syntax_Syntax.lbdef
                              in
-                          let uu____26097 =
+                          let uu____26105 =
                             if Prims.op_Negation check_t
                             then (g_acc, t)
                             else
@@ -10111,247 +10121,247 @@ and (build_let_rec_env :
                                  FStar_TypeChecker_Env.push_univ_vars env0
                                    univ_vars
                                   in
-                               let uu____26116 =
-                                 let uu____26123 =
-                                   let uu____26124 =
+                               let uu____26124 =
+                                 let uu____26131 =
+                                   let uu____26132 =
                                      FStar_Syntax_Util.type_u ()  in
                                    FStar_All.pipe_left
-                                     FStar_Pervasives_Native.fst uu____26124
+                                     FStar_Pervasives_Native.fst uu____26132
                                     in
                                  tc_check_tot_or_gtot_term
-                                   (let uu___3357_26135 = env01  in
+                                   (let uu___3357_26143 = env01  in
                                     {
                                       FStar_TypeChecker_Env.solver =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.solver);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.solver);
                                       FStar_TypeChecker_Env.range =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.range);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.range);
                                       FStar_TypeChecker_Env.curmodule =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.curmodule);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.curmodule);
                                       FStar_TypeChecker_Env.gamma =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.gamma);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.gamma);
                                       FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.gamma_sig);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.gamma_sig);
                                       FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.gamma_cache);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.gamma_cache);
                                       FStar_TypeChecker_Env.modules =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.modules);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.modules);
                                       FStar_TypeChecker_Env.expected_typ =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.expected_typ);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.expected_typ);
                                       FStar_TypeChecker_Env.sigtab =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.sigtab);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.sigtab);
                                       FStar_TypeChecker_Env.attrtab =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.attrtab);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.attrtab);
                                       FStar_TypeChecker_Env.instantiate_imp =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.instantiate_imp);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.instantiate_imp);
                                       FStar_TypeChecker_Env.effects =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.effects);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.effects);
                                       FStar_TypeChecker_Env.generalize =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.generalize);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.generalize);
                                       FStar_TypeChecker_Env.letrecs =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.letrecs);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.letrecs);
                                       FStar_TypeChecker_Env.top_level =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.top_level);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.top_level);
                                       FStar_TypeChecker_Env.check_uvars =
                                         true;
                                       FStar_TypeChecker_Env.use_eq =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.use_eq);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.use_eq);
                                       FStar_TypeChecker_Env.use_eq_strict =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.use_eq_strict);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.use_eq_strict);
                                       FStar_TypeChecker_Env.is_iface =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.is_iface);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.is_iface);
                                       FStar_TypeChecker_Env.admit =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.admit);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.admit);
                                       FStar_TypeChecker_Env.lax =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.lax);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.lax);
                                       FStar_TypeChecker_Env.lax_universes =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.lax_universes);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.phase1);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.phase1);
                                       FStar_TypeChecker_Env.failhard =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.failhard);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.failhard);
                                       FStar_TypeChecker_Env.nosynth =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.nosynth);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.nosynth);
                                       FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.uvar_subtyping);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.tc_term =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.tc_term);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.type_of =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.type_of);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.type_of);
                                       FStar_TypeChecker_Env.universe_of =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.universe_of);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.universe_of);
                                       FStar_TypeChecker_Env.check_type_of =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.check_type_of);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.check_type_of);
                                       FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.use_bv_sorts);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.use_bv_sorts);
                                       FStar_TypeChecker_Env.qtbl_name_and_index
                                         =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.qtbl_name_and_index);
                                       FStar_TypeChecker_Env.normalized_eff_names
                                         =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.normalized_eff_names);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.normalized_eff_names);
                                       FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.fv_delta_depths);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.fv_delta_depths);
                                       FStar_TypeChecker_Env.proof_ns =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.proof_ns);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.proof_ns);
                                       FStar_TypeChecker_Env.synth_hook =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.synth_hook);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.synth_hook);
                                       FStar_TypeChecker_Env.try_solve_implicits_hook
                                         =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                       FStar_TypeChecker_Env.splice =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.splice);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.splice);
                                       FStar_TypeChecker_Env.mpreprocess =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.mpreprocess);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.mpreprocess);
                                       FStar_TypeChecker_Env.postprocess =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.postprocess);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.postprocess);
                                       FStar_TypeChecker_Env.is_native_tactic
                                         =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.is_native_tactic);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.is_native_tactic);
                                       FStar_TypeChecker_Env.identifier_info =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.identifier_info);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.identifier_info);
                                       FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.tc_hooks);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.tc_hooks);
                                       FStar_TypeChecker_Env.dsenv =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.dsenv);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.nbe =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.nbe);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.strict_args_tab);
+                                        (uu___3357_26143.FStar_TypeChecker_Env.strict_args_tab);
                                       FStar_TypeChecker_Env.erasable_types_tab
                                         =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.erasable_types_tab)
-                                    }) t uu____26123
+                                        (uu___3357_26143.FStar_TypeChecker_Env.erasable_types_tab)
+                                    }) t uu____26131
                                   in
-                               match uu____26116 with
-                               | (t1,uu____26144,g) ->
-                                   let uu____26146 =
-                                     let uu____26147 =
-                                       let uu____26148 =
+                               match uu____26124 with
+                               | (t1,uu____26152,g) ->
+                                   let uu____26154 =
+                                     let uu____26155 =
+                                       let uu____26156 =
                                          FStar_All.pipe_right g
                                            (FStar_TypeChecker_Rel.resolve_implicits
                                               env2)
                                           in
-                                       FStar_All.pipe_right uu____26148
+                                       FStar_All.pipe_right uu____26156
                                          (FStar_TypeChecker_Rel.discharge_guard
                                             env2)
                                         in
                                      FStar_TypeChecker_Env.conj_guard g_acc
-                                       uu____26147
+                                       uu____26155
                                       in
-                                   let uu____26149 = norm env01 t1  in
-                                   (uu____26146, uu____26149))
+                                   let uu____26157 = norm env01 t1  in
+                                   (uu____26154, uu____26157))
                              in
-                          (match uu____26097 with
+                          (match uu____26105 with
                            | (g,t1) ->
                                let env3 =
-                                 let uu____26169 =
+                                 let uu____26177 =
                                    termination_check_enabled
                                      lb.FStar_Syntax_Syntax.lbname e t1
                                     in
-                                 if uu____26169
+                                 if uu____26177
                                  then
-                                   let uu___3367_26172 = env2  in
+                                   let uu___3367_26180 = env2  in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.solver);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.range);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.curmodule);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.gamma);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.modules);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.sigtab);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.attrtab);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.effects);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.generalize);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
                                        (((lb.FStar_Syntax_Syntax.lbname), t1,
                                           univ_vars) ::
                                        (env2.FStar_TypeChecker_Env.letrecs));
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.top_level);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.use_eq);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.use_eq);
                                      FStar_TypeChecker_Env.use_eq_strict =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.use_eq_strict);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.use_eq_strict);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.is_iface);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.admit);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.lax);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.phase1);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.failhard);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.nosynth);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.tc_term);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.type_of);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.universe_of);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.try_solve_implicits_hook
                                        =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.splice);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.mpreprocess =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.mpreprocess);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.mpreprocess);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.postprocess);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.is_native_tactic =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.is_native_tactic);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.is_native_tactic);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.dsenv);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.nbe);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.strict_args_tab);
+                                       (uu___3367_26180.FStar_TypeChecker_Env.strict_args_tab);
                                      FStar_TypeChecker_Env.erasable_types_tab
                                        =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.erasable_types_tab)
+                                       (uu___3367_26180.FStar_TypeChecker_Env.erasable_types_tab)
                                    }
                                  else
                                    FStar_TypeChecker_Env.push_let_binding
@@ -10359,24 +10369,24 @@ and (build_let_rec_env :
                                      (univ_vars, t1)
                                   in
                                let lb1 =
-                                 let uu___3370_26186 = lb  in
+                                 let uu___3370_26194 = lb  in
                                  {
                                    FStar_Syntax_Syntax.lbname =
-                                     (uu___3370_26186.FStar_Syntax_Syntax.lbname);
+                                     (uu___3370_26194.FStar_Syntax_Syntax.lbname);
                                    FStar_Syntax_Syntax.lbunivs = univ_vars;
                                    FStar_Syntax_Syntax.lbtyp = t1;
                                    FStar_Syntax_Syntax.lbeff =
-                                     (uu___3370_26186.FStar_Syntax_Syntax.lbeff);
+                                     (uu___3370_26194.FStar_Syntax_Syntax.lbeff);
                                    FStar_Syntax_Syntax.lbdef = e;
                                    FStar_Syntax_Syntax.lbattrs =
-                                     (uu___3370_26186.FStar_Syntax_Syntax.lbattrs);
+                                     (uu___3370_26194.FStar_Syntax_Syntax.lbattrs);
                                    FStar_Syntax_Syntax.lbpos =
-                                     (uu___3370_26186.FStar_Syntax_Syntax.lbpos)
+                                     (uu___3370_26194.FStar_Syntax_Syntax.lbpos)
                                  }  in
                                ((lb1 :: lbs1), env3, g))))
             ([], env, FStar_TypeChecker_Env.trivial_guard) lbs
            in
-        match uu____26016 with
+        match uu____26024 with
         | (lbs1,env1,g) -> ((FStar_List.rev lbs1), env1, g)
 
 and (check_let_recs :
@@ -10387,64 +10397,64 @@ and (check_let_recs :
   =
   fun env  ->
     fun lbs  ->
-      let uu____26212 =
-        let uu____26221 =
+      let uu____26220 =
+        let uu____26229 =
           FStar_All.pipe_right lbs
             (FStar_List.map
                (fun lb  ->
-                  let uu____26247 =
+                  let uu____26255 =
                     FStar_Syntax_Util.abs_formals
                       lb.FStar_Syntax_Syntax.lbdef
                      in
-                  match uu____26247 with
+                  match uu____26255 with
                   | (bs,t,lcomp) ->
                       (match bs with
                        | [] ->
-                           let uu____26277 =
+                           let uu____26285 =
                              FStar_Syntax_Syntax.range_of_lbname
                                lb.FStar_Syntax_Syntax.lbname
                               in
                            FStar_Errors.raise_error
                              (FStar_Errors.Fatal_RecursiveFunctionLiteral,
                                "Only function literals may be defined recursively")
-                             uu____26277
-                       | uu____26284 ->
+                             uu____26285
+                       | uu____26292 ->
                            let lb1 =
-                             let uu___3387_26287 = lb  in
-                             let uu____26288 =
+                             let uu___3387_26295 = lb  in
+                             let uu____26296 =
                                FStar_Syntax_Util.abs bs t lcomp  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbname);
+                                 (uu___3387_26295.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___3387_26295.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___3387_26295.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = uu____26288;
+                                 (uu___3387_26295.FStar_Syntax_Syntax.lbeff);
+                               FStar_Syntax_Syntax.lbdef = uu____26296;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___3387_26295.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbpos)
+                                 (uu___3387_26295.FStar_Syntax_Syntax.lbpos)
                              }  in
-                           let uu____26291 =
-                             let uu____26298 =
+                           let uu____26299 =
+                             let uu____26306 =
                                FStar_TypeChecker_Env.set_expected_typ env
                                  lb1.FStar_Syntax_Syntax.lbtyp
                                 in
-                             tc_tot_or_gtot_term uu____26298
+                             tc_tot_or_gtot_term uu____26306
                                lb1.FStar_Syntax_Syntax.lbdef
                               in
-                           (match uu____26291 with
+                           (match uu____26299 with
                             | (e,c,g) ->
-                                ((let uu____26307 =
-                                    let uu____26309 =
+                                ((let uu____26315 =
+                                    let uu____26317 =
                                       FStar_TypeChecker_Common.is_total_lcomp
                                         c
                                        in
-                                    Prims.op_Negation uu____26309  in
-                                  if uu____26307
+                                    Prims.op_Negation uu____26317  in
+                                  if uu____26315
                                   then
                                     FStar_Errors.raise_error
                                       (FStar_Errors.Fatal_UnexpectedGTotForLetRec,
@@ -10462,8 +10472,8 @@ and (check_let_recs :
                                      in
                                   (lb2, g)))))))
            in
-        FStar_All.pipe_right uu____26221 FStar_List.unzip  in
-      match uu____26212 with
+        FStar_All.pipe_right uu____26229 FStar_List.unzip  in
+      match uu____26220 with
       | (lbs1,gs) ->
           let g_lbs =
             FStar_List.fold_right FStar_TypeChecker_Env.conj_guard gs
@@ -10482,12 +10492,12 @@ and (check_let_bound_def :
   fun top_level  ->
     fun env  ->
       fun lb  ->
-        let uu____26365 = FStar_TypeChecker_Env.clear_expected_typ env  in
-        match uu____26365 with
-        | (env1,uu____26384) ->
+        let uu____26373 = FStar_TypeChecker_Env.clear_expected_typ env  in
+        match uu____26373 with
+        | (env1,uu____26392) ->
             let e1 = lb.FStar_Syntax_Syntax.lbdef  in
-            let uu____26392 = check_lbtyp top_level env lb  in
-            (match uu____26392 with
+            let uu____26400 = check_lbtyp top_level env lb  in
+            (match uu____26400 with
              | (topt,wf_annot,univ_vars,univ_opening,env11) ->
                  (if (Prims.op_Negation top_level) && (univ_vars <> [])
                   then
@@ -10497,144 +10507,144 @@ and (check_let_bound_def :
                       e1.FStar_Syntax_Syntax.pos
                   else ();
                   (let e11 = FStar_Syntax_Subst.subst univ_opening e1  in
-                   let uu____26441 =
+                   let uu____26449 =
                      tc_maybe_toplevel_term
-                       (let uu___3418_26450 = env11  in
+                       (let uu___3418_26458 = env11  in
                         {
                           FStar_TypeChecker_Env.solver =
-                            (uu___3418_26450.FStar_TypeChecker_Env.solver);
+                            (uu___3418_26458.FStar_TypeChecker_Env.solver);
                           FStar_TypeChecker_Env.range =
-                            (uu___3418_26450.FStar_TypeChecker_Env.range);
+                            (uu___3418_26458.FStar_TypeChecker_Env.range);
                           FStar_TypeChecker_Env.curmodule =
-                            (uu___3418_26450.FStar_TypeChecker_Env.curmodule);
+                            (uu___3418_26458.FStar_TypeChecker_Env.curmodule);
                           FStar_TypeChecker_Env.gamma =
-                            (uu___3418_26450.FStar_TypeChecker_Env.gamma);
+                            (uu___3418_26458.FStar_TypeChecker_Env.gamma);
                           FStar_TypeChecker_Env.gamma_sig =
-                            (uu___3418_26450.FStar_TypeChecker_Env.gamma_sig);
+                            (uu___3418_26458.FStar_TypeChecker_Env.gamma_sig);
                           FStar_TypeChecker_Env.gamma_cache =
-                            (uu___3418_26450.FStar_TypeChecker_Env.gamma_cache);
+                            (uu___3418_26458.FStar_TypeChecker_Env.gamma_cache);
                           FStar_TypeChecker_Env.modules =
-                            (uu___3418_26450.FStar_TypeChecker_Env.modules);
+                            (uu___3418_26458.FStar_TypeChecker_Env.modules);
                           FStar_TypeChecker_Env.expected_typ =
-                            (uu___3418_26450.FStar_TypeChecker_Env.expected_typ);
+                            (uu___3418_26458.FStar_TypeChecker_Env.expected_typ);
                           FStar_TypeChecker_Env.sigtab =
-                            (uu___3418_26450.FStar_TypeChecker_Env.sigtab);
+                            (uu___3418_26458.FStar_TypeChecker_Env.sigtab);
                           FStar_TypeChecker_Env.attrtab =
-                            (uu___3418_26450.FStar_TypeChecker_Env.attrtab);
+                            (uu___3418_26458.FStar_TypeChecker_Env.attrtab);
                           FStar_TypeChecker_Env.instantiate_imp =
-                            (uu___3418_26450.FStar_TypeChecker_Env.instantiate_imp);
+                            (uu___3418_26458.FStar_TypeChecker_Env.instantiate_imp);
                           FStar_TypeChecker_Env.effects =
-                            (uu___3418_26450.FStar_TypeChecker_Env.effects);
+                            (uu___3418_26458.FStar_TypeChecker_Env.effects);
                           FStar_TypeChecker_Env.generalize =
-                            (uu___3418_26450.FStar_TypeChecker_Env.generalize);
+                            (uu___3418_26458.FStar_TypeChecker_Env.generalize);
                           FStar_TypeChecker_Env.letrecs =
-                            (uu___3418_26450.FStar_TypeChecker_Env.letrecs);
+                            (uu___3418_26458.FStar_TypeChecker_Env.letrecs);
                           FStar_TypeChecker_Env.top_level = top_level;
                           FStar_TypeChecker_Env.check_uvars =
-                            (uu___3418_26450.FStar_TypeChecker_Env.check_uvars);
+                            (uu___3418_26458.FStar_TypeChecker_Env.check_uvars);
                           FStar_TypeChecker_Env.use_eq =
-                            (uu___3418_26450.FStar_TypeChecker_Env.use_eq);
+                            (uu___3418_26458.FStar_TypeChecker_Env.use_eq);
                           FStar_TypeChecker_Env.use_eq_strict =
-                            (uu___3418_26450.FStar_TypeChecker_Env.use_eq_strict);
+                            (uu___3418_26458.FStar_TypeChecker_Env.use_eq_strict);
                           FStar_TypeChecker_Env.is_iface =
-                            (uu___3418_26450.FStar_TypeChecker_Env.is_iface);
+                            (uu___3418_26458.FStar_TypeChecker_Env.is_iface);
                           FStar_TypeChecker_Env.admit =
-                            (uu___3418_26450.FStar_TypeChecker_Env.admit);
+                            (uu___3418_26458.FStar_TypeChecker_Env.admit);
                           FStar_TypeChecker_Env.lax =
-                            (uu___3418_26450.FStar_TypeChecker_Env.lax);
+                            (uu___3418_26458.FStar_TypeChecker_Env.lax);
                           FStar_TypeChecker_Env.lax_universes =
-                            (uu___3418_26450.FStar_TypeChecker_Env.lax_universes);
+                            (uu___3418_26458.FStar_TypeChecker_Env.lax_universes);
                           FStar_TypeChecker_Env.phase1 =
-                            (uu___3418_26450.FStar_TypeChecker_Env.phase1);
+                            (uu___3418_26458.FStar_TypeChecker_Env.phase1);
                           FStar_TypeChecker_Env.failhard =
-                            (uu___3418_26450.FStar_TypeChecker_Env.failhard);
+                            (uu___3418_26458.FStar_TypeChecker_Env.failhard);
                           FStar_TypeChecker_Env.nosynth =
-                            (uu___3418_26450.FStar_TypeChecker_Env.nosynth);
+                            (uu___3418_26458.FStar_TypeChecker_Env.nosynth);
                           FStar_TypeChecker_Env.uvar_subtyping =
-                            (uu___3418_26450.FStar_TypeChecker_Env.uvar_subtyping);
+                            (uu___3418_26458.FStar_TypeChecker_Env.uvar_subtyping);
                           FStar_TypeChecker_Env.tc_term =
-                            (uu___3418_26450.FStar_TypeChecker_Env.tc_term);
+                            (uu___3418_26458.FStar_TypeChecker_Env.tc_term);
                           FStar_TypeChecker_Env.type_of =
-                            (uu___3418_26450.FStar_TypeChecker_Env.type_of);
+                            (uu___3418_26458.FStar_TypeChecker_Env.type_of);
                           FStar_TypeChecker_Env.universe_of =
-                            (uu___3418_26450.FStar_TypeChecker_Env.universe_of);
+                            (uu___3418_26458.FStar_TypeChecker_Env.universe_of);
                           FStar_TypeChecker_Env.check_type_of =
-                            (uu___3418_26450.FStar_TypeChecker_Env.check_type_of);
+                            (uu___3418_26458.FStar_TypeChecker_Env.check_type_of);
                           FStar_TypeChecker_Env.use_bv_sorts =
-                            (uu___3418_26450.FStar_TypeChecker_Env.use_bv_sorts);
+                            (uu___3418_26458.FStar_TypeChecker_Env.use_bv_sorts);
                           FStar_TypeChecker_Env.qtbl_name_and_index =
-                            (uu___3418_26450.FStar_TypeChecker_Env.qtbl_name_and_index);
+                            (uu___3418_26458.FStar_TypeChecker_Env.qtbl_name_and_index);
                           FStar_TypeChecker_Env.normalized_eff_names =
-                            (uu___3418_26450.FStar_TypeChecker_Env.normalized_eff_names);
+                            (uu___3418_26458.FStar_TypeChecker_Env.normalized_eff_names);
                           FStar_TypeChecker_Env.fv_delta_depths =
-                            (uu___3418_26450.FStar_TypeChecker_Env.fv_delta_depths);
+                            (uu___3418_26458.FStar_TypeChecker_Env.fv_delta_depths);
                           FStar_TypeChecker_Env.proof_ns =
-                            (uu___3418_26450.FStar_TypeChecker_Env.proof_ns);
+                            (uu___3418_26458.FStar_TypeChecker_Env.proof_ns);
                           FStar_TypeChecker_Env.synth_hook =
-                            (uu___3418_26450.FStar_TypeChecker_Env.synth_hook);
+                            (uu___3418_26458.FStar_TypeChecker_Env.synth_hook);
                           FStar_TypeChecker_Env.try_solve_implicits_hook =
-                            (uu___3418_26450.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                            (uu___3418_26458.FStar_TypeChecker_Env.try_solve_implicits_hook);
                           FStar_TypeChecker_Env.splice =
-                            (uu___3418_26450.FStar_TypeChecker_Env.splice);
+                            (uu___3418_26458.FStar_TypeChecker_Env.splice);
                           FStar_TypeChecker_Env.mpreprocess =
-                            (uu___3418_26450.FStar_TypeChecker_Env.mpreprocess);
+                            (uu___3418_26458.FStar_TypeChecker_Env.mpreprocess);
                           FStar_TypeChecker_Env.postprocess =
-                            (uu___3418_26450.FStar_TypeChecker_Env.postprocess);
+                            (uu___3418_26458.FStar_TypeChecker_Env.postprocess);
                           FStar_TypeChecker_Env.is_native_tactic =
-                            (uu___3418_26450.FStar_TypeChecker_Env.is_native_tactic);
+                            (uu___3418_26458.FStar_TypeChecker_Env.is_native_tactic);
                           FStar_TypeChecker_Env.identifier_info =
-                            (uu___3418_26450.FStar_TypeChecker_Env.identifier_info);
+                            (uu___3418_26458.FStar_TypeChecker_Env.identifier_info);
                           FStar_TypeChecker_Env.tc_hooks =
-                            (uu___3418_26450.FStar_TypeChecker_Env.tc_hooks);
+                            (uu___3418_26458.FStar_TypeChecker_Env.tc_hooks);
                           FStar_TypeChecker_Env.dsenv =
-                            (uu___3418_26450.FStar_TypeChecker_Env.dsenv);
+                            (uu___3418_26458.FStar_TypeChecker_Env.dsenv);
                           FStar_TypeChecker_Env.nbe =
-                            (uu___3418_26450.FStar_TypeChecker_Env.nbe);
+                            (uu___3418_26458.FStar_TypeChecker_Env.nbe);
                           FStar_TypeChecker_Env.strict_args_tab =
-                            (uu___3418_26450.FStar_TypeChecker_Env.strict_args_tab);
+                            (uu___3418_26458.FStar_TypeChecker_Env.strict_args_tab);
                           FStar_TypeChecker_Env.erasable_types_tab =
-                            (uu___3418_26450.FStar_TypeChecker_Env.erasable_types_tab)
+                            (uu___3418_26458.FStar_TypeChecker_Env.erasable_types_tab)
                         }) e11
                       in
-                   match uu____26441 with
+                   match uu____26449 with
                    | (e12,c1,g1) ->
-                       let uu____26465 =
-                         let uu____26470 =
+                       let uu____26473 =
+                         let uu____26478 =
                            FStar_TypeChecker_Env.set_range env11
                              e12.FStar_Syntax_Syntax.pos
                             in
                          FStar_TypeChecker_Util.strengthen_precondition
                            (FStar_Pervasives_Native.Some
-                              (fun uu____26476  ->
+                              (fun uu____26484  ->
                                  FStar_Util.return_all
                                    FStar_TypeChecker_Err.ill_kinded_type))
-                           uu____26470 e12 c1 wf_annot
+                           uu____26478 e12 c1 wf_annot
                           in
-                       (match uu____26465 with
+                       (match uu____26473 with
                         | (c11,guard_f) ->
                             let g11 =
                               FStar_TypeChecker_Env.conj_guard g1 guard_f  in
-                            ((let uu____26493 =
+                            ((let uu____26501 =
                                 FStar_TypeChecker_Env.debug env
                                   FStar_Options.Extreme
                                  in
-                              if uu____26493
+                              if uu____26501
                               then
-                                let uu____26496 =
+                                let uu____26504 =
                                   FStar_Syntax_Print.lbname_to_string
                                     lb.FStar_Syntax_Syntax.lbname
                                    in
-                                let uu____26498 =
+                                let uu____26506 =
                                   FStar_TypeChecker_Common.lcomp_to_string
                                     c11
                                    in
-                                let uu____26500 =
+                                let uu____26508 =
                                   FStar_TypeChecker_Rel.guard_to_string env
                                     g11
                                    in
                                 FStar_Util.print3
                                   "checked let-bound def %s : %s guard is %s\n"
-                                  uu____26496 uu____26498 uu____26500
+                                  uu____26504 uu____26506 uu____26508
                               else ());
                              (e12, univ_vars, c11, g11,
                                (FStar_Option.isSome topt)))))))
@@ -10654,23 +10664,23 @@ and (check_lbtyp :
         let t = FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp  in
         match t.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_unknown  ->
-            let uu____26539 =
+            let uu____26547 =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs
                in
-            (match uu____26539 with
+            (match uu____26547 with
              | (univ_opening,univ_vars) ->
-                 let uu____26572 =
+                 let uu____26580 =
                    FStar_TypeChecker_Env.push_univ_vars env univ_vars  in
                  (FStar_Pervasives_Native.None,
                    FStar_TypeChecker_Env.trivial_guard, univ_vars,
-                   univ_opening, uu____26572))
-        | uu____26577 ->
-            let uu____26578 =
+                   univ_opening, uu____26580))
+        | uu____26585 ->
+            let uu____26586 =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs
                in
-            (match uu____26578 with
+            (match uu____26586 with
              | (univ_opening,univ_vars) ->
                  let t1 = FStar_Syntax_Subst.subst univ_opening t  in
                  let env1 =
@@ -10679,45 +10689,45 @@ and (check_lbtyp :
                    top_level &&
                      (Prims.op_Negation env.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____26628 =
+                   let uu____26636 =
                      FStar_TypeChecker_Env.set_expected_typ env1 t1  in
                    ((FStar_Pervasives_Native.Some t1),
                      FStar_TypeChecker_Env.trivial_guard, univ_vars,
-                     univ_opening, uu____26628)
+                     univ_opening, uu____26636)
                  else
-                   (let uu____26635 = FStar_Syntax_Util.type_u ()  in
-                    match uu____26635 with
-                    | (k,uu____26655) ->
-                        let uu____26656 = tc_check_tot_or_gtot_term env1 t1 k
+                   (let uu____26643 = FStar_Syntax_Util.type_u ()  in
+                    match uu____26643 with
+                    | (k,uu____26663) ->
+                        let uu____26664 = tc_check_tot_or_gtot_term env1 t1 k
                            in
-                        (match uu____26656 with
-                         | (t2,uu____26678,g) ->
-                             ((let uu____26681 =
+                        (match uu____26664 with
+                         | (t2,uu____26686,g) ->
+                             ((let uu____26689 =
                                  FStar_TypeChecker_Env.debug env
                                    FStar_Options.Medium
                                   in
-                               if uu____26681
+                               if uu____26689
                                then
-                                 let uu____26684 =
-                                   let uu____26686 =
+                                 let uu____26692 =
+                                   let uu____26694 =
                                      FStar_Syntax_Util.range_of_lbname
                                        lb.FStar_Syntax_Syntax.lbname
                                       in
-                                   FStar_Range.string_of_range uu____26686
+                                   FStar_Range.string_of_range uu____26694
                                     in
-                                 let uu____26687 =
+                                 let uu____26695 =
                                    FStar_Syntax_Print.term_to_string t2  in
                                  FStar_Util.print2
                                    "(%s) Checked type annotation %s\n"
-                                   uu____26684 uu____26687
+                                   uu____26692 uu____26695
                                else ());
                               (let t3 = norm env1 t2  in
-                               let uu____26693 =
+                               let uu____26701 =
                                  FStar_TypeChecker_Env.set_expected_typ env1
                                    t3
                                   in
                                ((FStar_Pervasives_Native.Some t3), g,
-                                 univ_vars, univ_opening, uu____26693))))))
+                                 univ_vars, univ_opening, uu____26701))))))
 
 and (tc_binder :
   FStar_TypeChecker_Env.env ->
@@ -10728,76 +10738,76 @@ and (tc_binder :
         FStar_TypeChecker_Env.guard_t * FStar_Syntax_Syntax.universe))
   =
   fun env  ->
-    fun uu____26699  ->
-      match uu____26699 with
+    fun uu____26707  ->
+      match uu____26707 with
       | (x,imp) ->
-          let uu____26726 = FStar_Syntax_Util.type_u ()  in
-          (match uu____26726 with
+          let uu____26734 = FStar_Syntax_Util.type_u ()  in
+          (match uu____26734 with
            | (tu,u) ->
-               ((let uu____26748 =
+               ((let uu____26756 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Extreme  in
-                 if uu____26748
+                 if uu____26756
                  then
-                   let uu____26751 = FStar_Syntax_Print.bv_to_string x  in
-                   let uu____26753 =
+                   let uu____26759 = FStar_Syntax_Print.bv_to_string x  in
+                   let uu____26761 =
                      FStar_Syntax_Print.term_to_string
                        x.FStar_Syntax_Syntax.sort
                       in
-                   let uu____26755 = FStar_Syntax_Print.term_to_string tu  in
+                   let uu____26763 = FStar_Syntax_Print.term_to_string tu  in
                    FStar_Util.print3 "Checking binder %s:%s at type %s\n"
-                     uu____26751 uu____26753 uu____26755
+                     uu____26759 uu____26761 uu____26763
                  else ());
-                (let uu____26760 =
+                (let uu____26768 =
                    tc_check_tot_or_gtot_term env x.FStar_Syntax_Syntax.sort
                      tu
                     in
-                 match uu____26760 with
-                 | (t,uu____26782,g) ->
-                     let uu____26784 =
+                 match uu____26768 with
+                 | (t,uu____26790,g) ->
+                     let uu____26792 =
                        match imp with
                        | FStar_Pervasives_Native.Some
                            (FStar_Syntax_Syntax.Meta tau) ->
-                           let uu____26800 =
+                           let uu____26808 =
                              tc_tactic FStar_Syntax_Syntax.t_unit
                                FStar_Syntax_Syntax.t_unit env tau
                               in
-                           (match uu____26800 with
-                            | (tau1,uu____26814,g1) ->
+                           (match uu____26808 with
+                            | (tau1,uu____26822,g1) ->
                                 ((FStar_Pervasives_Native.Some
                                     (FStar_Syntax_Syntax.Meta tau1)), g1))
-                       | uu____26818 ->
+                       | uu____26826 ->
                            (imp, FStar_TypeChecker_Env.trivial_guard)
                         in
-                     (match uu____26784 with
+                     (match uu____26792 with
                       | (imp1,g') ->
                           let x1 =
-                            ((let uu___3480_26853 = x  in
+                            ((let uu___3480_26861 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___3480_26853.FStar_Syntax_Syntax.ppname);
+                                  (uu___3480_26861.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___3480_26853.FStar_Syntax_Syntax.index);
+                                  (uu___3480_26861.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t
                               }), imp1)
                              in
-                          ((let uu____26855 =
+                          ((let uu____26863 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.High
                                in
-                            if uu____26855
+                            if uu____26863
                             then
-                              let uu____26858 =
+                              let uu____26866 =
                                 FStar_Syntax_Print.bv_to_string
                                   (FStar_Pervasives_Native.fst x1)
                                  in
-                              let uu____26862 =
+                              let uu____26870 =
                                 FStar_Syntax_Print.term_to_string t  in
                               FStar_Util.print2
-                                "Pushing binder %s at type %s\n" uu____26858
-                                uu____26862
+                                "Pushing binder %s at type %s\n" uu____26866
+                                uu____26870
                             else ());
-                           (let uu____26867 = push_binding env x1  in
-                            (x1, uu____26867, g, u)))))))
+                           (let uu____26875 = push_binding env x1  in
+                            (x1, uu____26875, g, u)))))))
 
 and (tc_binders :
   FStar_TypeChecker_Env.env ->
@@ -10807,30 +10817,30 @@ and (tc_binders :
   =
   fun env  ->
     fun bs  ->
-      (let uu____26879 =
+      (let uu____26887 =
          FStar_TypeChecker_Env.debug env FStar_Options.Extreme  in
-       if uu____26879
+       if uu____26887
        then
-         let uu____26882 = FStar_Syntax_Print.binders_to_string ", " bs  in
-         FStar_Util.print1 "Checking binders %s\n" uu____26882
+         let uu____26890 = FStar_Syntax_Print.binders_to_string ", " bs  in
+         FStar_Util.print1 "Checking binders %s\n" uu____26890
        else ());
       (let rec aux env1 bs1 =
          match bs1 with
          | [] -> ([], env1, FStar_TypeChecker_Env.trivial_guard, [])
          | b::bs2 ->
-             let uu____26995 = tc_binder env1 b  in
-             (match uu____26995 with
+             let uu____27003 = tc_binder env1 b  in
+             (match uu____27003 with
               | (b1,env',g,u) ->
-                  let uu____27044 = aux env' bs2  in
-                  (match uu____27044 with
+                  let uu____27052 = aux env' bs2  in
+                  (match uu____27052 with
                    | (bs3,env'1,g',us) ->
-                       let uu____27105 =
-                         let uu____27106 =
+                       let uu____27113 =
+                         let uu____27114 =
                            FStar_TypeChecker_Env.close_guard_univs [u] 
                              [b1] g'
                             in
-                         FStar_TypeChecker_Env.conj_guard g uu____27106  in
-                       ((b1 :: bs3), env'1, uu____27105, (u :: us))))
+                         FStar_TypeChecker_Env.conj_guard g uu____27114  in
+                       ((b1 :: bs3), env'1, uu____27113, (u :: us))))
           in
        aux env bs)
 
@@ -10847,30 +10857,30 @@ and (tc_smt_pats :
     fun pats  ->
       let tc_args en1 args =
         FStar_List.fold_right
-          (fun uu____27214  ->
-             fun uu____27215  ->
-               match (uu____27214, uu____27215) with
+          (fun uu____27222  ->
+             fun uu____27223  ->
+               match (uu____27222, uu____27223) with
                | ((t,imp),(args1,g)) ->
                    (FStar_All.pipe_right t (check_no_smt_theory_symbols en1);
-                    (let uu____27307 = tc_term en1 t  in
-                     match uu____27307 with
-                     | (t1,uu____27327,g') ->
-                         let uu____27329 =
+                    (let uu____27315 = tc_term en1 t  in
+                     match uu____27315 with
+                     | (t1,uu____27335,g') ->
+                         let uu____27337 =
                            FStar_TypeChecker_Env.conj_guard g g'  in
-                         (((t1, imp) :: args1), uu____27329)))) args
+                         (((t1, imp) :: args1), uu____27337)))) args
           ([], FStar_TypeChecker_Env.trivial_guard)
          in
       FStar_List.fold_right
         (fun p  ->
-           fun uu____27383  ->
-             match uu____27383 with
+           fun uu____27391  ->
+             match uu____27391 with
              | (pats1,g) ->
-                 let uu____27410 = tc_args en p  in
-                 (match uu____27410 with
+                 let uu____27418 = tc_args en p  in
+                 (match uu____27418 with
                   | (args,g') ->
-                      let uu____27423 = FStar_TypeChecker_Env.conj_guard g g'
+                      let uu____27431 = FStar_TypeChecker_Env.conj_guard g g'
                          in
-                      ((args :: pats1), uu____27423))) pats
+                      ((args :: pats1), uu____27431))) pats
         ([], FStar_TypeChecker_Env.trivial_guard)
 
 and (tc_tot_or_gtot_term :
@@ -10881,70 +10891,70 @@ and (tc_tot_or_gtot_term :
   =
   fun env  ->
     fun e  ->
-      let uu____27436 = tc_maybe_toplevel_term env e  in
-      match uu____27436 with
+      let uu____27444 = tc_maybe_toplevel_term env e  in
+      match uu____27444 with
       | (e1,c,g) ->
-          let uu____27452 = FStar_TypeChecker_Common.is_tot_or_gtot_lcomp c
+          let uu____27460 = FStar_TypeChecker_Common.is_tot_or_gtot_lcomp c
              in
-          if uu____27452
+          if uu____27460
           then (e1, c, g)
           else
             (let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g
                 in
-             let uu____27464 = FStar_TypeChecker_Common.lcomp_comp c  in
-             match uu____27464 with
+             let uu____27472 = FStar_TypeChecker_Common.lcomp_comp c  in
+             match uu____27472 with
              | (c1,g_c) ->
                  let c2 = norm_c env c1  in
-                 let uu____27478 =
-                   let uu____27484 =
+                 let uu____27486 =
+                   let uu____27492 =
                      FStar_TypeChecker_Util.is_pure_effect env
                        (FStar_Syntax_Util.comp_effect_name c2)
                       in
-                   if uu____27484
+                   if uu____27492
                    then
-                     let uu____27492 =
+                     let uu____27500 =
                        FStar_Syntax_Syntax.mk_Total
                          (FStar_Syntax_Util.comp_result c2)
                         in
-                     (uu____27492, false)
+                     (uu____27500, false)
                    else
-                     (let uu____27497 =
+                     (let uu____27505 =
                         FStar_Syntax_Syntax.mk_GTotal
                           (FStar_Syntax_Util.comp_result c2)
                          in
-                      (uu____27497, true))
+                      (uu____27505, true))
                     in
-                 (match uu____27478 with
+                 (match uu____27486 with
                   | (target_comp,allow_ghost) ->
-                      let uu____27510 =
+                      let uu____27518 =
                         FStar_TypeChecker_Rel.sub_comp env c2 target_comp  in
-                      (match uu____27510 with
+                      (match uu____27518 with
                        | FStar_Pervasives_Native.Some g' ->
-                           let uu____27520 =
+                           let uu____27528 =
                              FStar_TypeChecker_Common.lcomp_of_comp
                                target_comp
                               in
-                           let uu____27521 =
-                             let uu____27522 =
+                           let uu____27529 =
+                             let uu____27530 =
                                FStar_TypeChecker_Env.conj_guard g_c g'  in
-                             FStar_TypeChecker_Env.conj_guard g1 uu____27522
+                             FStar_TypeChecker_Env.conj_guard g1 uu____27530
                               in
-                           (e1, uu____27520, uu____27521)
-                       | uu____27523 ->
+                           (e1, uu____27528, uu____27529)
+                       | uu____27531 ->
                            if allow_ghost
                            then
-                             let uu____27533 =
+                             let uu____27541 =
                                FStar_TypeChecker_Err.expected_ghost_expression
                                  e1 c2
                                 in
-                             FStar_Errors.raise_error uu____27533
+                             FStar_Errors.raise_error uu____27541
                                e1.FStar_Syntax_Syntax.pos
                            else
-                             (let uu____27547 =
+                             (let uu____27555 =
                                 FStar_TypeChecker_Err.expected_pure_expression
                                   e1 c2
                                  in
-                              FStar_Errors.raise_error uu____27547
+                              FStar_Errors.raise_error uu____27555
                                 e1.FStar_Syntax_Syntax.pos))))
 
 and (tc_check_tot_or_gtot_term :
@@ -10967,8 +10977,8 @@ and (tc_trivial_guard :
   =
   fun env  ->
     fun t  ->
-      let uu____27571 = tc_tot_or_gtot_term env t  in
-      match uu____27571 with
+      let uu____27579 = tc_tot_or_gtot_term env t  in
+      match uu____27579 with
       | (t1,c,g) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env g; (t1, c))
 
@@ -10980,9 +10990,9 @@ let (tc_check_trivial_guard :
   fun env  ->
     fun t  ->
       fun k  ->
-        let uu____27602 = tc_check_tot_or_gtot_term env t k  in
-        match uu____27602 with
-        | (t1,uu____27610,g) ->
+        let uu____27610 = tc_check_tot_or_gtot_term env t k  in
+        match uu____27610 with
+        | (t1,uu____27618,g) ->
             (FStar_TypeChecker_Rel.force_trivial_guard env g; t1)
   
 let (type_of_tot_term :
@@ -10993,157 +11003,157 @@ let (type_of_tot_term :
   =
   fun env  ->
     fun e  ->
-      (let uu____27631 =
+      (let uu____27639 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "RelCheck")
           in
-       if uu____27631
+       if uu____27639
        then
-         let uu____27636 = FStar_Syntax_Print.term_to_string e  in
-         FStar_Util.print1 "Checking term %s\n" uu____27636
+         let uu____27644 = FStar_Syntax_Print.term_to_string e  in
+         FStar_Util.print1 "Checking term %s\n" uu____27644
        else ());
       (let env1 =
-         let uu___3572_27642 = env  in
+         let uu___3572_27650 = env  in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___3572_27642.FStar_TypeChecker_Env.solver);
+             (uu___3572_27650.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___3572_27642.FStar_TypeChecker_Env.range);
+             (uu___3572_27650.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___3572_27642.FStar_TypeChecker_Env.curmodule);
+             (uu___3572_27650.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
-             (uu___3572_27642.FStar_TypeChecker_Env.gamma);
+             (uu___3572_27650.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___3572_27642.FStar_TypeChecker_Env.gamma_sig);
+             (uu___3572_27650.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___3572_27642.FStar_TypeChecker_Env.gamma_cache);
+             (uu___3572_27650.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___3572_27642.FStar_TypeChecker_Env.modules);
+             (uu___3572_27650.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___3572_27642.FStar_TypeChecker_Env.expected_typ);
+             (uu___3572_27650.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___3572_27642.FStar_TypeChecker_Env.sigtab);
+             (uu___3572_27650.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___3572_27642.FStar_TypeChecker_Env.attrtab);
+             (uu___3572_27650.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___3572_27642.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___3572_27650.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___3572_27642.FStar_TypeChecker_Env.effects);
+             (uu___3572_27650.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___3572_27642.FStar_TypeChecker_Env.generalize);
+             (uu___3572_27650.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs = [];
            FStar_TypeChecker_Env.top_level = false;
            FStar_TypeChecker_Env.check_uvars =
-             (uu___3572_27642.FStar_TypeChecker_Env.check_uvars);
+             (uu___3572_27650.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___3572_27642.FStar_TypeChecker_Env.use_eq);
+             (uu___3572_27650.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___3572_27642.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___3572_27650.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
-             (uu___3572_27642.FStar_TypeChecker_Env.is_iface);
+             (uu___3572_27650.FStar_TypeChecker_Env.is_iface);
            FStar_TypeChecker_Env.admit =
-             (uu___3572_27642.FStar_TypeChecker_Env.admit);
+             (uu___3572_27650.FStar_TypeChecker_Env.admit);
            FStar_TypeChecker_Env.lax =
-             (uu___3572_27642.FStar_TypeChecker_Env.lax);
+             (uu___3572_27650.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___3572_27642.FStar_TypeChecker_Env.lax_universes);
+             (uu___3572_27650.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___3572_27642.FStar_TypeChecker_Env.phase1);
+             (uu___3572_27650.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___3572_27642.FStar_TypeChecker_Env.failhard);
+             (uu___3572_27650.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___3572_27642.FStar_TypeChecker_Env.nosynth);
+             (uu___3572_27650.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___3572_27642.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___3572_27650.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___3572_27642.FStar_TypeChecker_Env.tc_term);
+             (uu___3572_27650.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___3572_27642.FStar_TypeChecker_Env.type_of);
+             (uu___3572_27650.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___3572_27642.FStar_TypeChecker_Env.universe_of);
+             (uu___3572_27650.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___3572_27642.FStar_TypeChecker_Env.check_type_of);
+             (uu___3572_27650.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___3572_27642.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___3572_27650.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___3572_27642.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___3572_27650.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___3572_27642.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___3572_27650.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___3572_27642.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___3572_27650.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___3572_27642.FStar_TypeChecker_Env.proof_ns);
+             (uu___3572_27650.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___3572_27642.FStar_TypeChecker_Env.synth_hook);
+             (uu___3572_27650.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___3572_27642.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___3572_27650.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___3572_27642.FStar_TypeChecker_Env.splice);
+             (uu___3572_27650.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___3572_27642.FStar_TypeChecker_Env.mpreprocess);
+             (uu___3572_27650.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___3572_27642.FStar_TypeChecker_Env.postprocess);
+             (uu___3572_27650.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.is_native_tactic =
-             (uu___3572_27642.FStar_TypeChecker_Env.is_native_tactic);
+             (uu___3572_27650.FStar_TypeChecker_Env.is_native_tactic);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___3572_27642.FStar_TypeChecker_Env.identifier_info);
+             (uu___3572_27650.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___3572_27642.FStar_TypeChecker_Env.tc_hooks);
+             (uu___3572_27650.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___3572_27642.FStar_TypeChecker_Env.dsenv);
+             (uu___3572_27650.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___3572_27642.FStar_TypeChecker_Env.nbe);
+             (uu___3572_27650.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___3572_27642.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___3572_27650.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___3572_27642.FStar_TypeChecker_Env.erasable_types_tab)
+             (uu___3572_27650.FStar_TypeChecker_Env.erasable_types_tab)
          }  in
-       let uu____27650 =
+       let uu____27658 =
          try
-           (fun uu___3576_27664  ->
+           (fun uu___3576_27672  ->
               match () with | () -> tc_tot_or_gtot_term env1 e) ()
          with
-         | FStar_Errors.Error (e1,msg,uu____27685) ->
-             let uu____27688 = FStar_TypeChecker_Env.get_range env1  in
-             FStar_Errors.raise_error (e1, msg) uu____27688
+         | FStar_Errors.Error (e1,msg,uu____27693) ->
+             let uu____27696 = FStar_TypeChecker_Env.get_range env1  in
+             FStar_Errors.raise_error (e1, msg) uu____27696
           in
-       match uu____27650 with
+       match uu____27658 with
        | (t,c,g) ->
            let c1 = FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env1 c
               in
-           let uu____27706 = FStar_TypeChecker_Common.is_total_lcomp c1  in
-           if uu____27706
+           let uu____27714 = FStar_TypeChecker_Common.is_total_lcomp c1  in
+           if uu____27714
            then (t, (c1.FStar_TypeChecker_Common.res_typ), g)
            else
-             (let uu____27717 =
-                let uu____27723 =
-                  let uu____27725 = FStar_Syntax_Print.term_to_string e  in
+             (let uu____27725 =
+                let uu____27731 =
+                  let uu____27733 = FStar_Syntax_Print.term_to_string e  in
                   FStar_Util.format1
                     "Implicit argument: Expected a total term; got a ghost term: %s"
-                    uu____27725
+                    uu____27733
                    in
-                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____27723)
+                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____27731)
                  in
-              let uu____27729 = FStar_TypeChecker_Env.get_range env1  in
-              FStar_Errors.raise_error uu____27717 uu____27729))
+              let uu____27737 = FStar_TypeChecker_Env.get_range env1  in
+              FStar_Errors.raise_error uu____27725 uu____27737))
   
 let level_of_type_fail :
-  'uuuuuu27745 .
+  'uuuuuu27753 .
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> Prims.string -> 'uuuuuu27745
+      FStar_Syntax_Syntax.term -> Prims.string -> 'uuuuuu27753
   =
   fun env  ->
     fun e  ->
       fun t  ->
-        let uu____27763 =
-          let uu____27769 =
-            let uu____27771 = FStar_Syntax_Print.term_to_string e  in
+        let uu____27771 =
+          let uu____27777 =
+            let uu____27779 = FStar_Syntax_Print.term_to_string e  in
             FStar_Util.format2 "Expected a term of type 'Type'; got %s : %s"
-              uu____27771 t
+              uu____27779 t
              in
-          (FStar_Errors.Fatal_UnexpectedTermType, uu____27769)  in
-        let uu____27775 = FStar_TypeChecker_Env.get_range env  in
-        FStar_Errors.raise_error uu____27763 uu____27775
+          (FStar_Errors.Fatal_UnexpectedTermType, uu____27777)  in
+        let uu____27783 = FStar_TypeChecker_Env.get_range env  in
+        FStar_Errors.raise_error uu____27771 uu____27783
   
 let (level_of_type :
   FStar_TypeChecker_Env.env ->
@@ -11154,12 +11164,12 @@ let (level_of_type :
     fun e  ->
       fun t  ->
         let rec aux retry t1 =
-          let uu____27809 =
-            let uu____27810 = FStar_Syntax_Util.unrefine t1  in
-            uu____27810.FStar_Syntax_Syntax.n  in
-          match uu____27809 with
+          let uu____27817 =
+            let uu____27818 = FStar_Syntax_Util.unrefine t1  in
+            uu____27818.FStar_Syntax_Syntax.n  in
+          match uu____27817 with
           | FStar_Syntax_Syntax.Tm_type u -> u
-          | uu____27814 ->
+          | uu____27822 ->
               if retry
               then
                 let t2 =
@@ -11169,113 +11179,113 @@ let (level_of_type :
                    in
                 aux false t2
               else
-                (let uu____27820 = FStar_Syntax_Util.type_u ()  in
-                 match uu____27820 with
+                (let uu____27828 = FStar_Syntax_Util.type_u ()  in
+                 match uu____27828 with
                  | (t_u,u) ->
                      let env1 =
-                       let uu___3608_27828 = env  in
+                       let uu___3608_27836 = env  in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3608_27828.FStar_TypeChecker_Env.solver);
+                           (uu___3608_27836.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3608_27828.FStar_TypeChecker_Env.range);
+                           (uu___3608_27836.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3608_27828.FStar_TypeChecker_Env.curmodule);
+                           (uu___3608_27836.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3608_27828.FStar_TypeChecker_Env.gamma);
+                           (uu___3608_27836.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3608_27828.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___3608_27836.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3608_27828.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___3608_27836.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3608_27828.FStar_TypeChecker_Env.modules);
+                           (uu___3608_27836.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3608_27828.FStar_TypeChecker_Env.expected_typ);
+                           (uu___3608_27836.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3608_27828.FStar_TypeChecker_Env.sigtab);
+                           (uu___3608_27836.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3608_27828.FStar_TypeChecker_Env.attrtab);
+                           (uu___3608_27836.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3608_27828.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___3608_27836.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3608_27828.FStar_TypeChecker_Env.effects);
+                           (uu___3608_27836.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3608_27828.FStar_TypeChecker_Env.generalize);
+                           (uu___3608_27836.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3608_27828.FStar_TypeChecker_Env.letrecs);
+                           (uu___3608_27836.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level =
-                           (uu___3608_27828.FStar_TypeChecker_Env.top_level);
+                           (uu___3608_27836.FStar_TypeChecker_Env.top_level);
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3608_27828.FStar_TypeChecker_Env.check_uvars);
+                           (uu___3608_27836.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3608_27828.FStar_TypeChecker_Env.use_eq);
+                           (uu___3608_27836.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.use_eq_strict =
-                           (uu___3608_27828.FStar_TypeChecker_Env.use_eq_strict);
+                           (uu___3608_27836.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3608_27828.FStar_TypeChecker_Env.is_iface);
+                           (uu___3608_27836.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3608_27828.FStar_TypeChecker_Env.admit);
+                           (uu___3608_27836.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3608_27828.FStar_TypeChecker_Env.lax_universes);
+                           (uu___3608_27836.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3608_27828.FStar_TypeChecker_Env.phase1);
+                           (uu___3608_27836.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3608_27828.FStar_TypeChecker_Env.failhard);
+                           (uu___3608_27836.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3608_27828.FStar_TypeChecker_Env.nosynth);
+                           (uu___3608_27836.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3608_27828.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___3608_27836.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3608_27828.FStar_TypeChecker_Env.tc_term);
+                           (uu___3608_27836.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3608_27828.FStar_TypeChecker_Env.type_of);
+                           (uu___3608_27836.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3608_27828.FStar_TypeChecker_Env.universe_of);
+                           (uu___3608_27836.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3608_27828.FStar_TypeChecker_Env.check_type_of);
+                           (uu___3608_27836.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts =
-                           (uu___3608_27828.FStar_TypeChecker_Env.use_bv_sorts);
+                           (uu___3608_27836.FStar_TypeChecker_Env.use_bv_sorts);
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3608_27828.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___3608_27836.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3608_27828.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___3608_27836.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3608_27828.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___3608_27836.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3608_27828.FStar_TypeChecker_Env.proof_ns);
+                           (uu___3608_27836.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3608_27828.FStar_TypeChecker_Env.synth_hook);
+                           (uu___3608_27836.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                           (uu___3608_27828.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                           (uu___3608_27836.FStar_TypeChecker_Env.try_solve_implicits_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3608_27828.FStar_TypeChecker_Env.splice);
+                           (uu___3608_27836.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.mpreprocess =
-                           (uu___3608_27828.FStar_TypeChecker_Env.mpreprocess);
+                           (uu___3608_27836.FStar_TypeChecker_Env.mpreprocess);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3608_27828.FStar_TypeChecker_Env.postprocess);
+                           (uu___3608_27836.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.is_native_tactic =
-                           (uu___3608_27828.FStar_TypeChecker_Env.is_native_tactic);
+                           (uu___3608_27836.FStar_TypeChecker_Env.is_native_tactic);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3608_27828.FStar_TypeChecker_Env.identifier_info);
+                           (uu___3608_27836.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3608_27828.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___3608_27836.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3608_27828.FStar_TypeChecker_Env.dsenv);
+                           (uu___3608_27836.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3608_27828.FStar_TypeChecker_Env.nbe);
+                           (uu___3608_27836.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3608_27828.FStar_TypeChecker_Env.strict_args_tab);
+                           (uu___3608_27836.FStar_TypeChecker_Env.strict_args_tab);
                          FStar_TypeChecker_Env.erasable_types_tab =
-                           (uu___3608_27828.FStar_TypeChecker_Env.erasable_types_tab)
+                           (uu___3608_27836.FStar_TypeChecker_Env.erasable_types_tab)
                        }  in
                      let g = FStar_TypeChecker_Rel.teq env1 t1 t_u  in
                      ((match g.FStar_TypeChecker_Common.guard_f with
                        | FStar_TypeChecker_Common.NonTrivial f ->
-                           let uu____27833 =
+                           let uu____27841 =
                              FStar_Syntax_Print.term_to_string t1  in
-                           level_of_type_fail env1 e uu____27833
-                       | uu____27835 ->
+                           level_of_type_fail env1 e uu____27841
+                       | uu____27843 ->
                            FStar_TypeChecker_Rel.force_trivial_guard env1 g);
                       u))
            in
@@ -11288,61 +11298,61 @@ let rec (universe_of_aux :
   =
   fun env  ->
     fun e  ->
-      let uu____27852 =
-        let uu____27853 = FStar_Syntax_Subst.compress e  in
-        uu____27853.FStar_Syntax_Syntax.n  in
-      match uu____27852 with
-      | FStar_Syntax_Syntax.Tm_bvar uu____27856 -> failwith "Impossible"
+      let uu____27860 =
+        let uu____27861 = FStar_Syntax_Subst.compress e  in
+        uu____27861.FStar_Syntax_Syntax.n  in
+      match uu____27860 with
+      | FStar_Syntax_Syntax.Tm_bvar uu____27864 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____27859 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_let uu____27875 ->
+      | FStar_Syntax_Syntax.Tm_delayed uu____27867 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_let uu____27883 ->
           let e1 = FStar_TypeChecker_Normalize.normalize [] env e  in
           universe_of_aux env e1
-      | FStar_Syntax_Syntax.Tm_abs (bs,t,uu____27892) ->
+      | FStar_Syntax_Syntax.Tm_abs (bs,t,uu____27900) ->
           level_of_type_fail env e "arrow type"
       | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
           FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
-      | FStar_Syntax_Syntax.Tm_meta (t,uu____27937) -> universe_of_aux env t
+      | FStar_Syntax_Syntax.Tm_meta (t,uu____27945) -> universe_of_aux env t
       | FStar_Syntax_Syntax.Tm_name n -> n.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____27944 =
+          let uu____27952 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____27944 with | ((uu____27953,t),uu____27955) -> t)
+          (match uu____27952 with | ((uu____27961,t),uu____27963) -> t)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____27961 = FStar_Syntax_Util.unfold_lazy i  in
-          universe_of_aux env uu____27961
+          let uu____27969 = FStar_Syntax_Util.unfold_lazy i  in
+          universe_of_aux env uu____27969
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____27964,(FStar_Util.Inl t,uu____27966),uu____27967) -> t
+          (uu____27972,(FStar_Util.Inl t,uu____27974),uu____27975) -> t
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____28014,(FStar_Util.Inr c,uu____28016),uu____28017) ->
+          (uu____28022,(FStar_Util.Inr c,uu____28024),uu____28025) ->
           FStar_Syntax_Util.comp_result c
       | FStar_Syntax_Syntax.Tm_type u ->
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ u))
             FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
-      | FStar_Syntax_Syntax.Tm_quoted uu____28065 -> FStar_Syntax_Util.ktype0
+      | FStar_Syntax_Syntax.Tm_quoted uu____28073 -> FStar_Syntax_Util.ktype0
       | FStar_Syntax_Syntax.Tm_constant sc ->
           tc_constant env e.FStar_Syntax_Syntax.pos sc
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____28074;
-             FStar_Syntax_Syntax.vars = uu____28075;_},us)
+             FStar_Syntax_Syntax.pos = uu____28082;
+             FStar_Syntax_Syntax.vars = uu____28083;_},us)
           ->
-          let uu____28081 =
+          let uu____28089 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____28081 with
-           | ((us',t),uu____28092) ->
+          (match uu____28089 with
+           | ((us',t),uu____28100) ->
                (if (FStar_List.length us) <> (FStar_List.length us')
                 then
-                  (let uu____28099 = FStar_TypeChecker_Env.get_range env  in
+                  (let uu____28107 = FStar_TypeChecker_Env.get_range env  in
                    FStar_Errors.raise_error
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
                        "Unexpected number of universe instantiations")
-                     uu____28099)
+                     uu____28107)
                 else
                   FStar_List.iter2
                     (fun u'  ->
@@ -11350,31 +11360,31 @@ let rec (universe_of_aux :
                          match u' with
                          | FStar_Syntax_Syntax.U_unif u'' ->
                              FStar_Syntax_Unionfind.univ_change u'' u
-                         | uu____28118 -> failwith "Impossible") us' us;
+                         | uu____28126 -> failwith "Impossible") us' us;
                 t))
-      | FStar_Syntax_Syntax.Tm_uinst uu____28120 ->
+      | FStar_Syntax_Syntax.Tm_uinst uu____28128 ->
           failwith "Impossible: Tm_uinst's head must be an fvar"
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____28129) ->
+      | FStar_Syntax_Syntax.Tm_refine (x,uu____28137) ->
           universe_of_aux env x.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____28156 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____28156 with
+          let uu____28164 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____28164 with
            | (bs1,c1) ->
                let us =
                  FStar_List.map
-                   (fun uu____28176  ->
-                      match uu____28176 with
-                      | (b,uu____28184) ->
-                          let uu____28189 =
+                   (fun uu____28184  ->
+                      match uu____28184 with
+                      | (b,uu____28192) ->
+                          let uu____28197 =
                             universe_of_aux env b.FStar_Syntax_Syntax.sort
                              in
                           level_of_type env b.FStar_Syntax_Syntax.sort
-                            uu____28189) bs1
+                            uu____28197) bs1
                   in
                let u_res =
                  let res = FStar_Syntax_Util.comp_result c1  in
-                 let uu____28194 = universe_of_aux env res  in
-                 level_of_type env res uu____28194  in
+                 let uu____28202 = universe_of_aux env res  in
+                 level_of_type env res uu____28202  in
                let u_c =
                  FStar_All.pipe_right c1
                    (FStar_TypeChecker_Util.universe_of_comp env u_res)
@@ -11390,204 +11400,204 @@ let rec (universe_of_aux :
             let hd2 = FStar_Syntax_Subst.compress hd1  in
             match hd2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_bvar uu____28305 ->
+            | FStar_Syntax_Syntax.Tm_bvar uu____28313 ->
                 failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_delayed uu____28321 ->
+            | FStar_Syntax_Syntax.Tm_delayed uu____28329 ->
                 failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_fvar uu____28351 ->
-                let uu____28352 = universe_of_aux env hd2  in
-                (uu____28352, args1)
-            | FStar_Syntax_Syntax.Tm_name uu____28363 ->
-                let uu____28364 = universe_of_aux env hd2  in
-                (uu____28364, args1)
-            | FStar_Syntax_Syntax.Tm_uvar uu____28375 ->
-                let uu____28388 = universe_of_aux env hd2  in
-                (uu____28388, args1)
-            | FStar_Syntax_Syntax.Tm_uinst uu____28399 ->
-                let uu____28406 = universe_of_aux env hd2  in
-                (uu____28406, args1)
-            | FStar_Syntax_Syntax.Tm_ascribed uu____28417 ->
-                let uu____28444 = universe_of_aux env hd2  in
-                (uu____28444, args1)
-            | FStar_Syntax_Syntax.Tm_refine uu____28455 ->
-                let uu____28462 = universe_of_aux env hd2  in
-                (uu____28462, args1)
-            | FStar_Syntax_Syntax.Tm_constant uu____28473 ->
-                let uu____28474 = universe_of_aux env hd2  in
-                (uu____28474, args1)
-            | FStar_Syntax_Syntax.Tm_arrow uu____28485 ->
-                let uu____28500 = universe_of_aux env hd2  in
-                (uu____28500, args1)
-            | FStar_Syntax_Syntax.Tm_meta uu____28511 ->
-                let uu____28518 = universe_of_aux env hd2  in
-                (uu____28518, args1)
-            | FStar_Syntax_Syntax.Tm_type uu____28529 ->
-                let uu____28530 = universe_of_aux env hd2  in
-                (uu____28530, args1)
-            | FStar_Syntax_Syntax.Tm_match (uu____28541,hd3::uu____28543) ->
-                let uu____28608 = FStar_Syntax_Subst.open_branch hd3  in
-                (match uu____28608 with
-                 | (uu____28623,uu____28624,hd4) ->
-                     let uu____28642 = FStar_Syntax_Util.head_and_args hd4
+            | FStar_Syntax_Syntax.Tm_fvar uu____28359 ->
+                let uu____28360 = universe_of_aux env hd2  in
+                (uu____28360, args1)
+            | FStar_Syntax_Syntax.Tm_name uu____28371 ->
+                let uu____28372 = universe_of_aux env hd2  in
+                (uu____28372, args1)
+            | FStar_Syntax_Syntax.Tm_uvar uu____28383 ->
+                let uu____28396 = universe_of_aux env hd2  in
+                (uu____28396, args1)
+            | FStar_Syntax_Syntax.Tm_uinst uu____28407 ->
+                let uu____28414 = universe_of_aux env hd2  in
+                (uu____28414, args1)
+            | FStar_Syntax_Syntax.Tm_ascribed uu____28425 ->
+                let uu____28452 = universe_of_aux env hd2  in
+                (uu____28452, args1)
+            | FStar_Syntax_Syntax.Tm_refine uu____28463 ->
+                let uu____28470 = universe_of_aux env hd2  in
+                (uu____28470, args1)
+            | FStar_Syntax_Syntax.Tm_constant uu____28481 ->
+                let uu____28482 = universe_of_aux env hd2  in
+                (uu____28482, args1)
+            | FStar_Syntax_Syntax.Tm_arrow uu____28493 ->
+                let uu____28508 = universe_of_aux env hd2  in
+                (uu____28508, args1)
+            | FStar_Syntax_Syntax.Tm_meta uu____28519 ->
+                let uu____28526 = universe_of_aux env hd2  in
+                (uu____28526, args1)
+            | FStar_Syntax_Syntax.Tm_type uu____28537 ->
+                let uu____28538 = universe_of_aux env hd2  in
+                (uu____28538, args1)
+            | FStar_Syntax_Syntax.Tm_match (uu____28549,hd3::uu____28551) ->
+                let uu____28616 = FStar_Syntax_Subst.open_branch hd3  in
+                (match uu____28616 with
+                 | (uu____28631,uu____28632,hd4) ->
+                     let uu____28650 = FStar_Syntax_Util.head_and_args hd4
                         in
-                     (match uu____28642 with
+                     (match uu____28650 with
                       | (hd5,args') ->
                           type_of_head retry hd5
                             (FStar_List.append args' args1)))
-            | uu____28707 when retry ->
+            | uu____28715 when retry ->
                 let e1 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Env.Beta;
                     FStar_TypeChecker_Env.DoNotUnfoldPureLets] env e
                    in
-                let uu____28709 = FStar_Syntax_Util.head_and_args e1  in
-                (match uu____28709 with
+                let uu____28717 = FStar_Syntax_Util.head_and_args e1  in
+                (match uu____28717 with
                  | (hd3,args2) -> type_of_head false hd3 args2)
-            | uu____28767 ->
-                let uu____28768 =
+            | uu____28775 ->
+                let uu____28776 =
                   FStar_TypeChecker_Env.clear_expected_typ env  in
-                (match uu____28768 with
-                 | (env1,uu____28790) ->
+                (match uu____28776 with
+                 | (env1,uu____28798) ->
                      let env2 =
-                       let uu___3769_28796 = env1  in
+                       let uu___3769_28804 = env1  in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3769_28796.FStar_TypeChecker_Env.solver);
+                           (uu___3769_28804.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3769_28796.FStar_TypeChecker_Env.range);
+                           (uu___3769_28804.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3769_28796.FStar_TypeChecker_Env.curmodule);
+                           (uu___3769_28804.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3769_28796.FStar_TypeChecker_Env.gamma);
+                           (uu___3769_28804.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3769_28796.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___3769_28804.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3769_28796.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___3769_28804.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3769_28796.FStar_TypeChecker_Env.modules);
+                           (uu___3769_28804.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3769_28796.FStar_TypeChecker_Env.expected_typ);
+                           (uu___3769_28804.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3769_28796.FStar_TypeChecker_Env.sigtab);
+                           (uu___3769_28804.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3769_28796.FStar_TypeChecker_Env.attrtab);
+                           (uu___3769_28804.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3769_28796.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___3769_28804.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3769_28796.FStar_TypeChecker_Env.effects);
+                           (uu___3769_28804.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3769_28796.FStar_TypeChecker_Env.generalize);
+                           (uu___3769_28804.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3769_28796.FStar_TypeChecker_Env.letrecs);
+                           (uu___3769_28804.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level = false;
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3769_28796.FStar_TypeChecker_Env.check_uvars);
+                           (uu___3769_28804.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3769_28796.FStar_TypeChecker_Env.use_eq);
+                           (uu___3769_28804.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.use_eq_strict =
-                           (uu___3769_28796.FStar_TypeChecker_Env.use_eq_strict);
+                           (uu___3769_28804.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3769_28796.FStar_TypeChecker_Env.is_iface);
+                           (uu___3769_28804.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3769_28796.FStar_TypeChecker_Env.admit);
+                           (uu___3769_28804.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3769_28796.FStar_TypeChecker_Env.lax_universes);
+                           (uu___3769_28804.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3769_28796.FStar_TypeChecker_Env.phase1);
+                           (uu___3769_28804.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3769_28796.FStar_TypeChecker_Env.failhard);
+                           (uu___3769_28804.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3769_28796.FStar_TypeChecker_Env.nosynth);
+                           (uu___3769_28804.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3769_28796.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___3769_28804.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3769_28796.FStar_TypeChecker_Env.tc_term);
+                           (uu___3769_28804.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3769_28796.FStar_TypeChecker_Env.type_of);
+                           (uu___3769_28804.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3769_28796.FStar_TypeChecker_Env.universe_of);
+                           (uu___3769_28804.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3769_28796.FStar_TypeChecker_Env.check_type_of);
+                           (uu___3769_28804.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts = true;
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3769_28796.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___3769_28804.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3769_28796.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___3769_28804.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3769_28796.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___3769_28804.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3769_28796.FStar_TypeChecker_Env.proof_ns);
+                           (uu___3769_28804.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3769_28796.FStar_TypeChecker_Env.synth_hook);
+                           (uu___3769_28804.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                           (uu___3769_28796.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                           (uu___3769_28804.FStar_TypeChecker_Env.try_solve_implicits_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3769_28796.FStar_TypeChecker_Env.splice);
+                           (uu___3769_28804.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.mpreprocess =
-                           (uu___3769_28796.FStar_TypeChecker_Env.mpreprocess);
+                           (uu___3769_28804.FStar_TypeChecker_Env.mpreprocess);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3769_28796.FStar_TypeChecker_Env.postprocess);
+                           (uu___3769_28804.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.is_native_tactic =
-                           (uu___3769_28796.FStar_TypeChecker_Env.is_native_tactic);
+                           (uu___3769_28804.FStar_TypeChecker_Env.is_native_tactic);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3769_28796.FStar_TypeChecker_Env.identifier_info);
+                           (uu___3769_28804.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3769_28796.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___3769_28804.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3769_28796.FStar_TypeChecker_Env.dsenv);
+                           (uu___3769_28804.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3769_28796.FStar_TypeChecker_Env.nbe);
+                           (uu___3769_28804.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3769_28796.FStar_TypeChecker_Env.strict_args_tab);
+                           (uu___3769_28804.FStar_TypeChecker_Env.strict_args_tab);
                          FStar_TypeChecker_Env.erasable_types_tab =
-                           (uu___3769_28796.FStar_TypeChecker_Env.erasable_types_tab)
+                           (uu___3769_28804.FStar_TypeChecker_Env.erasable_types_tab)
                        }  in
-                     ((let uu____28801 =
+                     ((let uu____28809 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env2)
                            (FStar_Options.Other "UniverseOf")
                           in
-                       if uu____28801
+                       if uu____28809
                        then
-                         let uu____28806 =
-                           let uu____28808 =
+                         let uu____28814 =
+                           let uu____28816 =
                              FStar_TypeChecker_Env.get_range env2  in
-                           FStar_Range.string_of_range uu____28808  in
-                         let uu____28809 =
+                           FStar_Range.string_of_range uu____28816  in
+                         let uu____28817 =
                            FStar_Syntax_Print.term_to_string hd2  in
                          FStar_Util.print2 "%s: About to type-check %s\n"
-                           uu____28806 uu____28809
+                           uu____28814 uu____28817
                        else ());
-                      (let uu____28814 = tc_term env2 hd2  in
-                       match uu____28814 with
-                       | (uu____28835,{
+                      (let uu____28822 = tc_term env2 hd2  in
+                       match uu____28822 with
+                       | (uu____28843,{
                                         FStar_TypeChecker_Common.eff_name =
-                                          uu____28836;
+                                          uu____28844;
                                         FStar_TypeChecker_Common.res_typ = t;
                                         FStar_TypeChecker_Common.cflags =
-                                          uu____28838;
+                                          uu____28846;
                                         FStar_TypeChecker_Common.comp_thunk =
-                                          uu____28839;_},g)
+                                          uu____28847;_},g)
                            ->
-                           ((let uu____28857 =
+                           ((let uu____28865 =
                                FStar_TypeChecker_Rel.solve_deferred_constraints
                                  env2 g
                                 in
-                             FStar_All.pipe_right uu____28857
-                               (fun uu____28858  -> ()));
+                             FStar_All.pipe_right uu____28865
+                               (fun uu____28866  -> ()));
                             (t, args1)))))
              in
-          let uu____28869 = type_of_head true hd args  in
-          (match uu____28869 with
+          let uu____28877 = type_of_head true hd args  in
+          (match uu____28877 with
            | (t,args1) ->
                let t1 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.UnfoldUntil
                       FStar_Syntax_Syntax.delta_constant] env t
                   in
-               let uu____28908 = FStar_Syntax_Util.arrow_formals_comp t1  in
-               (match uu____28908 with
+               let uu____28916 = FStar_Syntax_Util.arrow_formals_comp t1  in
+               (match uu____28916 with
                 | (bs,res) ->
                     let res1 = FStar_Syntax_Util.comp_result res  in
                     if (FStar_List.length bs) = (FStar_List.length args1)
@@ -11596,14 +11606,14 @@ let rec (universe_of_aux :
                          in
                       FStar_Syntax_Subst.subst subst res1
                     else
-                      (let uu____28936 =
+                      (let uu____28944 =
                          FStar_Syntax_Print.term_to_string res1  in
-                       level_of_type_fail env e uu____28936)))
-      | FStar_Syntax_Syntax.Tm_match (uu____28938,hd::uu____28940) ->
-          let uu____29005 = FStar_Syntax_Subst.open_branch hd  in
-          (match uu____29005 with
-           | (uu____29006,uu____29007,hd1) -> universe_of_aux env hd1)
-      | FStar_Syntax_Syntax.Tm_match (uu____29025,[]) ->
+                       level_of_type_fail env e uu____28944)))
+      | FStar_Syntax_Syntax.Tm_match (uu____28946,hd::uu____28948) ->
+          let uu____29013 = FStar_Syntax_Subst.open_branch hd  in
+          (match uu____29013 with
+           | (uu____29014,uu____29015,hd1) -> universe_of_aux env hd1)
+      | FStar_Syntax_Syntax.Tm_match (uu____29033,[]) ->
           level_of_type_fail env e "empty match cases"
   
 let (universe_of :
@@ -11612,8 +11622,8 @@ let (universe_of :
   =
   fun env  ->
     fun e  ->
-      let uu____29072 = universe_of_aux env e  in
-      level_of_type env e uu____29072
+      let uu____29080 = universe_of_aux env e  in
+      level_of_type env e uu____29080
   
 let (tc_tparams :
   FStar_TypeChecker_Env.env_t ->
@@ -11623,8 +11633,8 @@ let (tc_tparams :
   =
   fun env0  ->
     fun tps  ->
-      let uu____29096 = tc_binders env0 tps  in
-      match uu____29096 with
+      let uu____29104 = tc_binders env0 tps  in
+      match uu____29104 with
       | (tps1,env,g,us) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env0 g; (tps1, env, us))
   
@@ -11641,142 +11651,142 @@ let rec (type_of_well_typed_term :
          in
       let t1 = FStar_Syntax_Subst.compress t  in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____29154 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_bvar uu____29172 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____29162 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_bvar uu____29180 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name x ->
           FStar_Pervasives_Native.Some (x.FStar_Syntax_Syntax.sort)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____29178 = FStar_Syntax_Util.unfold_lazy i  in
-          type_of_well_typed_term env uu____29178
+          let uu____29186 = FStar_Syntax_Util.unfold_lazy i  in
+          type_of_well_typed_term env uu____29186
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____29180 =
+          let uu____29188 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env []
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          FStar_Util.bind_opt uu____29180
-            (fun uu____29194  ->
-               match uu____29194 with
-               | (t2,uu____29202) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu____29188
+            (fun uu____29202  ->
+               match uu____29202 with
+               | (t2,uu____29210) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____29204;
-             FStar_Syntax_Syntax.vars = uu____29205;_},us)
+             FStar_Syntax_Syntax.pos = uu____29212;
+             FStar_Syntax_Syntax.vars = uu____29213;_},us)
           ->
-          let uu____29211 =
+          let uu____29219 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env us
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          FStar_Util.bind_opt uu____29211
-            (fun uu____29225  ->
-               match uu____29225 with
-               | (t2,uu____29233) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu____29219
+            (fun uu____29233  ->
+               match uu____29233 with
+               | (t2,uu____29241) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify ) ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect
-          uu____29234) -> FStar_Pervasives_Native.None
+          uu____29242) -> FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_constant sc ->
-          let uu____29236 = tc_constant env t1.FStar_Syntax_Syntax.pos sc  in
-          FStar_Pervasives_Native.Some uu____29236
+          let uu____29244 = tc_constant env t1.FStar_Syntax_Syntax.pos sc  in
+          FStar_Pervasives_Native.Some uu____29244
       | FStar_Syntax_Syntax.Tm_type u ->
-          let uu____29238 = mk_tm_type (FStar_Syntax_Syntax.U_succ u)  in
-          FStar_Pervasives_Native.Some uu____29238
+          let uu____29246 = mk_tm_type (FStar_Syntax_Syntax.U_succ u)  in
+          FStar_Pervasives_Native.Some uu____29246
       | FStar_Syntax_Syntax.Tm_abs
           (bs,body,FStar_Pervasives_Native.Some
            { FStar_Syntax_Syntax.residual_effect = eff;
              FStar_Syntax_Syntax.residual_typ = FStar_Pervasives_Native.Some
                tbody;
-             FStar_Syntax_Syntax.residual_flags = uu____29243;_})
+             FStar_Syntax_Syntax.residual_flags = uu____29251;_})
           ->
           let mk_comp =
-            let uu____29287 =
+            let uu____29295 =
               FStar_Ident.lid_equals eff FStar_Parser_Const.effect_Tot_lid
                in
-            if uu____29287
+            if uu____29295
             then FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_Total'
             else
-              (let uu____29318 =
+              (let uu____29326 =
                  FStar_Ident.lid_equals eff
                    FStar_Parser_Const.effect_GTot_lid
                   in
-               if uu____29318
+               if uu____29326
                then
                  FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_GTotal'
                else FStar_Pervasives_Native.None)
              in
           FStar_Util.bind_opt mk_comp
             (fun f  ->
-               let uu____29388 = universe_of_well_typed_term env tbody  in
-               FStar_Util.bind_opt uu____29388
+               let uu____29396 = universe_of_well_typed_term env tbody  in
+               FStar_Util.bind_opt uu____29396
                  (fun u  ->
-                    let uu____29396 =
-                      let uu____29399 =
-                        let uu____29406 =
-                          let uu____29407 =
-                            let uu____29422 =
+                    let uu____29404 =
+                      let uu____29407 =
+                        let uu____29414 =
+                          let uu____29415 =
+                            let uu____29430 =
                               f tbody (FStar_Pervasives_Native.Some u)  in
-                            (bs, uu____29422)  in
-                          FStar_Syntax_Syntax.Tm_arrow uu____29407  in
-                        FStar_Syntax_Syntax.mk uu____29406  in
-                      uu____29399 FStar_Pervasives_Native.None
+                            (bs, uu____29430)  in
+                          FStar_Syntax_Syntax.Tm_arrow uu____29415  in
+                        FStar_Syntax_Syntax.mk uu____29414  in
+                      uu____29407 FStar_Pervasives_Native.None
                         t1.FStar_Syntax_Syntax.pos
                        in
-                    FStar_Pervasives_Native.Some uu____29396))
+                    FStar_Pervasives_Native.Some uu____29404))
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____29459 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____29459 with
+          let uu____29467 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____29467 with
            | (bs1,c1) ->
                let rec aux env1 us bs2 =
                  match bs2 with
                  | [] ->
-                     let uu____29518 =
+                     let uu____29526 =
                        universe_of_well_typed_term env1
                          (FStar_Syntax_Util.comp_result c1)
                         in
-                     FStar_Util.bind_opt uu____29518
+                     FStar_Util.bind_opt uu____29526
                        (fun uc  ->
-                          let uu____29526 =
+                          let uu____29534 =
                             mk_tm_type (FStar_Syntax_Syntax.U_max (uc :: us))
                              in
-                          FStar_Pervasives_Native.Some uu____29526)
+                          FStar_Pervasives_Native.Some uu____29534)
                  | (x,imp)::bs3 ->
-                     let uu____29552 =
+                     let uu____29560 =
                        universe_of_well_typed_term env1
                          x.FStar_Syntax_Syntax.sort
                         in
-                     FStar_Util.bind_opt uu____29552
+                     FStar_Util.bind_opt uu____29560
                        (fun u_x  ->
                           let env2 = FStar_TypeChecker_Env.push_bv env1 x  in
                           aux env2 (u_x :: us) bs3)
                   in
                aux env [] bs1)
-      | FStar_Syntax_Syntax.Tm_abs uu____29561 ->
+      | FStar_Syntax_Syntax.Tm_abs uu____29569 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____29581) ->
-          let uu____29586 =
+      | FStar_Syntax_Syntax.Tm_refine (x,uu____29589) ->
+          let uu____29594 =
             universe_of_well_typed_term env x.FStar_Syntax_Syntax.sort  in
-          FStar_Util.bind_opt uu____29586
+          FStar_Util.bind_opt uu____29594
             (fun u_x  ->
-               let uu____29594 = mk_tm_type u_x  in
-               FStar_Pervasives_Native.Some uu____29594)
+               let uu____29602 = mk_tm_type u_x  in
+               FStar_Pervasives_Native.Some uu____29602)
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____29599;
-             FStar_Syntax_Syntax.vars = uu____29600;_},a::hd::rest)
+             FStar_Syntax_Syntax.pos = uu____29607;
+             FStar_Syntax_Syntax.vars = uu____29608;_},a::hd::rest)
           ->
           let rest1 = hd :: rest  in
-          let uu____29679 = FStar_Syntax_Util.head_and_args t1  in
-          (match uu____29679 with
-           | (unary_op,uu____29699) ->
+          let uu____29687 = FStar_Syntax_Util.head_and_args t1  in
+          (match uu____29687 with
+           | (unary_op,uu____29707) ->
                let head =
-                 let uu____29727 =
+                 let uu____29735 =
                    FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
                     in
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))
-                   FStar_Pervasives_Native.None uu____29727
+                   FStar_Pervasives_Native.None uu____29735
                   in
                let t2 =
                  FStar_Syntax_Syntax.mk
@@ -11788,21 +11798,21 @@ let rec (type_of_well_typed_term :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____29775;
-             FStar_Syntax_Syntax.vars = uu____29776;_},a1::a2::hd::rest)
+             FStar_Syntax_Syntax.pos = uu____29783;
+             FStar_Syntax_Syntax.vars = uu____29784;_},a1::a2::hd::rest)
           ->
           let rest1 = hd :: rest  in
-          let uu____29872 = FStar_Syntax_Util.head_and_args t1  in
-          (match uu____29872 with
-           | (unary_op,uu____29892) ->
+          let uu____29880 = FStar_Syntax_Util.head_and_args t1  in
+          (match uu____29880 with
+           | (unary_op,uu____29900) ->
                let head =
-                 let uu____29920 =
+                 let uu____29928 =
                    FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos
                     in
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))
-                   FStar_Pervasives_Native.None uu____29920
+                   FStar_Pervasives_Native.None uu____29928
                   in
                let t2 =
                  FStar_Syntax_Syntax.mk
@@ -11814,32 +11824,32 @@ let rec (type_of_well_typed_term :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____29976;
-             FStar_Syntax_Syntax.vars = uu____29977;_},uu____29978::[])
+             FStar_Syntax_Syntax.pos = uu____29984;
+             FStar_Syntax_Syntax.vars = uu____29985;_},uu____29986::[])
           -> FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_range
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____30017;
-             FStar_Syntax_Syntax.vars = uu____30018;_},(t2,uu____30020)::uu____30021::[])
+             FStar_Syntax_Syntax.pos = uu____30025;
+             FStar_Syntax_Syntax.vars = uu____30026;_},(t2,uu____30028)::uu____30029::[])
           -> type_of_well_typed_term env t2
       | FStar_Syntax_Syntax.Tm_app (hd,args) ->
           let t_hd = type_of_well_typed_term env hd  in
           let rec aux t_hd1 =
-            let uu____30117 =
-              let uu____30118 =
+            let uu____30125 =
+              let uu____30126 =
                 FStar_TypeChecker_Normalize.unfold_whnf env t_hd1  in
-              uu____30118.FStar_Syntax_Syntax.n  in
-            match uu____30117 with
+              uu____30126.FStar_Syntax_Syntax.n  in
+            match uu____30125 with
             | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                 let n_args = FStar_List.length args  in
                 let n_bs = FStar_List.length bs  in
                 let bs_t_opt =
                   if n_args < n_bs
                   then
-                    let uu____30191 = FStar_Util.first_N n_args bs  in
-                    match uu____30191 with
+                    let uu____30199 = FStar_Util.first_N n_args bs  in
+                    match uu____30199 with
                     | (bs1,rest) ->
                         let t2 =
                           FStar_Syntax_Syntax.mk
@@ -11847,24 +11857,24 @@ let rec (type_of_well_typed_term :
                             FStar_Pervasives_Native.None
                             t_hd1.FStar_Syntax_Syntax.pos
                            in
-                        let uu____30279 =
-                          let uu____30284 = FStar_Syntax_Syntax.mk_Total t2
+                        let uu____30287 =
+                          let uu____30292 = FStar_Syntax_Syntax.mk_Total t2
                              in
-                          FStar_Syntax_Subst.open_comp bs1 uu____30284  in
-                        (match uu____30279 with
+                          FStar_Syntax_Subst.open_comp bs1 uu____30292  in
+                        (match uu____30287 with
                          | (bs2,c1) ->
                              FStar_Pervasives_Native.Some
                                (bs2, (FStar_Syntax_Util.comp_result c1)))
                   else
                     if n_args = n_bs
                     then
-                      (let uu____30338 = FStar_Syntax_Subst.open_comp bs c
+                      (let uu____30346 = FStar_Syntax_Subst.open_comp bs c
                           in
-                       match uu____30338 with
+                       match uu____30346 with
                        | (bs1,c1) ->
-                           let uu____30359 =
+                           let uu____30367 =
                              FStar_Syntax_Util.is_tot_or_gtot_comp c1  in
-                           if uu____30359
+                           if uu____30367
                            then
                              FStar_Pervasives_Native.Some
                                (bs1, (FStar_Syntax_Util.comp_result c1))
@@ -11872,8 +11882,8 @@ let rec (type_of_well_typed_term :
                     else FStar_Pervasives_Native.None
                    in
                 FStar_Util.bind_opt bs_t_opt
-                  (fun uu____30441  ->
-                     match uu____30441 with
+                  (fun uu____30449  ->
+                     match uu____30449 with
                      | (bs1,t2) ->
                          let subst =
                            FStar_List.map2
@@ -11884,36 +11894,36 @@ let rec (type_of_well_typed_term :
                                       (FStar_Pervasives_Native.fst a))) bs1
                              args
                             in
-                         let uu____30517 = FStar_Syntax_Subst.subst subst t2
+                         let uu____30525 = FStar_Syntax_Subst.subst subst t2
                             in
-                         FStar_Pervasives_Native.Some uu____30517)
-            | FStar_Syntax_Syntax.Tm_refine (x,uu____30519) ->
+                         FStar_Pervasives_Native.Some uu____30525)
+            | FStar_Syntax_Syntax.Tm_refine (x,uu____30527) ->
                 aux x.FStar_Syntax_Syntax.sort
-            | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____30525,uu____30526) ->
+            | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____30533,uu____30534) ->
                 aux t2
-            | uu____30567 -> FStar_Pervasives_Native.None  in
+            | uu____30575 -> FStar_Pervasives_Native.None  in
           FStar_Util.bind_opt t_hd aux
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____30568,(FStar_Util.Inl t2,uu____30570),uu____30571) ->
+          (uu____30576,(FStar_Util.Inl t2,uu____30578),uu____30579) ->
           FStar_Pervasives_Native.Some t2
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____30618,(FStar_Util.Inr c,uu____30620),uu____30621) ->
+          (uu____30626,(FStar_Util.Inr c,uu____30628),uu____30629) ->
           FStar_Pervasives_Native.Some (FStar_Syntax_Util.comp_result c)
       | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
-          let uu____30686 =
+          let uu____30694 =
             FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
              in
-          FStar_Pervasives_Native.Some uu____30686
+          FStar_Pervasives_Native.Some uu____30694
       | FStar_Syntax_Syntax.Tm_quoted (tm,qi) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_term
-      | FStar_Syntax_Syntax.Tm_meta (t2,uu____30694) ->
+      | FStar_Syntax_Syntax.Tm_meta (t2,uu____30702) ->
           type_of_well_typed_term env t2
-      | FStar_Syntax_Syntax.Tm_match uu____30699 ->
+      | FStar_Syntax_Syntax.Tm_match uu____30707 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_let uu____30722 ->
+      | FStar_Syntax_Syntax.Tm_let uu____30730 ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uinst uu____30736 ->
+      | FStar_Syntax_Syntax.Tm_uinst uu____30744 ->
           FStar_Pervasives_Native.None
 
 and (universe_of_well_typed_term :
@@ -11923,14 +11933,14 @@ and (universe_of_well_typed_term :
   =
   fun env  ->
     fun t  ->
-      let uu____30747 = type_of_well_typed_term env t  in
-      match uu____30747 with
+      let uu____30755 = type_of_well_typed_term env t  in
+      match uu____30755 with
       | FStar_Pervasives_Native.Some
           { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_type u;
-            FStar_Syntax_Syntax.pos = uu____30753;
-            FStar_Syntax_Syntax.vars = uu____30754;_}
+            FStar_Syntax_Syntax.pos = uu____30761;
+            FStar_Syntax_Syntax.vars = uu____30762;_}
           -> FStar_Pervasives_Native.Some u
-      | uu____30757 -> FStar_Pervasives_Native.None
+      | uu____30765 -> FStar_Pervasives_Native.None
 
 let (check_type_of_well_typed_term' :
   Prims.bool ->
@@ -11944,148 +11954,148 @@ let (check_type_of_well_typed_term' :
         fun k  ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k  in
           let env2 =
-            let uu___4048_30785 = env1  in
+            let uu___4048_30793 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___4048_30785.FStar_TypeChecker_Env.solver);
+                (uu___4048_30793.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___4048_30785.FStar_TypeChecker_Env.range);
+                (uu___4048_30793.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___4048_30785.FStar_TypeChecker_Env.curmodule);
+                (uu___4048_30793.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___4048_30785.FStar_TypeChecker_Env.gamma);
+                (uu___4048_30793.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___4048_30785.FStar_TypeChecker_Env.gamma_sig);
+                (uu___4048_30793.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___4048_30785.FStar_TypeChecker_Env.gamma_cache);
+                (uu___4048_30793.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___4048_30785.FStar_TypeChecker_Env.modules);
+                (uu___4048_30793.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___4048_30785.FStar_TypeChecker_Env.expected_typ);
+                (uu___4048_30793.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___4048_30785.FStar_TypeChecker_Env.sigtab);
+                (uu___4048_30793.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___4048_30785.FStar_TypeChecker_Env.attrtab);
+                (uu___4048_30793.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___4048_30785.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___4048_30793.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___4048_30785.FStar_TypeChecker_Env.effects);
+                (uu___4048_30793.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___4048_30785.FStar_TypeChecker_Env.generalize);
+                (uu___4048_30793.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___4048_30785.FStar_TypeChecker_Env.letrecs);
+                (uu___4048_30793.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___4048_30785.FStar_TypeChecker_Env.top_level);
+                (uu___4048_30793.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___4048_30785.FStar_TypeChecker_Env.check_uvars);
+                (uu___4048_30793.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___4048_30785.FStar_TypeChecker_Env.use_eq);
+                (uu___4048_30793.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___4048_30785.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___4048_30793.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___4048_30785.FStar_TypeChecker_Env.is_iface);
+                (uu___4048_30793.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___4048_30785.FStar_TypeChecker_Env.admit);
+                (uu___4048_30793.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___4048_30785.FStar_TypeChecker_Env.lax);
+                (uu___4048_30793.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___4048_30785.FStar_TypeChecker_Env.lax_universes);
+                (uu___4048_30793.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___4048_30785.FStar_TypeChecker_Env.phase1);
+                (uu___4048_30793.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___4048_30785.FStar_TypeChecker_Env.failhard);
+                (uu___4048_30793.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___4048_30785.FStar_TypeChecker_Env.nosynth);
+                (uu___4048_30793.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___4048_30785.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___4048_30793.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___4048_30785.FStar_TypeChecker_Env.tc_term);
+                (uu___4048_30793.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___4048_30785.FStar_TypeChecker_Env.type_of);
+                (uu___4048_30793.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___4048_30785.FStar_TypeChecker_Env.universe_of);
+                (uu___4048_30793.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___4048_30785.FStar_TypeChecker_Env.check_type_of);
+                (uu___4048_30793.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___4048_30785.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___4048_30793.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___4048_30785.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___4048_30793.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___4048_30785.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___4048_30793.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___4048_30785.FStar_TypeChecker_Env.proof_ns);
+                (uu___4048_30793.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___4048_30785.FStar_TypeChecker_Env.synth_hook);
+                (uu___4048_30793.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___4048_30785.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___4048_30793.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___4048_30785.FStar_TypeChecker_Env.splice);
+                (uu___4048_30793.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___4048_30785.FStar_TypeChecker_Env.mpreprocess);
+                (uu___4048_30793.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___4048_30785.FStar_TypeChecker_Env.postprocess);
+                (uu___4048_30793.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.is_native_tactic =
-                (uu___4048_30785.FStar_TypeChecker_Env.is_native_tactic);
+                (uu___4048_30793.FStar_TypeChecker_Env.is_native_tactic);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___4048_30785.FStar_TypeChecker_Env.identifier_info);
+                (uu___4048_30793.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___4048_30785.FStar_TypeChecker_Env.tc_hooks);
+                (uu___4048_30793.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___4048_30785.FStar_TypeChecker_Env.dsenv);
+                (uu___4048_30793.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___4048_30785.FStar_TypeChecker_Env.nbe);
+                (uu___4048_30793.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___4048_30785.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___4048_30793.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___4048_30785.FStar_TypeChecker_Env.erasable_types_tab)
+                (uu___4048_30793.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let slow_check uu____30792 =
+          let slow_check uu____30800 =
             if must_total
             then
-              let uu____30794 = env2.FStar_TypeChecker_Env.type_of env2 t  in
-              match uu____30794 with | (uu____30801,uu____30802,g) -> g
+              let uu____30802 = env2.FStar_TypeChecker_Env.type_of env2 t  in
+              match uu____30802 with | (uu____30809,uu____30810,g) -> g
             else
-              (let uu____30806 = env2.FStar_TypeChecker_Env.tc_term env2 t
+              (let uu____30814 = env2.FStar_TypeChecker_Env.tc_term env2 t
                   in
-               match uu____30806 with | (uu____30813,uu____30814,g) -> g)
+               match uu____30814 with | (uu____30821,uu____30822,g) -> g)
              in
-          let uu____30816 = type_of_well_typed_term env2 t  in
-          match uu____30816 with
+          let uu____30824 = type_of_well_typed_term env2 t  in
+          match uu____30824 with
           | FStar_Pervasives_Native.None  -> slow_check ()
           | FStar_Pervasives_Native.Some k' ->
-              ((let uu____30821 =
+              ((let uu____30829 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                     (FStar_Options.Other "FastImplicits")
                    in
-                if uu____30821
+                if uu____30829
                 then
-                  let uu____30826 =
+                  let uu____30834 =
                     FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos  in
-                  let uu____30828 = FStar_Syntax_Print.term_to_string t  in
-                  let uu____30830 = FStar_Syntax_Print.term_to_string k'  in
-                  let uu____30832 = FStar_Syntax_Print.term_to_string k  in
+                  let uu____30836 = FStar_Syntax_Print.term_to_string t  in
+                  let uu____30838 = FStar_Syntax_Print.term_to_string k'  in
+                  let uu____30840 = FStar_Syntax_Print.term_to_string k  in
                   FStar_Util.print4 "(%s) Fast check  %s : %s <:? %s\n"
-                    uu____30826 uu____30828 uu____30830 uu____30832
+                    uu____30834 uu____30836 uu____30838 uu____30840
                 else ());
                (let g = FStar_TypeChecker_Rel.subtype_nosmt env2 k' k  in
-                (let uu____30841 =
+                (let uu____30849 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                      (FStar_Options.Other "FastImplicits")
                     in
-                 if uu____30841
+                 if uu____30849
                  then
-                   let uu____30846 =
+                   let uu____30854 =
                      FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos
                       in
-                   let uu____30848 = FStar_Syntax_Print.term_to_string t  in
-                   let uu____30850 = FStar_Syntax_Print.term_to_string k'  in
-                   let uu____30852 = FStar_Syntax_Print.term_to_string k  in
+                   let uu____30856 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____30858 = FStar_Syntax_Print.term_to_string k'  in
+                   let uu____30860 = FStar_Syntax_Print.term_to_string k  in
                    FStar_Util.print5 "(%s) Fast check %s: %s : %s <: %s\n"
-                     uu____30846
+                     uu____30854
                      (if FStar_Option.isSome g
                       then "succeeded with guard"
-                      else "failed") uu____30848 uu____30850 uu____30852
+                      else "failed") uu____30856 uu____30858 uu____30860
                  else ());
                 (match g with
                  | FStar_Pervasives_Native.None  -> slow_check ()
@@ -12103,116 +12113,116 @@ let (check_type_of_well_typed_term :
         fun k  ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k  in
           let env2 =
-            let uu___4079_30889 = env1  in
+            let uu___4079_30897 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___4079_30889.FStar_TypeChecker_Env.solver);
+                (uu___4079_30897.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___4079_30889.FStar_TypeChecker_Env.range);
+                (uu___4079_30897.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___4079_30889.FStar_TypeChecker_Env.curmodule);
+                (uu___4079_30897.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___4079_30889.FStar_TypeChecker_Env.gamma);
+                (uu___4079_30897.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___4079_30889.FStar_TypeChecker_Env.gamma_sig);
+                (uu___4079_30897.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___4079_30889.FStar_TypeChecker_Env.gamma_cache);
+                (uu___4079_30897.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___4079_30889.FStar_TypeChecker_Env.modules);
+                (uu___4079_30897.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___4079_30889.FStar_TypeChecker_Env.expected_typ);
+                (uu___4079_30897.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___4079_30889.FStar_TypeChecker_Env.sigtab);
+                (uu___4079_30897.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___4079_30889.FStar_TypeChecker_Env.attrtab);
+                (uu___4079_30897.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___4079_30889.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___4079_30897.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___4079_30889.FStar_TypeChecker_Env.effects);
+                (uu___4079_30897.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___4079_30889.FStar_TypeChecker_Env.generalize);
+                (uu___4079_30897.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___4079_30889.FStar_TypeChecker_Env.letrecs);
+                (uu___4079_30897.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___4079_30889.FStar_TypeChecker_Env.top_level);
+                (uu___4079_30897.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___4079_30889.FStar_TypeChecker_Env.check_uvars);
+                (uu___4079_30897.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___4079_30889.FStar_TypeChecker_Env.use_eq);
+                (uu___4079_30897.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___4079_30889.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___4079_30897.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___4079_30889.FStar_TypeChecker_Env.is_iface);
+                (uu___4079_30897.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___4079_30889.FStar_TypeChecker_Env.admit);
+                (uu___4079_30897.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___4079_30889.FStar_TypeChecker_Env.lax);
+                (uu___4079_30897.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___4079_30889.FStar_TypeChecker_Env.lax_universes);
+                (uu___4079_30897.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___4079_30889.FStar_TypeChecker_Env.phase1);
+                (uu___4079_30897.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___4079_30889.FStar_TypeChecker_Env.failhard);
+                (uu___4079_30897.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___4079_30889.FStar_TypeChecker_Env.nosynth);
+                (uu___4079_30897.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___4079_30889.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___4079_30897.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___4079_30889.FStar_TypeChecker_Env.tc_term);
+                (uu___4079_30897.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___4079_30889.FStar_TypeChecker_Env.type_of);
+                (uu___4079_30897.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___4079_30889.FStar_TypeChecker_Env.universe_of);
+                (uu___4079_30897.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___4079_30889.FStar_TypeChecker_Env.check_type_of);
+                (uu___4079_30897.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___4079_30889.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___4079_30897.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___4079_30889.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___4079_30897.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___4079_30889.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___4079_30897.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___4079_30889.FStar_TypeChecker_Env.proof_ns);
+                (uu___4079_30897.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___4079_30889.FStar_TypeChecker_Env.synth_hook);
+                (uu___4079_30897.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___4079_30889.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___4079_30897.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___4079_30889.FStar_TypeChecker_Env.splice);
+                (uu___4079_30897.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___4079_30889.FStar_TypeChecker_Env.mpreprocess);
+                (uu___4079_30897.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___4079_30889.FStar_TypeChecker_Env.postprocess);
+                (uu___4079_30897.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.is_native_tactic =
-                (uu___4079_30889.FStar_TypeChecker_Env.is_native_tactic);
+                (uu___4079_30897.FStar_TypeChecker_Env.is_native_tactic);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___4079_30889.FStar_TypeChecker_Env.identifier_info);
+                (uu___4079_30897.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___4079_30889.FStar_TypeChecker_Env.tc_hooks);
+                (uu___4079_30897.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___4079_30889.FStar_TypeChecker_Env.dsenv);
+                (uu___4079_30897.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___4079_30889.FStar_TypeChecker_Env.nbe);
+                (uu___4079_30897.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___4079_30889.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___4079_30897.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___4079_30889.FStar_TypeChecker_Env.erasable_types_tab)
+                (uu___4079_30897.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let slow_check uu____30896 =
+          let slow_check uu____30904 =
             if must_total
             then
-              let uu____30898 = env2.FStar_TypeChecker_Env.type_of env2 t  in
-              match uu____30898 with | (uu____30905,uu____30906,g) -> g
+              let uu____30906 = env2.FStar_TypeChecker_Env.type_of env2 t  in
+              match uu____30906 with | (uu____30913,uu____30914,g) -> g
             else
-              (let uu____30910 = env2.FStar_TypeChecker_Env.tc_term env2 t
+              (let uu____30918 = env2.FStar_TypeChecker_Env.tc_term env2 t
                   in
-               match uu____30910 with | (uu____30917,uu____30918,g) -> g)
+               match uu____30918 with | (uu____30925,uu____30926,g) -> g)
              in
-          let uu____30920 =
-            let uu____30922 = FStar_Options.__temp_fast_implicits ()  in
-            FStar_All.pipe_left Prims.op_Negation uu____30922  in
-          if uu____30920
+          let uu____30928 =
+            let uu____30930 = FStar_Options.__temp_fast_implicits ()  in
+            FStar_All.pipe_left Prims.op_Negation uu____30930  in
+          if uu____30928
           then slow_check ()
           else check_type_of_well_typed_term' must_total env2 t k
   

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -6399,12 +6399,14 @@ let (maybe_add_implicit_binders :
                          let uu____17522 =
                            FStar_All.pipe_right imps
                              (FStar_Util.for_all
-                                (fun uu____17542  ->
-                                   match uu____17542 with
-                                   | (x,uu____17551) ->
-                                       FStar_Util.starts_with
-                                         (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                         "'"))
+                                (fun uu____17543  ->
+                                   match uu____17543 with
+                                   | (x,uu____17552) ->
+                                       let uu____17557 =
+                                         FStar_Ident.text_of_id
+                                           x.FStar_Syntax_Syntax.ppname
+                                          in
+                                       FStar_Util.starts_with uu____17557 "'"))
                             in
                          if uu____17522
                          then
@@ -6412,18 +6414,18 @@ let (maybe_add_implicit_binders :
                            let imps1 =
                              FStar_All.pipe_right imps
                                (FStar_List.map
-                                  (fun uu____17600  ->
-                                     match uu____17600 with
+                                  (fun uu____17603  ->
+                                     match uu____17603 with
                                      | (x,i) ->
-                                         let uu____17619 =
+                                         let uu____17622 =
                                            FStar_Syntax_Syntax.set_range_of_bv
                                              x r
                                             in
-                                         (uu____17619, i)))
+                                         (uu____17622, i)))
                               in
                            FStar_List.append imps1 bs
                          else bs)
-                | uu____17630 -> bs))
+                | uu____17633 -> bs))
   
 let (maybe_lift :
   FStar_TypeChecker_Env.env ->
@@ -6439,7 +6441,7 @@ let (maybe_lift :
           fun t  ->
             let m1 = FStar_TypeChecker_Env.norm_eff_name env c1  in
             let m2 = FStar_TypeChecker_Env.norm_eff_name env c2  in
-            let uu____17659 =
+            let uu____17662 =
               ((FStar_Ident.lid_equals m1 m2) ||
                  ((FStar_Syntax_Util.is_pure_effect c1) &&
                     (FStar_Syntax_Util.is_ghost_effect c2)))
@@ -6447,7 +6449,7 @@ let (maybe_lift :
                 ((FStar_Syntax_Util.is_pure_effect c2) &&
                    (FStar_Syntax_Util.is_ghost_effect c1))
                in
-            if uu____17659
+            if uu____17662
             then e
             else
               FStar_Syntax_Syntax.mk
@@ -6466,13 +6468,13 @@ let (maybe_monadic :
       fun c  ->
         fun t  ->
           let m = FStar_TypeChecker_Env.norm_eff_name env c  in
-          let uu____17690 =
+          let uu____17693 =
             ((is_pure_or_ghost_effect env m) ||
                (FStar_Ident.lid_equals m FStar_Parser_Const.effect_Tot_lid))
               ||
               (FStar_Ident.lid_equals m FStar_Parser_Const.effect_GTot_lid)
              in
-          if uu____17690
+          if uu____17693
           then e
           else
             FStar_Syntax_Syntax.mk
@@ -6491,20 +6493,20 @@ let (mk_toplevel_definition :
   fun env  ->
     fun lident  ->
       fun def  ->
-        (let uu____17733 =
+        (let uu____17736 =
            FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED")  in
-         if uu____17733
+         if uu____17736
          then
-           ((let uu____17738 = FStar_Ident.text_of_lid lident  in
-             d uu____17738);
-            (let uu____17740 = FStar_Ident.text_of_lid lident  in
-             let uu____17742 = FStar_Syntax_Print.term_to_string def  in
+           ((let uu____17741 = FStar_Ident.string_of_lid lident  in
+             d uu____17741);
+            (let uu____17743 = FStar_Ident.string_of_lid lident  in
+             let uu____17745 = FStar_Syntax_Print.term_to_string def  in
              FStar_Util.print2 "Registering top-level definition: %s\n%s\n"
-               uu____17740 uu____17742))
+               uu____17743 uu____17745))
          else ());
         (let fv =
-           let uu____17748 = FStar_Syntax_Util.incr_delta_qualifier def  in
-           FStar_Syntax_Syntax.lid_as_fv lident uu____17748
+           let uu____17751 = FStar_Syntax_Util.incr_delta_qualifier def  in
+           FStar_Syntax_Syntax.lid_as_fv lident uu____17751
              FStar_Pervasives_Native.None
             in
          let lbname = FStar_Util.Inr fv  in
@@ -6518,67 +6520,67 @@ let (mk_toplevel_definition :
            FStar_Syntax_Syntax.mk_sigelt
              (FStar_Syntax_Syntax.Sig_let (lb, [lident]))
             in
-         let uu____17760 =
+         let uu____17763 =
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
              FStar_Pervasives_Native.None FStar_Range.dummyRange
             in
-         ((let uu___2085_17762 = sig_ctx  in
+         ((let uu___2085_17765 = sig_ctx  in
            {
              FStar_Syntax_Syntax.sigel =
-               (uu___2085_17762.FStar_Syntax_Syntax.sigel);
+               (uu___2085_17765.FStar_Syntax_Syntax.sigel);
              FStar_Syntax_Syntax.sigrng =
-               (uu___2085_17762.FStar_Syntax_Syntax.sigrng);
+               (uu___2085_17765.FStar_Syntax_Syntax.sigrng);
              FStar_Syntax_Syntax.sigquals =
                [FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen];
              FStar_Syntax_Syntax.sigmeta =
-               (uu___2085_17762.FStar_Syntax_Syntax.sigmeta);
+               (uu___2085_17765.FStar_Syntax_Syntax.sigmeta);
              FStar_Syntax_Syntax.sigattrs =
-               (uu___2085_17762.FStar_Syntax_Syntax.sigattrs);
+               (uu___2085_17765.FStar_Syntax_Syntax.sigattrs);
              FStar_Syntax_Syntax.sigopts =
-               (uu___2085_17762.FStar_Syntax_Syntax.sigopts)
-           }), uu____17760))
+               (uu___2085_17765.FStar_Syntax_Syntax.sigopts)
+           }), uu____17763))
   
 let (check_sigelt_quals :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env  ->
     fun se  ->
-      let visibility uu___11_17780 =
-        match uu___11_17780 with
+      let visibility uu___11_17783 =
+        match uu___11_17783 with
         | FStar_Syntax_Syntax.Private  -> true
-        | uu____17783 -> false  in
-      let reducibility uu___12_17791 =
-        match uu___12_17791 with
+        | uu____17786 -> false  in
+      let reducibility uu___12_17794 =
+        match uu___12_17794 with
         | FStar_Syntax_Syntax.Abstract  -> true
         | FStar_Syntax_Syntax.Irreducible  -> true
         | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen  -> true
         | FStar_Syntax_Syntax.Visible_default  -> true
         | FStar_Syntax_Syntax.Inline_for_extraction  -> true
-        | uu____17798 -> false  in
-      let assumption uu___13_17806 =
-        match uu___13_17806 with
+        | uu____17801 -> false  in
+      let assumption uu___13_17809 =
+        match uu___13_17809 with
         | FStar_Syntax_Syntax.Assumption  -> true
         | FStar_Syntax_Syntax.New  -> true
-        | uu____17810 -> false  in
-      let reification uu___14_17818 =
-        match uu___14_17818 with
+        | uu____17813 -> false  in
+      let reification uu___14_17821 =
+        match uu___14_17821 with
         | FStar_Syntax_Syntax.Reifiable  -> true
-        | FStar_Syntax_Syntax.Reflectable uu____17821 -> true
-        | uu____17823 -> false  in
-      let inferred uu___15_17831 =
-        match uu___15_17831 with
-        | FStar_Syntax_Syntax.Discriminator uu____17833 -> true
-        | FStar_Syntax_Syntax.Projector uu____17835 -> true
-        | FStar_Syntax_Syntax.RecordType uu____17841 -> true
-        | FStar_Syntax_Syntax.RecordConstructor uu____17851 -> true
+        | FStar_Syntax_Syntax.Reflectable uu____17824 -> true
+        | uu____17826 -> false  in
+      let inferred uu___15_17834 =
+        match uu___15_17834 with
+        | FStar_Syntax_Syntax.Discriminator uu____17836 -> true
+        | FStar_Syntax_Syntax.Projector uu____17838 -> true
+        | FStar_Syntax_Syntax.RecordType uu____17844 -> true
+        | FStar_Syntax_Syntax.RecordConstructor uu____17854 -> true
         | FStar_Syntax_Syntax.ExceptionConstructor  -> true
         | FStar_Syntax_Syntax.HasMaskedEffect  -> true
         | FStar_Syntax_Syntax.Effect  -> true
-        | uu____17864 -> false  in
-      let has_eq uu___16_17872 =
-        match uu___16_17872 with
+        | uu____17867 -> false  in
+      let has_eq uu___16_17875 =
+        match uu___16_17875 with
         | FStar_Syntax_Syntax.Noeq  -> true
         | FStar_Syntax_Syntax.Unopteq  -> true
-        | uu____17876 -> false  in
+        | uu____17879 -> false  in
       let quals_combo_ok quals q =
         match q with
         | FStar_Syntax_Syntax.Assumption  ->
@@ -6706,7 +6708,7 @@ let (check_sigelt_quals :
                     ((((reification x) || (inferred x)) || (visibility x)) ||
                        (x = FStar_Syntax_Syntax.TotalEffect))
                       || (x = FStar_Syntax_Syntax.Visible_default)))
-        | FStar_Syntax_Syntax.Reflectable uu____17955 ->
+        | FStar_Syntax_Syntax.Reflectable uu____17958 ->
             FStar_All.pipe_right quals
               (FStar_List.for_all
                  (fun x  ->
@@ -6714,16 +6716,16 @@ let (check_sigelt_quals :
                        (x = FStar_Syntax_Syntax.TotalEffect))
                       || (x = FStar_Syntax_Syntax.Visible_default)))
         | FStar_Syntax_Syntax.Private  -> true
-        | uu____17962 -> true  in
+        | uu____17965 -> true  in
       let check_erasable quals se1 r =
         let lids = FStar_Syntax_Util.lids_of_sigelt se1  in
         let val_exists =
           FStar_All.pipe_right lids
             (FStar_Util.for_some
                (fun l  ->
-                  let uu____17995 =
+                  let uu____17998 =
                     FStar_TypeChecker_Env.try_lookup_val_decl env l  in
-                  FStar_Option.isSome uu____17995))
+                  FStar_Option.isSome uu____17998))
            in
         let val_has_erasable_attr =
           FStar_All.pipe_right lids
@@ -6732,8 +6734,8 @@ let (check_sigelt_quals :
                   let attrs_opt =
                     FStar_TypeChecker_Env.lookup_attrs_of_lid env l  in
                   (FStar_Option.isSome attrs_opt) &&
-                    (let uu____18026 = FStar_Option.get attrs_opt  in
-                     FStar_Syntax_Util.has_attribute uu____18026
+                    (let uu____18029 = FStar_Option.get attrs_opt  in
+                     FStar_Syntax_Util.has_attribute uu____18029
                        FStar_Parser_Const.erasable_attr)))
            in
         let se_has_erasable_attr =
@@ -6761,27 +6763,27 @@ let (check_sigelt_quals :
         if se_has_erasable_attr
         then
           (match se1.FStar_Syntax_Syntax.sigel with
-           | FStar_Syntax_Syntax.Sig_bundle uu____18046 ->
-               let uu____18055 =
-                 let uu____18057 =
+           | FStar_Syntax_Syntax.Sig_bundle uu____18049 ->
+               let uu____18058 =
+                 let uu____18060 =
                    FStar_All.pipe_right quals
                      (FStar_Util.for_some
-                        (fun uu___17_18063  ->
-                           match uu___17_18063 with
+                        (fun uu___17_18066  ->
+                           match uu___17_18066 with
                            | FStar_Syntax_Syntax.Noeq  -> true
-                           | uu____18066 -> false))
+                           | uu____18069 -> false))
                     in
-                 Prims.op_Negation uu____18057  in
-               if uu____18055
+                 Prims.op_Negation uu____18060  in
+               if uu____18058
                then
                  FStar_Errors.raise_error
                    (FStar_Errors.Fatal_QulifierListNotPermitted,
                      "Incompatible attributes and qualifiers: erasable types do not support decidable equality and must be marked `noeq`")
                    r
                else ()
-           | FStar_Syntax_Syntax.Sig_declare_typ uu____18073 -> ()
-           | FStar_Syntax_Syntax.Sig_fail uu____18080 -> ()
-           | uu____18093 ->
+           | FStar_Syntax_Syntax.Sig_declare_typ uu____18076 -> ()
+           | FStar_Syntax_Syntax.Sig_fail uu____18083 -> ()
+           | uu____18096 ->
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_QulifierListNotPermitted,
                    "Illegal attribute: the `erasable` attribute is only permitted on inductive type definitions")
@@ -6792,68 +6794,68 @@ let (check_sigelt_quals :
           (FStar_List.filter
              (fun x  -> Prims.op_Negation (x = FStar_Syntax_Syntax.Logic)))
          in
-      let uu____18107 =
-        let uu____18109 =
+      let uu____18110 =
+        let uu____18112 =
           FStar_All.pipe_right quals
             (FStar_Util.for_some
-               (fun uu___18_18115  ->
-                  match uu___18_18115 with
+               (fun uu___18_18118  ->
+                  match uu___18_18118 with
                   | FStar_Syntax_Syntax.OnlyName  -> true
-                  | uu____18118 -> false))
+                  | uu____18121 -> false))
            in
-        FStar_All.pipe_right uu____18109 Prims.op_Negation  in
-      if uu____18107
+        FStar_All.pipe_right uu____18112 Prims.op_Negation  in
+      if uu____18110
       then
         let r = FStar_Syntax_Util.range_of_sigelt se  in
         let no_dup_quals =
           FStar_Util.remove_dups (fun x  -> fun y  -> x = y) quals  in
         let err' msg =
-          let uu____18139 =
-            let uu____18145 =
-              let uu____18147 = FStar_Syntax_Print.quals_to_string quals  in
+          let uu____18142 =
+            let uu____18148 =
+              let uu____18150 = FStar_Syntax_Print.quals_to_string quals  in
               FStar_Util.format2
                 "The qualifier list \"[%s]\" is not permissible for this element%s"
-                uu____18147 msg
+                uu____18150 msg
                in
-            (FStar_Errors.Fatal_QulifierListNotPermitted, uu____18145)  in
-          FStar_Errors.raise_error uu____18139 r  in
+            (FStar_Errors.Fatal_QulifierListNotPermitted, uu____18148)  in
+          FStar_Errors.raise_error uu____18142 r  in
         let err msg = err' (Prims.op_Hat ": " msg)  in
-        let err'1 uu____18165 = err' ""  in
+        let err'1 uu____18168 = err' ""  in
         (if (FStar_List.length quals) <> (FStar_List.length no_dup_quals)
          then err "duplicate qualifiers"
          else ();
-         (let uu____18173 =
-            let uu____18175 =
+         (let uu____18176 =
+            let uu____18178 =
               FStar_All.pipe_right quals
                 (FStar_List.for_all (quals_combo_ok quals))
                in
-            Prims.op_Negation uu____18175  in
-          if uu____18173 then err "ill-formed combination" else ());
+            Prims.op_Negation uu____18178  in
+          if uu____18176 then err "ill-formed combination" else ());
          check_erasable quals se r;
          (match se.FStar_Syntax_Syntax.sigel with
-          | FStar_Syntax_Syntax.Sig_let ((is_rec,uu____18186),uu____18187) ->
-              ((let uu____18199 =
+          | FStar_Syntax_Syntax.Sig_let ((is_rec,uu____18189),uu____18190) ->
+              ((let uu____18202 =
                   is_rec &&
                     (FStar_All.pipe_right quals
                        (FStar_List.contains
                           FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen))
                    in
-                if uu____18199
+                if uu____18202
                 then err "recursive definitions cannot be marked inline"
                 else ());
-               (let uu____18208 =
+               (let uu____18211 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_some
                        (fun x  -> (assumption x) || (has_eq x)))
                    in
-                if uu____18208
+                if uu____18211
                 then
                   err
                     "definitions cannot be assumed or marked with equality qualifiers"
                 else ()))
-          | FStar_Syntax_Syntax.Sig_bundle uu____18219 ->
-              ((let uu____18229 =
-                  let uu____18231 =
+          | FStar_Syntax_Syntax.Sig_bundle uu____18222 ->
+              ((let uu____18232 =
+                  let uu____18234 =
                     FStar_All.pipe_right quals
                       (FStar_Util.for_all
                          (fun x  ->
@@ -6865,43 +6867,43 @@ let (check_sigelt_quals :
                                || (visibility x))
                               || (has_eq x)))
                      in
-                  Prims.op_Negation uu____18231  in
-                if uu____18229 then err'1 () else ());
-               (let uu____18241 =
+                  Prims.op_Negation uu____18234  in
+                if uu____18232 then err'1 () else ());
+               (let uu____18244 =
                   (FStar_All.pipe_right quals
                      (FStar_List.existsb
-                        (fun uu___19_18247  ->
-                           match uu___19_18247 with
+                        (fun uu___19_18250  ->
+                           match uu___19_18250 with
                            | FStar_Syntax_Syntax.Unopteq  -> true
-                           | uu____18250 -> false)))
+                           | uu____18253 -> false)))
                     &&
                     (FStar_Syntax_Util.has_attribute
                        se.FStar_Syntax_Syntax.sigattrs
                        FStar_Parser_Const.erasable_attr)
                    in
-                if uu____18241
+                if uu____18244
                 then
                   err
                     "unopteq is not allowed on an erasable inductives since they don't have decidable equality"
                 else ()))
-          | FStar_Syntax_Syntax.Sig_declare_typ uu____18256 ->
-              let uu____18263 =
+          | FStar_Syntax_Syntax.Sig_declare_typ uu____18259 ->
+              let uu____18266 =
                 FStar_All.pipe_right quals (FStar_Util.for_some has_eq)  in
-              if uu____18263 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_assume uu____18271 ->
-              let uu____18278 =
-                let uu____18280 =
+              if uu____18266 then err'1 () else ()
+          | FStar_Syntax_Syntax.Sig_assume uu____18274 ->
+              let uu____18281 =
+                let uu____18283 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_all
                        (fun x  ->
                           (visibility x) ||
                             (x = FStar_Syntax_Syntax.Assumption)))
                    in
-                Prims.op_Negation uu____18280  in
-              if uu____18278 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_new_effect uu____18290 ->
-              let uu____18291 =
-                let uu____18293 =
+                Prims.op_Negation uu____18283  in
+              if uu____18281 then err'1 () else ()
+          | FStar_Syntax_Syntax.Sig_new_effect uu____18293 ->
+              let uu____18294 =
+                let uu____18296 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_all
                        (fun x  ->
@@ -6910,18 +6912,18 @@ let (check_sigelt_quals :
                              || (visibility x))
                             || (reification x)))
                    in
-                Prims.op_Negation uu____18293  in
-              if uu____18291 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_effect_abbrev uu____18303 ->
-              let uu____18316 =
-                let uu____18318 =
+                Prims.op_Negation uu____18296  in
+              if uu____18294 then err'1 () else ()
+          | FStar_Syntax_Syntax.Sig_effect_abbrev uu____18306 ->
+              let uu____18319 =
+                let uu____18321 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_all
                        (fun x  -> (inferred x) || (visibility x)))
                    in
-                Prims.op_Negation uu____18318  in
-              if uu____18316 then err'1 () else ()
-          | uu____18328 -> ()))
+                Prims.op_Negation uu____18321  in
+              if uu____18319 then err'1 () else ()
+          | uu____18331 -> ()))
       else ()
   
 let (must_erase_for_extraction :
@@ -6929,13 +6931,13 @@ let (must_erase_for_extraction :
   fun g  ->
     fun t  ->
       let rec descend env t1 =
-        let uu____18367 =
-          let uu____18368 = FStar_Syntax_Subst.compress t1  in
-          uu____18368.FStar_Syntax_Syntax.n  in
-        match uu____18367 with
-        | FStar_Syntax_Syntax.Tm_arrow uu____18372 ->
-            let uu____18387 = FStar_Syntax_Util.arrow_formals_comp t1  in
-            (match uu____18387 with
+        let uu____18370 =
+          let uu____18371 = FStar_Syntax_Subst.compress t1  in
+          uu____18371.FStar_Syntax_Syntax.n  in
+        match uu____18370 with
+        | FStar_Syntax_Syntax.Tm_arrow uu____18375 ->
+            let uu____18390 = FStar_Syntax_Util.arrow_formals_comp t1  in
+            (match uu____18390 with
              | (bs,c) ->
                  let env1 = FStar_TypeChecker_Env.push_binders env bs  in
                  (FStar_Syntax_Util.is_ghost_effect
@@ -6944,16 +6946,16 @@ let (must_erase_for_extraction :
                    ((FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
                       (aux env1 (FStar_Syntax_Util.comp_result c))))
         | FStar_Syntax_Syntax.Tm_refine
-            ({ FStar_Syntax_Syntax.ppname = uu____18396;
-               FStar_Syntax_Syntax.index = uu____18397;
-               FStar_Syntax_Syntax.sort = t2;_},uu____18399)
+            ({ FStar_Syntax_Syntax.ppname = uu____18399;
+               FStar_Syntax_Syntax.index = uu____18400;
+               FStar_Syntax_Syntax.sort = t2;_},uu____18402)
             -> aux env t2
-        | FStar_Syntax_Syntax.Tm_app (head,uu____18408) -> descend env head
-        | FStar_Syntax_Syntax.Tm_uinst (head,uu____18434) -> descend env head
+        | FStar_Syntax_Syntax.Tm_app (head,uu____18411) -> descend env head
+        | FStar_Syntax_Syntax.Tm_uinst (head,uu____18437) -> descend env head
         | FStar_Syntax_Syntax.Tm_fvar fv ->
             FStar_TypeChecker_Env.fv_has_attr env fv
               FStar_Parser_Const.must_erase_for_extraction_attr
-        | uu____18440 -> false
+        | uu____18443 -> false
       
       and aux env t1 =
         let t2 =
@@ -6972,15 +6974,15 @@ let (must_erase_for_extraction :
         let res =
           (FStar_TypeChecker_Env.non_informative env t2) || (descend env t2)
            in
-        (let uu____18450 =
+        (let uu____18453 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Extraction")
             in
-         if uu____18450
+         if uu____18453
          then
-           let uu____18455 = FStar_Syntax_Print.term_to_string t2  in
+           let uu____18458 = FStar_Syntax_Print.term_to_string t2  in
            FStar_Util.print2 "must_erase=%s: %s\n"
-             (if res then "true" else "false") uu____18455
+             (if res then "true" else "false") uu____18458
          else ());
         res
        in aux g t
@@ -7003,48 +7005,49 @@ let (fresh_effect_repr :
             fun u  ->
               fun a_tm  ->
                 let fail t =
-                  let uu____18520 =
+                  let uu____18523 =
                     FStar_TypeChecker_Err.unexpected_signature_for_monad env
                       eff_name t
                      in
-                  FStar_Errors.raise_error uu____18520 r  in
-                let uu____18530 =
+                  FStar_Errors.raise_error uu____18523 r  in
+                let uu____18533 =
                   FStar_TypeChecker_Env.inst_tscheme signature_ts  in
-                match uu____18530 with
-                | (uu____18539,signature) ->
-                    let uu____18541 =
-                      let uu____18542 = FStar_Syntax_Subst.compress signature
+                match uu____18533 with
+                | (uu____18542,signature) ->
+                    let uu____18544 =
+                      let uu____18545 = FStar_Syntax_Subst.compress signature
                          in
-                      uu____18542.FStar_Syntax_Syntax.n  in
-                    (match uu____18541 with
-                     | FStar_Syntax_Syntax.Tm_arrow (bs,uu____18550) ->
+                      uu____18545.FStar_Syntax_Syntax.n  in
+                    (match uu____18544 with
+                     | FStar_Syntax_Syntax.Tm_arrow (bs,uu____18553) ->
                          let bs1 = FStar_Syntax_Subst.open_binders bs  in
                          (match bs1 with
                           | a::bs2 ->
-                              let uu____18598 =
+                              let uu____18601 =
                                 FStar_TypeChecker_Env.uvars_for_binders env
                                   bs2
                                   [FStar_Syntax_Syntax.NT
                                      ((FStar_Pervasives_Native.fst a), a_tm)]
                                   (fun b  ->
-                                     let uu____18613 =
+                                     let uu____18617 =
                                        FStar_Syntax_Print.binder_to_string b
                                         in
-                                     let uu____18615 =
+                                     let uu____18619 =
+                                       FStar_Ident.string_of_lid eff_name  in
+                                     let uu____18621 =
                                        FStar_Range.string_of_range r  in
                                      FStar_Util.format3
                                        "uvar for binder %s when creating a fresh repr for %s at %s"
-                                       uu____18613 eff_name.FStar_Ident.str
-                                       uu____18615) r
+                                       uu____18617 uu____18619 uu____18621) r
                                  in
-                              (match uu____18598 with
+                              (match uu____18601 with
                                | (is,g) ->
-                                   let uu____18628 =
+                                   let uu____18634 =
                                      match repr_ts_opt with
                                      | FStar_Pervasives_Native.None  ->
                                          let eff_c =
-                                           let uu____18630 =
-                                             let uu____18631 =
+                                           let uu____18636 =
+                                             let uu____18637 =
                                                FStar_List.map
                                                  FStar_Syntax_Syntax.as_arg
                                                  is
@@ -7057,54 +7060,54 @@ let (fresh_effect_repr :
                                                FStar_Syntax_Syntax.result_typ
                                                  = a_tm;
                                                FStar_Syntax_Syntax.effect_args
-                                                 = uu____18631;
+                                                 = uu____18637;
                                                FStar_Syntax_Syntax.flags = []
                                              }  in
                                            FStar_Syntax_Syntax.mk_Comp
-                                             uu____18630
+                                             uu____18636
                                             in
-                                         let uu____18650 =
-                                           let uu____18657 =
-                                             let uu____18658 =
-                                               let uu____18673 =
-                                                 let uu____18682 =
+                                         let uu____18656 =
+                                           let uu____18663 =
+                                             let uu____18664 =
+                                               let uu____18679 =
+                                                 let uu____18688 =
                                                    FStar_Syntax_Syntax.null_binder
                                                      FStar_Syntax_Syntax.t_unit
                                                     in
-                                                 [uu____18682]  in
-                                               (uu____18673, eff_c)  in
+                                                 [uu____18688]  in
+                                               (uu____18679, eff_c)  in
                                              FStar_Syntax_Syntax.Tm_arrow
-                                               uu____18658
+                                               uu____18664
                                               in
-                                           FStar_Syntax_Syntax.mk uu____18657
+                                           FStar_Syntax_Syntax.mk uu____18663
                                             in
-                                         uu____18650
+                                         uu____18656
                                            FStar_Pervasives_Native.None r
                                      | FStar_Pervasives_Native.Some repr_ts
                                          ->
                                          let repr =
-                                           let uu____18713 =
+                                           let uu____18719 =
                                              FStar_TypeChecker_Env.inst_tscheme_with
                                                repr_ts [u]
                                               in
-                                           FStar_All.pipe_right uu____18713
+                                           FStar_All.pipe_right uu____18719
                                              FStar_Pervasives_Native.snd
                                             in
-                                         let uu____18722 =
-                                           let uu____18727 =
+                                         let uu____18728 =
+                                           let uu____18733 =
                                              FStar_List.map
                                                FStar_Syntax_Syntax.as_arg
                                                (a_tm :: is)
                                               in
                                            FStar_Syntax_Syntax.mk_Tm_app repr
-                                             uu____18727
+                                             uu____18733
                                             in
-                                         uu____18722
+                                         uu____18728
                                            FStar_Pervasives_Native.None r
                                       in
-                                   (uu____18628, g))
-                          | uu____18736 -> fail signature)
-                     | uu____18737 -> fail signature)
+                                   (uu____18634, g))
+                          | uu____18742 -> fail signature)
+                     | uu____18743 -> fail signature)
   
 let (fresh_effect_repr_en :
   FStar_TypeChecker_Env.env ->
@@ -7119,16 +7122,16 @@ let (fresh_effect_repr_en :
       fun eff_name  ->
         fun u  ->
           fun a_tm  ->
-            let uu____18768 =
+            let uu____18774 =
               FStar_All.pipe_right eff_name
                 (FStar_TypeChecker_Env.get_effect_decl env)
                in
-            FStar_All.pipe_right uu____18768
+            FStar_All.pipe_right uu____18774
               (fun ed  ->
-                 let uu____18776 =
+                 let uu____18782 =
                    FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr  in
                  fresh_effect_repr env r eff_name
-                   ed.FStar_Syntax_Syntax.signature uu____18776 u a_tm)
+                   ed.FStar_Syntax_Syntax.signature uu____18782 u a_tm)
   
 let (layered_effect_indices_as_binders :
   FStar_TypeChecker_Env.env ->
@@ -7144,29 +7147,29 @@ let (layered_effect_indices_as_binders :
         fun sig_ts  ->
           fun u  ->
             fun a_tm  ->
-              let uu____18812 =
+              let uu____18818 =
                 FStar_TypeChecker_Env.inst_tscheme_with sig_ts [u]  in
-              match uu____18812 with
-              | (uu____18817,sig_tm) ->
+              match uu____18818 with
+              | (uu____18823,sig_tm) ->
                   let fail t =
-                    let uu____18825 =
+                    let uu____18831 =
                       FStar_TypeChecker_Err.unexpected_signature_for_monad
                         env eff_name t
                        in
-                    FStar_Errors.raise_error uu____18825 r  in
-                  let uu____18831 =
-                    let uu____18832 = FStar_Syntax_Subst.compress sig_tm  in
-                    uu____18832.FStar_Syntax_Syntax.n  in
-                  (match uu____18831 with
-                   | FStar_Syntax_Syntax.Tm_arrow (bs,uu____18836) ->
+                    FStar_Errors.raise_error uu____18831 r  in
+                  let uu____18837 =
+                    let uu____18838 = FStar_Syntax_Subst.compress sig_tm  in
+                    uu____18838.FStar_Syntax_Syntax.n  in
+                  (match uu____18837 with
+                   | FStar_Syntax_Syntax.Tm_arrow (bs,uu____18842) ->
                        let bs1 = FStar_Syntax_Subst.open_binders bs  in
                        (match bs1 with
-                        | (a',uu____18859)::bs2 ->
+                        | (a',uu____18865)::bs2 ->
                             FStar_All.pipe_right bs2
                               (FStar_Syntax_Subst.subst_binders
                                  [FStar_Syntax_Syntax.NT (a', a_tm)])
-                        | uu____18881 -> fail sig_tm)
-                   | uu____18882 -> fail sig_tm)
+                        | uu____18887 -> fail sig_tm)
+                   | uu____18888 -> fail sig_tm)
   
 let (lift_tf_layered_effect :
   FStar_Ident.lident ->
@@ -7179,217 +7182,217 @@ let (lift_tf_layered_effect :
     fun lift_ts  ->
       fun env  ->
         fun c  ->
-          (let uu____18913 =
+          (let uu____18919 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "LayeredEffects")
               in
-           if uu____18913
+           if uu____18919
            then
-             let uu____18918 = FStar_Syntax_Print.comp_to_string c  in
-             let uu____18920 = FStar_Syntax_Print.lid_to_string tgt  in
+             let uu____18924 = FStar_Syntax_Print.comp_to_string c  in
+             let uu____18926 = FStar_Syntax_Print.lid_to_string tgt  in
              FStar_Util.print2 "Lifting comp %s to layered effect %s {\n"
-               uu____18918 uu____18920
+               uu____18924 uu____18926
            else ());
           (let r = FStar_TypeChecker_Env.get_range env  in
            let ct = FStar_Syntax_Util.comp_to_comp_typ c  in
-           let uu____18927 =
-             let uu____18938 =
+           let uu____18933 =
+             let uu____18944 =
                FStar_List.hd ct.FStar_Syntax_Syntax.comp_univs  in
-             let uu____18939 =
+             let uu____18945 =
                FStar_All.pipe_right ct.FStar_Syntax_Syntax.effect_args
                  (FStar_List.map FStar_Pervasives_Native.fst)
                 in
-             (uu____18938, (ct.FStar_Syntax_Syntax.result_typ), uu____18939)
+             (uu____18944, (ct.FStar_Syntax_Syntax.result_typ), uu____18945)
               in
-           match uu____18927 with
+           match uu____18933 with
            | (u,a,c_is) ->
-               let uu____18987 =
+               let uu____18993 =
                  FStar_TypeChecker_Env.inst_tscheme_with lift_ts [u]  in
-               (match uu____18987 with
-                | (uu____18996,lift_t) ->
+               (match uu____18993 with
+                | (uu____19002,lift_t) ->
                     let lift_t_shape_error s =
-                      let uu____19007 =
+                      let uu____19013 =
                         FStar_Ident.string_of_lid
                           ct.FStar_Syntax_Syntax.effect_name
                          in
-                      let uu____19009 = FStar_Ident.string_of_lid tgt  in
-                      let uu____19011 =
+                      let uu____19015 = FStar_Ident.string_of_lid tgt  in
+                      let uu____19017 =
                         FStar_Syntax_Print.term_to_string lift_t  in
                       FStar_Util.format4
                         "Lift from %s to %s has unexpected shape, reason: %s (lift:%s)"
-                        uu____19007 uu____19009 s uu____19011
+                        uu____19013 uu____19015 s uu____19017
                        in
-                    let uu____19014 =
-                      let uu____19047 =
-                        let uu____19048 = FStar_Syntax_Subst.compress lift_t
+                    let uu____19020 =
+                      let uu____19053 =
+                        let uu____19054 = FStar_Syntax_Subst.compress lift_t
                            in
-                        uu____19048.FStar_Syntax_Syntax.n  in
-                      match uu____19047 with
+                        uu____19054.FStar_Syntax_Syntax.n  in
+                      match uu____19053 with
                       | FStar_Syntax_Syntax.Tm_arrow (bs,c1) when
                           (FStar_List.length bs) >= (Prims.of_int (2)) ->
-                          let uu____19112 =
+                          let uu____19118 =
                             FStar_Syntax_Subst.open_comp bs c1  in
-                          (match uu____19112 with
+                          (match uu____19118 with
                            | (a_b::bs1,c2) ->
-                               let uu____19172 =
+                               let uu____19178 =
                                  FStar_All.pipe_right bs1
                                    (FStar_List.splitAt
                                       ((FStar_List.length bs1) -
                                          Prims.int_one))
                                   in
-                               (a_b, uu____19172, c2))
-                      | uu____19260 ->
-                          let uu____19261 =
-                            let uu____19267 =
+                               (a_b, uu____19178, c2))
+                      | uu____19266 ->
+                          let uu____19267 =
+                            let uu____19273 =
                               lift_t_shape_error
                                 "either not an arrow or not enough binders"
                                in
                             (FStar_Errors.Fatal_UnexpectedEffect,
-                              uu____19267)
+                              uu____19273)
                              in
-                          FStar_Errors.raise_error uu____19261 r
+                          FStar_Errors.raise_error uu____19267 r
                        in
-                    (match uu____19014 with
+                    (match uu____19020 with
                      | (a_b,(rest_bs,f_b::[]),lift_c) ->
-                         let uu____19385 =
-                           let uu____19392 =
-                             let uu____19393 =
-                               let uu____19394 =
-                                 let uu____19401 =
+                         let uu____19391 =
+                           let uu____19398 =
+                             let uu____19399 =
+                               let uu____19400 =
+                                 let uu____19407 =
                                    FStar_All.pipe_right a_b
                                      FStar_Pervasives_Native.fst
                                     in
-                                 (uu____19401, a)  in
-                               FStar_Syntax_Syntax.NT uu____19394  in
-                             [uu____19393]  in
+                                 (uu____19407, a)  in
+                               FStar_Syntax_Syntax.NT uu____19400  in
+                             [uu____19399]  in
                            FStar_TypeChecker_Env.uvars_for_binders env
-                             rest_bs uu____19392
+                             rest_bs uu____19398
                              (fun b  ->
-                                let uu____19418 =
+                                let uu____19424 =
                                   FStar_Syntax_Print.binder_to_string b  in
-                                let uu____19420 =
+                                let uu____19426 =
                                   FStar_Ident.string_of_lid
                                     ct.FStar_Syntax_Syntax.effect_name
                                    in
-                                let uu____19422 =
+                                let uu____19428 =
                                   FStar_Ident.string_of_lid tgt  in
-                                let uu____19424 =
+                                let uu____19430 =
                                   FStar_Range.string_of_range r  in
                                 FStar_Util.format4
                                   "implicit var for binder %s of %s~>%s at %s"
-                                  uu____19418 uu____19420 uu____19422
-                                  uu____19424) r
+                                  uu____19424 uu____19426 uu____19428
+                                  uu____19430) r
                             in
-                         (match uu____19385 with
+                         (match uu____19391 with
                           | (rest_bs_uvars,g) ->
-                              ((let uu____19438 =
+                              ((let uu____19444 =
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.debug env)
                                     (FStar_Options.Other "LayeredEffects")
                                    in
-                                if uu____19438
+                                if uu____19444
                                 then
-                                  let uu____19443 =
+                                  let uu____19449 =
                                     FStar_List.fold_left
                                       (fun s  ->
                                          fun u1  ->
-                                           let uu____19452 =
-                                             let uu____19454 =
+                                           let uu____19458 =
+                                             let uu____19460 =
                                                FStar_Syntax_Print.term_to_string
                                                  u1
                                                 in
-                                             Prims.op_Hat ";;;;" uu____19454
+                                             Prims.op_Hat ";;;;" uu____19460
                                               in
-                                           Prims.op_Hat s uu____19452) ""
+                                           Prims.op_Hat s uu____19458) ""
                                       rest_bs_uvars
                                      in
                                   FStar_Util.print1 "Introduced uvars: %s\n"
-                                    uu____19443
+                                    uu____19449
                                 else ());
                                (let substs =
                                   FStar_List.map2
                                     (fun b  ->
                                        fun t  ->
-                                         let uu____19485 =
-                                           let uu____19492 =
+                                         let uu____19491 =
+                                           let uu____19498 =
                                              FStar_All.pipe_right b
                                                FStar_Pervasives_Native.fst
                                               in
-                                           (uu____19492, t)  in
-                                         FStar_Syntax_Syntax.NT uu____19485)
+                                           (uu____19498, t)  in
+                                         FStar_Syntax_Syntax.NT uu____19491)
                                     (a_b :: rest_bs) (a :: rest_bs_uvars)
                                    in
                                 let guard_f =
                                   let f_sort =
-                                    let uu____19511 =
+                                    let uu____19517 =
                                       FStar_All.pipe_right
                                         (FStar_Pervasives_Native.fst f_b).FStar_Syntax_Syntax.sort
                                         (FStar_Syntax_Subst.subst substs)
                                        in
-                                    FStar_All.pipe_right uu____19511
+                                    FStar_All.pipe_right uu____19517
                                       FStar_Syntax_Subst.compress
                                      in
                                   let f_sort_is =
-                                    let uu____19517 =
+                                    let uu____19523 =
                                       FStar_TypeChecker_Env.is_layered_effect
                                         env
                                         ct.FStar_Syntax_Syntax.effect_name
                                        in
-                                    effect_args_from_repr f_sort uu____19517
+                                    effect_args_from_repr f_sort uu____19523
                                       r
                                      in
                                   FStar_List.fold_left2
                                     (fun g1  ->
                                        fun i1  ->
                                          fun i2  ->
-                                           let uu____19526 =
+                                           let uu____19532 =
                                              FStar_TypeChecker_Rel.teq env i1
                                                i2
                                               in
                                            FStar_TypeChecker_Env.conj_guard
-                                             g1 uu____19526)
+                                             g1 uu____19532)
                                     FStar_TypeChecker_Env.trivial_guard c_is
                                     f_sort_is
                                    in
                                 let lift_ct =
-                                  let uu____19528 =
+                                  let uu____19534 =
                                     FStar_All.pipe_right lift_c
                                       (FStar_Syntax_Subst.subst_comp substs)
                                      in
-                                  FStar_All.pipe_right uu____19528
+                                  FStar_All.pipe_right uu____19534
                                     FStar_Syntax_Util.comp_to_comp_typ
                                    in
                                 let is =
-                                  let uu____19532 =
+                                  let uu____19538 =
                                     FStar_TypeChecker_Env.is_layered_effect
                                       env tgt
                                      in
                                   effect_args_from_repr
                                     lift_ct.FStar_Syntax_Syntax.result_typ
-                                    uu____19532 r
+                                    uu____19538 r
                                    in
                                 let fml =
-                                  let uu____19537 =
-                                    let uu____19542 =
+                                  let uu____19543 =
+                                    let uu____19548 =
                                       FStar_List.hd
                                         lift_ct.FStar_Syntax_Syntax.comp_univs
                                        in
-                                    let uu____19543 =
-                                      let uu____19544 =
+                                    let uu____19549 =
+                                      let uu____19550 =
                                         FStar_List.hd
                                           lift_ct.FStar_Syntax_Syntax.effect_args
                                          in
-                                      FStar_Pervasives_Native.fst uu____19544
+                                      FStar_Pervasives_Native.fst uu____19550
                                        in
-                                    (uu____19542, uu____19543)  in
-                                  match uu____19537 with
+                                    (uu____19548, uu____19549)  in
+                                  match uu____19543 with
                                   | (u1,wp) ->
                                       FStar_TypeChecker_Env.pure_precondition_for_trivial_post
                                         env u1
                                         lift_ct.FStar_Syntax_Syntax.result_typ
                                         wp FStar_Range.dummyRange
                                    in
-                                (let uu____19570 =
+                                (let uu____19576 =
                                    (FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug env)
                                       (FStar_Options.Other "LayeredEffects"))
@@ -7398,17 +7401,17 @@ let (lift_tf_layered_effect :
                                         (FStar_TypeChecker_Env.debug env)
                                         FStar_Options.Extreme)
                                     in
-                                 if uu____19570
+                                 if uu____19576
                                  then
-                                   let uu____19576 =
+                                   let uu____19582 =
                                      FStar_Syntax_Print.term_to_string fml
                                       in
                                    FStar_Util.print1 "Guard for lift is: %s"
-                                     uu____19576
+                                     uu____19582
                                  else ());
                                 (let c1 =
-                                   let uu____19582 =
-                                     let uu____19583 =
+                                   let uu____19588 =
+                                     let uu____19589 =
                                        FStar_All.pipe_right is
                                          (FStar_List.map
                                             FStar_Syntax_Syntax.as_arg)
@@ -7419,42 +7422,42 @@ let (lift_tf_layered_effect :
                                        FStar_Syntax_Syntax.effect_name = tgt;
                                        FStar_Syntax_Syntax.result_typ = a;
                                        FStar_Syntax_Syntax.effect_args =
-                                         uu____19583;
+                                         uu____19589;
                                        FStar_Syntax_Syntax.flags = []
                                      }  in
-                                   FStar_Syntax_Syntax.mk_Comp uu____19582
+                                   FStar_Syntax_Syntax.mk_Comp uu____19588
                                     in
-                                 (let uu____19607 =
+                                 (let uu____19613 =
                                     FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug env)
                                       (FStar_Options.Other "LayeredEffects")
                                      in
-                                  if uu____19607
+                                  if uu____19613
                                   then
-                                    let uu____19612 =
+                                    let uu____19618 =
                                       FStar_Syntax_Print.comp_to_string c1
                                        in
                                     FStar_Util.print1 "} Lifted comp: %s\n"
-                                      uu____19612
+                                      uu____19618
                                   else ());
-                                 (let uu____19617 =
-                                    let uu____19618 =
+                                 (let uu____19623 =
+                                    let uu____19624 =
                                       FStar_TypeChecker_Env.conj_guard g
                                         guard_f
                                        in
-                                    let uu____19619 =
+                                    let uu____19625 =
                                       FStar_TypeChecker_Env.guard_of_guard_formula
                                         (FStar_TypeChecker_Common.NonTrivial
                                            fml)
                                        in
                                     FStar_TypeChecker_Env.conj_guard
-                                      uu____19618 uu____19619
+                                      uu____19624 uu____19625
                                      in
-                                  (c1, uu____19617)))))))))
+                                  (c1, uu____19623)))))))))
   
 let lift_tf_layered_effect_term :
-  'uuuuuu19633 .
-    'uuuuuu19633 ->
+  'uuuuuu19639 .
+    'uuuuuu19639 ->
       FStar_Syntax_Syntax.sub_eff ->
         FStar_Syntax_Syntax.universe ->
           FStar_Syntax_Syntax.typ ->
@@ -7466,68 +7469,68 @@ let lift_tf_layered_effect_term :
         fun a  ->
           fun e  ->
             let lift =
-              let uu____19662 =
-                let uu____19667 =
+              let uu____19668 =
+                let uu____19673 =
                   FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift
                     FStar_Util.must
                    in
-                FStar_All.pipe_right uu____19667
+                FStar_All.pipe_right uu____19673
                   (fun ts  -> FStar_TypeChecker_Env.inst_tscheme_with ts [u])
                  in
-              FStar_All.pipe_right uu____19662 FStar_Pervasives_Native.snd
+              FStar_All.pipe_right uu____19668 FStar_Pervasives_Native.snd
                in
             let rest_bs =
               let lift_t =
                 FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift_wp
                   FStar_Util.must
                  in
-              let uu____19710 =
-                let uu____19711 =
-                  let uu____19714 =
+              let uu____19716 =
+                let uu____19717 =
+                  let uu____19720 =
                     FStar_All.pipe_right lift_t FStar_Pervasives_Native.snd
                      in
-                  FStar_All.pipe_right uu____19714
+                  FStar_All.pipe_right uu____19720
                     FStar_Syntax_Subst.compress
                    in
-                uu____19711.FStar_Syntax_Syntax.n  in
-              match uu____19710 with
-              | FStar_Syntax_Syntax.Tm_arrow (uu____19737::bs,uu____19739)
+                uu____19717.FStar_Syntax_Syntax.n  in
+              match uu____19716 with
+              | FStar_Syntax_Syntax.Tm_arrow (uu____19743::bs,uu____19745)
                   when (FStar_List.length bs) >= Prims.int_one ->
-                  let uu____19779 =
+                  let uu____19785 =
                     FStar_All.pipe_right bs
                       (FStar_List.splitAt
                          ((FStar_List.length bs) - Prims.int_one))
                      in
-                  FStar_All.pipe_right uu____19779
+                  FStar_All.pipe_right uu____19785
                     FStar_Pervasives_Native.fst
-              | uu____19885 ->
-                  let uu____19886 =
-                    let uu____19892 =
-                      let uu____19894 =
+              | uu____19891 ->
+                  let uu____19892 =
+                    let uu____19898 =
+                      let uu____19900 =
                         FStar_Syntax_Print.tscheme_to_string lift_t  in
                       FStar_Util.format1
                         "lift_t tscheme %s is not an arrow with enough binders"
-                        uu____19894
+                        uu____19900
                        in
-                    (FStar_Errors.Fatal_UnexpectedEffect, uu____19892)  in
-                  FStar_Errors.raise_error uu____19886
+                    (FStar_Errors.Fatal_UnexpectedEffect, uu____19898)  in
+                  FStar_Errors.raise_error uu____19892
                     (FStar_Pervasives_Native.snd lift_t).FStar_Syntax_Syntax.pos
                in
             let args =
-              let uu____19921 = FStar_Syntax_Syntax.as_arg a  in
-              let uu____19930 =
-                let uu____19941 =
+              let uu____19927 = FStar_Syntax_Syntax.as_arg a  in
+              let uu____19936 =
+                let uu____19947 =
                   FStar_All.pipe_right rest_bs
                     (FStar_List.map
-                       (fun uu____19977  ->
+                       (fun uu____19983  ->
                           FStar_Syntax_Syntax.as_arg
                             FStar_Syntax_Syntax.unit_const))
                    in
-                let uu____19984 =
-                  let uu____19995 = FStar_Syntax_Syntax.as_arg e  in
-                  [uu____19995]  in
-                FStar_List.append uu____19941 uu____19984  in
-              uu____19921 :: uu____19930  in
+                let uu____19990 =
+                  let uu____20001 = FStar_Syntax_Syntax.as_arg e  in
+                  [uu____20001]  in
+                FStar_List.append uu____19947 uu____19990  in
+              uu____19927 :: uu____19936  in
             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (lift, args))
               FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
   
@@ -7538,40 +7541,40 @@ let (get_field_projector_name :
   fun env  ->
     fun datacon  ->
       fun index  ->
-        let uu____20066 = FStar_TypeChecker_Env.lookup_datacon env datacon
+        let uu____20072 = FStar_TypeChecker_Env.lookup_datacon env datacon
            in
-        match uu____20066 with
-        | (uu____20071,t) ->
+        match uu____20072 with
+        | (uu____20077,t) ->
             let err n =
-              let uu____20081 =
-                let uu____20087 =
-                  let uu____20089 = FStar_Ident.string_of_lid datacon  in
-                  let uu____20091 = FStar_Util.string_of_int n  in
-                  let uu____20093 = FStar_Util.string_of_int index  in
+              let uu____20087 =
+                let uu____20093 =
+                  let uu____20095 = FStar_Ident.string_of_lid datacon  in
+                  let uu____20097 = FStar_Util.string_of_int n  in
+                  let uu____20099 = FStar_Util.string_of_int index  in
                   FStar_Util.format3
                     "Data constructor %s does not have enough binders (has %s, tried %s)"
-                    uu____20089 uu____20091 uu____20093
+                    uu____20095 uu____20097 uu____20099
                    in
-                (FStar_Errors.Fatal_UnexpectedDataConstructor, uu____20087)
+                (FStar_Errors.Fatal_UnexpectedDataConstructor, uu____20093)
                  in
-              let uu____20097 = FStar_TypeChecker_Env.get_range env  in
-              FStar_Errors.raise_error uu____20081 uu____20097  in
-            let uu____20098 =
-              let uu____20099 = FStar_Syntax_Subst.compress t  in
-              uu____20099.FStar_Syntax_Syntax.n  in
-            (match uu____20098 with
-             | FStar_Syntax_Syntax.Tm_arrow (bs,uu____20103) ->
+              let uu____20103 = FStar_TypeChecker_Env.get_range env  in
+              FStar_Errors.raise_error uu____20087 uu____20103  in
+            let uu____20104 =
+              let uu____20105 = FStar_Syntax_Subst.compress t  in
+              uu____20105.FStar_Syntax_Syntax.n  in
+            (match uu____20104 with
+             | FStar_Syntax_Syntax.Tm_arrow (bs,uu____20109) ->
                  let bs1 =
                    FStar_All.pipe_right bs
                      (FStar_List.filter
-                        (fun uu____20158  ->
-                           match uu____20158 with
-                           | (uu____20166,q) ->
+                        (fun uu____20164  ->
+                           match uu____20164 with
+                           | (uu____20172,q) ->
                                (match q with
                                 | FStar_Pervasives_Native.Some
                                     (FStar_Syntax_Syntax.Implicit (true )) ->
                                     false
-                                | uu____20175 -> true)))
+                                | uu____20181 -> true)))
                     in
                  if (FStar_List.length bs1) <= index
                  then err (FStar_List.length bs1)
@@ -7579,7 +7582,7 @@ let (get_field_projector_name :
                    (let b = FStar_List.nth bs1 index  in
                     FStar_Syntax_Util.mk_field_projector_name datacon
                       (FStar_Pervasives_Native.fst b) index)
-             | uu____20209 -> err Prims.int_zero)
+             | uu____20215 -> err Prims.int_zero)
   
 let (get_mlift_for_subeff :
   FStar_TypeChecker_Env.env ->
@@ -7587,24 +7590,24 @@ let (get_mlift_for_subeff :
   =
   fun env  ->
     fun sub  ->
-      let uu____20222 =
+      let uu____20228 =
         (FStar_TypeChecker_Env.is_layered_effect env
            sub.FStar_Syntax_Syntax.source)
           ||
           (FStar_TypeChecker_Env.is_layered_effect env
              sub.FStar_Syntax_Syntax.target)
          in
-      if uu____20222
+      if uu____20228
       then
-        let uu____20225 =
-          let uu____20238 =
+        let uu____20231 =
+          let uu____20244 =
             FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift_wp
               FStar_Util.must
              in
-          lift_tf_layered_effect sub.FStar_Syntax_Syntax.target uu____20238
+          lift_tf_layered_effect sub.FStar_Syntax_Syntax.target uu____20244
            in
         {
-          FStar_TypeChecker_Env.mlift_wp = uu____20225;
+          FStar_TypeChecker_Env.mlift_wp = uu____20231;
           FStar_TypeChecker_Env.mlift_term =
             (FStar_Pervasives_Native.Some
                (lift_tf_layered_effect_term env sub))
@@ -7612,91 +7615,91 @@ let (get_mlift_for_subeff :
       else
         (let mk_mlift_wp ts env1 c =
            let ct = FStar_Syntax_Util.comp_to_comp_typ c  in
-           let uu____20273 =
+           let uu____20279 =
              FStar_TypeChecker_Env.inst_tscheme_with ts
                ct.FStar_Syntax_Syntax.comp_univs
               in
-           match uu____20273 with
-           | (uu____20282,lift_t) ->
+           match uu____20279 with
+           | (uu____20288,lift_t) ->
                let wp = FStar_List.hd ct.FStar_Syntax_Syntax.effect_args  in
-               let uu____20301 =
-                 let uu____20302 =
-                   let uu___2461_20303 = ct  in
-                   let uu____20304 =
-                     let uu____20315 =
-                       let uu____20324 =
-                         let uu____20325 =
-                           let uu____20332 =
-                             let uu____20333 =
-                               let uu____20350 =
-                                 let uu____20361 =
+               let uu____20307 =
+                 let uu____20308 =
+                   let uu___2461_20309 = ct  in
+                   let uu____20310 =
+                     let uu____20321 =
+                       let uu____20330 =
+                         let uu____20331 =
+                           let uu____20338 =
+                             let uu____20339 =
+                               let uu____20356 =
+                                 let uu____20367 =
                                    FStar_Syntax_Syntax.as_arg
                                      ct.FStar_Syntax_Syntax.result_typ
                                     in
-                                 [uu____20361; wp]  in
-                               (lift_t, uu____20350)  in
-                             FStar_Syntax_Syntax.Tm_app uu____20333  in
-                           FStar_Syntax_Syntax.mk uu____20332  in
-                         uu____20325 FStar_Pervasives_Native.None
+                                 [uu____20367; wp]  in
+                               (lift_t, uu____20356)  in
+                             FStar_Syntax_Syntax.Tm_app uu____20339  in
+                           FStar_Syntax_Syntax.mk uu____20338  in
+                         uu____20331 FStar_Pervasives_Native.None
                            (FStar_Pervasives_Native.fst wp).FStar_Syntax_Syntax.pos
                           in
-                       FStar_All.pipe_right uu____20324
+                       FStar_All.pipe_right uu____20330
                          FStar_Syntax_Syntax.as_arg
                         in
-                     [uu____20315]  in
+                     [uu____20321]  in
                    {
                      FStar_Syntax_Syntax.comp_univs =
-                       (uu___2461_20303.FStar_Syntax_Syntax.comp_univs);
+                       (uu___2461_20309.FStar_Syntax_Syntax.comp_univs);
                      FStar_Syntax_Syntax.effect_name =
                        (sub.FStar_Syntax_Syntax.target);
                      FStar_Syntax_Syntax.result_typ =
-                       (uu___2461_20303.FStar_Syntax_Syntax.result_typ);
-                     FStar_Syntax_Syntax.effect_args = uu____20304;
+                       (uu___2461_20309.FStar_Syntax_Syntax.result_typ);
+                     FStar_Syntax_Syntax.effect_args = uu____20310;
                      FStar_Syntax_Syntax.flags =
-                       (uu___2461_20303.FStar_Syntax_Syntax.flags)
+                       (uu___2461_20309.FStar_Syntax_Syntax.flags)
                    }  in
-                 FStar_Syntax_Syntax.mk_Comp uu____20302  in
-               (uu____20301, FStar_TypeChecker_Common.trivial_guard)
+                 FStar_Syntax_Syntax.mk_Comp uu____20308  in
+               (uu____20307, FStar_TypeChecker_Common.trivial_guard)
             in
          let mk_mlift_term ts u r e =
-           let uu____20461 = FStar_TypeChecker_Env.inst_tscheme_with ts [u]
+           let uu____20467 = FStar_TypeChecker_Env.inst_tscheme_with ts [u]
               in
-           match uu____20461 with
-           | (uu____20468,lift_t) ->
-               let uu____20470 =
-                 let uu____20477 =
-                   let uu____20478 =
-                     let uu____20495 =
-                       let uu____20506 = FStar_Syntax_Syntax.as_arg r  in
-                       let uu____20515 =
-                         let uu____20526 =
+           match uu____20467 with
+           | (uu____20474,lift_t) ->
+               let uu____20476 =
+                 let uu____20483 =
+                   let uu____20484 =
+                     let uu____20501 =
+                       let uu____20512 = FStar_Syntax_Syntax.as_arg r  in
+                       let uu____20521 =
+                         let uu____20532 =
                            FStar_Syntax_Syntax.as_arg FStar_Syntax_Syntax.tun
                             in
-                         let uu____20535 =
-                           let uu____20546 = FStar_Syntax_Syntax.as_arg e  in
-                           [uu____20546]  in
-                         uu____20526 :: uu____20535  in
-                       uu____20506 :: uu____20515  in
-                     (lift_t, uu____20495)  in
-                   FStar_Syntax_Syntax.Tm_app uu____20478  in
-                 FStar_Syntax_Syntax.mk uu____20477  in
-               uu____20470 FStar_Pervasives_Native.None
+                         let uu____20541 =
+                           let uu____20552 = FStar_Syntax_Syntax.as_arg e  in
+                           [uu____20552]  in
+                         uu____20532 :: uu____20541  in
+                       uu____20512 :: uu____20521  in
+                     (lift_t, uu____20501)  in
+                   FStar_Syntax_Syntax.Tm_app uu____20484  in
+                 FStar_Syntax_Syntax.mk uu____20483  in
+               uu____20476 FStar_Pervasives_Native.None
                  e.FStar_Syntax_Syntax.pos
             in
-         let uu____20599 =
-           let uu____20612 =
+         let uu____20605 =
+           let uu____20618 =
              FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift_wp
                FStar_Util.must
               in
-           FStar_All.pipe_right uu____20612 mk_mlift_wp  in
+           FStar_All.pipe_right uu____20618 mk_mlift_wp  in
          {
-           FStar_TypeChecker_Env.mlift_wp = uu____20599;
+           FStar_TypeChecker_Env.mlift_wp = uu____20605;
            FStar_TypeChecker_Env.mlift_term =
              (match sub.FStar_Syntax_Syntax.lift with
               | FStar_Pervasives_Native.None  ->
                   FStar_Pervasives_Native.Some
-                    ((fun uu____20648  ->
-                        fun uu____20649  -> fun e  -> FStar_Util.return_all e))
+                    ((fun uu____20654  ->
+                        fun uu____20655  -> fun e  -> FStar_Util.return_all e))
               | FStar_Pervasives_Native.Some ts ->
                   FStar_Pervasives_Native.Some (mk_mlift_term ts))
          })
@@ -7707,10 +7710,10 @@ let (update_env_sub_eff :
   =
   fun env  ->
     fun sub  ->
-      let uu____20672 = get_mlift_for_subeff env sub  in
+      let uu____20678 = get_mlift_for_subeff env sub  in
       FStar_TypeChecker_Env.update_effect_lattice env
         sub.FStar_Syntax_Syntax.source sub.FStar_Syntax_Syntax.target
-        uu____20672
+        uu____20678
   
 let (update_env_polymonadic_bind :
   FStar_TypeChecker_Env.env ->

--- a/src/ocaml-output/FStar_Universal.ml
+++ b/src/ocaml-output/FStar_Universal.ml
@@ -1097,72 +1097,74 @@ let (tc_one_file :
                (let uu____1106 = FStar_Options.codegen ()  in
                 uu____1106 = FStar_Pervasives_Native.None) ||
                  (let uu____1112 =
-                    FStar_Options.should_extract
-                      (tcmod.FStar_Syntax_Syntax.name).FStar_Ident.str
-                     in
+                    let uu____1114 =
+                      FStar_Ident.string_of_lid
+                        tcmod.FStar_Syntax_Syntax.name
+                       in
+                    FStar_Options.should_extract uu____1114  in
                   Prims.op_Negation uu____1112)
                 in
              if uu____1102
              then (FStar_Pervasives_Native.None, Prims.int_zero)
              else
                FStar_Util.record_time
-                 (fun uu____1131  ->
+                 (fun uu____1133  ->
                     with_env env1
                       (fun env2  ->
-                         let uu____1139 =
+                         let uu____1141 =
                            FStar_Extraction_ML_Modul.extract env2 tcmod  in
-                         match uu____1139 with | (uu____1148,defs) -> defs))
+                         match uu____1141 with | (uu____1150,defs) -> defs))
               in
            let maybe_extract_ml_iface tcmod env1 =
-             let uu____1170 =
-               let uu____1172 = FStar_Options.codegen ()  in
-               uu____1172 = FStar_Pervasives_Native.None  in
-             if uu____1170
+             let uu____1172 =
+               let uu____1174 = FStar_Options.codegen ()  in
+               uu____1174 = FStar_Pervasives_Native.None  in
+             if uu____1172
              then (env1, Prims.int_zero)
              else
                FStar_Util.record_time
-                 (fun uu____1191  ->
-                    let uu____1192 =
+                 (fun uu____1193  ->
+                    let uu____1194 =
                       with_env env1
                         (fun env2  ->
                            FStar_Extraction_ML_Modul.extract_iface env2 tcmod)
                        in
-                    match uu____1192 with | (env2,uu____1204) -> env2)
+                    match uu____1194 with | (env2,uu____1206) -> env2)
               in
-           let tc_source_file uu____1218 =
-             let uu____1219 = parse env pre_fn fn  in
-             match uu____1219 with
+           let tc_source_file uu____1220 =
+             let uu____1221 = parse env pre_fn fn  in
+             match uu____1221 with
              | (fmod,env1) ->
                  let mii =
-                   let uu____1235 =
-                     let uu____1236 =
+                   let uu____1237 =
+                     let uu____1238 =
                        FStar_Extraction_ML_UEnv.tcenv_of_uenv env1  in
-                     uu____1236.FStar_TypeChecker_Env.dsenv  in
-                   FStar_Syntax_DsEnv.inclusion_info uu____1235
+                     uu____1238.FStar_TypeChecker_Env.dsenv  in
+                   FStar_Syntax_DsEnv.inclusion_info uu____1237
                      fmod.FStar_Syntax_Syntax.name
                     in
-                 let check_mod uu____1250 =
+                 let check_mod uu____1252 =
                    let check env2 =
                      with_tcenv_of_env env2
                        (fun tcenv  ->
                           (match tcenv.FStar_TypeChecker_Env.gamma with
                            | [] -> ()
-                           | uu____1290 ->
+                           | uu____1292 ->
                                failwith
                                  "Impossible: gamma contains leaked names");
-                          (let uu____1294 =
+                          (let uu____1296 =
                              FStar_TypeChecker_Tc.check_module tcenv fmod
                                (FStar_Util.is_some pre_fn)
                               in
-                           match uu____1294 with
+                           match uu____1296 with
                            | (modul,env3) ->
                                (maybe_restore_opts ();
                                 (let smt_decls =
-                                   let uu____1324 =
-                                     let uu____1326 = FStar_Options.lax ()
+                                   let uu____1326 =
+                                     let uu____1328 = FStar_Options.lax ()
                                         in
-                                     Prims.op_Negation uu____1326  in
-                                   if uu____1324
+                                     Prims.op_Negation uu____1328  in
+                                   if uu____1326
                                    then
                                      let smt_decls =
                                        FStar_SMTEncoding_Encode.encode_modul
@@ -1172,21 +1174,25 @@ let (tc_one_file :
                                    else ([], [])  in
                                  ((modul, smt_decls), env3)))))
                       in
-                   let uu____1363 =
-                     FStar_Profiling.profile (fun uu____1393  -> check env1)
-                       (FStar_Pervasives_Native.Some
-                          ((fmod.FStar_Syntax_Syntax.name).FStar_Ident.str))
-                       "FStar.Universal.tc_source_file"
+                   let uu____1365 =
+                     let uu____1380 =
+                       let uu____1384 =
+                         FStar_Ident.string_of_lid
+                           fmod.FStar_Syntax_Syntax.name
+                          in
+                       FStar_Pervasives_Native.Some uu____1384  in
+                     FStar_Profiling.profile (fun uu____1402  -> check env1)
+                       uu____1380 "FStar.Universal.tc_source_file"
                       in
-                   match uu____1363 with
+                   match uu____1365 with
                    | ((tcmod,smt_decls),env2) ->
                        let tc_time = Prims.int_zero  in
-                       let uu____1432 = maybe_extract_mldefs tcmod env2  in
-                       (match uu____1432 with
+                       let uu____1440 = maybe_extract_mldefs tcmod env2  in
+                       (match uu____1440 with
                         | (extracted_defs,extract_time) ->
-                            let uu____1456 =
+                            let uu____1464 =
                               maybe_extract_ml_iface tcmod env2  in
-                            (match uu____1456 with
+                            (match uu____1464 with
                              | (env3,iface_extraction_time) ->
                                  ({
                                     FStar_CheckedFiles.checked_module = tcmod;
@@ -1197,75 +1203,79 @@ let (tc_one_file :
                                       (extract_time + iface_extraction_time)
                                   }, extracted_defs, env3)))
                     in
-                 let uu____1476 =
-                   (FStar_Options.should_verify
-                      (fmod.FStar_Syntax_Syntax.name).FStar_Ident.str)
-                     &&
+                 let uu____1484 =
+                   (let uu____1488 =
+                      FStar_Ident.string_of_lid fmod.FStar_Syntax_Syntax.name
+                       in
+                    FStar_Options.should_verify uu____1488) &&
                      ((FStar_Options.record_hints ()) ||
                         (FStar_Options.use_hints ()))
                     in
-                 if uu____1476
+                 if uu____1484
                  then
-                   let uu____1487 = FStar_Parser_ParseIt.find_file fn  in
-                   FStar_SMTEncoding_Solver.with_hints_db uu____1487
+                   let uu____1499 = FStar_Parser_ParseIt.find_file fn  in
+                   FStar_SMTEncoding_Solver.with_hints_db uu____1499
                      check_mod
                  else check_mod ()
               in
-           let uu____1499 =
-             let uu____1501 = FStar_Options.cache_off ()  in
-             Prims.op_Negation uu____1501  in
-           if uu____1499
+           let uu____1511 =
+             let uu____1513 = FStar_Options.cache_off ()  in
+             Prims.op_Negation uu____1513  in
+           if uu____1511
            then
-             let uu____1512 =
+             let uu____1524 =
                FStar_CheckedFiles.load_module_from_cache env fn  in
-             match uu____1512 with
+             match uu____1524 with
              | FStar_Pervasives_Native.None  ->
-                 ((let uu____1524 =
-                     let uu____1526 = FStar_Parser_Dep.module_name_of_file fn
+                 ((let uu____1536 =
+                     let uu____1538 = FStar_Parser_Dep.module_name_of_file fn
                         in
-                     FStar_Options.should_be_already_cached uu____1526  in
-                   if uu____1524
+                     FStar_Options.should_be_already_cached uu____1538  in
+                   if uu____1536
                    then
-                     let uu____1529 =
-                       let uu____1535 =
+                     let uu____1541 =
+                       let uu____1547 =
                          FStar_Util.format1
                            "Expected %s to already be checked" fn
                           in
                        (FStar_Errors.Error_AlreadyCachedAssertionFailure,
-                         uu____1535)
+                         uu____1547)
                         in
-                     FStar_Errors.raise_err uu____1529
+                     FStar_Errors.raise_err uu____1541
                    else ());
-                  (let uu____1542 =
-                     (let uu____1546 = FStar_Options.codegen ()  in
-                      FStar_Option.isSome uu____1546) &&
+                  (let uu____1554 =
+                     (let uu____1558 = FStar_Options.codegen ()  in
+                      FStar_Option.isSome uu____1558) &&
                        (FStar_Options.cmi ())
                       in
-                   if uu____1542
+                   if uu____1554
                    then
-                     let uu____1550 =
-                       let uu____1556 =
+                     let uu____1562 =
+                       let uu____1568 =
                          FStar_Util.format1
                            "Cross-module inlining expects all modules to be checked first; %s was not checked"
                            fn
                           in
                        (FStar_Errors.Error_AlreadyCachedAssertionFailure,
-                         uu____1556)
+                         uu____1568)
                         in
-                     FStar_Errors.raise_err uu____1550
+                     FStar_Errors.raise_err uu____1562
                    else ());
-                  (let uu____1562 = tc_source_file ()  in
-                   match uu____1562 with
+                  (let uu____1574 = tc_source_file ()  in
+                   match uu____1574 with
                    | (tc_result,mllib,env1) ->
-                       ((let uu____1587 =
-                           (let uu____1591 = FStar_Errors.get_err_count ()
+                       ((let uu____1599 =
+                           (let uu____1603 = FStar_Errors.get_err_count ()
                                in
-                            uu____1591 = Prims.int_zero) &&
+                            uu____1603 = Prims.int_zero) &&
                              ((FStar_Options.lax ()) ||
-                                (FStar_Options.should_verify
-                                   ((tc_result.FStar_CheckedFiles.checked_module).FStar_Syntax_Syntax.name).FStar_Ident.str))
+                                (let uu____1608 =
+                                   FStar_Ident.string_of_lid
+                                     (tc_result.FStar_CheckedFiles.checked_module).FStar_Syntax_Syntax.name
+                                    in
+                                 FStar_Options.should_verify uu____1608))
                             in
-                         if uu____1587
+                         if uu____1599
                          then
                            FStar_CheckedFiles.store_module_to_cache env1 fn
                              parsing_data tc_result
@@ -1274,38 +1284,40 @@ let (tc_one_file :
              | FStar_Pervasives_Native.Some tc_result ->
                  let tcmod = tc_result.FStar_CheckedFiles.checked_module  in
                  let smt_decls = tc_result.FStar_CheckedFiles.smt_decls  in
-                 ((let uu____1610 =
-                     FStar_Options.dump_module
-                       (tcmod.FStar_Syntax_Syntax.name).FStar_Ident.str
-                      in
-                   if uu____1610
+                 ((let uu____1625 =
+                     let uu____1627 =
+                       FStar_Ident.string_of_lid
+                         tcmod.FStar_Syntax_Syntax.name
+                        in
+                     FStar_Options.dump_module uu____1627  in
+                   if uu____1625
                    then
-                     let uu____1613 =
+                     let uu____1630 =
                        FStar_Syntax_Print.modul_to_string tcmod  in
                      FStar_Util.print1 "Module after type checking:\n%s\n"
-                       uu____1613
+                       uu____1630
                    else ());
                   (let extend_tcenv tcmod1 tcenv =
-                     let uu____1633 =
-                       let uu____1638 =
+                     let uu____1650 =
+                       let uu____1655 =
                          FStar_ToSyntax_ToSyntax.add_modul_to_env tcmod1
                            tc_result.FStar_CheckedFiles.mii
                            (FStar_TypeChecker_Normalize.erase_universes tcenv)
                           in
                        FStar_All.pipe_left (with_dsenv_of_tcenv tcenv)
-                         uu____1638
+                         uu____1655
                         in
-                     match uu____1633 with
-                     | (uu____1654,tcenv1) ->
+                     match uu____1650 with
+                     | (uu____1671,tcenv1) ->
                          let env1 =
                            FStar_TypeChecker_Tc.load_checked_module tcenv1
                              tcmod1
                             in
                          (maybe_restore_opts ();
-                          (let uu____1659 =
-                             let uu____1661 = FStar_Options.lax ()  in
-                             Prims.op_Negation uu____1661  in
-                           if uu____1659
+                          (let uu____1676 =
+                             let uu____1678 = FStar_Options.lax ()  in
+                             Prims.op_Negation uu____1678  in
+                           if uu____1676
                            then
                              (FStar_SMTEncoding_Encode.encode_modul_from_cache
                                 env1 tcmod1 smt_decls;
@@ -1315,41 +1327,44 @@ let (tc_one_file :
                       in
                    let env1 =
                      FStar_Profiling.profile
-                       (fun uu____1670  ->
-                          let uu____1671 =
+                       (fun uu____1687  ->
+                          let uu____1688 =
                             with_tcenv_of_env env (extend_tcenv tcmod)  in
-                          FStar_All.pipe_right uu____1671
+                          FStar_All.pipe_right uu____1688
                             FStar_Pervasives_Native.snd)
                        FStar_Pervasives_Native.None
                        "FStar.Universal.extend_tcenv"
                       in
                    let mllib =
-                     let uu____1685 =
-                       ((let uu____1689 = FStar_Options.codegen ()  in
-                         uu____1689 <> FStar_Pervasives_Native.None) &&
-                          (FStar_Options.should_extract
-                             (tcmod.FStar_Syntax_Syntax.name).FStar_Ident.str))
+                     let uu____1702 =
+                       ((let uu____1706 = FStar_Options.codegen ()  in
+                         uu____1706 <> FStar_Pervasives_Native.None) &&
+                          (let uu____1712 =
+                             FStar_Ident.string_of_lid
+                               tcmod.FStar_Syntax_Syntax.name
+                              in
+                           FStar_Options.should_extract uu____1712))
                          &&
                          ((Prims.op_Negation
                              tcmod.FStar_Syntax_Syntax.is_interface)
                             ||
-                            (let uu____1695 = FStar_Options.codegen ()  in
-                             uu____1695 =
+                            (let uu____1715 = FStar_Options.codegen ()  in
+                             uu____1715 =
                                (FStar_Pervasives_Native.Some
                                   FStar_Options.Kremlin)))
                         in
-                     if uu____1685
+                     if uu____1702
                      then
-                       let uu____1703 = maybe_extract_mldefs tcmod env1  in
-                       match uu____1703 with
+                       let uu____1723 = maybe_extract_mldefs tcmod env1  in
+                       match uu____1723 with
                        | (extracted_defs,_extraction_time) -> extracted_defs
                      else FStar_Pervasives_Native.None  in
-                   let uu____1723 = maybe_extract_ml_iface tcmod env1  in
-                   match uu____1723 with
+                   let uu____1743 = maybe_extract_ml_iface tcmod env1  in
+                   match uu____1743 with
                    | (env2,_time) -> (tc_result, mllib, env2)))
            else
-             (let uu____1745 = tc_source_file ()  in
-              match uu____1745 with
+             (let uu____1765 = tc_source_file ()  in
+              match uu____1765 with
               | (tc_result,mllib,env1) -> (tc_result, mllib, env1)))
   
 let (tc_one_file_for_ide :
@@ -1364,12 +1379,12 @@ let (tc_one_file_for_ide :
       fun fn  ->
         fun parsing_data  ->
           let env1 = env_of_tcenv env  in
-          let uu____1809 = tc_one_file env1 pre_fn fn parsing_data  in
-          match uu____1809 with
-          | (tc_result,uu____1823,env2) ->
-              let uu____1829 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env2
+          let uu____1829 = tc_one_file env1 pre_fn fn parsing_data  in
+          match uu____1829 with
+          | (tc_result,uu____1843,env2) ->
+              let uu____1849 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env2
                  in
-              (tc_result, uu____1829)
+              (tc_result, uu____1849)
   
 let (needs_interleaving : Prims.string -> Prims.string -> Prims.bool) =
   fun intf  ->
@@ -1377,11 +1392,11 @@ let (needs_interleaving : Prims.string -> Prims.string -> Prims.bool) =
       let m1 = FStar_Parser_Dep.lowercase_module_name intf  in
       let m2 = FStar_Parser_Dep.lowercase_module_name impl  in
       ((m1 = m2) &&
-         (let uu____1852 = FStar_Util.get_file_extension intf  in
-          FStar_List.mem uu____1852 ["fsti"; "fsi"]))
+         (let uu____1872 = FStar_Util.get_file_extension intf  in
+          FStar_List.mem uu____1872 ["fsti"; "fsi"]))
         &&
-        (let uu____1861 = FStar_Util.get_file_extension impl  in
-         FStar_List.mem uu____1861 ["fst"; "fs"])
+        (let uu____1881 = FStar_Util.get_file_extension impl  in
+         FStar_List.mem uu____1881 ["fst"; "fs"])
   
 let (tc_one_file_from_remaining :
   Prims.string Prims.list ->
@@ -1394,32 +1409,32 @@ let (tc_one_file_from_remaining :
   fun remaining  ->
     fun env  ->
       fun deps  ->
-        let uu____1904 =
+        let uu____1924 =
           match remaining with
           | intf::impl::remaining1 when needs_interleaving intf impl ->
-              let uu____1945 =
-                let uu____1954 =
+              let uu____1965 =
+                let uu____1974 =
                   FStar_All.pipe_right impl
                     (FStar_Parser_Dep.parsing_data_of deps)
                    in
                 tc_one_file env (FStar_Pervasives_Native.Some intf) impl
-                  uu____1954
+                  uu____1974
                  in
-              (match uu____1945 with
+              (match uu____1965 with
                | (m,mllib,env1) -> (remaining1, (m, mllib, env1)))
           | intf_or_impl::remaining1 ->
-              let uu____1999 =
-                let uu____2008 =
+              let uu____2019 =
+                let uu____2028 =
                   FStar_All.pipe_right intf_or_impl
                     (FStar_Parser_Dep.parsing_data_of deps)
                    in
                 tc_one_file env FStar_Pervasives_Native.None intf_or_impl
-                  uu____2008
+                  uu____2028
                  in
-              (match uu____1999 with
+              (match uu____2019 with
                | (m,mllib,env1) -> (remaining1, (m, mllib, env1)))
           | [] -> failwith "Impossible: Empty remaining modules"  in
-        match uu____1904 with
+        match uu____1924 with
         | (remaining1,(nmods,mllib,env1)) -> (remaining1, nmods, mllib, env1)
   
 let rec (tc_fold_interleave :
@@ -1433,31 +1448,31 @@ let rec (tc_fold_interleave :
   fun deps  ->
     fun acc  ->
       fun remaining  ->
-        let as_list uu___0_2164 =
-          match uu___0_2164 with
+        let as_list uu___0_2184 =
+          match uu___0_2184 with
           | FStar_Pervasives_Native.None  -> []
           | FStar_Pervasives_Native.Some l -> [l]  in
         match remaining with
         | [] -> acc
-        | uu____2181 ->
-            let uu____2185 = acc  in
-            (match uu____2185 with
+        | uu____2201 ->
+            let uu____2205 = acc  in
+            (match uu____2205 with
              | (mods,mllibs,env) ->
-                 let uu____2217 =
+                 let uu____2237 =
                    tc_one_file_from_remaining remaining env deps  in
-                 (match uu____2217 with
+                 (match uu____2237 with
                   | (remaining1,nmod,mllib,env1) ->
-                      ((let uu____2256 =
-                          let uu____2258 =
+                      ((let uu____2276 =
+                          let uu____2278 =
                             FStar_Options.profile_group_by_decls ()  in
-                          Prims.op_Negation uu____2258  in
-                        if uu____2256
+                          Prims.op_Negation uu____2278  in
+                        if uu____2276
                         then
-                          let uu____2261 =
+                          let uu____2281 =
                             FStar_Ident.string_of_lid
                               (nmod.FStar_CheckedFiles.checked_module).FStar_Syntax_Syntax.name
                              in
-                          FStar_Profiling.report_and_clear uu____2261
+                          FStar_Profiling.report_and_clear uu____2281
                         else ());
                        tc_fold_interleave deps
                          ((FStar_List.append mods [nmod]),
@@ -1471,43 +1486,43 @@ let (batch_mode_tc :
   =
   fun filenames  ->
     fun dep_graph  ->
-      (let uu____2298 =
+      (let uu____2318 =
          FStar_Options.debug_at_level_no_module (FStar_Options.Other "Dep")
           in
-       if uu____2298
+       if uu____2318
        then
          (FStar_Util.print_endline "Auto-deps kicked in; here's some info.";
           FStar_Util.print1
             "Here's the list of filenames we will process: %s\n"
             (FStar_String.concat " " filenames);
-          (let uu____2307 =
-             let uu____2309 =
+          (let uu____2327 =
+             let uu____2329 =
                FStar_All.pipe_right filenames
                  (FStar_List.filter FStar_Options.should_verify_file)
                 in
-             FStar_String.concat " " uu____2309  in
+             FStar_String.concat " " uu____2329  in
            FStar_Util.print1
-             "Here's the list of modules we will verify: %s\n" uu____2307))
+             "Here's the list of modules we will verify: %s\n" uu____2327))
        else ());
       (let env =
-         let uu____2325 = init_env dep_graph  in
-         FStar_Extraction_ML_UEnv.new_uenv uu____2325  in
-       let uu____2326 = tc_fold_interleave dep_graph ([], [], env) filenames
+         let uu____2345 = init_env dep_graph  in
+         FStar_Extraction_ML_UEnv.new_uenv uu____2345  in
+       let uu____2346 = tc_fold_interleave dep_graph ([], [], env) filenames
           in
-       match uu____2326 with
+       match uu____2346 with
        | (all_mods,mllibs,env1) ->
            (emit mllibs;
             (let solver_refresh env2 =
-               let uu____2370 =
+               let uu____2390 =
                  with_tcenv_of_env env2
                    (fun tcenv  ->
-                      (let uu____2379 =
+                      (let uu____2399 =
                          (FStar_Options.interactive ()) &&
-                           (let uu____2382 = FStar_Errors.get_err_count ()
+                           (let uu____2402 = FStar_Errors.get_err_count ()
                                in
-                            uu____2382 = Prims.int_zero)
+                            uu____2402 = Prims.int_zero)
                           in
-                       if uu____2379
+                       if uu____2399
                        then
                          (tcenv.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.refresh
                            ()
@@ -1516,6 +1531,6 @@ let (batch_mode_tc :
                            ());
                       ((), tcenv))
                   in
-               FStar_All.pipe_left FStar_Pervasives_Native.snd uu____2370  in
+               FStar_All.pipe_left FStar_Pervasives_Native.snd uu____2390  in
              (all_mods, env1, solver_refresh))))
   

--- a/src/parser/FStar.Parser.Const.fs
+++ b/src/parser/FStar.Parser.Const.fs
@@ -330,8 +330,8 @@ let next_id = fst gen_reset
 
 let sli (l:lident) : string =
   if FStar.Options.print_real_names()
-  then l.str
-  else l.ident.idText
+  then string_of_lid l
+  else text_of_id (ident_of_lid l)
 
 let const_to_string x = match x with
   | Const_effect -> "Effect"
@@ -362,7 +362,7 @@ let is_tuple_constructor_string (s:string) :bool =
   U.starts_with s "FStar.Pervasives.Native.tuple"
 
 let is_tuple_constructor_id  id  = is_tuple_constructor_string (text_of_id id)
-let is_tuple_constructor_lid lid = is_tuple_constructor_string (text_of_lid lid)
+let is_tuple_constructor_lid lid = is_tuple_constructor_string (string_of_lid lid)
 
 let mk_tuple_data_lid n r =
   let t = U.format1 "Mktuple%s" (U.string_of_int n) in
@@ -374,12 +374,12 @@ let is_tuple_datacon_string (s:string) :bool =
   U.starts_with s "FStar.Pervasives.Native.Mktuple"
 
 let is_tuple_datacon_id  id  = is_tuple_datacon_string (text_of_id id)
-let is_tuple_datacon_lid lid = is_tuple_datacon_string (text_of_lid lid)
+let is_tuple_datacon_lid lid = is_tuple_datacon_string (string_of_lid lid)
 
 let is_tuple_data_lid f n =
   lid_equals f (mk_tuple_data_lid n dummyRange)
 
-let is_tuple_data_lid' f = is_tuple_datacon_string f.str
+let is_tuple_data_lid' f = is_tuple_datacon_string (string_of_lid f)
 
 
 (* Dtuples *)
@@ -395,7 +395,7 @@ let mk_dtuple_lid n r =
 let is_dtuple_constructor_string (s:string) :bool =
   s = "Prims.dtuple2" || U.starts_with s "FStar.Pervasives.dtuple"
 
-let is_dtuple_constructor_lid lid = is_dtuple_constructor_string lid.str
+let is_dtuple_constructor_lid lid = is_dtuple_constructor_string (string_of_lid lid)
 
 let mk_dtuple_data_lid n r =
   let t = U.format1 "Mkdtuple%s" (U.string_of_int n) in
@@ -407,10 +407,10 @@ let is_dtuple_datacon_string (s:string) :bool =
 let is_dtuple_data_lid f n =
   lid_equals f (mk_dtuple_data_lid n dummyRange)
 
-let is_dtuple_data_lid' f = is_dtuple_datacon_string (text_of_lid f)
+let is_dtuple_data_lid' f = is_dtuple_datacon_string (string_of_lid f)
 
 let is_name (lid:lident) =
-  let c = U.char_at lid.ident.idText 0 in
+  let c = U.char_at (text_of_id (ident_of_lid lid)) 0 in
   U.is_upper c
 
 (* tactic constants *)

--- a/src/parser/parse.fsy
+++ b/src/parser/parse.fsy
@@ -768,7 +768,7 @@ typars:
 tvarinsts:
   TYP_APP_LESS separated_nonempty_list_COMMA_tvar_ TYP_APP_GREATER
     {let (_1, tvs, _3) = ((), $2, ()) in
-      ( map (fun tv -> mk_binder (TVariable(tv)) tv.idRange Kind None) tvs )}
+      ( map (fun tv -> mk_binder (TVariable(tv)) (range_of_id tv) Kind None) tvs )}
 
 typeDefinition:
   
@@ -1101,7 +1101,7 @@ let p =     ( (x, y) ) in
       ( p )}
 | qlident
     {let lid = $1 in
-      ( lid, mk_pattern (PatVar (lid.ident, None)) (rhs parseState 1) )}
+      ( lid, mk_pattern (PatVar (ident_of_lid lid, None)) (rhs parseState 1) )}
 
 patternOrMultibinder:
   LBRACK_BAR UNDERSCORE COLON simpleArrow BAR_RBRACK
@@ -1237,15 +1237,15 @@ lidentOrOperator:
 | LPAREN OPPREFIX RPAREN
     {let (_1, op, _3) = ((), $2, ()) in
 let id =     ( mk_ident (op, rhs parseState 1) ) in
-    ( {id with idText = compile_op' id.idText id.idRange} )}
+    ( mk_ident (compile_op' (text_of_id id) (range_of_id id), range_of_id id) )}
 | LPAREN binop_name RPAREN
     {let (_1, op, _3) = ((), $2, ()) in
 let id =     ( op ) in
-    ( {id with idText = compile_op' id.idText id.idRange} )}
+    ( mk_ident (compile_op' (text_of_id id) (range_of_id id), range_of_id id) )}
 | LPAREN TILDE RPAREN
     {let (_1, op, _3) = ((), $2, ()) in
 let id =     ( mk_ident (op, rhs parseState 1) ) in
-    ( {id with idText = compile_op' id.idText id.idRange} )}
+    ( mk_ident (compile_op' (text_of_id id) (range_of_id id), range_of_id id) )}
 
 lidentOrUnderscore:
   IDENT
@@ -1336,7 +1336,8 @@ let op_expr =
 in
       (
         let (op, e2, _) = op_expr in
-        mk_term (Op({op with idText = op.idText ^ "<-"}, [ e1; e2; e3 ])) (rhs2 parseState 1 4) Expr
+        let opid = mk_ident (text_of_id op ^ "<-", range_of_id op) in
+        mk_term (Op(opid, [ e1; e2; e3 ])) (rhs2 parseState 1 4) Expr
       )}
 | atomicTermNotQUident DOT_LBRACK term RBRACK LARROW noSeqTerm
     {let (e1, _1, e, _3_inlined1, _3, e3) = ($1, (), $3, (), (), $6) in
@@ -1346,7 +1347,8 @@ let op_expr =
 in
       (
         let (op, e2, _) = op_expr in
-        mk_term (Op({op with idText = op.idText ^ "<-"}, [ e1; e2; e3 ])) (rhs2 parseState 1 4) Expr
+        let opid = mk_ident (text_of_id op ^ "<-", range_of_id op) in
+        mk_term (Op(opid, [ e1; e2; e3 ])) (rhs2 parseState 1 4) Expr
       )}
 | atomicTermNotQUident DOT_LBRACK_BAR term BAR_RBRACK LARROW noSeqTerm
     {let (e1, _1, e, _3_inlined1, _3, e3) = ($1, (), $3, (), (), $6) in
@@ -1356,7 +1358,8 @@ let op_expr =
 in
       (
         let (op, e2, _) = op_expr in
-        mk_term (Op({op with idText = op.idText ^ "<-"}, [ e1; e2; e3 ])) (rhs2 parseState 1 4) Expr
+        let opid = mk_ident (text_of_id op ^ "<-", range_of_id op) in
+        mk_term (Op(opid, [ e1; e2; e3 ])) (rhs2 parseState 1 4) Expr
       )}
 | atomicTermNotQUident DOT_LENS_PAREN_LEFT term LENS_PAREN_RIGHT LARROW noSeqTerm
     {let (e1, _1, e, _3_inlined1, _3, e3) = ($1, (), $3, (), (), $6) in
@@ -1366,7 +1369,8 @@ let op_expr =
 in
       (
         let (op, e2, _) = op_expr in
-        mk_term (Op({op with idText = op.idText ^ "<-"}, [ e1; e2; e3 ])) (rhs2 parseState 1 4) Expr
+        let opid = mk_ident (text_of_id op ^ "<-", range_of_id op) in
+        mk_term (Op(opid, [ e1; e2; e3 ])) (rhs2 parseState 1 4) Expr
       )}
 | REQUIRES typ
     {let (_1, t) = ((), $2) in
@@ -2030,7 +2034,7 @@ let e =     ( (x, y) ) in
                                                  ( e )}
 | qlident
     {let lid = $1 in
-                ( lid, mk_term (Name (lid_of_ids [ lid.ident ])) (rhs parseState 1) Un )}
+                ( lid, mk_term (Name (lid_of_ids [ ident_of_lid lid ])) (rhs parseState 1) Un )}
 
 appTerm:
   indexingTerm list_argTerm_
@@ -2321,7 +2325,7 @@ universeFrom:
 | ident nonempty_list_atomicUniverse_
     {let (max, us) = ($1, $2) in
       (
-        if text_of_id max <> text_of_lid max_lid
+        if text_of_id max <> string_of_lid max_lid
         then log_issue (rhs parseState 1) (Error_InvalidUniverseVar, "A lower case ident " ^ text_of_id max ^
                           " was found in a universe context. " ^
                           "It should be either max or a universe variable 'usomething.");
@@ -2342,7 +2346,7 @@ atomicUniverse:
       )}
 | lident
     {let u = $1 in
-             ( mk_term (Uvar u) u.idRange Expr )}
+             ( mk_term (Uvar u) (range_of_id u) Expr )}
 | LPAREN universeFrom RPAREN
     {let (_1, u, _3) = ((), $2, ()) in
     ( u (*mk_term (Paren u) (rhs2 parseState 1 3) Expr*) )}
@@ -2477,5 +2481,4 @@ in
    ( x :: xs )}
 
 %%
-
 

--- a/src/reflection/FStar.Reflection.Basic.fs
+++ b/src/reflection/FStar.Reflection.Basic.fs
@@ -364,7 +364,7 @@ let is_free (x:bv) (t:term) : bool =
 let lookup_attr (attr:term) (env:Env.env) : list<fv> =
     match (SS.compress attr).n with
     | Tm_fvar fv ->
-        let ses = Env.lookup_attr env (Ident.text_of_lid (lid_of_fv fv)) in
+        let ses = Env.lookup_attr env (Ident.string_of_lid (lid_of_fv fv)) in
         List.concatMap (fun se -> match U.lid_of_sigelt se with
                                   | None -> []
                                   // FIXME: Get a proper delta depth
@@ -378,7 +378,7 @@ let defs_in_module (env:Env.env) (modul:name) : list<fv> =
     List.concatMap
         (fun l ->
                 (* must succeed, ids_of_lid always returns a non-empty list *)
-                let ns = Ident.ids_of_lid l |> init |> List.map Ident.string_of_ident in
+                let ns = Ident.ids_of_lid l |> init |> List.map Ident.text_of_id in
                 if ns = modul
                 then [S.lid_as_fv l (S.Delta_constant_at_level 999) None]
                 else [])
@@ -511,7 +511,7 @@ let pack_sigelt (sv:sigelt_view) : sigelt =
 
 let inspect_bv (bv:bv) : bv_view =
     {
-      bv_ppname = Ident.string_of_ident bv.ppname;
+      bv_ppname = Ident.text_of_id bv.ppname;
       bv_index = Z.of_int_fs bv.index;
       bv_sort = bv.sort;
     }

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fs
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fs
@@ -1584,7 +1584,7 @@ and encode_formula (phi:typ) (env:env_t) : (term * decls_t)  = (* expects phi to
         let pats, decls' = encode_smt_patterns ps env in
         let body, decls'' = encode_formula body env in
         let guards = match pats with
-          | [[{tm=App(Var gf, [p])}]] when Ident.text_of_lid Const.guard_free = gf -> []
+          | [[{tm=App(Var gf, [p])}]] when Ident.string_of_lid Const.guard_free = gf -> []
           | _ -> guards in
         vars, pats, mk_and_l guards, body, decls@decls'@decls'' in
 

--- a/src/smtencoding/FStar.SMTEncoding.Solver.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Solver.fs
@@ -605,7 +605,7 @@ let ask_and_report_errors env all_labels prefix query suffix : unit =
         let qname, index =
             match env.qtbl_name_and_index with
             | _, None -> failwith "No query name set!"
-            | _, Some (q, n) -> Ident.text_of_lid q, n
+            | _, Some (q, n) -> Ident.string_of_lid q, n
         in
         let rlimit =
             Prims.op_Multiply

--- a/src/smtencoding/FStar.SMTEncoding.Term.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Term.fs
@@ -895,8 +895,8 @@ let rec declToSmt' print_captions z3options decl =
   | Assume a ->
     let fact_ids_to_string ids =
         ids |> List.map (function
-        | Name n -> "Name " ^Ident.text_of_lid n
-        | Namespace ns -> "Namespace " ^Ident.text_of_lid ns
+        | Name n -> "Name " ^ Ident.string_of_lid n
+        | Namespace ns -> "Namespace " ^ Ident.string_of_lid ns
         | Tag t -> "Tag " ^t)
     in
     let fids =

--- a/src/syntax/FStar.Syntax.MutRecTy.fs
+++ b/src/syntax/FStar.Syntax.MutRecTy.fs
@@ -121,7 +121,7 @@ let disentangle_abbrevs_from_bundle
                   begin match U.find_map type_abbrev_sigelts replacee with
                       | Some se ->
                           if FStar.List.existsb (fun x -> lid_equals x fv.fv_name.v) !in_progress
-                          then let msg = U.format1 "Cycle on %s in mutually recursive type abbreviations" fv.fv_name.v.str in
+                          then let msg = U.format1 "Cycle on %s in mutually recursive type abbreviations" (string_of_lid fv.fv_name.v) in
                                raise_error (Errors.Fatal_CycleInRecTypeAbbreviation, msg) (range_of_lid fv.fv_name.v)
                           else unfold_abbrev se
                       | _ -> t

--- a/src/syntax/FStar.Syntax.Subst.fs
+++ b/src/syntax/FStar.Syntax.Subst.fs
@@ -35,7 +35,7 @@ module S = FStar.Syntax.Syntax
 
 (* A subst_t is a composition of parallel substitutions, expressed as a list of lists *)
 let subst_to_string s =
-    s |> List.map (fun (b, _) -> b.ppname.idText) |> String.concat ", "
+    s |> List.map (fun (b, _) -> (text_of_id b.ppname)) |> String.concat ", "
 
 (* apply_until_some f s
       applies f to each element of s until it returns (Some t)
@@ -136,7 +136,7 @@ let subst_univ_bv x s = U.find_map s (function
     | UN(y, t) when (x=y) -> Some t
     | _ -> None)
 let subst_univ_nm (x:univ_name) s = U.find_map s (function
-    | UD(y, i) when (x.idText=y.idText) -> Some (U_bvar i)
+    | UD(y, i) when (ident_equals x y) -> Some (U_bvar i)
     | _ -> None)
 
 let rec subst_univ s u =

--- a/src/syntax/FStar.Syntax.Syntax.fs
+++ b/src/syntax/FStar.Syntax.Syntax.fs
@@ -484,21 +484,24 @@ let contains_reflectable (l: list<qualifier>): bool =
 let withinfo v r = {v=v; p=r}
 let withsort v = withinfo v dummyRange
 
-let bv_eq (bv1:bv) (bv2:bv) = bv1.ppname.idText=bv2.ppname.idText && bv1.index=bv2.index
+let bv_eq (bv1:bv) (bv2:bv) =
+    ident_equals bv1.ppname bv2.ppname && bv1.index=bv2.index
+
 let order_bv x y =
-  let i = String.compare x.ppname.idText y.ppname.idText in
+  let i = String.compare (text_of_id x.ppname) (text_of_id y.ppname) in
   if i = 0
   then x.index - y.index
   else i
 
-let order_ident x y = String.compare x.idText y.idText
-let order_fv x y = String.compare x.str y.str
+let order_ident x y = String.compare (text_of_id x) (text_of_id y)
+let order_fv x y = String.compare (string_of_lid x) (string_of_lid y)
 
 let range_of_lbname (l:lbname) = match l with
-    | Inl x -> x.ppname.idRange
+    | Inl x -> range_of_id x.ppname
     | Inr fv -> range_of_lid fv.fv_name.v
-let range_of_bv x = x.ppname.idRange
-let set_range_of_bv x r = {x with ppname=Ident.mk_ident(x.ppname.idText, r)}
+let range_of_bv x = range_of_id x.ppname
+
+let set_range_of_bv x r = {x with ppname = set_id_range r x.ppname }
 
 
 (* Helpers *)
@@ -609,7 +612,7 @@ let null_binder t : binder = null_bv t, None
 let imp_tag = Implicit false
 let iarg t : arg = t, Some imp_tag
 let as_arg t : arg = t, None
-let is_null_bv (b:bv) = b.ppname.idText = null_id.idText
+let is_null_bv (b:bv) = text_of_id b.ppname = text_of_id null_id
 let is_null_binder (b:binder) = is_null_bv (fst b)
 
 let is_top_level = function
@@ -659,7 +662,9 @@ let lbname_eq l1 l2 = match l1, l2 with
   | _ -> false
 let fv_eq fv1 fv2 = lid_equals fv1.fv_name.v fv2.fv_name.v
 let fv_eq_lid fv lid = lid_equals fv.fv_name.v lid
-let set_bv_range bv r = {bv with ppname=mk_ident(bv.ppname.idText, r)}
+
+let set_bv_range bv r = {bv with ppname = set_id_range r bv.ppname}
+
 let lid_as_fv l dd dq : fv = {
     fv_name=withinfo l (range_of_lid l);
     fv_delta=dd;

--- a/src/syntax/FStar.Syntax.Syntax.fsi
+++ b/src/syntax/FStar.Syntax.Syntax.fsi
@@ -542,8 +542,8 @@ val bv_to_tm:       bv -> term
 val bv_to_name:     bv -> term
 val binders_to_names: binders -> list<term>
 
-val bv_eq:           bv -> bv -> Tot<bool>
-val order_bv:        bv -> bv -> Tot<int>
+val bv_eq:           bv -> bv -> bool
+val order_bv:        bv -> bv -> int
 val range_of_lbname: lbname -> range
 val range_of_bv:     bv -> range
 val set_range_of_bv: bv -> range -> bv

--- a/src/tactics/FStar.Tactics.Basic.fs
+++ b/src/tactics/FStar.Tactics.Basic.fs
@@ -914,7 +914,7 @@ let rewrite (h:binder) : tac<unit> = wrap_err "rewrite" <|
 let rename_to (b : binder) (s : string) : tac<binder> = wrap_err "rename_to" <|
     bind cur_goal (fun goal ->
     let bv, q = b in
-    let bv' = freshen_bv ({ bv with ppname = mk_ident (s, bv.ppname.idRange) }) in
+    let bv' = freshen_bv ({ bv with ppname = mk_ident (s, (range_of_id bv.ppname)) }) in
     bind (subst_goal bv bv' goal) (function
     | None -> fail "binder not found in environment"
     | Some (bv',  goal) ->
@@ -1311,7 +1311,7 @@ let t_destruct (s_tm : term) : tac<list<(fv * Z.t)>> = wrap_err "destruct" <|
                         let bs, comp =
                           let rename_bv bv =
                               let ppname = bv.ppname in
-                              let ppname = { ppname with idText = "a" ^ ppname.idText } in
+                              let ppname = mk_ident ("a" ^ text_of_id ppname, range_of_id ppname) in
                               // freshen just to be extra safe.. probably not needed
                               freshen_bv ({ bv with ppname = ppname })
                           in

--- a/src/tactics/FStar.Tactics.Printing.fs
+++ b/src/tactics/FStar.Tactics.Printing.fs
@@ -30,8 +30,8 @@ let goal_to_string_verbose (g:goal) : string =
 
 let unshadow (bs : binders) (t : term) : binders * term =
     (* string name of a bv *)
-    let s b = b.ppname.idText in
-    let sset bv s = S.gen_bv s (Some bv.ppname.idRange) bv.sort in
+    let s b = (text_of_id b.ppname) in
+    let sset bv s = S.gen_bv s (Some (range_of_id bv.ppname)) bv.sort in
     let fresh_until b f =
         let rec aux i =
             let t = b ^ "'" ^ string_of_int i in

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -160,7 +160,7 @@ let desugar_name mk setpos env resolve l =
 let compile_op_lid n s r = [mk_ident(compile_op n s r, r)] |> lid_of_ids
 
 let op_as_term env arity rng op : option<S.term> =
-  let r l dd = Some (S.lid_as_fv (set_lid_range l op.idRange) dd None |> S.fv_to_tm) in
+  let r l dd = Some (S.lid_as_fv (set_lid_range l (range_of_id op)) dd None |> S.fv_to_tm) in
   let fallback () =
     match Ident.text_of_id op with
     | "=" ->
@@ -217,14 +217,14 @@ let op_as_term env arity rng op : option<S.term> =
       r C.iff_lid (Delta_constant_at_level 2)
     | _ -> None
   in
-  match desugar_name' (fun t -> {t with pos=op.idRange})
-        env true (compile_op_lid arity op.idText op.idRange) with
+  match desugar_name' (fun t -> {t with pos=(range_of_id op)})
+        env true (compile_op_lid arity (text_of_id op) (range_of_id op)) with
   | Some t -> Some t
   | _ -> fallback()
 
 let sort_ftv ftv =
-  BU.sort_with (fun x y -> String.compare x.idText y.idText) <|
-      BU.remove_dups (fun x y -> x.idText = y.idText) ftv
+  BU.sort_with (fun x y -> String.compare (text_of_id x) (text_of_id y)) <|
+      BU.remove_dups (fun x y -> (text_of_id x) = (text_of_id y)) ftv
 
 let rec free_type_vars_b env binder = match binder.b with
   | Variable _ -> env, []
@@ -328,7 +328,7 @@ let close env t =
   let ftv = sort_ftv <| free_type_vars env t in
   if List.length ftv = 0
   then t
-  else let binders = ftv |> List.map (fun x -> mk_binder (TAnnotated(x, tm_type x.idRange)) x.idRange Type_level (Some Implicit)) in
+  else let binders = ftv |> List.map (fun x -> mk_binder (TAnnotated(x, tm_type (range_of_id x))) (range_of_id x) Type_level (Some Implicit)) in
        let result = mk_term (Product(binders, t)) t.range t.level in
        result
 
@@ -336,7 +336,7 @@ let close_fun env t =
   let ftv = sort_ftv <| free_type_vars env t in
   if List.length ftv = 0
   then t
-  else let binders = ftv |> List.map (fun x -> mk_binder (TAnnotated(x, tm_type x.idRange)) x.idRange Type_level (Some Implicit)) in
+  else let binders = ftv |> List.map (fun x -> mk_binder (TAnnotated(x, tm_type (range_of_id x))) (range_of_id x) Type_level (Some Implicit)) in
        let t = match (unparen t).tm with
         | Product _ -> t
         | _ -> mk_term (App(mk_term (Name C.effect_Tot_lid) t.range t.level, t, Nothing)) t.range t.level in
@@ -394,7 +394,7 @@ let rec gather_pattern_bound_vars_maybe_top acc p =
   | PatAscribed (pat, _) -> gather_pattern_bound_vars_maybe_top acc pat
 
 let gather_pattern_bound_vars : pattern -> set<Ident.ident> =
-  let acc = new_set (fun id1 id2 -> if id1.idText = id2.idText then 0 else 1) in
+  let acc = new_set (fun id1 id2 -> if (text_of_id id1) = (text_of_id id2) then 0 else 1) in
   fun p -> gather_pattern_bound_vars_maybe_top acc p
 
 type bnd =
@@ -580,7 +580,7 @@ let rec desugar_maybe_non_constant_universe t
             let uarg = desugar_maybe_non_constant_universe targ in
             aux t (uarg::univargs)
         | Var max_lid ->
-            assert (Ident.text_of_lid max_lid = "max") ;
+            assert (Ident.string_of_lid max_lid = "max") ;
             if List.existsb (function Inr _ -> true | _ -> false) univargs
             then Inr (U_max (List.map (function Inl n -> int_to_universe n | Inr u -> u) univargs))
             else
@@ -617,9 +617,9 @@ let check_fields env fields rg =
         then ()
         else let msg = BU.format3
                        "Field %s belongs to record type %s, whereas field %s does not"
-                       f.str
-                       record.typename.str
-                       f'.str
+                       (string_of_lid f)
+                       (string_of_lid record.typename)
+                       (string_of_lid f')
              in
              raise_error (Errors.Fatal_FieldsNotBelongToSameRecordType, msg) rg
     in
@@ -644,7 +644,7 @@ let check_linear_pattern_variables pats r =
             raise_error ( Errors.Fatal_NonLinearPatternNotPermitted,
                           BU.format1
                             "Non-linear patterns are not permitted: `%s` appears more than once in this pattern."
-                             (duplicate_bv.ppname.idText) )
+                             ((text_of_id duplicate_bv.ppname)) )
 
                         r
       in
@@ -664,7 +664,7 @@ let check_linear_pattern_variables pats r =
       raise_error ( Errors.Fatal_IncoherentPatterns,
                     BU.format1
                       "Patterns in this match are incoherent, variable %s is bound in some but not all patterns."
-                       (first_nonlinear_var.ppname.idText) )
+                       ((text_of_id first_nonlinear_var.ppname)) )
                   r
     in
     List.iter aux ps
@@ -683,7 +683,7 @@ let rec desugar_data_pat
      * the cases of a PatOr, so different ocurrences of
      * a same (surface) variable are mapped to exactly the
      * same internal variable. *)
-    match BU.find_opt (fun y -> y.ppname.idText=x.idText) l with
+    match BU.find_opt (fun y -> (text_of_id y.ppname = text_of_id x)) l with
     | Some y -> l, e, y
     | _ ->
       let e, x = push_bv e x in
@@ -705,7 +705,7 @@ let rec desugar_data_pat
 
       | PatOp op ->
         (* Turn into a PatVar and recurse *)
-        let id_op = mk_ident (compile_op 0 op.idText op.idRange, op.idRange) in
+        let id_op = mk_ident (compile_op 0 (text_of_id op) (range_of_id op), (range_of_id op)) in
         let p = { p with pat = PatVar (id_op, None) } in
         aux loc env p
 
@@ -800,12 +800,12 @@ let rec desugar_data_pat
       | PatRecord (fields) ->
         (* elaborate into an application and recurse *)
         let record = check_fields env fields p.prange in
-        let fields = fields |> List.map (fun (f, p) -> (f.ident, p)) in
+        let fields = fields |> List.map (fun (f, p) -> (ident_of_lid f, p)) in
         let args = record.fields |> List.map (fun (f, _) ->
-          match fields |> List.tryFind (fun (g, _) -> f.idText = g.idText) with
+          match fields |> List.tryFind (fun (g, _) -> (text_of_id f) = (text_of_id g)) with
             | None -> mk_pattern (PatWild None) p.prange
             | Some (_, p) -> p) in
-        let app = mk_pattern (PatApp(mk_pattern (PatName (lid_of_ids (record.typename.ns @ [record.constrname]))) p.prange, args)) p.prange in
+        let app = mk_pattern (PatApp(mk_pattern (PatName (lid_of_ids (ns_of_lid record.typename @ [record.constrname]))) p.prange, args)) p.prange in
         let env, e, b, p, annots = aux loc env app in
         let p = match p.v with
             | Pat_cons(fv, args) -> pos <| Pat_cons(({fv with fv_qual=Some (Record_ctor (record.typename, record.fields |> List.map fst))}), args)
@@ -847,7 +847,7 @@ and desugar_binding_pat_maybe_top top env p
     //     or F* gets confused between tuple2 and tuple3 apparently?
         env, LetBinder(qualify env x, (ty, tacopt)), []
     in
-    let op_to_ident x = mk_ident (compile_op 0 x.idText x.idRange, x.idRange) in
+    let op_to_ident x = mk_ident (compile_op 0 (text_of_id x) (range_of_id x), (range_of_id x)) in
     match p.pat with
     | PatOp x ->
         mklet (op_to_ident x) tun None
@@ -958,7 +958,8 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
     | Const c ->
         mk (Tm_constant c), noaqs
 
-    | Op({idText = "=!="; idRange=r}, args) ->
+    | Op(id, args) when text_of_id id = "=!=" ->
+      let r = range_of_id id in
       let e = mk_term (Op(Ident.mk_ident ("==", r), args)) top.range top.level in
       desugar_term_aq env (mk_term(Op(Ident.mk_ident ("~",r), [e])) top.range top.level)
 
@@ -970,7 +971,8 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
        * on the presence of a Paren node in the AST. *)
       let rec flatten t = match t.tm with
         // * is left-associative
-        | Op({idText = "*"}, [t1;t2]) when
+        | Op(id, [t1;t2]) when
+           text_of_id id = "*" &&
            op_as_term env 2 top.range op_star |> Option.isNone ->
           flatten t1 @ [ t2 ]
         | _ -> [t]
@@ -1008,31 +1010,38 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
               op, noaqs
       end
 
-    | Construct (n, [(a, _)]) when n.str = "SMTPat" ->
+    | Construct (n, [(a, _)]) when (string_of_lid n) = "SMTPat" ->
         desugar_term_maybe_top top_level env
           ({top with tm = App ({top with tm = Var (smt_pat_lid top.range)}, a, Nothing)})
 
-    | Construct (n, [(a, _)]) when n.str = "SMTPatT" ->
+    | Construct (n, [(a, _)]) when (string_of_lid n) = "SMTPatT" ->
         Errors.log_issue top.range (Errors.Warning_SMTPatTDeprecated, "SMTPatT is deprecated; please just use SMTPat");
         desugar_term_maybe_top top_level env
           ({top with tm = App ({top with tm = Var (smt_pat_lid top.range) }, a, Nothing)})
 
-    | Construct (n, [(a, _)]) when n.str = "SMTPatOr" ->
+    | Construct (n, [(a, _)]) when (string_of_lid n) = "SMTPatOr" ->
         desugar_term_maybe_top top_level env
           ({top with tm = App ({top with tm = Var (smt_pat_or_lid top.range)}, a, Nothing)})
 
-    | Name {str="Type0"}  -> mk (Tm_type U_zero), noaqs
-    | Name {str="Type"}   -> mk (Tm_type U_unknown), noaqs
-    | Construct ({str="Type"}, [t, UnivApp]) -> mk (Tm_type (desugar_universe t)), noaqs
-    | Name {str="Effect"} -> mk (Tm_constant Const_effect), noaqs
-    | Name {str="True"}   -> S.fvar (Ident.set_lid_range Const.true_lid top.range) delta_constant None, //NS delta: wrong, but maybe intentionally so
+    | Name lid when string_of_lid lid = "Type0"  ->
+        mk (Tm_type U_zero), noaqs
+    | Name lid when string_of_lid lid = "Type"   ->
+        mk (Tm_type U_unknown), noaqs
+    | Construct (lid, [t, UnivApp]) when string_of_lid lid = "Type" ->
+        mk (Tm_type (desugar_universe t)), noaqs
+    | Name lid when string_of_lid lid = "Effect" ->
+        mk (Tm_constant Const_effect), noaqs
+    | Name lid when string_of_lid lid = "True"   ->
+        S.fvar (Ident.set_lid_range Const.true_lid top.range) delta_constant None, //NS delta: wrong, but maybe intentionally so
                              noaqs
-    | Name {str="False"}   -> S.fvar (Ident.set_lid_range Const.false_lid top.range) delta_constant None, //NS delta: wrong, but maybe intentionally so
+    | Name lid when string_of_lid lid = "False"   ->
+        S.fvar (Ident.set_lid_range Const.false_lid top.range) delta_constant None, //NS delta: wrong, but maybe intentionally so
                               noaqs
-    | Projector (eff_name, {idText = txt})
-      when is_special_effect_combinator txt && Env.is_effect_name env eff_name ->
+    | Projector (eff_name, id)
+      when is_special_effect_combinator (text_of_id id) && Env.is_effect_name env eff_name ->
       (* TODO : would it be possible to normalize the effect name at that point so that *)
       (* we get back the original effect definition instead of an effect abbreviation *)
+      let txt = text_of_id id in
       begin match try_lookup_effect_defn env eff_name with
         | Some ed ->
           let lid = U.dm4f_lid ed txt in
@@ -1040,7 +1049,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
         | None ->
           failwith (BU.format2 "Member %s of effect %s is not accessible \
                                 (using an effect abbreviation instead of the original effect ?)"
-                               (Ident.text_of_lid eff_name)
+                               (Ident.string_of_lid eff_name)
                                txt)
       end
 
@@ -1061,13 +1070,13 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
       | Some (resolve, new_name) ->
         desugar_name mk setpos env resolve (mk_field_projector_name_from_ident new_name i), noaqs
       | _ ->
-        raise_error (Errors.Fatal_EffectNotFound, (BU.format1 "Data constructor or effect %s not found" l.str)) top.range
+        raise_error (Errors.Fatal_EffectNotFound, (BU.format1 "Data constructor or effect %s not found" (string_of_lid l))) top.range
       end
 
     | Discrim lid ->
       begin match Env.try_lookup_datacon env lid with
       | None ->
-        raise_error (Errors.Fatal_DataContructorNotFound, (BU.format1 "Data constructor %s not found" lid.str)) top.range
+        raise_error (Errors.Fatal_DataContructorNotFound, (BU.format1 "Data constructor %s not found" (string_of_lid lid))) top.range
       | _ ->
         let lid' = U.mk_discriminator lid in
         desugar_name mk setpos env true lid', noaqs
@@ -1091,8 +1100,8 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
         | None ->
             let err =
               match Env.try_lookup_effect_name env l with
-              | None -> (Errors.Fatal_ConstructorNotFound, ("Constructor " ^ l.str ^ " not found"))
-              | Some _ -> (Errors.Fatal_UnexpectedEffect, ("Effect " ^ l.str ^ " used at an unexpected position"))
+              | None -> (Errors.Fatal_ConstructorNotFound, ("Constructor " ^ (string_of_lid l) ^ " not found"))
+              | Some _ -> (Errors.Fatal_UnexpectedEffect, ("Effect " ^ (string_of_lid l) ^ " used at an unexpected position"))
             in
             raise_error err top.range
         end
@@ -1173,7 +1182,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
       | Some id ->
           raise_error (Errors.Fatal_NonLinearPatternNotPermitted,
                        BU.format1
-                         "Non-linear patterns are not permitted: `%s` appears more than once in this function definition." id.idText)
+                         "Non-linear patterns are not permitted: `%s` appears more than once in this function definition." (text_of_id id))
                       (range_of_id id)
       end;
 
@@ -1266,10 +1275,10 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
       aux [] [] top
 
     | Bind(x, t1, t2) ->
-      let xpat = AST.mk_pattern (AST.PatVar(x, None)) x.idRange in
+      let xpat = AST.mk_pattern (AST.PatVar(x, None)) (range_of_id x) in
       let k = AST.mk_term (Abs([xpat], t2)) t2.range t2.level in
-      let bind_lid = Ident.lid_of_path ["bind"] x.idRange in
-      let bind = AST.mk_term (AST.Var bind_lid) x.idRange AST.Expr in
+      let bind_lid = Ident.lid_of_path ["bind"] (range_of_id x) in
+      let bind = AST.mk_term (AST.Var bind_lid) (range_of_id x) AST.Expr in
       desugar_term_aq env (AST.mkExplicitApp bind [t1; k] top.range)
 
     | Seq(t1, t2) ->
@@ -1315,7 +1324,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
                 let dummy_ref = BU.mk_ref true in
                 env, Inl xx, S.mk_binder xx::rec_bindings, used_marker::used_markers
               | Inr l ->
-                let env, used_marker = push_top_level_rec_binding env l.ident S.delta_equational in
+                let env, used_marker = push_top_level_rec_binding env (ident_of_lid l) S.delta_equational in
                 env, Inr l, rec_bindings, used_marker::used_markers in
             env, (lbname::fnames), rec_bindings, used_markers) (env, [], [], []) funs
         in
@@ -1392,7 +1401,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
             if not !used_marker then
               let nm, gl, rng =
                 match f with
-                | Inl x -> (string_of_ident x, "Local", range_of_id x)
+                | Inl x -> (text_of_id x, "Local", range_of_id x)
                 | Inr l -> (string_of_lid l, "Global", range_of_lid l)
               in
               Errors.log_issue rng (Errors.Warning_UnusedLetRec,
@@ -1489,16 +1498,16 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
     | Record(eopt, fields) ->
       let record = check_fields env fields top.range in
       (* Namespace qualifier given by the user, needed to requalify fields in 'recterm' (MUST NOT be already resolved, since it will be re-resolved afterwards and thus may undergo rewriting e.g. by module abbrev *)
-      let user_ns = let (f, _) = List.hd fields in f.ns in
+      let user_ns = let (f, _) = List.hd fields in ns_of_lid f in
       let get_field xopt f =
-        let found = fields |> BU.find_opt (fun (g, _) -> f.idText = g.ident.idText) in
+        let found = fields |> BU.find_opt (fun (g, _) -> (text_of_id f) = (text_of_id (ident_of_lid g))) in
         let fn = lid_of_ids (user_ns @ [f]) in
         match found with
           | Some (_, e) -> (fn, e)
           | None ->
             match xopt with
               | None ->
-                raise_error (Errors.Fatal_MissingFieldInRecord, (BU.format2 "Field %s of record type %s is missing" f.idText record.typename.str)) top.range
+                raise_error (Errors.Fatal_MissingFieldInRecord, (BU.format2 "Field %s of record type %s is missing" (text_of_id f) (string_of_lid record.typename))) top.range
               | Some x ->
                 (fn, mk_term (Project(x, fn)) x.range x.level) in
 
@@ -1511,9 +1520,9 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
 
         | Some e ->
           let x = FStar.Ident.gen e.range in
-          let xterm = mk_term (Var (lid_of_ids [x])) x.idRange Expr in
+          let xterm = mk_term (Var (lid_of_ids [x])) (range_of_id x) Expr in
           let record = Record(None, record.fields |> List.map (fun (f, _) -> get_field (Some xterm) f)) in
-          Let(NoLetQualifier, [None, (mk_pattern (PatVar (x, None)) x.idRange, e)], mk_term record top.range top.level) in
+          Let(NoLetQualifier, [None, (mk_pattern (PatVar (x, None)) (range_of_id x), e)], mk_term record top.range top.level) in
 
       let recterm = mk_term recterm top.range top.level in
       let e, s = desugar_term_aq env recterm in
@@ -1528,8 +1537,8 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
     | Project(e, f) ->
       let constrname, is_rec = fail_or env  (try_lookup_dc_by_field_name env) f in
       let e, s = desugar_term_aq env e in
-      let projname = mk_field_projector_name_from_ident constrname f.ident in
-      let qual = if is_rec then Some (Record_projector (constrname, f.ident)) else None in
+      let projname = mk_field_projector_name_from_ident constrname (ident_of_lid f) in
+      let qual = if is_rec then Some (Record_projector (constrname, ident_of_lid f)) else None in
       mk <| Tm_app(S.fvar (Ident.set_lid_range projname (range_of_lid f)) (Delta_equational_at_level 1) qual, //NS delta: ok, projector
                    [as_arg e]), s
 
@@ -1666,7 +1675,7 @@ and desugar_comp r (allow_type_promotion:bool) env t =
       | _ -> false
     in
     let is_app head (t, _) = match (unparen t).tm with
-      | App({tm=Var d}, _, _) -> d.ident.idText = head
+      | App({tm=Var d}, _, _) -> (text_of_id (ident_of_lid d)) = head
       | _ -> false
     in
     let is_smt_pat (t,_) =
@@ -1674,14 +1683,14 @@ and desugar_comp r (allow_type_promotion:bool) env t =
       // TODO: remove this first match once we fully migrate
       | Construct (cons, [{tm=Construct (smtpat, _)}, _; _]) ->
         Ident.lid_equals cons C.cons_lid &&
-        BU.for_some (fun s -> smtpat.str = s)
+        BU.for_some (fun s -> (string_of_lid smtpat) = s)
           (* the smt pattern does not seem to be disambiguated yet at this point *)
           ["SMTPat"; "SMTPatT"; "SMTPatOr"]
           (* [C.smtpat_lid ; C.smtpatT_lid ; C.smtpatOr_lid] *)
 
       | Construct (cons, [{tm=Var smtpat}, _; _]) ->
         Ident.lid_equals cons C.cons_lid &&
-        BU.for_some (fun s -> smtpat.str = s)
+        BU.for_some (fun s -> (string_of_lid smtpat) = s)
           (* the smt pattern does not seem to be disambiguated yet at this point *)
           ["smt_pat" ; "smt_pat_or"]
           (* [C.smtpat_lid ; C.smtpatT_lid ; C.smtpatOr_lid] *)
@@ -1691,7 +1700,7 @@ and desugar_comp r (allow_type_promotion:bool) env t =
     let pre_process_comp_typ (t:AST.term) =
       let head, args = head_and_args t in
       match head.tm with
-      | Name lemma when (lemma.ident.idText = "Lemma") ->
+      | Name lemma when ((text_of_id (ident_of_lid lemma)) = "Lemma") ->
         (* need to add the unit result type and the empty smt_pat list, if n *)
         let unit_tm = mk_term (Name C.unit_lid) t.range Type_level, Nothing in
         let nil_pat = mk_term (Name C.nil_lid) t.range Expr, Nothing in
@@ -1791,19 +1800,19 @@ and desugar_comp r (allow_type_promotion:bool) env t =
 
       (* we're right at the beginning of Prims, when Tot isn't yet fully defined *)
       | Name l when (lid_equals (Env.current_module env) C.prims_lid
-                          && l.ident.idText = "Tot") ->
+                          && (text_of_id (ident_of_lid l)) = "Tot") ->
         (* we have an explicit effect annotation ... no need to add anything *)
         (Ident.set_lid_range Const.effect_Tot_lid head.range,  []), args
 
       (* we're right at the beginning of Prims, when GTot isn't yet fully defined *)
       | Name l when (lid_equals (Env.current_module env) C.prims_lid
-                          && l.ident.idText = "GTot") ->
+                          && (text_of_id (ident_of_lid l)) = "GTot") ->
         (* we have an explicit effect annotation ... no need to add anything *)
         (Ident.set_lid_range Const.effect_GTot_lid head.range, []), args
 
-      | Name l when (l.ident.idText="Type"
-                      || l.ident.idText="Type0"
-                      || l.ident.idText="Effect") ->
+      | Name l when ((text_of_id (ident_of_lid l))="Type"
+                      || (text_of_id (ident_of_lid l))="Type0"
+                      || (text_of_id (ident_of_lid l))="Effect") ->
         (* the default effect for Type is always Tot *)
         (Ident.set_lid_range Const.effect_Tot_lid head.range, []), [t, Nothing]
 
@@ -1906,7 +1915,7 @@ and desugar_formula env (f:term) : S.term =
         let names =
           names |> List.map
           (fun i ->
-          { fail_or2 (try_lookup_id env) i with pos=i.idRange })
+          { fail_or2 (try_lookup_id env) i with pos=(range_of_id i) })
         in
         let pats =
           pats |> List.map
@@ -1967,7 +1976,7 @@ and desugar_formula env (f:term) : S.term =
 and desugar_binder env b : option<ident> * S.term = match b.b with
   | TAnnotated(x, t)
   | Annotated(x, t) -> Some x, desugar_typ env t
-  | TVariable x     -> Some x, mk (Tm_type U_unknown) None x.idRange
+  | TVariable x     -> Some x, mk (Tm_type U_unknown) None (range_of_id x)
   | NoName t        -> None, desugar_typ env t
   | Variable x      -> Some x, tun
 
@@ -1998,7 +2007,7 @@ let typars_of_binders env bs =
 let desugar_attributes (env:env_t) (cattributes:list<term>) : list<cflag> =
     let desugar_attribute t =
         match (unparen t).tm with
-            | Var ({str="cps"}) -> CPS
+            | Var lid when string_of_lid lid = "cps" -> CPS
             | _ -> raise_error (Errors.Fatal_UnknownAttribute, "Unknown attribute " ^ term_to_string t) t.range
     in List.map desugar_attribute cattributes
 
@@ -2043,7 +2052,7 @@ let mk_indexed_projector_names iquals fvq env lid (fields:list<S.binder>) =
         let only_decl =
             lid_equals C.prims_lid  (Env.current_module env)
             || fvq<>Data_ctor
-            || Options.dont_gen_projectors (Env.current_module env).str
+            || Options.dont_gen_projectors (string_of_lid (Env.current_module env))
         in
         let no_decl = Syntax.is_type x.sort in
         let quals q =
@@ -2153,9 +2162,9 @@ let rec desugar_tycon env (d: AST.decl) quals tcs : (env_t * sigelts) =
     | TyconVariant(id, _, _, _) -> id in
   let binder_to_term b = match b.b with
     | Annotated (x, _)
-    | Variable x -> mk_term (Var (lid_of_ids [x])) x.idRange Expr
+    | Variable x -> mk_term (Var (lid_of_ids [x])) (range_of_id x) Expr
     | TAnnotated(a, _)
-    | TVariable a -> mk_term (Tvar a) a.idRange Type_level
+    | TVariable a -> mk_term (Tvar a) (range_of_id a) Type_level
     | NoName t -> t in
   let tot = mk_term (Name (C.effect_Tot_lid)) rng Expr in
   let with_constructor_effect t = mk_term (App(tot, t, Nothing)) t.range t.level in
@@ -2167,17 +2176,17 @@ let rec desugar_tycon env (d: AST.decl) quals tcs : (env_t * sigelts) =
       t binders in
   let tycon_record_as_variant = function
     | TyconRecord(id, parms, kopt, fields) ->
-      let constrName = mk_ident("Mk" ^ id.idText, id.idRange) in
-      let mfields = List.map (fun (x,t) -> mk_binder (Annotated(x,t)) x.idRange Expr None) fields in
-      let result = apply_binders (mk_term (Var (lid_of_ids [id])) id.idRange Type_level) parms in
-      let constrTyp = mk_term (Product(mfields, with_constructor_effect result)) id.idRange Type_level in
-      //let _ = BU.print_string (BU.format2 "Translated record %s to constructor %s\n" (id.idText) (term_to_string constrTyp)) in
+      let constrName = mk_ident("Mk" ^ (text_of_id id), (range_of_id id)) in
+      let mfields = List.map (fun (x,t) -> mk_binder (Annotated(x,t)) (range_of_id x) Expr None) fields in
+      let result = apply_binders (mk_term (Var (lid_of_ids [id])) (range_of_id id) Type_level) parms in
+      let constrTyp = mk_term (Product(mfields, with_constructor_effect result)) (range_of_id id) Type_level in
+      //let _ = BU.print_string (BU.format2 "Translated record %s to constructor %s\n" ((text_of_id id)) (term_to_string constrTyp)) in
 
       let names = id :: binder_idents parms in
       List.iter (fun (f, _) ->
           if BU.for_some (fun i -> ident_equals f i) names then
               raise_error (Errors.Error_FieldShadow,
-                              BU.format1 "Field %s shadows the record's name or a parameter of it, please rename it" (string_of_ident f)) f.idRange)
+                              BU.format1 "Field %s shadows the record's name or a parameter of it, please rename it" (text_of_id f)) (range_of_id f))
           fields;
 
       TyconVariant(id, parms, kopt, [(constrName, Some constrTyp, false)]), fields |> List.map fst
@@ -2188,7 +2197,7 @@ let rec desugar_tycon env (d: AST.decl) quals tcs : (env_t * sigelts) =
       let k = match kopt with
         | None -> U.ktype
         | Some k -> desugar_term _env' k in
-      let tconstr = apply_binders (mk_term (Var (lid_of_ids [id])) id.idRange Type_level) binders in
+      let tconstr = apply_binders (mk_term (Var (lid_of_ids [id])) (range_of_id id) Type_level) binders in
       let qlid = qualify _env id in
       let typars = Subst.close_binders typars in
       let k = Subst.close typars k in
@@ -2210,7 +2219,7 @@ let rec desugar_tycon env (d: AST.decl) quals tcs : (env_t * sigelts) =
   match tcs with
     | [TyconAbstract(id, bs, kopt)] ->
         let kopt = match kopt with
-            | None -> Some (tm_type_z id.idRange)
+            | None -> Some (tm_type_z (range_of_id id))
             | _ -> kopt in
         let tc = TyconAbstract(id, bs, kopt) in
         let _, _, se, _ = desugar_abstract_tc quals env [] tc in
@@ -2231,7 +2240,7 @@ let rec desugar_tycon env (d: AST.decl) quals tcs : (env_t * sigelts) =
                        sigquals = quals }
            | _ -> failwith "Impossible" in
         let env = push_sigelt env se in
-        (* let _ = pr "Pushed %s\n" (text_of_lid (qualify env (tycon_id tc))) in *)
+        (* let _ = pr "Pushed %s\n" (string_of_lid (qualify env (tycon_id tc))) in *)
         env, [se]
 
     | [TyconAbbrev(id, binders, kopt, t)] ->
@@ -2401,7 +2410,7 @@ let desugar_binders env binders =
 
 let push_reflect_effect env quals (effect_name:Ident.lid) range =
     if quals |> BU.for_some (function S.Reflectable _ -> true | _ -> false)
-    then let monad_env = Env.enter_monad_scope env effect_name.ident in
+    then let monad_env = Env.enter_monad_scope env (ident_of_lid effect_name) in
          let reflect_lid = Ident.id_of_text "reflect" |> Env.qualify monad_env in
          let quals = [S.Assumption; S.Reflectable effect_name] in
          let refl_decl = { sigel = S.Sig_declare_typ(reflect_lid, [], S.tun);
@@ -2636,7 +2645,7 @@ let rec desugar_effect env d (quals: qualifiers) (is_layered:bool) eff_name eff_
 
     let env = push_sigelt env0 se in
     let env = actions |> List.fold_left (fun env a ->
-        //printfn "Pushing action %s\n" a.action_name.str;
+        //printfn "Pushing action %s\n" (string_of_lid a.action_name);
         push_sigelt env (U.action_as_lb mname a a.action_defn.pos)) env
     in
     let env = push_reflect_effect env qualifiers mname d.drange in
@@ -3257,7 +3266,7 @@ let desugar_partial_modul curmod (env:env_t) (m:AST.modul) : env_t * Syntax.modu
 let desugar_modul env (m:AST.modul) : env_t * Syntax.modul =
   let env, modul, pop_when_done = desugar_modul_common None env m in
   let env, modul = Env.finish_module_or_interface env modul in
-  if Options.dump_module modul.name.str
+  if Options.dump_module (string_of_lid modul.name)
   then BU.print1 "Module after desugaring:\n%s\n" (Print.modul_to_string modul);
   (if pop_when_done then export_interface modul.name env else env), modul
 

--- a/src/typechecker/FStar.TypeChecker.Cfg.fs
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fs
@@ -233,7 +233,7 @@ let empty_prim_steps () : prim_step_set =
     BU.psmap_empty ()
 
 let add_step (s : primitive_step) (ss : prim_step_set) =
-    BU.psmap_add ss (I.text_of_lid s.name) s
+    BU.psmap_add ss (I.string_of_lid s.name) s
 
 let merge_steps (s1 : prim_step_set) (s2 : prim_step_set) : prim_step_set =
     BU.psmap_merge s1 s2
@@ -266,10 +266,10 @@ let cfg_to_string cfg =
 let cfg_env cfg = cfg.tcenv
 
 let find_prim_step cfg fv =
-    BU.psmap_try_find cfg.primitive_steps (I.text_of_lid fv.fv_name.v)
+    BU.psmap_try_find cfg.primitive_steps (I.string_of_lid fv.fv_name.v)
 
 let is_prim_step cfg fv =
-    BU.is_some (BU.psmap_try_find cfg.primitive_steps (I.text_of_lid fv.fv_name.v))
+    BU.is_some (BU.psmap_try_find cfg.primitive_steps (I.string_of_lid fv.fv_name.v))
 
 let log cfg f =
     if cfg.debug.gen then f () else ()
@@ -309,7 +309,7 @@ let built_in_primitive_steps : prim_step_set =
         let a = U.unlazy_emb a in
         match (SS.compress hd).n, args with
         | Tm_fvar fv1, [(arg, _)]
-            when BU.ends_with (Ident.text_of_lid fv1.fv_name.v) "int_to_t" ->
+            when BU.ends_with (Ident.string_of_lid fv1.fv_name.v) "int_to_t" ->
             let arg = U.unlazy_emb arg in
             begin match (SS.compress arg).n with
             | Tm_constant (FC.Const_int (i, None)) ->

--- a/src/typechecker/FStar.TypeChecker.Common.fs
+++ b/src/typechecker/FStar.TypeChecker.Common.fs
@@ -209,7 +209,7 @@ let check_uvar_ctx_invariant (reason:string) (r:range) (should_check:bool) (g:ga
     let print_gamma gamma =
         (gamma |> List.map (function
           | Binding_var x -> "Binding_var " ^ (Print.bv_to_string x)
-          | Binding_univ u -> "Binding_univ " ^ u.idText
+          | Binding_univ u -> "Binding_univ " ^ (text_of_id u)
           | Binding_lid (l, _) -> "Binding_lid " ^ (Ident.string_of_lid l)))//  @
     // (env.gamma_sig |> List.map (fun (ls, _) ->
     //     "Binding_sig " ^ (ls |> List.map Ident.string_of_lid |> String.concat ", ")

--- a/src/typechecker/FStar.TypeChecker.DMFF.fs
+++ b/src/typechecker/FStar.TypeChecker.DMFF.fs
@@ -924,7 +924,7 @@ and infer (env: env) (e: term): nm * term * term =
       let env, u_binders = List.fold_left (fun (env, acc) (bv, qual) ->
         let c = bv.sort in
         if is_C c then
-          let xw = S.gen_bv (bv.ppname.idText ^ "__w") None (star_type' env c) in
+          let xw = S.gen_bv ((text_of_id bv.ppname) ^ "__w") None (star_type' env c) in
           let x = { bv with sort = trans_F_ env c (S.bv_to_name xw) } in
           let env = { env with subst = NT (bv, S.bv_to_name xw) :: env.subst } in
           env, S.mk_binder x :: S.mk_binder xw :: acc
@@ -1298,10 +1298,10 @@ and trans_F_ (env: env_) (c: typ) (wp: term): term =
       let bvs, binders = List.split (List.map (fun (bv, q) ->
         let h = bv.sort in
         if is_C h then
-          let w' = S.gen_bv (bv.ppname.idText ^ "__w'") None (star_type' env h) in
+          let w' = S.gen_bv ((text_of_id bv.ppname) ^ "__w'") None (star_type' env h) in
           w', [ w', q; S.null_bv (trans_F_ env h (S.bv_to_name w')), q ]
         else
-          let x = S.gen_bv (bv.ppname.idText ^ "__x") None (star_type' env h) in
+          let x = S.gen_bv ((text_of_id bv.ppname) ^ "__x") None (star_type' env h) in
           x, [ x, q ]
       ) binders_orig) in
       let binders = List.flatten binders in
@@ -1474,7 +1474,7 @@ let cps_and_elaborate (env:FStar.TypeChecker.Env.env) (ed:S.eff_decl)
               (Print.term_to_string body)
               (match what' with
                | None -> "None"
-               | Some rc -> FStar.Ident.text_of_lid rc.residual_effect)
+               | Some rc -> FStar.Ident.string_of_lid rc.residual_effect)
           in raise_error (Errors.Fatal_WrongBodyTypeForReturnWP, error_msg)
         in
         begin match what' with
@@ -1574,7 +1574,7 @@ let cps_and_elaborate (env:FStar.TypeChecker.Env.env) (ed:S.eff_decl)
     let dmff_env, action_t, action_wp, action_elab =
       elaborate_and_star dmff_env' action_params (action.action_univs, action.action_defn)
     in
-    let name = action.action_name.ident.idText in
+    let name = text_of_id (ident_of_lid action.action_name) in
     let action_typ_with_wp = trans_F dmff_env' action_t action_wp in
     let action_params = SS.close_binders action_params in
     let action_elab = SS.close action_params action_elab in

--- a/src/typechecker/FStar.TypeChecker.Err.fs
+++ b/src/typechecker/FStar.TypeChecker.Err.fs
@@ -179,7 +179,7 @@ let totality_check  = "This term may not terminate"
 
 let unexpected_signature_for_monad env m k =
   (Errors.Fatal_UnexpectedSignatureForMonad, (format2 "Unexpected signature for monad \"%s\". Expected a signature of the form (a:Type => WP a => Effect); got %s"
-    m.str (N.term_to_string env k)))
+    (string_of_lid m) (N.term_to_string env k)))
 
 let expected_a_term_of_type_t_got_a_function env msg t e =
   (Errors.Fatal_ExpectTermGotFunction, (format3 "Expected a term of type \"%s\"; got a function \"%s\" (%s)"

--- a/src/typechecker/FStar.TypeChecker.NBE.fs
+++ b/src/typechecker/FStar.TypeChecker.NBE.fs
@@ -171,10 +171,10 @@ let zeta_false (cfg:config) =
     else cfg
 let cache_add (cfg:config) (fv:fv) (v:t) =
   let lid = fv.fv_name.v in
-  BU.smap_add cfg.fv_cache lid.str v
+  BU.smap_add cfg.fv_cache (string_of_lid lid) v
 let try_in_cache (cfg:config) (fv:fv) : option<t> =
   let lid = fv.fv_name.v in
-  BU.smap_try_find cfg.fv_cache lid.str
+  BU.smap_try_find cfg.fv_cache (string_of_lid lid)
 let debug cfg f =
   log_nbe cfg.core_cfg f
 
@@ -1056,12 +1056,12 @@ and translate_monadic_lift (msrc, mtgt, ty) cfg bs e : t =
     match Env.monad_leq cfg.core_cfg.tcenv msrc mtgt with
     | None ->
       failwith (BU.format2 "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
-                            (Ident.text_of_lid msrc)
-                            (Ident.text_of_lid mtgt))
+                            (Ident.string_of_lid msrc)
+                            (Ident.string_of_lid mtgt))
     | Some {mlift={mlift_term=None}} ->
       failwith (BU.format2 "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
-                            (Ident.text_of_lid msrc)
-                            (Ident.text_of_lid mtgt))
+                            (Ident.string_of_lid msrc)
+                            (Ident.string_of_lid mtgt))
 
     | Some {mlift={mlift_term=Some lift}} ->
       (* We don't have any reasonable wp to provide so we just pass unknown *)

--- a/src/typechecker/FStar.TypeChecker.NBETerm.fs
+++ b/src/typechecker/FStar.TypeChecker.NBETerm.fs
@@ -699,7 +699,7 @@ let arg_as_list   (e:embedding<'a>) (a:arg) = fst a |> unembed (e_list e) bogus_
 let arg_as_bounded_int ((a, _) : arg) : option<(fv * Z.t)> =
     match a with
     | FV (fv1, [], [(Constant (Int i), _)])
-      when BU.ends_with (Ident.text_of_lid fv1.fv_name.v)
+      when BU.ends_with (Ident.string_of_lid fv1.fv_name.v)
                         "int_to_t" ->
       Some (fv1, i)
     | _ -> None

--- a/src/typechecker/FStar.TypeChecker.Normalize.fs
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fs
@@ -1858,12 +1858,12 @@ and reify_lift cfg e msrc mtgt t : term =
     match Env.monad_leq env msrc mtgt with
     | None ->
       failwith (BU.format2 "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
-                            (Ident.text_of_lid msrc)
-                            (Ident.text_of_lid mtgt))
+                            (Ident.string_of_lid msrc)
+                            (Ident.string_of_lid mtgt))
     | Some {mlift={mlift_term=None}} ->
       failwith (BU.format2 "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
-                            (Ident.text_of_lid msrc)
-                            (Ident.text_of_lid mtgt))
+                            (Ident.string_of_lid msrc)
+                            (Ident.string_of_lid mtgt))
     | Some {mlift={mlift_term=Some lift}} ->
       (*
        * AR: we need to apply the lift combinator to `e`

--- a/src/typechecker/FStar.TypeChecker.Rel.fs
+++ b/src/typechecker/FStar.TypeChecker.Rel.fs
@@ -911,7 +911,7 @@ let fv_delta_depth env fv =
     let d = Env.delta_depth_of_fv env fv in
     match d with
     | Delta_abstract d ->
-      if env.curmodule.str = fv.fv_name.v.nsstr && not env.is_iface  //AR: TODO: this is to prevent unfolding of abstract symbols in the extracted interface
+      if string_of_lid env.curmodule = nsstr fv.fv_name.v && not env.is_iface  //AR: TODO: this is to prevent unfolding of abstract symbols in the extracted interface
                                                                      //    a better way would be create new fvs with appripriate delta_depth at extraction time
       then d //we're in the defining module
       else delta_constant
@@ -1314,7 +1314,7 @@ let rec really_solve_universe_eq pid_orig wl u1 u2 =
                                         (Print.univ_to_string u2))
 
         | U_name x, U_name y ->
-          if x.idText = y.idText
+          if (text_of_id x) = (text_of_id y)
           then USolved wl
           else ufailed_simple "Incompatible universes"
 
@@ -3285,7 +3285,7 @@ and solve_c (env:Env.env) (problem:problem<comp>) (wl:worklist) : solution =
                  else begin
                     let c1 = Env.unfold_effect_abbrev env c1 in
                     let c2 = Env.unfold_effect_abbrev env c2 in
-                    if debug env <| Options.Other "Rel" then BU.print2 "solve_c for %s and %s\n" (c1.effect_name.str) (c2.effect_name.str);
+                    if debug env <| Options.Other "Rel" then BU.print2 "solve_c for %s and %s\n" (string_of_lid c1.effect_name) (string_of_lid c2.effect_name);
                     match Env.monad_leq env c1.effect_name c2.effect_name with
                     | None ->
                        giveup env (mklstr (fun () -> BU.format2 "incompatible monad ordering: %s </: %s"

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fs
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fs
@@ -134,13 +134,13 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
   //we don't support effect binders in layered effects yet
   if List.length ed.univs <> 0 || List.length ed.binders <> 0 then
     raise_error
-      (Errors.Fatal_UnexpectedEffect, "Binders are not supported for layered effects (" ^ ed.mname.str ^")")
+      (Errors.Fatal_UnexpectedEffect, "Binders are not supported for layered effects (" ^ (string_of_lid ed.mname) ^")")
       (range_of_lid ed.mname);
 
   let log_combinator s (us, t, ty) =
     if Env.debug env0 <| Options.Other "LayeredEffects" then
       BU.print4 "Typechecked %s:%s = %s:%s\n"
-        ed.mname.str s
+        (string_of_lid ed.mname) s
         (Print.tscheme_to_string (us, t)) (Print.tscheme_to_string (us, ty)) in
 
   //helper function to get (a:Type ?u), returns the binder and ?u
@@ -158,7 +158,7 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
    *   - Record k in the effect declaration (along with the combinator)
    *)
 
-  let check_and_gen = check_and_gen env0 ed.mname.str in
+  let check_and_gen = check_and_gen env0 (string_of_lid ed.mname) in
 
 
   (*
@@ -248,7 +248,7 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
 
   let not_an_arrow_error comb n t r =
     raise_error (Errors.Fatal_UnexpectedEffect,
-      BU.format5 "Type of %s:%s is not an arrow with >= %s binders (%s::%s)" ed.mname.str comb
+      BU.format5 "Type of %s:%s is not an arrow with >= %s binders (%s::%s)" (string_of_lid ed.mname) comb
         (string_of_int n) (Print.tag_of_term t) (Print.term_to_string t)
     ) r in
 
@@ -335,7 +335,7 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
 
     //the computation type of the bind combinator can be a PURE type
     let pure_wp_uvar, g_pure_wp_uvar = pure_wp_uvar (Env.push_binders env bs) repr
-      (BU.format1 "implicit for pure_wp in checking bind for %s" ed.mname.str)
+      (BU.format1 "implicit for pure_wp in checking bind for %s" (string_of_lid ed.mname))
       r in
 
     let k = U.arrow (bs@[f; g]) (S.mk_Comp ({
@@ -391,7 +391,7 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
     let ret_t, guard_ret_t = fresh_repr r (Env.push_binders env bs) u (fst a |> S.bv_to_name) in
 
     let pure_wp_uvar, guard_wp = pure_wp_uvar (Env.push_binders env bs) ret_t 
-      (BU.format1 "implicit for pure_wp in checking stronger for %s" ed.mname.str)
+      (BU.format1 "implicit for pure_wp in checking stronger for %s" (string_of_lid ed.mname))
       r in
     let c = S.mk_Comp ({
       comp_univs = [ Env.new_u_univ () ];
@@ -573,7 +573,7 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
     if List.length act.action_params <> 0
     then raise_error (Errors.Fatal_MalformedActionDeclaration,
       BU.format3 "Action %s:%s has non-empty action params (%s)"
-        ed.mname.str act.action_name.str (Print.binders_to_string "; " act.action_params)) r;
+        (string_of_lid ed.mname) (string_of_lid act.action_name) (Print.binders_to_string "; " act.action_params)) r;
 
     let env, act =
       let usubst, us = SS.univ_var_opening act.action_univs in
@@ -617,13 +617,13 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
         let env = Env.push_binders env bs in
         let t, u = U.type_u () in
         let reason = BU.format2 "implicit for return type of action %s:%s"
-          ed.mname.str act.action_name.str in
+          (string_of_lid ed.mname) (string_of_lid act.action_name) in
         let a_tm, _, g_tm = TcUtil.new_implicit_var reason r env t in
         let repr, g = fresh_repr r env u a_tm in
         U.arrow bs (S.mk_Total' repr (Env.new_u_univ () |> Some)), Env.conj_guard g g_tm
       | _ -> raise_error (Errors.Fatal_ActionMustHaveFunctionType,
         BU.format3 "Unexpected non-function type for action %s:%s (%s)"
-          ed.mname.str act.action_name.str (Print.term_to_string act_typ)) r in
+          (string_of_lid ed.mname) (string_of_lid act.action_name) (Print.term_to_string act_typ)) r in
 
     if Env.debug env <| Options.Other "LayeredEffects" then
       BU.print1 "Expected action type: %s\n" (Print.term_to_string k);
@@ -637,7 +637,7 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
     let act_typ =
       let err_msg t = BU.format3
         "Unexpected (k-)type of action %s:%s, expected bs -> repr<u> i_1 ... i_n, found: %s"
-        ed.mname.str act.action_name.str (Print.term_to_string t) in
+        (string_of_lid ed.mname) (string_of_lid act.action_name) (Print.term_to_string t) in
       let repr_args t : universes * term * args =
         match (SS.compress t).n with
         | Tm_app (head, a::is) ->
@@ -679,7 +679,7 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
           action_typ = SS.close_univ_vars act.action_univs act_typ }
         else raise_error (Errors.Fatal_UnexpectedNumberOfUniverse,
                (BU.format4 "Expected and generalized universes in the declaration for %s:%s are different, input: %s, but after gen: %s"
-                 ed.mname.str act.action_name.str (Print.univ_names_to_string us) (Print.univ_names_to_string act.action_univs)))
+                 (string_of_lid ed.mname) (string_of_lid act.action_name) (Print.univ_names_to_string us) (Print.univ_names_to_string act.action_univs)))
              r in
 
     act in
@@ -729,7 +729,7 @@ let tc_non_layered_eff_decl env0 (ed:S.eff_decl) (_quals : list<qualifier>) : S.
       then us, bs
       else raise_error (Errors.Fatal_UnexpectedNumberOfUniverse,
              (BU.format3 "Expected and generalized universes in effect declaration for %s are different, expected: %s, but found %s"
-               ed.mname.str (BU.string_of_int (List.length ed_univs)) (BU.string_of_int (List.length us))))
+               (string_of_lid ed.mname) (BU.string_of_int (List.length ed_univs)) (BU.string_of_int (List.length us))))
              (range_of_lid ed.mname)
   in
 
@@ -783,7 +783,7 @@ let tc_non_layered_eff_decl env0 (ed:S.eff_decl) (_quals : list<qualifier>) : S.
       if List.length g_us <> n then
         let error = BU.format4
           "Expected %s:%s to be universe-polymorphic in %s universes, found %s"
-          ed.mname.str comb (string_of_int n) (g_us |> List.length |> string_of_int) in
+          (string_of_lid ed.mname) comb (string_of_int n) (g_us |> List.length |> string_of_int) in
         raise_error (Errors.Fatal_MismatchUniversePolymorphic, error) t.pos
     end;
     match us with
@@ -794,7 +794,7 @@ let tc_non_layered_eff_decl env0 (ed:S.eff_decl) (_quals : list<qualifier>) : S.
      then g_us, t
      else raise_error (Errors.Fatal_UnexpectedNumberOfUniverse,
             (BU.format4 "Expected and generalized universes in the declaration for %s:%s are different, expected: %s, but found %s"
-               ed.mname.str comb (BU.string_of_int (List.length us)) (BU.string_of_int (List.length g_us))))
+               (string_of_lid ed.mname) comb (BU.string_of_int (List.length us)) (BU.string_of_int (List.length g_us))))
             t.pos
   in
 
@@ -821,7 +821,7 @@ let tc_non_layered_eff_decl env0 (ed:S.eff_decl) (_quals : list<qualifier>) : S.
 
   let log_combinator s ts =
     if Env.debug env <| Options.Other "ED" then
-      BU.print3 "Typechecked %s:%s = %s\n" ed.mname.str s (Print.tscheme_to_string ts) in
+      BU.print3 "Typechecked %s:%s = %s\n" (string_of_lid ed.mname) s (Print.tscheme_to_string ts) in
 
   let ret_wp =
     let a, wp_sort = fresh_a_and_wp () in
@@ -1012,7 +1012,7 @@ let tc_non_layered_eff_decl env0 (ed:S.eff_decl) (_quals : list<qualifier>) : S.
           let env' = { Env.set_expected_typ env act_typ with instantiate_imp = false } in
           if Env.debug env (Options.Other "ED") then
             BU.print3 "Checking action %s:\n[definition]: %s\n[cps'd type]: %s\n"
-              (text_of_lid act.action_name) (Print.term_to_string act.action_defn)
+              (string_of_lid act.action_name) (Print.term_to_string act.action_defn)
               (Print.term_to_string act_typ);
           let act_defn, _, g_a = tc_tot_or_gtot_term env' act.action_defn in
 
@@ -1264,7 +1264,7 @@ let tc_lift env sub r =
     let expected_k  = U.arrow [S.mk_binder a; S.null_binder wp_a_src] (S.mk_Total wp_a_tgt) in
     let repr_type eff_name a wp =
       if not (is_reifiable_effect env eff_name)
-      then raise_error (Errors.Fatal_EffectCannotBeReified, (BU.format1 "Effect %s cannot be reified" eff_name.str)) (Env.get_range env);
+      then raise_error (Errors.Fatal_EffectCannotBeReified, (BU.format1 "Effect %s cannot be reified" (string_of_lid eff_name))) (Env.get_range env);
       match Env.effect_decl_opt env eff_name with
       | None -> failwith "internal error: reifiable effect has no decl?"
       | Some (ed, qualifiers) ->

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fs
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fs
@@ -730,7 +730,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     let c, g_c = TcComm.lcomp_comp c in
     let ef = U.comp_effect_name c in
     if not (is_user_reifiable_effect env ef) then
-        raise_error (Errors.Fatal_EffectCannotBeReified, (BU.format1 "Effect %s cannot be reified" ef.str)) e.pos;
+        raise_error (Errors.Fatal_EffectCannotBeReified, (BU.format1 "Effect %s cannot be reified" (string_of_lid ef))) e.pos;
     let repr = Env.reify_comp env c u_c in
     let e = mk (Tm_app(reify_op, [(e, aqual)])) None top.pos in
     let c =
@@ -755,7 +755,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
 
     if not (is_user_reflectable_effect env l) then
       raise_error (Errors.Fatal_EffectCannotBeReified,
-        BU.format1 "Effect %s cannot be reflected" l.str) e.pos;
+        BU.format1 "Effect %s cannot be reflected" (string_of_lid l)) e.pos;
 
     let reflect_op, _ = U.head_and_args top in
 
@@ -1037,7 +1037,7 @@ and tc_value env (e:term) : term
         | Some (Record_ctor _) -> true
         | _ -> false in
     if is_data_ctor dc && not(Env.is_datacon env v.v)
-    then raise_error (Errors.Fatal_MissingDataConstructor, (BU.format1 "Expected a data constructor; got %s" v.v.str)) (Env.get_range env)
+    then raise_error (Errors.Fatal_MissingDataConstructor, (BU.format1 "Expected a data constructor; got %s" (string_of_lid v.v))) (Env.get_range env)
     else value_check_expected_typ env e tc implicits in
 
   //As a general naming convention, we use e for the term being analyzed and its subterms as e1, e2, etc.
@@ -1755,7 +1755,7 @@ and check_application_args env head (chead:comp) ghead args expected_topt : term
                    if warn_effectful_args then
                      Errors.log_issue e.pos (Errors.Warning_EffectfulArgumentToErasedFunction,
                                              (format3 "Effectful argument %s (%s) to erased function %s, consider let binding it"
-                                                      (Print.term_to_string e) c.eff_name.str (Print.term_to_string head)));
+                                                      (Print.term_to_string e) (string_of_lid c.eff_name) (Print.term_to_string head)));
                    if Env.debug env Options.Extreme then
                        BU.print_string "... lifting!\n";
                    let x = S.new_bv None c.res_typ in

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -182,14 +182,14 @@ let extract_let_rec_annotation env {lbname=lbname; lbunivs=univ_vars; lbtyp=t; l
 
 //            | Pat_cons(fv, []), Tm_fvar fv' ->
 //              if not (Syntax.fv_eq fv fv')
-//              then failwith (BU.format2 "Expected pattern constructor %s; got %s" fv.fv_name.v.str fv'.fv_name.v.str);
+//              then failwith (BU.format2 "Expected pattern constructor %s; got %s" (string_of_lid fv.fv_name.v) (string_of_lid fv'.fv_name.v));
 //              pkg (Pat_cons(fv', []))
 
 //            | Pat_cons(fv, argpats), Tm_app({n=Tm_fvar(fv')}, args)
 //            | Pat_cons(fv, argpats), Tm_app({n=Tm_uinst({n=Tm_fvar(fv')}, _)}, args) ->
 
 //              if fv_eq fv fv' |> not
-//              then failwith (BU.format2 "Expected pattern constructor %s; got %s" fv.fv_name.v.str fv'.fv_name.v.str);
+//              then failwith (BU.format2 "Expected pattern constructor %s; got %s" (string_of_lid fv.fv_name.v) (string_of_lid fv'.fv_name.v));
 
 //              let fv = fv' in
 //              let rec match_args matched_pats args argpats = match args, argpats with
@@ -2454,7 +2454,7 @@ let maybe_add_implicit_binders (env:env) (bs:binders)  : binders =
                         | None -> bs
                         | Some ([], _, _) -> bs //no implicits
                         | Some (imps, _,  _) ->
-                          if imps |> BU.for_all (fun (x, _) -> BU.starts_with x.ppname.idText "'")
+                          if imps |> BU.for_all (fun (x, _) -> BU.starts_with (text_of_id x.ppname) "'")
                           then let r = pos bs in
                                let imps = imps |> List.map (fun (x, i) -> (S.set_range_of_bv x r, i)) in
                                imps@bs //we have a prefix of ticked variables
@@ -2489,8 +2489,8 @@ let d s = BU.print1 "\x1b[01;36m%s\x1b[00m\n" s
 let mk_toplevel_definition (env: env_t) lident (def: term): sigelt * term =
   // Debug
   if Env.debug env (Options.Other "ED") then begin
-    d (text_of_lid lident);
-    BU.print2 "Registering top-level definition: %s\n%s\n" (text_of_lid lident) (Print.term_to_string def)
+    d (string_of_lid lident);
+    BU.print2 "Registering top-level definition: %s\n%s\n" (string_of_lid lident) (Print.term_to_string def)
   end;
   // Allocate a new top-level name.
   let fv = S.lid_as_fv lident (U.incr_delta_qualifier def) None in
@@ -2730,7 +2730,7 @@ let fresh_effect_repr env r eff_name signature_ts repr_ts_opt u a_tm =
        let is, g = Env.uvars_for_binders env bs [NT (fst a, a_tm)]
          (fun b -> BU.format3
            "uvar for binder %s when creating a fresh repr for %s at %s"
-           (Print.binder_to_string b) eff_name.str (Range.string_of_range r)) r in
+           (Print.binder_to_string b) (string_of_lid eff_name) (Range.string_of_range r)) r in
        (match repr_ts_opt with
         | None ->  //no repr, return thunked computation type
           let eff_c = mk_Comp ({


### PR DESCRIPTION
The types `ident` and `lident` are currently exposed throughout the compiler, and the fields are read and modified in several places. This means it's hard to guarantee that some invariants of the type are kept. For instance that the `str` field of an `lid` really coincides with what its string representation should be (it actually does! but that could be broken by a careless change).

This module hides the types and adds some more functions to the interface of `FStar.Ident` to keep the functionality, plus some documentation on the interface.

Separately I noticed that `string_of_lid` was computing the string instead of just using the cached `str` field. This actually improves performance noticeably, particularly in extraction.

This is mainly motivated by a branch I have where `ident`s and `lid`s keep an internal hash to do fast equality comparisons. I still need to tweak that and decide what's best for performance, but this prefix of the changes should be desirable regardless.

NB: We previously had duplication between `text_of_id` and `string_of_ident`, and separately `text_of_lid` and `string_of_lid`. This PR unifies into `text_of_id` and `string_of_lid` since they were the most used variants, but the inconsistent naming is annoying. Should we go for `text_of`? Or another variant?