### PR TITLE
Fun implicits

### DIFF
--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -1745,13 +1745,13 @@ let (range_of_bv : bv -> FStar_Range.range) =
 let (set_range_of_bv : bv -> FStar_Range.range -> bv) =
   fun x  ->
     fun r  ->
-      let uu___414_8247 = x  in
+      let uu___415_8247 = x  in
       let uu____8248 =
         FStar_Ident.mk_ident (((x.ppname).FStar_Ident.idText), r)  in
       {
         ppname = uu____8248;
-        index = (uu___414_8247.index);
-        sort = (uu___414_8247.sort)
+        index = (uu___415_8247.index);
+        sort = (uu___415_8247.sort)
       }
   
 let (on_antiquoted : (term -> term) -> quoteinfo -> quoteinfo) =
@@ -1764,8 +1764,8 @@ let (on_antiquoted : (term -> term) -> quoteinfo -> quoteinfo) =
              | (bv1,t) -> let uu____8296 = f t  in (bv1, uu____8296))
           qi.antiquotes
          in
-      let uu___422_8297 = qi  in
-      { qkind = (uu___422_8297.qkind); antiquotes = aq }
+      let uu___423_8297 = qi  in
+      { qkind = (uu___423_8297.qkind); antiquotes = aq }
   
 let (lookup_aq : bv -> antiquotations -> term FStar_Pervasives_Native.option)
   =
@@ -2006,9 +2006,16 @@ let (is_implicit : aqual -> Prims.bool) =
     | FStar_Pervasives_Native.Some (Implicit uu____9211) -> true
     | uu____9214 -> false
   
-let (as_implicit : Prims.bool -> aqual) =
+let (is_implicit_or_meta : aqual -> Prims.bool) =
   fun uu___4_9222  ->
-    if uu___4_9222
+    match uu___4_9222 with
+    | FStar_Pervasives_Native.Some (Implicit uu____9224) -> true
+    | FStar_Pervasives_Native.Some (Meta uu____9227) -> true
+    | uu____9231 -> false
+  
+let (as_implicit : Prims.bool -> aqual) =
+  fun uu___5_9239  ->
+    if uu___5_9239
     then FStar_Pervasives_Native.Some imp_tag
     else FStar_Pervasives_Native.None
   
@@ -2016,23 +2023,23 @@ let (pat_bvs : pat -> bv Prims.list) =
   fun p  ->
     let rec aux b p1 =
       match p1.v with
-      | Pat_dot_term uu____9260 -> b
-      | Pat_constant uu____9267 -> b
+      | Pat_dot_term uu____9277 -> b
+      | Pat_constant uu____9284 -> b
       | Pat_wild x -> x :: b
       | Pat_var x -> x :: b
-      | Pat_cons (uu____9270,pats) ->
+      | Pat_cons (uu____9287,pats) ->
           FStar_List.fold_left
             (fun b1  ->
-               fun uu____9304  ->
-                 match uu____9304 with | (p2,uu____9317) -> aux b1 p2) b pats
+               fun uu____9321  ->
+                 match uu____9321 with | (p2,uu____9334) -> aux b1 p2) b pats
        in
-    let uu____9324 = aux [] p  in
-    FStar_All.pipe_left FStar_List.rev uu____9324
+    let uu____9341 = aux [] p  in
+    FStar_All.pipe_left FStar_List.rev uu____9341
   
 let (range_of_ropt :
   FStar_Range.range FStar_Pervasives_Native.option -> FStar_Range.range) =
-  fun uu___5_9338  ->
-    match uu___5_9338 with
+  fun uu___6_9355  ->
+    match uu___6_9355 with
     | FStar_Pervasives_Native.None  -> FStar_Range.dummyRange
     | FStar_Pervasives_Native.Some r -> r
   
@@ -2044,45 +2051,45 @@ let (gen_bv :
     fun r  ->
       fun t  ->
         let id = FStar_Ident.mk_ident (s, (range_of_ropt r))  in
-        let uu____9378 = FStar_Ident.next_id ()  in
-        { ppname = id; index = uu____9378; sort = t }
+        let uu____9395 = FStar_Ident.next_id ()  in
+        { ppname = id; index = uu____9395; sort = t }
   
 let (new_bv : FStar_Range.range FStar_Pervasives_Native.option -> typ -> bv)
   = fun ropt  -> fun t  -> gen_bv FStar_Ident.reserved_prefix ropt t 
 let (freshen_bv : bv -> bv) =
   fun bv1  ->
-    let uu____9401 = is_null_bv bv1  in
-    if uu____9401
+    let uu____9418 = is_null_bv bv1  in
+    if uu____9418
     then
-      let uu____9404 =
-        let uu____9407 = range_of_bv bv1  in
-        FStar_Pervasives_Native.Some uu____9407  in
-      new_bv uu____9404 bv1.sort
+      let uu____9421 =
+        let uu____9424 = range_of_bv bv1  in
+        FStar_Pervasives_Native.Some uu____9424  in
+      new_bv uu____9421 bv1.sort
     else
-      (let uu___604_9410 = bv1  in
-       let uu____9411 = FStar_Ident.next_id ()  in
+      (let uu___613_9427 = bv1  in
+       let uu____9428 = FStar_Ident.next_id ()  in
        {
-         ppname = (uu___604_9410.ppname);
-         index = uu____9411;
-         sort = (uu___604_9410.sort)
+         ppname = (uu___613_9427.ppname);
+         index = uu____9428;
+         sort = (uu___613_9427.sort)
        })
   
 let (freshen_binder : binder -> binder) =
   fun b  ->
-    let uu____9419 = b  in
-    match uu____9419 with
-    | (bv1,aq) -> let uu____9426 = freshen_bv bv1  in (uu____9426, aq)
+    let uu____9436 = b  in
+    match uu____9436 with
+    | (bv1,aq) -> let uu____9443 = freshen_bv bv1  in (uu____9443, aq)
   
 let (new_univ_name :
   FStar_Range.range FStar_Pervasives_Native.option -> univ_name) =
   fun ropt  ->
     let id = FStar_Ident.next_id ()  in
-    let uu____9441 =
-      let uu____9447 =
-        let uu____9449 = FStar_Util.string_of_int id  in
-        Prims.op_Hat FStar_Ident.reserved_prefix uu____9449  in
-      (uu____9447, (range_of_ropt ropt))  in
-    FStar_Ident.mk_ident uu____9441
+    let uu____9458 =
+      let uu____9464 =
+        let uu____9466 = FStar_Util.string_of_int id  in
+        Prims.op_Hat FStar_Ident.reserved_prefix uu____9466  in
+      (uu____9464, (range_of_ropt ropt))  in
+    FStar_Ident.mk_ident uu____9458
   
 let (lbname_eq :
   (bv,FStar_Ident.lident) FStar_Util.either ->
@@ -2093,7 +2100,7 @@ let (lbname_eq :
       match (l1, l2) with
       | (FStar_Util.Inl x,FStar_Util.Inl y) -> bv_eq x y
       | (FStar_Util.Inr l,FStar_Util.Inr m) -> FStar_Ident.lid_equals l m
-      | uu____9509 -> false
+      | uu____9526 -> false
   
 let (fv_eq : fv -> fv -> Prims.bool) =
   fun fv1  ->
@@ -2104,13 +2111,13 @@ let (fv_eq_lid : fv -> FStar_Ident.lident -> Prims.bool) =
 let (set_bv_range : bv -> FStar_Range.range -> bv) =
   fun bv1  ->
     fun r  ->
-      let uu___631_9558 = bv1  in
-      let uu____9559 =
+      let uu___640_9575 = bv1  in
+      let uu____9576 =
         FStar_Ident.mk_ident (((bv1.ppname).FStar_Ident.idText), r)  in
       {
-        ppname = uu____9559;
-        index = (uu___631_9558.index);
-        sort = (uu___631_9558.sort)
+        ppname = uu____9576;
+        index = (uu___640_9575.index);
+        sort = (uu___640_9575.sort)
       }
   
 let (lid_as_fv :
@@ -2120,15 +2127,15 @@ let (lid_as_fv :
   fun l  ->
     fun dd  ->
       fun dq  ->
-        let uu____9581 =
-          let uu____9582 = FStar_Ident.range_of_lid l  in
-          withinfo l uu____9582  in
-        { fv_name = uu____9581; fv_delta = dd; fv_qual = dq }
+        let uu____9598 =
+          let uu____9599 = FStar_Ident.range_of_lid l  in
+          withinfo l uu____9599  in
+        { fv_name = uu____9598; fv_delta = dd; fv_qual = dq }
   
 let (fv_to_tm : fv -> term) =
   fun fv1  ->
-    let uu____9589 = FStar_Ident.range_of_lid (fv1.fv_name).v  in
-    mk (Tm_fvar fv1) FStar_Pervasives_Native.None uu____9589
+    let uu____9606 = FStar_Ident.range_of_lid (fv1.fv_name).v  in
+    mk (Tm_fvar fv1) FStar_Pervasives_Native.None uu____9606
   
 let (fvar :
   FStar_Ident.lident ->
@@ -2136,38 +2143,38 @@ let (fvar :
   =
   fun l  ->
     fun dd  ->
-      fun dq  -> let uu____9610 = lid_as_fv l dd dq  in fv_to_tm uu____9610
+      fun dq  -> let uu____9627 = lid_as_fv l dd dq  in fv_to_tm uu____9627
   
 let (lid_of_fv : fv -> FStar_Ident.lid) = fun fv1  -> (fv1.fv_name).v 
 let (range_of_fv : fv -> FStar_Range.range) =
   fun fv1  ->
-    let uu____9623 = lid_of_fv fv1  in FStar_Ident.range_of_lid uu____9623
+    let uu____9640 = lid_of_fv fv1  in FStar_Ident.range_of_lid uu____9640
   
 let (set_range_of_fv : fv -> FStar_Range.range -> fv) =
   fun fv1  ->
     fun r  ->
-      let uu___644_9635 = fv1  in
-      let uu____9636 =
-        let uu___646_9637 = fv1.fv_name  in
-        let uu____9638 =
-          let uu____9639 = lid_of_fv fv1  in
-          FStar_Ident.set_lid_range uu____9639 r  in
-        { v = uu____9638; p = (uu___646_9637.p) }  in
+      let uu___653_9652 = fv1  in
+      let uu____9653 =
+        let uu___655_9654 = fv1.fv_name  in
+        let uu____9655 =
+          let uu____9656 = lid_of_fv fv1  in
+          FStar_Ident.set_lid_range uu____9656 r  in
+        { v = uu____9655; p = (uu___655_9654.p) }  in
       {
-        fv_name = uu____9636;
-        fv_delta = (uu___644_9635.fv_delta);
-        fv_qual = (uu___644_9635.fv_qual)
+        fv_name = uu____9653;
+        fv_delta = (uu___653_9652.fv_delta);
+        fv_qual = (uu___653_9652.fv_qual)
       }
   
 let (has_simple_attribute : term Prims.list -> Prims.string -> Prims.bool) =
   fun l  ->
     fun s  ->
       FStar_List.existsb
-        (fun uu___6_9665  ->
-           match uu___6_9665 with
-           | { n = Tm_constant (FStar_Const.Const_string (data,uu____9670));
-               pos = uu____9671; vars = uu____9672;_} when data = s -> true
-           | uu____9679 -> false) l
+        (fun uu___7_9682  ->
+           match uu___7_9682 with
+           | { n = Tm_constant (FStar_Const.Const_string (data,uu____9687));
+               pos = uu____9688; vars = uu____9689;_} when data = s -> true
+           | uu____9696 -> false) l
   
 let rec (eq_pat : pat -> pat -> Prims.bool) =
   fun p1  ->
@@ -2175,20 +2182,20 @@ let rec (eq_pat : pat -> pat -> Prims.bool) =
       match ((p1.v), (p2.v)) with
       | (Pat_constant c1,Pat_constant c2) -> FStar_Const.eq_const c1 c2
       | (Pat_cons (fv1,as1),Pat_cons (fv2,as2)) ->
-          let uu____9738 = fv_eq fv1 fv2  in
-          if uu____9738
+          let uu____9755 = fv_eq fv1 fv2  in
+          if uu____9755
           then
-            let uu____9743 = FStar_List.zip as1 as2  in
-            FStar_All.pipe_right uu____9743
+            let uu____9760 = FStar_List.zip as1 as2  in
+            FStar_All.pipe_right uu____9760
               (FStar_List.for_all
-                 (fun uu____9810  ->
-                    match uu____9810 with
+                 (fun uu____9827  ->
+                    match uu____9827 with
                     | ((p11,b1),(p21,b2)) -> (b1 = b2) && (eq_pat p11 p21)))
           else false
-      | (Pat_var uu____9848,Pat_var uu____9849) -> true
-      | (Pat_wild uu____9851,Pat_wild uu____9852) -> true
+      | (Pat_var uu____9865,Pat_var uu____9866) -> true
+      | (Pat_wild uu____9868,Pat_wild uu____9869) -> true
       | (Pat_dot_term (bv1,t1),Pat_dot_term (bv2,t2)) -> true
-      | (uu____9867,uu____9868) -> false
+      | (uu____9884,uu____9885) -> false
   
 let (delta_constant : delta_depth) = Delta_constant_at_level Prims.int_zero 
 let (delta_equational : delta_depth) =
@@ -2197,28 +2204,28 @@ let (fvconst : FStar_Ident.lident -> fv) =
   fun l  -> lid_as_fv l delta_constant FStar_Pervasives_Native.None 
 let (tconst : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9886 =
-      let uu____9893 = let uu____9894 = fvconst l  in Tm_fvar uu____9894  in
-      mk uu____9893  in
-    uu____9886 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____9903 =
+      let uu____9910 = let uu____9911 = fvconst l  in Tm_fvar uu____9911  in
+      mk uu____9910  in
+    uu____9903 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (tabbrev : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9901 =
-      let uu____9908 =
-        let uu____9909 =
+    let uu____9918 =
+      let uu____9925 =
+        let uu____9926 =
           lid_as_fv l (Delta_constant_at_level Prims.int_one)
             FStar_Pervasives_Native.None
            in
-        Tm_fvar uu____9909  in
-      mk uu____9908  in
-    uu____9901 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        Tm_fvar uu____9926  in
+      mk uu____9925  in
+    uu____9918 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (tdataconstr : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9917 =
+    let uu____9934 =
       lid_as_fv l delta_constant (FStar_Pervasives_Native.Some Data_ctor)  in
-    fv_to_tm uu____9917
+    fv_to_tm uu____9934
   
 let (t_unit : term) = tconst FStar_Parser_Const.unit_lid 
 let (t_bool : term) = tconst FStar_Parser_Const.bool_lid 
@@ -2241,75 +2248,75 @@ let (t_norm_step : term) = tconst FStar_Parser_Const.norm_step_lid
 let (t_tac_of : term -> term -> term) =
   fun a  ->
     fun b  ->
-      let uu____9947 =
-        let uu____9952 =
-          let uu____9953 = tabbrev FStar_Parser_Const.tac_lid  in
-          mk_Tm_uinst uu____9953 [U_zero; U_zero]  in
-        let uu____9954 =
-          let uu____9955 = as_arg a  in
-          let uu____9964 = let uu____9975 = as_arg b  in [uu____9975]  in
-          uu____9955 :: uu____9964  in
-        mk_Tm_app uu____9952 uu____9954  in
-      uu____9947 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____9964 =
+        let uu____9969 =
+          let uu____9970 = tabbrev FStar_Parser_Const.tac_lid  in
+          mk_Tm_uinst uu____9970 [U_zero; U_zero]  in
+        let uu____9971 =
+          let uu____9972 = as_arg a  in
+          let uu____9981 = let uu____9992 = as_arg b  in [uu____9992]  in
+          uu____9972 :: uu____9981  in
+        mk_Tm_app uu____9969 uu____9971  in
+      uu____9964 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_tactic_of : term -> term) =
   fun t  ->
-    let uu____10014 =
-      let uu____10019 =
-        let uu____10020 = tabbrev FStar_Parser_Const.tactic_lid  in
-        mk_Tm_uinst uu____10020 [U_zero]  in
-      let uu____10021 = let uu____10022 = as_arg t  in [uu____10022]  in
-      mk_Tm_app uu____10019 uu____10021  in
-    uu____10014 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____10031 =
+      let uu____10036 =
+        let uu____10037 = tabbrev FStar_Parser_Const.tactic_lid  in
+        mk_Tm_uinst uu____10037 [U_zero]  in
+      let uu____10038 = let uu____10039 = as_arg t  in [uu____10039]  in
+      mk_Tm_app uu____10036 uu____10038  in
+    uu____10031 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_tactic_unit : term) = t_tactic_of t_unit 
 let (t_list_of : term -> term) =
   fun t  ->
-    let uu____10054 =
-      let uu____10059 =
-        let uu____10060 = tabbrev FStar_Parser_Const.list_lid  in
-        mk_Tm_uinst uu____10060 [U_zero]  in
-      let uu____10061 = let uu____10062 = as_arg t  in [uu____10062]  in
-      mk_Tm_app uu____10059 uu____10061  in
-    uu____10054 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____10071 =
+      let uu____10076 =
+        let uu____10077 = tabbrev FStar_Parser_Const.list_lid  in
+        mk_Tm_uinst uu____10077 [U_zero]  in
+      let uu____10078 = let uu____10079 = as_arg t  in [uu____10079]  in
+      mk_Tm_app uu____10076 uu____10078  in
+    uu____10071 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_option_of : term -> term) =
   fun t  ->
-    let uu____10093 =
-      let uu____10098 =
-        let uu____10099 = tabbrev FStar_Parser_Const.option_lid  in
-        mk_Tm_uinst uu____10099 [U_zero]  in
-      let uu____10100 = let uu____10101 = as_arg t  in [uu____10101]  in
-      mk_Tm_app uu____10098 uu____10100  in
-    uu____10093 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____10110 =
+      let uu____10115 =
+        let uu____10116 = tabbrev FStar_Parser_Const.option_lid  in
+        mk_Tm_uinst uu____10116 [U_zero]  in
+      let uu____10117 = let uu____10118 = as_arg t  in [uu____10118]  in
+      mk_Tm_app uu____10115 uu____10117  in
+    uu____10110 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_tuple2_of : term -> term -> term) =
   fun t1  ->
     fun t2  ->
-      let uu____10137 =
-        let uu____10142 =
-          let uu____10143 = tabbrev FStar_Parser_Const.lid_tuple2  in
-          mk_Tm_uinst uu____10143 [U_zero; U_zero]  in
-        let uu____10144 =
-          let uu____10145 = as_arg t1  in
-          let uu____10154 = let uu____10165 = as_arg t2  in [uu____10165]  in
-          uu____10145 :: uu____10154  in
-        mk_Tm_app uu____10142 uu____10144  in
-      uu____10137 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____10154 =
+        let uu____10159 =
+          let uu____10160 = tabbrev FStar_Parser_Const.lid_tuple2  in
+          mk_Tm_uinst uu____10160 [U_zero; U_zero]  in
+        let uu____10161 =
+          let uu____10162 = as_arg t1  in
+          let uu____10171 = let uu____10182 = as_arg t2  in [uu____10182]  in
+          uu____10162 :: uu____10171  in
+        mk_Tm_app uu____10159 uu____10161  in
+      uu____10154 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (t_either_of : term -> term -> term) =
   fun t1  ->
     fun t2  ->
-      let uu____10209 =
-        let uu____10214 =
-          let uu____10215 = tabbrev FStar_Parser_Const.either_lid  in
-          mk_Tm_uinst uu____10215 [U_zero; U_zero]  in
-        let uu____10216 =
-          let uu____10217 = as_arg t1  in
-          let uu____10226 = let uu____10237 = as_arg t2  in [uu____10237]  in
-          uu____10217 :: uu____10226  in
-        mk_Tm_app uu____10214 uu____10216  in
-      uu____10209 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____10226 =
+        let uu____10231 =
+          let uu____10232 = tabbrev FStar_Parser_Const.either_lid  in
+          mk_Tm_uinst uu____10232 [U_zero; U_zero]  in
+        let uu____10233 =
+          let uu____10234 = as_arg t1  in
+          let uu____10243 = let uu____10254 = as_arg t2  in [uu____10254]  in
+          uu____10234 :: uu____10243  in
+        mk_Tm_app uu____10231 uu____10233  in
+      uu____10226 FStar_Pervasives_Native.None FStar_Range.dummyRange
   
 let (unit_const : term) =
   mk (Tm_constant FStar_Const.Const_unit) FStar_Pervasives_Native.None

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -4305,107 +4305,124 @@ and (tc_abs :
                    | ([],[]) ->
                        (env2, [], FStar_Pervasives_Native.None,
                          FStar_TypeChecker_Env.trivial_guard, subst)
+                   | ((uu____12268,FStar_Pervasives_Native.None )::uu____12269,
+                      (hd_e,q)::uu____12272) when
+                       FStar_Syntax_Syntax.is_implicit_or_meta q ->
+                       let bv =
+                         let uu____12324 =
+                           let uu____12327 =
+                             FStar_Ident.range_of_id
+                               hd_e.FStar_Syntax_Syntax.ppname
+                              in
+                           FStar_Pervasives_Native.Some uu____12327  in
+                         let uu____12328 =
+                           FStar_Syntax_Subst.subst subst
+                             hd_e.FStar_Syntax_Syntax.sort
+                            in
+                         FStar_Syntax_Syntax.new_bv uu____12324 uu____12328
+                          in
+                       aux (env2, subst) ((bv, q) :: bs2) bs_expected1
                    | ((hd,imp)::bs3,(hd_expected,imp')::bs_expected2) ->
                        ((let special q1 q2 =
                            match (q1, q2) with
                            | (FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Meta
-                              uu____12352),FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Meta uu____12353)) -> true
+                              uu____12423),FStar_Pervasives_Native.Some
+                              (FStar_Syntax_Syntax.Meta uu____12424)) -> true
                            | (FStar_Pervasives_Native.None
                               ,FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Equality )) -> true
                            | (FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Implicit
-                              uu____12368),FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Meta uu____12369)) -> true
-                           | uu____12378 -> false  in
-                         let uu____12388 =
+                              uu____12439),FStar_Pervasives_Native.Some
+                              (FStar_Syntax_Syntax.Meta uu____12440)) -> true
+                           | uu____12449 -> false  in
+                         let uu____12459 =
                            (Prims.op_Negation (special imp imp')) &&
-                             (let uu____12391 =
+                             (let uu____12462 =
                                 FStar_Syntax_Util.eq_aqual imp imp'  in
-                              uu____12391 <> FStar_Syntax_Util.Equal)
+                              uu____12462 <> FStar_Syntax_Util.Equal)
                             in
-                         if uu____12388
+                         if uu____12459
                          then
-                           let uu____12393 =
-                             let uu____12399 =
-                               let uu____12401 =
+                           let uu____12464 =
+                             let uu____12470 =
+                               let uu____12472 =
                                  FStar_Syntax_Print.bv_to_string hd  in
                                FStar_Util.format1
                                  "Inconsistent implicit argument annotation on argument %s"
-                                 uu____12401
+                                 uu____12472
                                 in
                              (FStar_Errors.Fatal_InconsistentImplicitArgumentAnnotation,
-                               uu____12399)
+                               uu____12470)
                               in
-                           let uu____12405 =
+                           let uu____12476 =
                              FStar_Syntax_Syntax.range_of_bv hd  in
-                           FStar_Errors.raise_error uu____12393 uu____12405
+                           FStar_Errors.raise_error uu____12464 uu____12476
                          else ());
                         (let expected_t =
                            FStar_Syntax_Subst.subst subst
                              hd_expected.FStar_Syntax_Syntax.sort
                             in
-                         let uu____12409 =
-                           let uu____12416 =
-                             let uu____12417 =
+                         let uu____12480 =
+                           let uu____12487 =
+                             let uu____12488 =
                                FStar_Syntax_Util.unmeta
                                  hd.FStar_Syntax_Syntax.sort
                                 in
-                             uu____12417.FStar_Syntax_Syntax.n  in
-                           match uu____12416 with
+                             uu____12488.FStar_Syntax_Syntax.n  in
+                           match uu____12487 with
                            | FStar_Syntax_Syntax.Tm_unknown  ->
                                (expected_t,
                                  FStar_TypeChecker_Env.trivial_guard)
-                           | uu____12428 ->
-                               ((let uu____12430 =
+                           | uu____12499 ->
+                               ((let uu____12501 =
                                    FStar_TypeChecker_Env.debug env2
                                      FStar_Options.High
                                     in
-                                 if uu____12430
+                                 if uu____12501
                                  then
-                                   let uu____12433 =
+                                   let uu____12504 =
                                      FStar_Syntax_Print.bv_to_string hd  in
                                    FStar_Util.print1 "Checking binder %s\n"
-                                     uu____12433
+                                     uu____12504
                                  else ());
-                                (let uu____12438 =
+                                (let uu____12509 =
                                    tc_tot_or_gtot_term env2
                                      hd.FStar_Syntax_Syntax.sort
                                     in
-                                 match uu____12438 with
-                                 | (t,uu____12452,g1_env) ->
+                                 match uu____12509 with
+                                 | (t,uu____12523,g1_env) ->
                                      let g2_env =
-                                       let uu____12455 =
+                                       let uu____12526 =
                                          FStar_TypeChecker_Rel.teq_nosmt env2
                                            t expected_t
                                           in
-                                       match uu____12455 with
+                                       match uu____12526 with
                                        | FStar_Pervasives_Native.Some g ->
                                            FStar_All.pipe_right g
                                              (FStar_TypeChecker_Rel.resolve_implicits
                                                 env2)
                                        | FStar_Pervasives_Native.None  ->
-                                           let uu____12459 =
+                                           let uu____12530 =
                                              FStar_TypeChecker_Rel.get_subtyping_prop
                                                env2 expected_t t
                                               in
-                                           (match uu____12459 with
+                                           (match uu____12530 with
                                             | FStar_Pervasives_Native.None 
                                                 ->
-                                                let uu____12462 =
+                                                let uu____12533 =
                                                   FStar_TypeChecker_Err.basic_type_error
                                                     env2
                                                     FStar_Pervasives_Native.None
                                                     expected_t t
                                                    in
-                                                let uu____12468 =
+                                                let uu____12539 =
                                                   FStar_TypeChecker_Env.get_range
                                                     env2
                                                    in
                                                 FStar_Errors.raise_error
-                                                  uu____12462 uu____12468
+                                                  uu____12533 uu____12539
                                             | FStar_Pervasives_Native.Some
                                                 g_env ->
                                                 FStar_TypeChecker_Util.label_guard
@@ -4413,45 +4430,45 @@ and (tc_abs :
                                                   "Type annotation on parameter incompatible with the expected type"
                                                   g_env)
                                         in
-                                     let uu____12471 =
+                                     let uu____12542 =
                                        FStar_TypeChecker_Env.conj_guard
                                          g1_env g2_env
                                         in
-                                     (t, uu____12471)))
+                                     (t, uu____12542)))
                             in
-                         match uu____12409 with
+                         match uu____12480 with
                          | (t,g_env) ->
                              let hd1 =
-                               let uu___1760_12497 = hd  in
+                               let uu___1772_12568 = hd  in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1760_12497.FStar_Syntax_Syntax.ppname);
+                                   (uu___1772_12568.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1760_12497.FStar_Syntax_Syntax.index);
+                                   (uu___1772_12568.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = t
                                }  in
                              let b = (hd1, imp)  in
                              let b_expected = (hd_expected, imp')  in
                              let env_b = push_binding env2 b  in
                              let subst1 =
-                               let uu____12520 =
+                               let uu____12591 =
                                  FStar_Syntax_Syntax.bv_to_name hd1  in
                                maybe_extend_subst subst b_expected
-                                 uu____12520
+                                 uu____12591
                                 in
-                             let uu____12523 =
+                             let uu____12594 =
                                aux (env_b, subst1) bs3 bs_expected2  in
-                             (match uu____12523 with
+                             (match uu____12594 with
                               | (env_bs,bs4,rest,g'_env_b,subst2) ->
                                   let g'_env =
                                     FStar_TypeChecker_Env.close_guard env_bs
                                       [b] g'_env_b
                                      in
-                                  let uu____12588 =
+                                  let uu____12659 =
                                     FStar_TypeChecker_Env.conj_guard g_env
                                       g'_env
                                      in
-                                  (env_bs, (b :: bs4), rest, uu____12588,
+                                  (env_bs, (b :: bs4), rest, uu____12659,
                                     subst2))))
                    | (rest,[]) ->
                        (env2, [],
@@ -4468,101 +4485,101 @@ and (tc_abs :
             | FStar_Pervasives_Native.None  ->
                 ((match env1.FStar_TypeChecker_Env.letrecs with
                   | [] -> ()
-                  | uu____12760 ->
+                  | uu____12831 ->
                       failwith
                         "Impossible: Can't have a let rec annotation but no expected type");
-                 (let uu____12770 = tc_binders env1 bs  in
-                  match uu____12770 with
-                  | (bs1,envbody,g_env,uu____12800) ->
+                 (let uu____12841 = tc_binders env1 bs  in
+                  match uu____12841 with
+                  | (bs1,envbody,g_env,uu____12871) ->
                       (FStar_Pervasives_Native.None, bs1, [],
                         FStar_Pervasives_Native.None, envbody, body1, g_env)))
             | FStar_Pervasives_Native.Some t ->
                 let t1 = FStar_Syntax_Subst.compress t  in
                 let rec as_function_typ norm1 t2 =
-                  let uu____12856 =
-                    let uu____12857 = FStar_Syntax_Subst.compress t2  in
-                    uu____12857.FStar_Syntax_Syntax.n  in
-                  match uu____12856 with
-                  | FStar_Syntax_Syntax.Tm_uvar uu____12890 ->
+                  let uu____12917 =
+                    let uu____12918 = FStar_Syntax_Subst.compress t2  in
+                    uu____12918.FStar_Syntax_Syntax.n  in
+                  match uu____12917 with
+                  | FStar_Syntax_Syntax.Tm_uvar uu____12941 ->
                       ((match env1.FStar_TypeChecker_Env.letrecs with
                         | [] -> ()
-                        | uu____12910 -> failwith "Impossible");
-                       (let uu____12920 = tc_binders env1 bs  in
-                        match uu____12920 with
-                        | (bs1,envbody,g_env,uu____12962) ->
-                            let uu____12963 =
+                        | uu____12961 -> failwith "Impossible");
+                       (let uu____12971 = tc_binders env1 bs  in
+                        match uu____12971 with
+                        | (bs1,envbody,g_env,uu____13003) ->
+                            let uu____13004 =
                               FStar_TypeChecker_Env.clear_expected_typ
                                 envbody
                                in
-                            (match uu____12963 with
-                             | (envbody1,uu____13001) ->
+                            (match uu____13004 with
+                             | (envbody1,uu____13032) ->
                                  ((FStar_Pervasives_Native.Some t2), bs1, [],
                                    FStar_Pervasives_Native.None, envbody1,
                                    body1, g_env))))
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                           uu____13022;
-                         FStar_Syntax_Syntax.pos = uu____13023;
-                         FStar_Syntax_Syntax.vars = uu____13024;_},uu____13025)
+                           uu____13043;
+                         FStar_Syntax_Syntax.pos = uu____13044;
+                         FStar_Syntax_Syntax.vars = uu____13045;_},uu____13046)
                       ->
                       ((match env1.FStar_TypeChecker_Env.letrecs with
                         | [] -> ()
-                        | uu____13069 -> failwith "Impossible");
-                       (let uu____13079 = tc_binders env1 bs  in
-                        match uu____13079 with
-                        | (bs1,envbody,g_env,uu____13121) ->
-                            let uu____13122 =
+                        | uu____13090 -> failwith "Impossible");
+                       (let uu____13100 = tc_binders env1 bs  in
+                        match uu____13100 with
+                        | (bs1,envbody,g_env,uu____13132) ->
+                            let uu____13133 =
                               FStar_TypeChecker_Env.clear_expected_typ
                                 envbody
                                in
-                            (match uu____13122 with
-                             | (envbody1,uu____13160) ->
+                            (match uu____13133 with
+                             | (envbody1,uu____13161) ->
                                  ((FStar_Pervasives_Native.Some t2), bs1, [],
                                    FStar_Pervasives_Native.None, envbody1,
                                    body1, g_env))))
-                  | FStar_Syntax_Syntax.Tm_refine (b,uu____13182) ->
-                      let uu____13187 =
+                  | FStar_Syntax_Syntax.Tm_refine (b,uu____13173) ->
+                      let uu____13178 =
                         as_function_typ norm1 b.FStar_Syntax_Syntax.sort  in
-                      (match uu____13187 with
-                       | (uu____13248,bs1,bs',copt,env_body,body2,g_env) ->
+                      (match uu____13178 with
+                       | (uu____13219,bs1,bs',copt,env_body,body2,g_env) ->
                            ((FStar_Pervasives_Native.Some t2), bs1, bs',
                              copt, env_body, body2, g_env))
                   | FStar_Syntax_Syntax.Tm_arrow (bs_expected,c_expected) ->
-                      let uu____13325 =
+                      let uu____13266 =
                         FStar_Syntax_Subst.open_comp bs_expected c_expected
                          in
-                      (match uu____13325 with
+                      (match uu____13266 with
                        | (bs_expected1,c_expected1) ->
                            let check_actuals_against_formals env2 bs1
                              bs_expected2 body2 =
-                             let rec handle_more uu____13470 c_expected2
+                             let rec handle_more uu____13401 c_expected2
                                body3 =
-                               match uu____13470 with
+                               match uu____13401 with
                                | (env_bs,bs2,more,guard_env,subst) ->
                                    (match more with
                                     | FStar_Pervasives_Native.None  ->
-                                        let uu____13584 =
+                                        let uu____13515 =
                                           FStar_Syntax_Subst.subst_comp subst
                                             c_expected2
                                            in
-                                        (env_bs, bs2, guard_env, uu____13584,
+                                        (env_bs, bs2, guard_env, uu____13515,
                                           body3)
                                     | FStar_Pervasives_Native.Some
                                         (FStar_Util.Inr more_bs_expected) ->
                                         let c =
-                                          let uu____13601 =
+                                          let uu____13532 =
                                             FStar_Syntax_Util.arrow
                                               more_bs_expected c_expected2
                                              in
                                           FStar_Syntax_Syntax.mk_Total
-                                            uu____13601
+                                            uu____13532
                                            in
-                                        let uu____13602 =
+                                        let uu____13533 =
                                           FStar_Syntax_Subst.subst_comp subst
                                             c
                                            in
-                                        (env_bs, bs2, guard_env, uu____13602,
+                                        (env_bs, bs2, guard_env, uu____13533,
                                           body3)
                                     | FStar_Pervasives_Native.Some
                                         (FStar_Util.Inl more_bs) ->
@@ -4570,11 +4587,11 @@ and (tc_abs :
                                           FStar_Syntax_Subst.subst_comp subst
                                             c_expected2
                                            in
-                                        let uu____13619 =
+                                        let uu____13550 =
                                           (FStar_Options.ml_ish ()) ||
                                             (FStar_Syntax_Util.is_named_tot c)
                                            in
-                                        if uu____13619
+                                        if uu____13550
                                         then
                                           let t3 =
                                             FStar_TypeChecker_Normalize.unfold_whnf
@@ -4586,18 +4603,18 @@ and (tc_abs :
                                            with
                                            | FStar_Syntax_Syntax.Tm_arrow
                                                (bs_expected3,c_expected3) ->
-                                               let uu____13685 =
+                                               let uu____13616 =
                                                  FStar_Syntax_Subst.open_comp
                                                    bs_expected3 c_expected3
                                                   in
-                                               (match uu____13685 with
+                                               (match uu____13616 with
                                                 | (bs_expected4,c_expected4)
                                                     ->
-                                                    let uu____13712 =
+                                                    let uu____13643 =
                                                       check_binders env_bs
                                                         more_bs bs_expected4
                                                        in
-                                                    (match uu____13712 with
+                                                    (match uu____13643 with
                                                      | (env_bs_bs',bs',more1,guard'_env_bs,subst1)
                                                          ->
                                                          let guard'_env =
@@ -4605,8 +4622,8 @@ and (tc_abs :
                                                              env_bs bs2
                                                              guard'_env_bs
                                                             in
-                                                         let uu____13767 =
-                                                           let uu____13794 =
+                                                         let uu____13698 =
+                                                           let uu____13725 =
                                                              FStar_TypeChecker_Env.conj_guard
                                                                guard_env
                                                                guard'_env
@@ -4615,13 +4632,13 @@ and (tc_abs :
                                                              (FStar_List.append
                                                                 bs2 bs'),
                                                              more1,
-                                                             uu____13794,
+                                                             uu____13725,
                                                              subst1)
                                                             in
                                                          handle_more
-                                                           uu____13767
+                                                           uu____13698
                                                            c_expected4 body3))
-                                           | uu____13817 ->
+                                           | uu____13748 ->
                                                let body4 =
                                                  FStar_Syntax_Util.abs
                                                    more_bs body3
@@ -4637,131 +4654,131 @@ and (tc_abs :
                                               in
                                            (env_bs, bs2, guard_env, c, body4)))
                                 in
-                             let uu____13846 =
+                             let uu____13777 =
                                check_binders env2 bs1 bs_expected2  in
-                             handle_more uu____13846 c_expected1 body2  in
+                             handle_more uu____13777 c_expected1 body2  in
                            let mk_letrec_env envbody bs1 c =
                              let letrecs = guard_letrecs envbody bs1 c  in
                              let envbody1 =
-                               let uu___1886_13911 = envbody  in
+                               let uu___1898_13842 = envbody  in
                                {
                                  FStar_TypeChecker_Env.solver =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.solver);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.solver);
                                  FStar_TypeChecker_Env.range =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.range);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.range);
                                  FStar_TypeChecker_Env.curmodule =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.curmodule);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.curmodule);
                                  FStar_TypeChecker_Env.gamma =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.gamma);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.gamma);
                                  FStar_TypeChecker_Env.gamma_sig =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.gamma_sig);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.gamma_sig);
                                  FStar_TypeChecker_Env.gamma_cache =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.gamma_cache);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.gamma_cache);
                                  FStar_TypeChecker_Env.modules =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.modules);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.modules);
                                  FStar_TypeChecker_Env.expected_typ =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.expected_typ);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.expected_typ);
                                  FStar_TypeChecker_Env.sigtab =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.sigtab);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.sigtab);
                                  FStar_TypeChecker_Env.attrtab =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.attrtab);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.attrtab);
                                  FStar_TypeChecker_Env.instantiate_imp =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.instantiate_imp);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.instantiate_imp);
                                  FStar_TypeChecker_Env.effects =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.effects);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.effects);
                                  FStar_TypeChecker_Env.generalize =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.generalize);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.generalize);
                                  FStar_TypeChecker_Env.letrecs = [];
                                  FStar_TypeChecker_Env.top_level =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.top_level);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.top_level);
                                  FStar_TypeChecker_Env.check_uvars =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.check_uvars);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.check_uvars);
                                  FStar_TypeChecker_Env.use_eq =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.use_eq);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.use_eq);
                                  FStar_TypeChecker_Env.use_eq_strict =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.use_eq_strict);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.use_eq_strict);
                                  FStar_TypeChecker_Env.is_iface =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.is_iface);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.is_iface);
                                  FStar_TypeChecker_Env.admit =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.admit);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.admit);
                                  FStar_TypeChecker_Env.lax =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.lax);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.lax);
                                  FStar_TypeChecker_Env.lax_universes =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.lax_universes);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.lax_universes);
                                  FStar_TypeChecker_Env.phase1 =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.phase1);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.phase1);
                                  FStar_TypeChecker_Env.failhard =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.failhard);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.failhard);
                                  FStar_TypeChecker_Env.nosynth =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.nosynth);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.nosynth);
                                  FStar_TypeChecker_Env.uvar_subtyping =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.uvar_subtyping);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.uvar_subtyping);
                                  FStar_TypeChecker_Env.tc_term =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.tc_term);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.tc_term);
                                  FStar_TypeChecker_Env.type_of =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.type_of);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.type_of);
                                  FStar_TypeChecker_Env.universe_of =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.universe_of);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.universe_of);
                                  FStar_TypeChecker_Env.check_type_of =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.check_type_of);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.check_type_of);
                                  FStar_TypeChecker_Env.use_bv_sorts =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.use_bv_sorts);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.use_bv_sorts);
                                  FStar_TypeChecker_Env.qtbl_name_and_index =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.qtbl_name_and_index);
                                  FStar_TypeChecker_Env.normalized_eff_names =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.normalized_eff_names);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.normalized_eff_names);
                                  FStar_TypeChecker_Env.fv_delta_depths =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.fv_delta_depths);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.fv_delta_depths);
                                  FStar_TypeChecker_Env.proof_ns =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.proof_ns);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.proof_ns);
                                  FStar_TypeChecker_Env.synth_hook =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.synth_hook);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.synth_hook);
                                  FStar_TypeChecker_Env.try_solve_implicits_hook
                                    =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                  FStar_TypeChecker_Env.splice =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.splice);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.splice);
                                  FStar_TypeChecker_Env.mpreprocess =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.mpreprocess);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.mpreprocess);
                                  FStar_TypeChecker_Env.postprocess =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.postprocess);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.postprocess);
                                  FStar_TypeChecker_Env.is_native_tactic =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.is_native_tactic);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.is_native_tactic);
                                  FStar_TypeChecker_Env.identifier_info =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.identifier_info);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.identifier_info);
                                  FStar_TypeChecker_Env.tc_hooks =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.tc_hooks);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.tc_hooks);
                                  FStar_TypeChecker_Env.dsenv =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.dsenv);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.dsenv);
                                  FStar_TypeChecker_Env.nbe =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.nbe);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.nbe);
                                  FStar_TypeChecker_Env.strict_args_tab =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.strict_args_tab);
+                                   (uu___1898_13842.FStar_TypeChecker_Env.strict_args_tab);
                                  FStar_TypeChecker_Env.erasable_types_tab =
-                                   (uu___1886_13911.FStar_TypeChecker_Env.erasable_types_tab)
+                                   (uu___1898_13842.FStar_TypeChecker_Env.erasable_types_tab)
                                }  in
-                             let uu____13918 =
+                             let uu____13849 =
                                FStar_All.pipe_right letrecs
                                  (FStar_List.fold_left
-                                    (fun uu____13984  ->
-                                       fun uu____13985  ->
-                                         match (uu____13984, uu____13985)
+                                    (fun uu____13915  ->
+                                       fun uu____13916  ->
+                                         match (uu____13915, uu____13916)
                                          with
                                          | ((env2,letrec_binders,g),(l,t3,u_names))
                                              ->
-                                             let uu____14076 =
-                                               let uu____14083 =
-                                                 let uu____14084 =
+                                             let uu____14007 =
+                                               let uu____14014 =
+                                                 let uu____14015 =
                                                    FStar_TypeChecker_Env.clear_expected_typ
                                                      env2
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____14084
+                                                   uu____14015
                                                    FStar_Pervasives_Native.fst
                                                   in
-                                               tc_term uu____14083 t3  in
-                                             (match uu____14076 with
-                                              | (t4,uu____14108,g') ->
+                                               tc_term uu____14014 t3  in
+                                             (match uu____14007 with
+                                              | (t4,uu____14039,g') ->
                                                   let env3 =
                                                     FStar_TypeChecker_Env.push_let_binding
                                                       env2 l (u_names, t4)
@@ -4769,84 +4786,84 @@ and (tc_abs :
                                                   let lb =
                                                     match l with
                                                     | FStar_Util.Inl x ->
-                                                        let uu____14121 =
+                                                        let uu____14052 =
                                                           FStar_Syntax_Syntax.mk_binder
-                                                            (let uu___1904_14124
+                                                            (let uu___1916_14055
                                                                = x  in
                                                              {
                                                                FStar_Syntax_Syntax.ppname
                                                                  =
-                                                                 (uu___1904_14124.FStar_Syntax_Syntax.ppname);
+                                                                 (uu___1916_14055.FStar_Syntax_Syntax.ppname);
                                                                FStar_Syntax_Syntax.index
                                                                  =
-                                                                 (uu___1904_14124.FStar_Syntax_Syntax.index);
+                                                                 (uu___1916_14055.FStar_Syntax_Syntax.index);
                                                                FStar_Syntax_Syntax.sort
                                                                  = t4
                                                              })
                                                            in
-                                                        uu____14121 ::
+                                                        uu____14052 ::
                                                           letrec_binders
-                                                    | uu____14125 ->
+                                                    | uu____14056 ->
                                                         letrec_binders
                                                      in
-                                                  let uu____14130 =
+                                                  let uu____14061 =
                                                     FStar_TypeChecker_Env.conj_guard
                                                       g g'
                                                      in
-                                                  (env3, lb, uu____14130)))
+                                                  (env3, lb, uu____14061)))
                                     (envbody1, [],
                                       FStar_TypeChecker_Env.trivial_guard))
                                 in
-                             match uu____13918 with
+                             match uu____13849 with
                              | (envbody2,letrec_binders,g) ->
-                                 let uu____14150 =
+                                 let uu____14081 =
                                    FStar_TypeChecker_Env.close_guard envbody2
                                      bs1 g
                                     in
-                                 (envbody2, letrec_binders, uu____14150)
+                                 (envbody2, letrec_binders, uu____14081)
                               in
-                           let uu____14153 =
+                           let uu____14084 =
                              check_actuals_against_formals env1 bs
                                bs_expected1 body1
                               in
-                           (match uu____14153 with
+                           (match uu____14084 with
                             | (envbody,bs1,g_env,c,body2) ->
-                                let uu____14229 = mk_letrec_env envbody bs1 c
+                                let uu____14120 = mk_letrec_env envbody bs1 c
                                    in
-                                (match uu____14229 with
+                                (match uu____14120 with
                                  | (envbody1,letrecs,g_annots) ->
                                      let envbody2 =
                                        FStar_TypeChecker_Env.set_expected_typ
                                          envbody1
                                          (FStar_Syntax_Util.comp_result c)
                                         in
-                                     let uu____14276 =
+                                     let uu____14157 =
                                        FStar_TypeChecker_Env.conj_guard g_env
                                          g_annots
                                         in
                                      ((FStar_Pervasives_Native.Some t2), bs1,
                                        letrecs,
                                        (FStar_Pervasives_Native.Some c),
-                                       envbody2, body2, uu____14276))))
-                  | uu____14293 ->
+                                       envbody2, body2, uu____14157))))
+                  | uu____14164 ->
                       if Prims.op_Negation norm1
                       then
-                        let uu____14325 =
-                          let uu____14326 =
+                        let uu____14186 =
+                          let uu____14187 =
                             FStar_All.pipe_right t2
                               (FStar_TypeChecker_Normalize.unfold_whnf env1)
                              in
-                          FStar_All.pipe_right uu____14326
+                          FStar_All.pipe_right uu____14187
                             FStar_Syntax_Util.unascribe
                            in
-                        as_function_typ true uu____14325
+                        as_function_typ true uu____14186
                       else
-                        (let uu____14330 =
+                        (let uu____14191 =
                            expected_function_typ env1
                              FStar_Pervasives_Native.None body1
                             in
-                         match uu____14330 with
-                         | (uu____14379,bs1,uu____14381,c_opt,envbody,body2,g_env)
+                         match uu____14191 with
+                         | (uu____14230,bs1,uu____14232,c_opt,envbody,body2,g_env)
                              ->
                              ((FStar_Pervasives_Native.Some t2), bs1, [],
                                c_opt, envbody, body2, g_env))
@@ -4854,14 +4871,14 @@ and (tc_abs :
                 as_function_typ false t1
              in
           let use_eq = env.FStar_TypeChecker_Env.use_eq  in
-          let uu____14413 = FStar_TypeChecker_Env.clear_expected_typ env  in
-          match uu____14413 with
+          let uu____14254 = FStar_TypeChecker_Env.clear_expected_typ env  in
+          match uu____14254 with
           | (env1,topt) ->
-              ((let uu____14433 =
+              ((let uu____14274 =
                   FStar_TypeChecker_Env.debug env1 FStar_Options.High  in
-                if uu____14433
+                if uu____14274
                 then
-                  let uu____14436 =
+                  let uu____14277 =
                     match topt with
                     | FStar_Pervasives_Native.None  -> "None"
                     | FStar_Pervasives_Native.Some t ->
@@ -4869,179 +4886,179 @@ and (tc_abs :
                      in
                   FStar_Util.print2
                     "!!!!!!!!!!!!!!!Expected type is %s, top_level=%s\n"
-                    uu____14436
+                    uu____14277
                     (if env1.FStar_TypeChecker_Env.top_level
                      then "true"
                      else "false")
                 else ());
-               (let uu____14450 = expected_function_typ env1 topt body  in
-                match uu____14450 with
+               (let uu____14291 = expected_function_typ env1 topt body  in
+                match uu____14291 with
                 | (tfun_opt,bs1,letrec_binders,c_opt,envbody,body1,g_env) ->
-                    ((let uu____14491 =
+                    ((let uu____14332 =
                         FStar_TypeChecker_Env.debug env1
                           FStar_Options.Extreme
                          in
-                      if uu____14491
+                      if uu____14332
                       then
-                        let uu____14494 =
+                        let uu____14335 =
                           match tfun_opt with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t
                            in
-                        let uu____14499 =
+                        let uu____14340 =
                           match c_opt with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.comp_to_string t
                            in
-                        let uu____14504 =
-                          let uu____14506 =
+                        let uu____14345 =
+                          let uu____14347 =
                             FStar_TypeChecker_Env.expected_typ envbody  in
-                          match uu____14506 with
+                          match uu____14347 with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t
                            in
                         FStar_Util.print3
                           "After expected_function_typ, tfun_opt: %s, c_opt: %s, and expected type in envbody: %s\n"
-                          uu____14494 uu____14499 uu____14504
+                          uu____14335 uu____14340 uu____14345
                       else ());
-                     (let uu____14516 =
+                     (let uu____14357 =
                         FStar_All.pipe_left
                           (FStar_TypeChecker_Env.debug env1)
                           (FStar_Options.Other "NYC")
                          in
-                      if uu____14516
+                      if uu____14357
                       then
-                        let uu____14521 =
+                        let uu____14362 =
                           FStar_Syntax_Print.binders_to_string ", " bs1  in
-                        let uu____14524 =
+                        let uu____14365 =
                           FStar_TypeChecker_Rel.guard_to_string env1 g_env
                            in
                         FStar_Util.print2
                           "!!!!!!!!!!!!!!!Guard for function with binders %s is %s\n"
-                          uu____14521 uu____14524
+                          uu____14362 uu____14365
                       else ());
                      (let envbody1 =
                         FStar_TypeChecker_Env.set_range envbody
                           body1.FStar_Syntax_Syntax.pos
                          in
-                      let uu____14530 =
+                      let uu____14371 =
                         let should_check_expected_effect =
-                          let uu____14543 =
-                            let uu____14550 =
-                              let uu____14551 =
+                          let uu____14384 =
+                            let uu____14391 =
+                              let uu____14392 =
                                 FStar_Syntax_Subst.compress body1  in
-                              uu____14551.FStar_Syntax_Syntax.n  in
-                            (c_opt, uu____14550)  in
-                          match uu____14543 with
+                              uu____14392.FStar_Syntax_Syntax.n  in
+                            (c_opt, uu____14391)  in
+                          match uu____14384 with
                           | (FStar_Pervasives_Native.None
                              ,FStar_Syntax_Syntax.Tm_ascribed
-                             (uu____14557,(FStar_Util.Inr
-                                           expected_c,uu____14559),uu____14560))
+                             (uu____14398,(FStar_Util.Inr
+                                           expected_c,uu____14400),uu____14401))
                               -> false
-                          | uu____14610 -> true  in
-                        let uu____14618 =
+                          | uu____14451 -> true  in
+                        let uu____14459 =
                           tc_term
-                            (let uu___1977_14627 = envbody1  in
+                            (let uu___1989_14468 = envbody1  in
                              {
                                FStar_TypeChecker_Env.solver =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.solver);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.solver);
                                FStar_TypeChecker_Env.range =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.range);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.range);
                                FStar_TypeChecker_Env.curmodule =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.curmodule);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.curmodule);
                                FStar_TypeChecker_Env.gamma =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.gamma);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.gamma);
                                FStar_TypeChecker_Env.gamma_sig =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.gamma_sig);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.gamma_sig);
                                FStar_TypeChecker_Env.gamma_cache =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.gamma_cache);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.gamma_cache);
                                FStar_TypeChecker_Env.modules =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.modules);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.modules);
                                FStar_TypeChecker_Env.expected_typ =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.expected_typ);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.expected_typ);
                                FStar_TypeChecker_Env.sigtab =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.sigtab);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.sigtab);
                                FStar_TypeChecker_Env.attrtab =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.attrtab);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.attrtab);
                                FStar_TypeChecker_Env.instantiate_imp =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.instantiate_imp);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.instantiate_imp);
                                FStar_TypeChecker_Env.effects =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.effects);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.effects);
                                FStar_TypeChecker_Env.generalize =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.generalize);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.generalize);
                                FStar_TypeChecker_Env.letrecs =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.letrecs);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.letrecs);
                                FStar_TypeChecker_Env.top_level = false;
                                FStar_TypeChecker_Env.check_uvars =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.check_uvars);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.check_uvars);
                                FStar_TypeChecker_Env.use_eq = use_eq;
                                FStar_TypeChecker_Env.use_eq_strict =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.use_eq_strict);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.use_eq_strict);
                                FStar_TypeChecker_Env.is_iface =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.is_iface);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.is_iface);
                                FStar_TypeChecker_Env.admit =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.admit);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.admit);
                                FStar_TypeChecker_Env.lax =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.lax);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.lax);
                                FStar_TypeChecker_Env.lax_universes =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.lax_universes);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.lax_universes);
                                FStar_TypeChecker_Env.phase1 =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.phase1);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.phase1);
                                FStar_TypeChecker_Env.failhard =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.failhard);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.failhard);
                                FStar_TypeChecker_Env.nosynth =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.nosynth);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.nosynth);
                                FStar_TypeChecker_Env.uvar_subtyping =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.uvar_subtyping);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.uvar_subtyping);
                                FStar_TypeChecker_Env.tc_term =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.tc_term);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.tc_term);
                                FStar_TypeChecker_Env.type_of =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.type_of);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.type_of);
                                FStar_TypeChecker_Env.universe_of =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.universe_of);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.universe_of);
                                FStar_TypeChecker_Env.check_type_of =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.check_type_of);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.check_type_of);
                                FStar_TypeChecker_Env.use_bv_sorts =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.use_bv_sorts);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.use_bv_sorts);
                                FStar_TypeChecker_Env.qtbl_name_and_index =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.qtbl_name_and_index);
                                FStar_TypeChecker_Env.normalized_eff_names =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.normalized_eff_names);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.normalized_eff_names);
                                FStar_TypeChecker_Env.fv_delta_depths =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.fv_delta_depths);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.fv_delta_depths);
                                FStar_TypeChecker_Env.proof_ns =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.proof_ns);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.proof_ns);
                                FStar_TypeChecker_Env.synth_hook =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.synth_hook);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.synth_hook);
                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                  =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                FStar_TypeChecker_Env.splice =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.splice);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.splice);
                                FStar_TypeChecker_Env.mpreprocess =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.mpreprocess);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.mpreprocess);
                                FStar_TypeChecker_Env.postprocess =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.postprocess);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.postprocess);
                                FStar_TypeChecker_Env.is_native_tactic =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.is_native_tactic);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.is_native_tactic);
                                FStar_TypeChecker_Env.identifier_info =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.identifier_info);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.identifier_info);
                                FStar_TypeChecker_Env.tc_hooks =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.tc_hooks);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.tc_hooks);
                                FStar_TypeChecker_Env.dsenv =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.dsenv);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.dsenv);
                                FStar_TypeChecker_Env.nbe =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.nbe);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.nbe);
                                FStar_TypeChecker_Env.strict_args_tab =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.strict_args_tab);
+                                 (uu___1989_14468.FStar_TypeChecker_Env.strict_args_tab);
                                FStar_TypeChecker_Env.erasable_types_tab =
-                                 (uu___1977_14627.FStar_TypeChecker_Env.erasable_types_tab)
+                                 (uu___1989_14468.FStar_TypeChecker_Env.erasable_types_tab)
                              }) body1
                            in
-                        match uu____14618 with
+                        match uu____14459 with
                         | (body2,cbody,guard_body) ->
                             let guard_body1 =
                               FStar_TypeChecker_Rel.solve_deferred_constraints
@@ -5049,179 +5066,179 @@ and (tc_abs :
                                in
                             if should_check_expected_effect
                             then
-                              let uu____14654 =
+                              let uu____14495 =
                                 FStar_TypeChecker_Common.lcomp_comp cbody  in
-                              (match uu____14654 with
+                              (match uu____14495 with
                                | (cbody1,g_lc) ->
-                                   let uu____14671 =
+                                   let uu____14512 =
                                      check_expected_effect
-                                       (let uu___1988_14680 = envbody1  in
+                                       (let uu___2000_14521 = envbody1  in
                                         {
                                           FStar_TypeChecker_Env.solver =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.solver);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.solver);
                                           FStar_TypeChecker_Env.range =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.range);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.range);
                                           FStar_TypeChecker_Env.curmodule =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.curmodule);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.curmodule);
                                           FStar_TypeChecker_Env.gamma =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.gamma);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.gamma);
                                           FStar_TypeChecker_Env.gamma_sig =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.gamma_sig);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.gamma_sig);
                                           FStar_TypeChecker_Env.gamma_cache =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.gamma_cache);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.gamma_cache);
                                           FStar_TypeChecker_Env.modules =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.modules);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.modules);
                                           FStar_TypeChecker_Env.expected_typ
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.expected_typ);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.expected_typ);
                                           FStar_TypeChecker_Env.sigtab =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.sigtab);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.sigtab);
                                           FStar_TypeChecker_Env.attrtab =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.attrtab);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.attrtab);
                                           FStar_TypeChecker_Env.instantiate_imp
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.instantiate_imp);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.instantiate_imp);
                                           FStar_TypeChecker_Env.effects =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.effects);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.effects);
                                           FStar_TypeChecker_Env.generalize =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.generalize);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.generalize);
                                           FStar_TypeChecker_Env.letrecs =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.letrecs);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.letrecs);
                                           FStar_TypeChecker_Env.top_level =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.top_level);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.top_level);
                                           FStar_TypeChecker_Env.check_uvars =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.check_uvars);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.check_uvars);
                                           FStar_TypeChecker_Env.use_eq =
                                             use_eq;
                                           FStar_TypeChecker_Env.use_eq_strict
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.use_eq_strict);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.use_eq_strict);
                                           FStar_TypeChecker_Env.is_iface =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.is_iface);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.is_iface);
                                           FStar_TypeChecker_Env.admit =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.admit);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.admit);
                                           FStar_TypeChecker_Env.lax =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.lax);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.lax);
                                           FStar_TypeChecker_Env.lax_universes
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.lax_universes);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.lax_universes);
                                           FStar_TypeChecker_Env.phase1 =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.phase1);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.phase1);
                                           FStar_TypeChecker_Env.failhard =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.failhard);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.failhard);
                                           FStar_TypeChecker_Env.nosynth =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.nosynth);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.nosynth);
                                           FStar_TypeChecker_Env.uvar_subtyping
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.uvar_subtyping);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.uvar_subtyping);
                                           FStar_TypeChecker_Env.tc_term =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.tc_term);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.tc_term);
                                           FStar_TypeChecker_Env.type_of =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.type_of);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.type_of);
                                           FStar_TypeChecker_Env.universe_of =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.universe_of);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.universe_of);
                                           FStar_TypeChecker_Env.check_type_of
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.check_type_of);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.check_type_of);
                                           FStar_TypeChecker_Env.use_bv_sorts
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.use_bv_sorts);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.use_bv_sorts);
                                           FStar_TypeChecker_Env.qtbl_name_and_index
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.qtbl_name_and_index);
                                           FStar_TypeChecker_Env.normalized_eff_names
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.normalized_eff_names);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.normalized_eff_names);
                                           FStar_TypeChecker_Env.fv_delta_depths
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.fv_delta_depths);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.fv_delta_depths);
                                           FStar_TypeChecker_Env.proof_ns =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.proof_ns);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.proof_ns);
                                           FStar_TypeChecker_Env.synth_hook =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.synth_hook);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.synth_hook);
                                           FStar_TypeChecker_Env.try_solve_implicits_hook
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                           FStar_TypeChecker_Env.splice =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.splice);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.splice);
                                           FStar_TypeChecker_Env.mpreprocess =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.mpreprocess);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.mpreprocess);
                                           FStar_TypeChecker_Env.postprocess =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.postprocess);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.postprocess);
                                           FStar_TypeChecker_Env.is_native_tactic
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.is_native_tactic);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.is_native_tactic);
                                           FStar_TypeChecker_Env.identifier_info
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.identifier_info);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.identifier_info);
                                           FStar_TypeChecker_Env.tc_hooks =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.tc_hooks);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.tc_hooks);
                                           FStar_TypeChecker_Env.dsenv =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.dsenv);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.dsenv);
                                           FStar_TypeChecker_Env.nbe =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.nbe);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.nbe);
                                           FStar_TypeChecker_Env.strict_args_tab
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.strict_args_tab);
+                                            (uu___2000_14521.FStar_TypeChecker_Env.strict_args_tab);
                                           FStar_TypeChecker_Env.erasable_types_tab
                                             =
-                                            (uu___1988_14680.FStar_TypeChecker_Env.erasable_types_tab)
+                                            (uu___2000_14521.FStar_TypeChecker_Env.erasable_types_tab)
                                         }) c_opt (body2, cbody1)
                                       in
-                                   (match uu____14671 with
+                                   (match uu____14512 with
                                     | (body3,cbody2,guard) ->
-                                        let uu____14694 =
-                                          let uu____14695 =
+                                        let uu____14535 =
+                                          let uu____14536 =
                                             FStar_TypeChecker_Env.conj_guard
                                               g_lc guard
                                              in
                                           FStar_TypeChecker_Env.conj_guard
-                                            guard_body1 uu____14695
+                                            guard_body1 uu____14536
                                            in
-                                        (body3, cbody2, uu____14694)))
+                                        (body3, cbody2, uu____14535)))
                             else
-                              (let uu____14702 =
+                              (let uu____14543 =
                                  FStar_TypeChecker_Common.lcomp_comp cbody
                                   in
-                               match uu____14702 with
+                               match uu____14543 with
                                | (cbody1,g_lc) ->
-                                   let uu____14719 =
+                                   let uu____14560 =
                                      FStar_TypeChecker_Env.conj_guard
                                        guard_body1 g_lc
                                       in
-                                   (body2, cbody1, uu____14719))
+                                   (body2, cbody1, uu____14560))
                          in
-                      match uu____14530 with
+                      match uu____14371 with
                       | (body2,cbody,guard_body) ->
                           let guard =
-                            let uu____14742 =
+                            let uu____14583 =
                               env1.FStar_TypeChecker_Env.top_level ||
-                                (let uu____14745 =
+                                (let uu____14586 =
                                    FStar_TypeChecker_Env.should_verify env1
                                     in
-                                 Prims.op_Negation uu____14745)
+                                 Prims.op_Negation uu____14586)
                                in
-                            if uu____14742
+                            if uu____14583
                             then
-                              let uu____14748 =
+                              let uu____14589 =
                                 FStar_TypeChecker_Rel.discharge_guard env1
                                   g_env
                                  in
-                              let uu____14749 =
+                              let uu____14590 =
                                 FStar_TypeChecker_Rel.discharge_guard
                                   envbody1 guard_body
                                  in
-                              FStar_TypeChecker_Env.conj_guard uu____14748
-                                uu____14749
+                              FStar_TypeChecker_Env.conj_guard uu____14589
+                                uu____14590
                             else
                               (let guard =
-                                 let uu____14753 =
+                                 let uu____14594 =
                                    FStar_TypeChecker_Env.close_guard env1
                                      (FStar_List.append bs1 letrec_binders)
                                      guard_body
                                     in
                                  FStar_TypeChecker_Env.conj_guard g_env
-                                   uu____14753
+                                   uu____14594
                                   in
                                guard)
                              in
@@ -5237,7 +5254,7 @@ and (tc_abs :
                                  (FStar_Syntax_Util.residual_comp_of_comp
                                     (FStar_Util.dflt cbody c_opt)))
                              in
-                          let uu____14768 =
+                          let uu____14609 =
                             match tfun_opt with
                             | FStar_Pervasives_Native.Some t ->
                                 let t1 = FStar_Syntax_Subst.compress t  in
@@ -5249,43 +5266,43 @@ and (tc_abs :
                                         "Impossible! tc_abs: if tfun_computed is Some, expected topt to also be Some"
                                    in
                                 (match t1.FStar_Syntax_Syntax.n with
-                                 | FStar_Syntax_Syntax.Tm_arrow uu____14792
+                                 | FStar_Syntax_Syntax.Tm_arrow uu____14633
                                      -> (e, t_annot, guard1)
-                                 | uu____14807 ->
+                                 | uu____14648 ->
                                      let lc =
-                                       let uu____14809 =
+                                       let uu____14650 =
                                          FStar_Syntax_Syntax.mk_Total
                                            tfun_computed
                                           in
-                                       FStar_All.pipe_right uu____14809
+                                       FStar_All.pipe_right uu____14650
                                          FStar_TypeChecker_Common.lcomp_of_comp
                                         in
-                                     let uu____14810 =
+                                     let uu____14651 =
                                        FStar_TypeChecker_Util.check_has_type
                                          env1 e lc t1
                                         in
-                                     (match uu____14810 with
-                                      | (e1,uu____14824,guard') ->
-                                          let uu____14826 =
+                                     (match uu____14651 with
+                                      | (e1,uu____14665,guard') ->
+                                          let uu____14667 =
                                             FStar_TypeChecker_Env.conj_guard
                                               guard1 guard'
                                              in
-                                          (e1, t_annot, uu____14826)))
+                                          (e1, t_annot, uu____14667)))
                             | FStar_Pervasives_Native.None  ->
                                 (e, tfun_computed, guard1)
                              in
-                          (match uu____14768 with
+                          (match uu____14609 with
                            | (e1,tfun,guard2) ->
                                let c = FStar_Syntax_Syntax.mk_Total tfun  in
-                               let uu____14837 =
-                                 let uu____14842 =
+                               let uu____14678 =
+                                 let uu____14683 =
                                    FStar_TypeChecker_Common.lcomp_of_comp c
                                     in
                                  FStar_TypeChecker_Util.strengthen_precondition
                                    FStar_Pervasives_Native.None env1 e1
-                                   uu____14842 guard2
+                                   uu____14683 guard2
                                   in
-                               (match uu____14837 with
+                               (match uu____14678 with
                                 | (c1,g) -> (e1, c1, g)))))))
 
 and (check_application_args :
@@ -5309,98 +5326,98 @@ and (check_application_args :
               let n_args = FStar_List.length args  in
               let r = FStar_TypeChecker_Env.get_range env  in
               let thead = FStar_Syntax_Util.comp_result chead  in
-              (let uu____14893 =
+              (let uu____14734 =
                  FStar_TypeChecker_Env.debug env FStar_Options.High  in
-               if uu____14893
+               if uu____14734
                then
-                 let uu____14896 =
+                 let uu____14737 =
                    FStar_Range.string_of_range head.FStar_Syntax_Syntax.pos
                     in
-                 let uu____14898 = FStar_Syntax_Print.term_to_string thead
+                 let uu____14739 = FStar_Syntax_Print.term_to_string thead
                     in
-                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____14896
-                   uu____14898
+                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____14737
+                   uu____14739
                else ());
-              (let monadic_application uu____14980 subst arg_comps_rev
+              (let monadic_application uu____14821 subst arg_comps_rev
                  arg_rets_rev guard fvs bs =
-                 match uu____14980 with
+                 match uu____14821 with
                  | (head1,chead1,ghead1,cres) ->
-                     let uu____15049 =
+                     let uu____14890 =
                        check_no_escape (FStar_Pervasives_Native.Some head1)
                          env fvs (FStar_Syntax_Util.comp_result cres)
                         in
-                     (match uu____15049 with
+                     (match uu____14890 with
                       | (rt,g0) ->
                           let cres1 =
                             FStar_Syntax_Util.set_result_typ cres rt  in
-                          let uu____15063 =
+                          let uu____14904 =
                             match bs with
                             | [] ->
                                 let g =
-                                  let uu____15079 =
+                                  let uu____14920 =
                                     FStar_TypeChecker_Env.conj_guard ghead1
                                       guard
                                      in
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.conj_guard g0)
-                                    uu____15079
+                                    uu____14920
                                    in
                                 (cres1, g)
-                            | uu____15080 ->
+                            | uu____14921 ->
                                 let g =
-                                  let uu____15090 =
-                                    let uu____15091 =
+                                  let uu____14931 =
+                                    let uu____14932 =
                                       FStar_TypeChecker_Env.conj_guard ghead1
                                         guard
                                        in
-                                    FStar_All.pipe_right uu____15091
+                                    FStar_All.pipe_right uu____14932
                                       (FStar_TypeChecker_Rel.solve_deferred_constraints
                                          env)
                                      in
                                   FStar_TypeChecker_Env.conj_guard g0
-                                    uu____15090
+                                    uu____14931
                                    in
-                                let uu____15092 =
-                                  let uu____15093 =
+                                let uu____14933 =
+                                  let uu____14934 =
                                     FStar_Syntax_Util.arrow bs cres1  in
-                                  FStar_Syntax_Syntax.mk_Total uu____15093
+                                  FStar_Syntax_Syntax.mk_Total uu____14934
                                    in
-                                (uu____15092, g)
+                                (uu____14933, g)
                              in
-                          (match uu____15063 with
+                          (match uu____14904 with
                            | (cres2,guard1) ->
-                               ((let uu____15103 =
+                               ((let uu____14944 =
                                    FStar_TypeChecker_Env.debug env
                                      FStar_Options.Medium
                                     in
-                                 if uu____15103
+                                 if uu____14944
                                  then
-                                   let uu____15106 =
+                                   let uu____14947 =
                                      FStar_Syntax_Print.comp_to_string cres2
                                       in
                                    FStar_Util.print1
                                      "\t Type of result cres is %s\n"
-                                     uu____15106
+                                     uu____14947
                                  else ());
-                                (let uu____15111 =
-                                   let uu____15116 =
-                                     let uu____15117 =
+                                (let uu____14952 =
+                                   let uu____14957 =
+                                     let uu____14958 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          chead1
                                         in
-                                     FStar_All.pipe_right uu____15117
+                                     FStar_All.pipe_right uu____14958
                                        FStar_TypeChecker_Common.lcomp_of_comp
                                       in
-                                   let uu____15118 =
-                                     let uu____15119 =
+                                   let uu____14959 =
+                                     let uu____14960 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          cres2
                                         in
-                                     FStar_All.pipe_right uu____15119
+                                     FStar_All.pipe_right uu____14960
                                        FStar_TypeChecker_Common.lcomp_of_comp
                                       in
-                                   (uu____15116, uu____15118)  in
-                                 match uu____15111 with
+                                   (uu____14957, uu____14959)  in
+                                 match uu____14952 with
                                  | (chead2,cres3) ->
                                      let cres4 =
                                        let head_is_pure_and_some_arg_is_effectful
@@ -5409,16 +5426,16 @@ and (check_application_args :
                                             chead2)
                                            &&
                                            (FStar_Util.for_some
-                                              (fun uu____15143  ->
-                                                 match uu____15143 with
-                                                 | (uu____15153,uu____15154,lc)
+                                              (fun uu____14984  ->
+                                                 match uu____14984 with
+                                                 | (uu____14994,uu____14995,lc)
                                                      ->
-                                                     (let uu____15162 =
+                                                     (let uu____15003 =
                                                         FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                           lc
                                                          in
                                                       Prims.op_Negation
-                                                        uu____15162)
+                                                        uu____15003)
                                                        ||
                                                        (FStar_TypeChecker_Util.should_not_inline_lc
                                                           lc)) arg_comps_rev)
@@ -5429,61 +5446,61 @@ and (check_application_args :
                                            FStar_Pervasives_Native.None
                                            head1.FStar_Syntax_Syntax.pos
                                           in
-                                       let uu____15175 =
+                                       let uu____15016 =
                                          (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                             cres3)
                                            &&
                                            head_is_pure_and_some_arg_is_effectful
                                           in
-                                       if uu____15175
+                                       if uu____15016
                                        then
-                                         ((let uu____15179 =
+                                         ((let uu____15020 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme
                                               in
-                                           if uu____15179
+                                           if uu____15020
                                            then
-                                             let uu____15182 =
+                                             let uu____15023 =
                                                FStar_Syntax_Print.term_to_string
                                                  term
                                                 in
                                              FStar_Util.print1
                                                "(a) Monadic app: Return inserted in monadic application: %s\n"
-                                               uu____15182
+                                               uu____15023
                                            else ());
                                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                             env term cres3)
                                        else
-                                         ((let uu____15190 =
+                                         ((let uu____15031 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme
                                               in
-                                           if uu____15190
+                                           if uu____15031
                                            then
-                                             let uu____15193 =
+                                             let uu____15034 =
                                                FStar_Syntax_Print.term_to_string
                                                  term
                                                 in
                                              FStar_Util.print1
                                                "(a) Monadic app: No return inserted in monadic application: %s\n"
-                                               uu____15193
+                                               uu____15034
                                            else ());
                                           cres3)
                                         in
                                      let comp =
                                        FStar_List.fold_left
                                          (fun out_c  ->
-                                            fun uu____15224  ->
-                                              match uu____15224 with
+                                            fun uu____15065  ->
+                                              match uu____15065 with
                                               | ((e,q),x,c) ->
-                                                  ((let uu____15266 =
+                                                  ((let uu____15107 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme
                                                        in
-                                                    if uu____15266
+                                                    if uu____15107
                                                     then
-                                                      let uu____15269 =
+                                                      let uu____15110 =
                                                         match x with
                                                         | FStar_Pervasives_Native.None
                                                              -> "_"
@@ -5492,25 +5509,25 @@ and (check_application_args :
                                                             FStar_Syntax_Print.bv_to_string
                                                               x1
                                                          in
-                                                      let uu____15274 =
+                                                      let uu____15115 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e
                                                          in
-                                                      let uu____15276 =
+                                                      let uu____15117 =
                                                         FStar_TypeChecker_Common.lcomp_to_string
                                                           c
                                                          in
                                                       FStar_Util.print3
                                                         "(b) Monadic app: Binding argument %s : %s of type (%s)\n"
-                                                        uu____15269
-                                                        uu____15274
-                                                        uu____15276
+                                                        uu____15110
+                                                        uu____15115
+                                                        uu____15117
                                                     else ());
-                                                   (let uu____15281 =
+                                                   (let uu____15122 =
                                                       FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                         c
                                                        in
-                                                    if uu____15281
+                                                    if uu____15122
                                                     then
                                                       FStar_TypeChecker_Util.bind
                                                         e.FStar_Syntax_Syntax.pos
@@ -5526,25 +5543,25 @@ and (check_application_args :
                                          arg_comps_rev
                                         in
                                      let comp1 =
-                                       (let uu____15292 =
+                                       (let uu____15133 =
                                           FStar_TypeChecker_Env.debug env
                                             FStar_Options.Extreme
                                            in
-                                        if uu____15292
+                                        if uu____15133
                                         then
-                                          let uu____15295 =
+                                          let uu____15136 =
                                             FStar_Syntax_Print.term_to_string
                                               head1
                                              in
                                           FStar_Util.print1
                                             "(c) Monadic app: Binding head %s\n"
-                                            uu____15295
+                                            uu____15136
                                         else ());
-                                       (let uu____15300 =
+                                       (let uu____15141 =
                                           FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                             chead2
                                            in
-                                        if uu____15300
+                                        if uu____15141
                                         then
                                           FStar_TypeChecker_Util.bind
                                             head1.FStar_Syntax_Syntax.pos env
@@ -5561,29 +5578,29 @@ and (check_application_args :
                                               comp))
                                         in
                                      let shortcuts_evaluation_order =
-                                       let uu____15311 =
-                                         let uu____15312 =
+                                       let uu____15152 =
+                                         let uu____15153 =
                                            FStar_Syntax_Subst.compress head1
                                             in
-                                         uu____15312.FStar_Syntax_Syntax.n
+                                         uu____15153.FStar_Syntax_Syntax.n
                                           in
-                                       match uu____15311 with
+                                       match uu____15152 with
                                        | FStar_Syntax_Syntax.Tm_fvar fv ->
                                            (FStar_Syntax_Syntax.fv_eq_lid fv
                                               FStar_Parser_Const.op_And)
                                              ||
                                              (FStar_Syntax_Syntax.fv_eq_lid
                                                 fv FStar_Parser_Const.op_Or)
-                                       | uu____15317 -> false  in
+                                       | uu____15158 -> false  in
                                      let app =
                                        if shortcuts_evaluation_order
                                        then
                                          let args1 =
                                            FStar_List.fold_left
                                              (fun args1  ->
-                                                fun uu____15340  ->
-                                                  match uu____15340 with
-                                                  | (arg,uu____15354,uu____15355)
+                                                fun uu____15181  ->
+                                                  match uu____15181 with
+                                                  | (arg,uu____15195,uu____15196)
                                                       -> arg :: args1) []
                                              arg_comps_rev
                                             in
@@ -5604,42 +5621,42 @@ and (check_application_args :
                                            comp1.FStar_TypeChecker_Common.eff_name
                                            comp1.FStar_TypeChecker_Common.res_typ
                                        else
-                                         (let uu____15366 =
-                                            let map_fun uu____15432 =
-                                              match uu____15432 with
-                                              | ((e,q),uu____15473,c) ->
-                                                  ((let uu____15496 =
+                                         (let uu____15207 =
+                                            let map_fun uu____15273 =
+                                              match uu____15273 with
+                                              | ((e,q),uu____15314,c) ->
+                                                  ((let uu____15337 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme
                                                        in
-                                                    if uu____15496
+                                                    if uu____15337
                                                     then
-                                                      let uu____15499 =
+                                                      let uu____15340 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e
                                                          in
-                                                      let uu____15501 =
+                                                      let uu____15342 =
                                                         FStar_TypeChecker_Common.lcomp_to_string
                                                           c
                                                          in
                                                       FStar_Util.print2
                                                         "For arg e=(%s) c=(%s)... "
-                                                        uu____15499
-                                                        uu____15501
+                                                        uu____15340
+                                                        uu____15342
                                                     else ());
-                                                   (let uu____15506 =
+                                                   (let uu____15347 =
                                                       FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                         c
                                                        in
-                                                    if uu____15506
+                                                    if uu____15347
                                                     then
-                                                      ((let uu____15532 =
+                                                      ((let uu____15373 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme
                                                            in
-                                                        if uu____15532
+                                                        if uu____15373
                                                         then
                                                           FStar_Util.print_string
                                                             "... not lifting\n"
@@ -5653,67 +5670,67 @@ and (check_application_args :
                                                             env
                                                             chead2.FStar_TypeChecker_Common.res_typ)
                                                            &&
-                                                           (let uu____15573 =
-                                                              let uu____15575
+                                                           (let uu____15414 =
+                                                              let uu____15416
                                                                 =
-                                                                let uu____15576
+                                                                let uu____15417
                                                                   =
                                                                   FStar_Syntax_Util.un_uinst
                                                                     head1
                                                                    in
-                                                                uu____15576.FStar_Syntax_Syntax.n
+                                                                uu____15417.FStar_Syntax_Syntax.n
                                                                  in
-                                                              match uu____15575
+                                                              match uu____15416
                                                               with
                                                               | FStar_Syntax_Syntax.Tm_fvar
                                                                   fv ->
-                                                                  let uu____15581
+                                                                  let uu____15422
                                                                     =
                                                                     FStar_Parser_Const.psconst
                                                                     "ignore"
                                                                      in
                                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                                     fv
-                                                                    uu____15581
-                                                              | uu____15583
+                                                                    uu____15422
+                                                              | uu____15424
                                                                   -> true
                                                                in
                                                             Prims.op_Negation
-                                                              uu____15573)
+                                                              uu____15414)
                                                           in
                                                        if warn_effectful_args
                                                        then
-                                                         (let uu____15587 =
-                                                            let uu____15593 =
-                                                              let uu____15595
+                                                         (let uu____15428 =
+                                                            let uu____15434 =
+                                                              let uu____15436
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   e
                                                                  in
-                                                              let uu____15597
+                                                              let uu____15438
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   head1
                                                                  in
                                                               FStar_Util.format3
                                                                 "Effectful argument %s (%s) to erased function %s, consider let binding it"
-                                                                uu____15595
+                                                                uu____15436
                                                                 (c.FStar_TypeChecker_Common.eff_name).FStar_Ident.str
-                                                                uu____15597
+                                                                uu____15438
                                                                in
                                                             (FStar_Errors.Warning_EffectfulArgumentToErasedFunction,
-                                                              uu____15593)
+                                                              uu____15434)
                                                              in
                                                           FStar_Errors.log_issue
                                                             e.FStar_Syntax_Syntax.pos
-                                                            uu____15587)
+                                                            uu____15428)
                                                        else ();
-                                                       (let uu____15604 =
+                                                       (let uu____15445 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme
                                                            in
-                                                        if uu____15604
+                                                        if uu____15445
                                                         then
                                                           FStar_Util.print_string
                                                             "... lifting!\n"
@@ -5730,62 +5747,62 @@ and (check_application_args :
                                                             comp1.FStar_TypeChecker_Common.eff_name
                                                             c.FStar_TypeChecker_Common.res_typ
                                                            in
-                                                        let uu____15612 =
-                                                          let uu____15621 =
+                                                        let uu____15453 =
+                                                          let uu____15462 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x
                                                              in
-                                                          (uu____15621, q)
+                                                          (uu____15462, q)
                                                            in
                                                         ((FStar_Pervasives_Native.Some
                                                             (x,
                                                               (c.FStar_TypeChecker_Common.eff_name),
                                                               (c.FStar_TypeChecker_Common.res_typ),
                                                               e1)),
-                                                          uu____15612)))))
+                                                          uu____15453)))))
                                                in
-                                            let uu____15650 =
-                                              let uu____15681 =
-                                                let uu____15710 =
-                                                  let uu____15721 =
-                                                    let uu____15730 =
+                                            let uu____15491 =
+                                              let uu____15522 =
+                                                let uu____15551 =
+                                                  let uu____15562 =
+                                                    let uu____15571 =
                                                       FStar_Syntax_Syntax.as_arg
                                                         head1
                                                        in
-                                                    (uu____15730,
+                                                    (uu____15571,
                                                       FStar_Pervasives_Native.None,
                                                       chead2)
                                                      in
-                                                  uu____15721 ::
+                                                  uu____15562 ::
                                                     arg_comps_rev
                                                    in
                                                 FStar_List.map map_fun
-                                                  uu____15710
+                                                  uu____15551
                                                  in
                                               FStar_All.pipe_left
-                                                FStar_List.split uu____15681
+                                                FStar_List.split uu____15522
                                                in
-                                            match uu____15650 with
+                                            match uu____15491 with
                                             | (lifted_args,reverse_args) ->
-                                                let uu____15931 =
-                                                  let uu____15932 =
+                                                let uu____15772 =
+                                                  let uu____15773 =
                                                     FStar_List.hd
                                                       reverse_args
                                                      in
                                                   FStar_Pervasives_Native.fst
-                                                    uu____15932
+                                                    uu____15773
                                                    in
-                                                let uu____15953 =
-                                                  let uu____15954 =
+                                                let uu____15794 =
+                                                  let uu____15795 =
                                                     FStar_List.tl
                                                       reverse_args
                                                      in
-                                                  FStar_List.rev uu____15954
+                                                  FStar_List.rev uu____15795
                                                    in
-                                                (lifted_args, uu____15931,
-                                                  uu____15953)
+                                                (lifted_args, uu____15772,
+                                                  uu____15794)
                                              in
-                                          match uu____15366 with
+                                          match uu____15207 with
                                           | (lifted_args,head2,args1) ->
                                               let app =
                                                 FStar_Syntax_Syntax.mk_Tm_app
@@ -5807,8 +5824,8 @@ and (check_application_args :
                                                   comp1.FStar_TypeChecker_Common.res_typ
                                                  in
                                               let bind_lifted_args e
-                                                uu___6_16065 =
-                                                match uu___6_16065 with
+                                                uu___6_15906 =
+                                                match uu___6_15906 with
                                                 | FStar_Pervasives_Native.None
                                                      -> e
                                                 | FStar_Pervasives_Native.Some
@@ -5820,32 +5837,32 @@ and (check_application_args :
                                                         e1.FStar_Syntax_Syntax.pos
                                                        in
                                                     let letbinding =
-                                                      let uu____16126 =
-                                                        let uu____16133 =
-                                                          let uu____16134 =
-                                                            let uu____16148 =
-                                                              let uu____16151
+                                                      let uu____15967 =
+                                                        let uu____15974 =
+                                                          let uu____15975 =
+                                                            let uu____15989 =
+                                                              let uu____15992
                                                                 =
-                                                                let uu____16152
+                                                                let uu____15993
                                                                   =
                                                                   FStar_Syntax_Syntax.mk_binder
                                                                     x
                                                                    in
-                                                                [uu____16152]
+                                                                [uu____15993]
                                                                  in
                                                               FStar_Syntax_Subst.close
-                                                                uu____16151 e
+                                                                uu____15992 e
                                                                in
                                                             ((false, [lb]),
-                                                              uu____16148)
+                                                              uu____15989)
                                                              in
                                                           FStar_Syntax_Syntax.Tm_let
-                                                            uu____16134
+                                                            uu____15975
                                                            in
                                                         FStar_Syntax_Syntax.mk
-                                                          uu____16133
+                                                          uu____15974
                                                          in
-                                                      uu____16126
+                                                      uu____15967
                                                         FStar_Pervasives_Native.None
                                                         e.FStar_Syntax_Syntax.pos
                                                        in
@@ -5862,210 +5879,210 @@ and (check_application_args :
                                                 bind_lifted_args app2
                                                 lifted_args)
                                         in
-                                     let uu____16204 =
+                                     let uu____16045 =
                                        FStar_TypeChecker_Util.strengthen_precondition
                                          FStar_Pervasives_Native.None env app
                                          comp1 guard1
                                         in
-                                     (match uu____16204 with
+                                     (match uu____16045 with
                                       | (comp2,g) ->
-                                          ((let uu____16222 =
+                                          ((let uu____16063 =
                                               FStar_TypeChecker_Env.debug env
                                                 FStar_Options.Extreme
                                                in
-                                            if uu____16222
+                                            if uu____16063
                                             then
-                                              let uu____16225 =
+                                              let uu____16066 =
                                                 FStar_Syntax_Print.term_to_string
                                                   app
                                                  in
-                                              let uu____16227 =
+                                              let uu____16068 =
                                                 FStar_TypeChecker_Common.lcomp_to_string
                                                   comp2
                                                  in
                                               FStar_Util.print2
                                                 "(d) Monadic app: type of app\n\t(%s)\n\t: %s\n"
-                                                uu____16225 uu____16227
+                                                uu____16066 uu____16068
                                             else ());
                                            (app, comp2, g)))))))
                   in
-               let rec tc_args head_info uu____16308 bs args1 =
-                 match uu____16308 with
+               let rec tc_args head_info uu____16149 bs args1 =
+                 match uu____16149 with
                  | (subst,outargs,arg_rets,g,fvs) ->
                      (match (bs, args1) with
                       | ((x,FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Implicit uu____16447))::rest,
-                         (uu____16449,FStar_Pervasives_Native.None )::uu____16450)
+                          (FStar_Syntax_Syntax.Implicit uu____16288))::rest,
+                         (uu____16290,FStar_Pervasives_Native.None )::uu____16291)
                           ->
                           let t =
                             FStar_Syntax_Subst.subst subst
                               x.FStar_Syntax_Syntax.sort
                              in
-                          let uu____16511 =
+                          let uu____16352 =
                             check_no_escape
                               (FStar_Pervasives_Native.Some head) env fvs t
                              in
-                          (match uu____16511 with
+                          (match uu____16352 with
                            | (t1,g_ex) ->
-                               let uu____16524 =
+                               let uu____16365 =
                                  FStar_TypeChecker_Util.new_implicit_var
                                    "Instantiating implicit argument in application"
                                    head.FStar_Syntax_Syntax.pos env t1
                                   in
-                               (match uu____16524 with
-                                | (varg,uu____16545,implicits) ->
+                               (match uu____16365 with
+                                | (varg,uu____16386,implicits) ->
                                     let subst1 =
                                       (FStar_Syntax_Syntax.NT (x, varg)) ::
                                       subst  in
                                     let arg =
-                                      let uu____16573 =
+                                      let uu____16414 =
                                         FStar_Syntax_Syntax.as_implicit true
                                          in
-                                      (varg, uu____16573)  in
+                                      (varg, uu____16414)  in
                                     let guard =
                                       FStar_List.fold_right
                                         FStar_TypeChecker_Env.conj_guard
                                         [g_ex; g] implicits
                                        in
-                                    let uu____16582 =
-                                      let uu____16617 =
-                                        let uu____16628 =
-                                          let uu____16637 =
-                                            let uu____16638 =
+                                    let uu____16423 =
+                                      let uu____16458 =
+                                        let uu____16469 =
+                                          let uu____16478 =
+                                            let uu____16479 =
                                               FStar_Syntax_Syntax.mk_Total t1
                                                in
-                                            FStar_All.pipe_right uu____16638
+                                            FStar_All.pipe_right uu____16479
                                               FStar_TypeChecker_Common.lcomp_of_comp
                                              in
                                           (arg, FStar_Pervasives_Native.None,
-                                            uu____16637)
+                                            uu____16478)
                                            in
-                                        uu____16628 :: outargs  in
-                                      (subst1, uu____16617, (arg ::
+                                        uu____16469 :: outargs  in
+                                      (subst1, uu____16458, (arg ::
                                         arg_rets), guard, fvs)
                                        in
-                                    tc_args head_info uu____16582 rest args1))
+                                    tc_args head_info uu____16423 rest args1))
                       | ((x,FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta tau))::rest,(uu____16684,FStar_Pervasives_Native.None
-                                                                 )::uu____16685)
+                          (FStar_Syntax_Syntax.Meta tau))::rest,(uu____16525,FStar_Pervasives_Native.None
+                                                                 )::uu____16526)
                           ->
                           let tau1 = FStar_Syntax_Subst.subst subst tau  in
-                          let uu____16747 =
+                          let uu____16588 =
                             tc_tactic FStar_Syntax_Syntax.t_unit
                               FStar_Syntax_Syntax.t_unit env tau1
                              in
-                          (match uu____16747 with
-                           | (tau2,uu____16761,g_tau) ->
+                          (match uu____16588 with
+                           | (tau2,uu____16602,g_tau) ->
                                let t =
                                  FStar_Syntax_Subst.subst subst
                                    x.FStar_Syntax_Syntax.sort
                                   in
-                               let uu____16764 =
+                               let uu____16605 =
                                  check_no_escape
                                    (FStar_Pervasives_Native.Some head) env
                                    fvs t
                                   in
-                               (match uu____16764 with
+                               (match uu____16605 with
                                 | (t1,g_ex) ->
-                                    let uu____16777 =
-                                      let uu____16790 =
-                                        let uu____16797 =
-                                          let uu____16802 =
+                                    let uu____16618 =
+                                      let uu____16631 =
+                                        let uu____16638 =
+                                          let uu____16643 =
                                             FStar_Dyn.mkdyn env  in
-                                          (uu____16802, tau2)  in
+                                          (uu____16643, tau2)  in
                                         FStar_Pervasives_Native.Some
-                                          uu____16797
+                                          uu____16638
                                          in
                                       FStar_TypeChecker_Env.new_implicit_var_aux
                                         "Instantiating meta argument in application"
                                         head.FStar_Syntax_Syntax.pos env t1
                                         FStar_Syntax_Syntax.Strict
-                                        uu____16790
+                                        uu____16631
                                        in
-                                    (match uu____16777 with
-                                     | (varg,uu____16815,implicits) ->
+                                    (match uu____16618 with
+                                     | (varg,uu____16656,implicits) ->
                                          let subst1 =
                                            (FStar_Syntax_Syntax.NT (x, varg))
                                            :: subst  in
                                          let arg =
-                                           let uu____16843 =
+                                           let uu____16684 =
                                              FStar_Syntax_Syntax.as_implicit
                                                true
                                               in
-                                           (varg, uu____16843)  in
+                                           (varg, uu____16684)  in
                                          let guard =
                                            FStar_List.fold_right
                                              FStar_TypeChecker_Env.conj_guard
                                              [g_ex; g; g_tau] implicits
                                             in
-                                         let uu____16852 =
-                                           let uu____16887 =
-                                             let uu____16898 =
-                                               let uu____16907 =
-                                                 let uu____16908 =
+                                         let uu____16693 =
+                                           let uu____16728 =
+                                             let uu____16739 =
+                                               let uu____16748 =
+                                                 let uu____16749 =
                                                    FStar_Syntax_Syntax.mk_Total
                                                      t1
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____16908
+                                                   uu____16749
                                                    FStar_TypeChecker_Common.lcomp_of_comp
                                                   in
                                                (arg,
                                                  FStar_Pervasives_Native.None,
-                                                 uu____16907)
+                                                 uu____16748)
                                                 in
-                                             uu____16898 :: outargs  in
-                                           (subst1, uu____16887, (arg ::
+                                             uu____16739 :: outargs  in
+                                           (subst1, uu____16728, (arg ::
                                              arg_rets), guard, fvs)
                                             in
-                                         tc_args head_info uu____16852 rest
+                                         tc_args head_info uu____16693 rest
                                            args1)))
                       | ((x,aqual)::rest,(e,aq)::rest') ->
                           ((match (aqual, aq) with
-                            | (uu____17024,FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Meta uu____17025)) ->
+                            | (uu____16865,FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Meta uu____16866)) ->
                                 FStar_Errors.raise_error
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                     "Inconsistent implicit qualifier; cannot apply meta arguments, just use #")
                                   e.FStar_Syntax_Syntax.pos
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Meta
-                               uu____17036),FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____17037)) ->
+                               uu____16877),FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____16878)) ->
                                 ()
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Implicit
-                               uu____17045),FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____17046)) ->
+                               uu____16886),FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____16887)) ->
                                 ()
                             | (FStar_Pervasives_Native.None
                                ,FStar_Pervasives_Native.None ) -> ()
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Equality
                                ),FStar_Pervasives_Native.None ) -> ()
-                            | uu____17061 ->
-                                let uu____17070 =
-                                  let uu____17076 =
-                                    let uu____17078 =
+                            | uu____16902 ->
+                                let uu____16911 =
+                                  let uu____16917 =
+                                    let uu____16919 =
                                       FStar_Syntax_Print.aqual_to_string
                                         aqual
                                        in
-                                    let uu____17080 =
+                                    let uu____16921 =
                                       FStar_Syntax_Print.aqual_to_string aq
                                        in
-                                    let uu____17082 =
+                                    let uu____16923 =
                                       FStar_Syntax_Print.bv_to_string x  in
-                                    let uu____17084 =
+                                    let uu____16925 =
                                       FStar_Syntax_Print.term_to_string e  in
                                     FStar_Util.format4
                                       "Inconsistent implicit qualifier; %s vs %s\nfor bvar %s and term %s"
-                                      uu____17078 uu____17080 uu____17082
-                                      uu____17084
+                                      uu____16919 uu____16921 uu____16923
+                                      uu____16925
                                      in
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
-                                    uu____17076)
+                                    uu____16917)
                                    in
-                                FStar_Errors.raise_error uu____17070
+                                FStar_Errors.raise_error uu____16911
                                   e.FStar_Syntax_Syntax.pos);
                            (let targ =
                               FStar_Syntax_Subst.subst subst
@@ -6074,202 +6091,202 @@ and (check_application_args :
                             let aqual1 =
                               FStar_Syntax_Subst.subst_imp subst aqual  in
                             let x1 =
-                              let uu___2267_17091 = x  in
+                              let uu___2279_16932 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___2267_17091.FStar_Syntax_Syntax.ppname);
+                                  (uu___2279_16932.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___2267_17091.FStar_Syntax_Syntax.index);
+                                  (uu___2279_16932.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = targ
                               }  in
-                            (let uu____17093 =
+                            (let uu____16934 =
                                FStar_TypeChecker_Env.debug env
                                  FStar_Options.Extreme
                                 in
-                             if uu____17093
+                             if uu____16934
                              then
-                               let uu____17096 =
+                               let uu____16937 =
                                  FStar_Syntax_Print.bv_to_string x1  in
-                               let uu____17098 =
+                               let uu____16939 =
                                  FStar_Syntax_Print.term_to_string
                                    x1.FStar_Syntax_Syntax.sort
                                   in
-                               let uu____17100 =
+                               let uu____16941 =
                                  FStar_Syntax_Print.term_to_string e  in
-                               let uu____17102 =
+                               let uu____16943 =
                                  FStar_Syntax_Print.subst_to_string subst  in
-                               let uu____17104 =
+                               let uu____16945 =
                                  FStar_Syntax_Print.term_to_string targ  in
                                FStar_Util.print5
                                  "\tFormal is %s : %s\tType of arg %s (after subst %s) = %s\n"
-                                 uu____17096 uu____17098 uu____17100
-                                 uu____17102 uu____17104
+                                 uu____16937 uu____16939 uu____16941
+                                 uu____16943 uu____16945
                              else ());
-                            (let uu____17109 =
+                            (let uu____16950 =
                                check_no_escape
                                  (FStar_Pervasives_Native.Some head) env fvs
                                  targ
                                 in
-                             match uu____17109 with
+                             match uu____16950 with
                              | (targ1,g_ex) ->
                                  let env1 =
                                    FStar_TypeChecker_Env.set_expected_typ env
                                      targ1
                                     in
                                  let env2 =
-                                   let uu___2276_17124 = env1  in
+                                   let uu___2288_16965 = env1  in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.solver);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.range);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.curmodule);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.gamma);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.modules);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.sigtab);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.attrtab);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.effects);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.generalize);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.letrecs);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.letrecs);
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.top_level);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
                                        (is_eq aqual1);
                                      FStar_TypeChecker_Env.use_eq_strict =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.use_eq_strict);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.use_eq_strict);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.is_iface);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.admit);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.lax);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.phase1);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.failhard);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.nosynth);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.tc_term);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.type_of);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.universe_of);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.try_solve_implicits_hook
                                        =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.splice);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.mpreprocess =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.mpreprocess);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.mpreprocess);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.postprocess);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.is_native_tactic =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.is_native_tactic);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.is_native_tactic);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.dsenv);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.nbe);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.strict_args_tab);
+                                       (uu___2288_16965.FStar_TypeChecker_Env.strict_args_tab);
                                      FStar_TypeChecker_Env.erasable_types_tab
                                        =
-                                       (uu___2276_17124.FStar_TypeChecker_Env.erasable_types_tab)
+                                       (uu___2288_16965.FStar_TypeChecker_Env.erasable_types_tab)
                                    }  in
-                                 ((let uu____17126 =
+                                 ((let uu____16967 =
                                      FStar_TypeChecker_Env.debug env2
                                        FStar_Options.High
                                       in
-                                   if uu____17126
+                                   if uu____16967
                                    then
-                                     let uu____17129 =
+                                     let uu____16970 =
                                        FStar_Syntax_Print.tag_of_term e  in
-                                     let uu____17131 =
+                                     let uu____16972 =
                                        FStar_Syntax_Print.term_to_string e
                                         in
-                                     let uu____17133 =
+                                     let uu____16974 =
                                        FStar_Syntax_Print.term_to_string
                                          targ1
                                         in
-                                     let uu____17135 =
+                                     let uu____16976 =
                                        FStar_Util.string_of_bool
                                          env2.FStar_TypeChecker_Env.use_eq
                                         in
                                      FStar_Util.print4
                                        "Checking arg (%s) %s at type %s with use_eq:%s\n"
-                                       uu____17129 uu____17131 uu____17133
-                                       uu____17135
+                                       uu____16970 uu____16972 uu____16974
+                                       uu____16976
                                    else ());
-                                  (let uu____17140 = tc_term env2 e  in
-                                   match uu____17140 with
+                                  (let uu____16981 = tc_term env2 e  in
+                                   match uu____16981 with
                                    | (e1,c,g_e) ->
                                        let g1 =
-                                         let uu____17157 =
+                                         let uu____16998 =
                                            FStar_TypeChecker_Env.conj_guard g
                                              g_e
                                             in
                                          FStar_All.pipe_left
                                            (FStar_TypeChecker_Env.conj_guard
-                                              g_ex) uu____17157
+                                              g_ex) uu____16998
                                           in
                                        let arg = (e1, aq)  in
                                        let xterm =
-                                         let uu____17180 =
-                                           let uu____17183 =
-                                             let uu____17192 =
+                                         let uu____17021 =
+                                           let uu____17024 =
+                                             let uu____17033 =
                                                FStar_Syntax_Syntax.bv_to_name
                                                  x1
                                                 in
                                              FStar_Syntax_Syntax.as_arg
-                                               uu____17192
+                                               uu____17033
                                               in
                                            FStar_Pervasives_Native.fst
-                                             uu____17183
+                                             uu____17024
                                             in
-                                         (uu____17180, aq)  in
-                                       let uu____17201 =
+                                         (uu____17021, aq)  in
+                                       let uu____17042 =
                                          (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                             c)
                                            ||
@@ -6277,13 +6294,13 @@ and (check_application_args :
                                               env2
                                               c.FStar_TypeChecker_Common.eff_name)
                                           in
-                                       if uu____17201
+                                       if uu____17042
                                        then
                                          let subst1 =
-                                           let uu____17211 = FStar_List.hd bs
+                                           let uu____17052 = FStar_List.hd bs
                                               in
                                            maybe_extend_subst subst
-                                             uu____17211 e1
+                                             uu____17052 e1
                                             in
                                          tc_args head_info
                                            (subst1,
@@ -6300,58 +6317,58 @@ and (check_application_args :
                                                    x1), c) :: outargs),
                                              (xterm :: arg_rets), g1, (x1 ::
                                              fvs)) rest rest')))))
-                      | (uu____17310,[]) ->
+                      | (uu____17151,[]) ->
                           monadic_application head_info subst outargs
                             arg_rets g fvs bs
-                      | ([],arg::uu____17346) ->
-                          let uu____17397 =
+                      | ([],arg::uu____17187) ->
+                          let uu____17238 =
                             monadic_application head_info subst outargs
                               arg_rets g fvs []
                              in
-                          (match uu____17397 with
+                          (match uu____17238 with
                            | (head1,chead1,ghead1) ->
-                               let uu____17419 =
-                                 let uu____17424 =
+                               let uu____17260 =
+                                 let uu____17265 =
                                    FStar_TypeChecker_Common.lcomp_comp chead1
                                     in
-                                 FStar_All.pipe_right uu____17424
-                                   (fun uu____17441  ->
-                                      match uu____17441 with
+                                 FStar_All.pipe_right uu____17265
+                                   (fun uu____17282  ->
+                                      match uu____17282 with
                                       | (c,g1) ->
-                                          let uu____17452 =
+                                          let uu____17293 =
                                             FStar_TypeChecker_Env.conj_guard
                                               ghead1 g1
                                              in
-                                          (c, uu____17452))
+                                          (c, uu____17293))
                                   in
-                               (match uu____17419 with
+                               (match uu____17260 with
                                 | (chead2,ghead2) ->
                                     let rec aux norm1 solve ghead3 tres =
                                       let tres1 =
-                                        let uu____17495 =
+                                        let uu____17336 =
                                           FStar_Syntax_Subst.compress tres
                                            in
-                                        FStar_All.pipe_right uu____17495
+                                        FStar_All.pipe_right uu____17336
                                           FStar_Syntax_Util.unrefine
                                          in
                                       match tres1.FStar_Syntax_Syntax.n with
                                       | FStar_Syntax_Syntax.Tm_arrow
                                           (bs1,cres') ->
-                                          let uu____17526 =
+                                          let uu____17367 =
                                             FStar_Syntax_Subst.open_comp bs1
                                               cres'
                                              in
-                                          (match uu____17526 with
+                                          (match uu____17367 with
                                            | (bs2,cres'1) ->
                                                let head_info1 =
                                                  (head1, chead2, ghead3,
                                                    cres'1)
                                                   in
-                                               ((let uu____17549 =
+                                               ((let uu____17390 =
                                                    FStar_TypeChecker_Env.debug
                                                      env FStar_Options.Low
                                                     in
-                                                 if uu____17549
+                                                 if uu____17390
                                                  then
                                                    FStar_Errors.log_issue
                                                      tres1.FStar_Syntax_Syntax.pos
@@ -6362,330 +6379,330 @@ and (check_application_args :
                                                   ([], [], [],
                                                     FStar_TypeChecker_Env.trivial_guard,
                                                     []) bs2 args1))
-                                      | uu____17596 when
+                                      | uu____17437 when
                                           Prims.op_Negation norm1 ->
                                           let rec norm_tres tres2 =
                                             let tres3 =
-                                              let uu____17604 =
+                                              let uu____17445 =
                                                 FStar_All.pipe_right tres2
                                                   (FStar_TypeChecker_Normalize.unfold_whnf
                                                      env)
                                                  in
                                               FStar_All.pipe_right
-                                                uu____17604
+                                                uu____17445
                                                 FStar_Syntax_Util.unascribe
                                                in
-                                            let uu____17605 =
-                                              let uu____17606 =
+                                            let uu____17446 =
+                                              let uu____17447 =
                                                 FStar_Syntax_Subst.compress
                                                   tres3
                                                  in
-                                              uu____17606.FStar_Syntax_Syntax.n
+                                              uu____17447.FStar_Syntax_Syntax.n
                                                in
-                                            match uu____17605 with
+                                            match uu____17446 with
                                             | FStar_Syntax_Syntax.Tm_refine
                                                 ({
                                                    FStar_Syntax_Syntax.ppname
-                                                     = uu____17609;
+                                                     = uu____17450;
                                                    FStar_Syntax_Syntax.index
-                                                     = uu____17610;
+                                                     = uu____17451;
                                                    FStar_Syntax_Syntax.sort =
-                                                     tres4;_},uu____17612)
+                                                     tres4;_},uu____17453)
                                                 -> norm_tres tres4
-                                            | uu____17620 -> tres3  in
-                                          let uu____17621 = norm_tres tres1
+                                            | uu____17461 -> tres3  in
+                                          let uu____17462 = norm_tres tres1
                                              in
-                                          aux true solve ghead3 uu____17621
-                                      | uu____17623 when
+                                          aux true solve ghead3 uu____17462
+                                      | uu____17464 when
                                           Prims.op_Negation solve ->
                                           let ghead4 =
                                             FStar_TypeChecker_Rel.solve_deferred_constraints
                                               env ghead3
                                              in
                                           aux norm1 true ghead4 tres1
-                                      | uu____17626 ->
-                                          let uu____17627 =
-                                            let uu____17633 =
-                                              let uu____17635 =
+                                      | uu____17467 ->
+                                          let uu____17468 =
+                                            let uu____17474 =
+                                              let uu____17476 =
                                                 FStar_TypeChecker_Normalize.term_to_string
                                                   env thead
                                                  in
-                                              let uu____17637 =
+                                              let uu____17478 =
                                                 FStar_Util.string_of_int
                                                   n_args
                                                  in
-                                              let uu____17639 =
+                                              let uu____17480 =
                                                 FStar_Syntax_Print.term_to_string
                                                   tres1
                                                  in
                                               FStar_Util.format3
                                                 "Too many arguments to function of type %s; got %s arguments, remaining type is %s"
-                                                uu____17635 uu____17637
-                                                uu____17639
+                                                uu____17476 uu____17478
+                                                uu____17480
                                                in
                                             (FStar_Errors.Fatal_ToManyArgumentToFunction,
-                                              uu____17633)
+                                              uu____17474)
                                              in
-                                          let uu____17643 =
+                                          let uu____17484 =
                                             FStar_Syntax_Syntax.argpos arg
                                              in
                                           FStar_Errors.raise_error
-                                            uu____17627 uu____17643
+                                            uu____17468 uu____17484
                                        in
                                     aux false false ghead2
                                       (FStar_Syntax_Util.comp_result chead2))))
                   in
                let rec check_function_app tf guard =
-                 let uu____17673 =
-                   let uu____17674 =
+                 let uu____17514 =
+                   let uu____17515 =
                      FStar_TypeChecker_Normalize.unfold_whnf env tf  in
-                   uu____17674.FStar_Syntax_Syntax.n  in
-                 match uu____17673 with
-                 | FStar_Syntax_Syntax.Tm_uvar uu____17683 ->
-                     let uu____17696 =
+                   uu____17515.FStar_Syntax_Syntax.n  in
+                 match uu____17514 with
+                 | FStar_Syntax_Syntax.Tm_uvar uu____17524 ->
+                     let uu____17537 =
                        FStar_List.fold_right
-                         (fun uu____17727  ->
-                            fun uu____17728  ->
-                              match uu____17728 with
+                         (fun uu____17568  ->
+                            fun uu____17569  ->
+                              match uu____17569 with
                               | (bs,guard1) ->
-                                  let uu____17755 =
-                                    let uu____17768 =
-                                      let uu____17769 =
+                                  let uu____17596 =
+                                    let uu____17609 =
+                                      let uu____17610 =
                                         FStar_Syntax_Util.type_u ()  in
-                                      FStar_All.pipe_right uu____17769
+                                      FStar_All.pipe_right uu____17610
                                         FStar_Pervasives_Native.fst
                                        in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env
-                                      uu____17768
+                                      uu____17609
                                      in
-                                  (match uu____17755 with
-                                   | (t,uu____17786,g) ->
-                                       let uu____17800 =
-                                         let uu____17803 =
+                                  (match uu____17596 with
+                                   | (t,uu____17627,g) ->
+                                       let uu____17641 =
+                                         let uu____17644 =
                                            FStar_Syntax_Syntax.null_binder t
                                             in
-                                         uu____17803 :: bs  in
-                                       let uu____17804 =
+                                         uu____17644 :: bs  in
+                                       let uu____17645 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1
                                           in
-                                       (uu____17800, uu____17804))) args
+                                       (uu____17641, uu____17645))) args
                          ([], guard)
                         in
-                     (match uu____17696 with
+                     (match uu____17537 with
                       | (bs,guard1) ->
-                          let uu____17821 =
-                            let uu____17828 =
-                              let uu____17841 =
-                                let uu____17842 = FStar_Syntax_Util.type_u ()
+                          let uu____17662 =
+                            let uu____17669 =
+                              let uu____17682 =
+                                let uu____17683 = FStar_Syntax_Util.type_u ()
                                    in
-                                FStar_All.pipe_right uu____17842
+                                FStar_All.pipe_right uu____17683
                                   FStar_Pervasives_Native.fst
                                  in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____17841
+                                uu____17682
                                in
-                            match uu____17828 with
-                            | (t,uu____17859,g) ->
-                                let uu____17873 = FStar_Options.ml_ish ()  in
-                                if uu____17873
+                            match uu____17669 with
+                            | (t,uu____17700,g) ->
+                                let uu____17714 = FStar_Options.ml_ish ()  in
+                                if uu____17714
                                 then
-                                  let uu____17882 =
+                                  let uu____17723 =
                                     FStar_Syntax_Util.ml_comp t r  in
-                                  let uu____17885 =
+                                  let uu____17726 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g
                                      in
-                                  (uu____17882, uu____17885)
+                                  (uu____17723, uu____17726)
                                 else
-                                  (let uu____17890 =
+                                  (let uu____17731 =
                                      FStar_Syntax_Syntax.mk_Total t  in
-                                   let uu____17893 =
+                                   let uu____17734 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g
                                       in
-                                   (uu____17890, uu____17893))
+                                   (uu____17731, uu____17734))
                              in
-                          (match uu____17821 with
+                          (match uu____17662 with
                            | (cres,guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres
                                   in
-                               ((let uu____17912 =
+                               ((let uu____17753 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme
                                     in
-                                 if uu____17912
+                                 if uu____17753
                                  then
-                                   let uu____17916 =
+                                   let uu____17757 =
                                      FStar_Syntax_Print.term_to_string head
                                       in
-                                   let uu____17918 =
+                                   let uu____17759 =
                                      FStar_Syntax_Print.term_to_string tf  in
-                                   let uu____17920 =
+                                   let uu____17761 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres
                                       in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____17916 uu____17918 uu____17920
+                                     uu____17757 uu____17759 uu____17761
                                  else ());
                                 (let g =
-                                   let uu____17926 =
+                                   let uu____17767 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres
                                       in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____17926
+                                     env uu____17767
                                     in
-                                 let uu____17927 =
+                                 let uu____17768 =
                                    FStar_TypeChecker_Env.conj_guard g guard2
                                     in
-                                 check_function_app bs_cres uu____17927))))
+                                 check_function_app bs_cres uu____17768))))
                  | FStar_Syntax_Syntax.Tm_app
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                          uu____17928;
-                        FStar_Syntax_Syntax.pos = uu____17929;
-                        FStar_Syntax_Syntax.vars = uu____17930;_},uu____17931)
+                          uu____17769;
+                        FStar_Syntax_Syntax.pos = uu____17770;
+                        FStar_Syntax_Syntax.vars = uu____17771;_},uu____17772)
                      ->
-                     let uu____17968 =
+                     let uu____17809 =
                        FStar_List.fold_right
-                         (fun uu____17999  ->
-                            fun uu____18000  ->
-                              match uu____18000 with
+                         (fun uu____17840  ->
+                            fun uu____17841  ->
+                              match uu____17841 with
                               | (bs,guard1) ->
-                                  let uu____18027 =
-                                    let uu____18040 =
-                                      let uu____18041 =
+                                  let uu____17868 =
+                                    let uu____17881 =
+                                      let uu____17882 =
                                         FStar_Syntax_Util.type_u ()  in
-                                      FStar_All.pipe_right uu____18041
+                                      FStar_All.pipe_right uu____17882
                                         FStar_Pervasives_Native.fst
                                        in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env
-                                      uu____18040
+                                      uu____17881
                                      in
-                                  (match uu____18027 with
-                                   | (t,uu____18058,g) ->
-                                       let uu____18072 =
-                                         let uu____18075 =
+                                  (match uu____17868 with
+                                   | (t,uu____17899,g) ->
+                                       let uu____17913 =
+                                         let uu____17916 =
                                            FStar_Syntax_Syntax.null_binder t
                                             in
-                                         uu____18075 :: bs  in
-                                       let uu____18076 =
+                                         uu____17916 :: bs  in
+                                       let uu____17917 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1
                                           in
-                                       (uu____18072, uu____18076))) args
+                                       (uu____17913, uu____17917))) args
                          ([], guard)
                         in
-                     (match uu____17968 with
+                     (match uu____17809 with
                       | (bs,guard1) ->
-                          let uu____18093 =
-                            let uu____18100 =
-                              let uu____18113 =
-                                let uu____18114 = FStar_Syntax_Util.type_u ()
+                          let uu____17934 =
+                            let uu____17941 =
+                              let uu____17954 =
+                                let uu____17955 = FStar_Syntax_Util.type_u ()
                                    in
-                                FStar_All.pipe_right uu____18114
+                                FStar_All.pipe_right uu____17955
                                   FStar_Pervasives_Native.fst
                                  in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____18113
+                                uu____17954
                                in
-                            match uu____18100 with
-                            | (t,uu____18131,g) ->
-                                let uu____18145 = FStar_Options.ml_ish ()  in
-                                if uu____18145
+                            match uu____17941 with
+                            | (t,uu____17972,g) ->
+                                let uu____17986 = FStar_Options.ml_ish ()  in
+                                if uu____17986
                                 then
-                                  let uu____18154 =
+                                  let uu____17995 =
                                     FStar_Syntax_Util.ml_comp t r  in
-                                  let uu____18157 =
+                                  let uu____17998 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g
                                      in
-                                  (uu____18154, uu____18157)
+                                  (uu____17995, uu____17998)
                                 else
-                                  (let uu____18162 =
+                                  (let uu____18003 =
                                      FStar_Syntax_Syntax.mk_Total t  in
-                                   let uu____18165 =
+                                   let uu____18006 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g
                                       in
-                                   (uu____18162, uu____18165))
+                                   (uu____18003, uu____18006))
                              in
-                          (match uu____18093 with
+                          (match uu____17934 with
                            | (cres,guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres
                                   in
-                               ((let uu____18184 =
+                               ((let uu____18025 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme
                                     in
-                                 if uu____18184
+                                 if uu____18025
                                  then
-                                   let uu____18188 =
+                                   let uu____18029 =
                                      FStar_Syntax_Print.term_to_string head
                                       in
-                                   let uu____18190 =
+                                   let uu____18031 =
                                      FStar_Syntax_Print.term_to_string tf  in
-                                   let uu____18192 =
+                                   let uu____18033 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres
                                       in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____18188 uu____18190 uu____18192
+                                     uu____18029 uu____18031 uu____18033
                                  else ());
                                 (let g =
-                                   let uu____18198 =
+                                   let uu____18039 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres
                                       in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____18198
+                                     env uu____18039
                                     in
-                                 let uu____18199 =
+                                 let uu____18040 =
                                    FStar_TypeChecker_Env.conj_guard g guard2
                                     in
-                                 check_function_app bs_cres uu____18199))))
+                                 check_function_app bs_cres uu____18040))))
                  | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                     let uu____18222 = FStar_Syntax_Subst.open_comp bs c  in
-                     (match uu____18222 with
+                     let uu____18063 = FStar_Syntax_Subst.open_comp bs c  in
+                     (match uu____18063 with
                       | (bs1,c1) ->
                           let head_info = (head, chead, ghead, c1)  in
-                          ((let uu____18245 =
+                          ((let uu____18086 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.Extreme
                                in
-                            if uu____18245
+                            if uu____18086
                             then
-                              let uu____18248 =
+                              let uu____18089 =
                                 FStar_Syntax_Print.term_to_string head  in
-                              let uu____18250 =
+                              let uu____18091 =
                                 FStar_Syntax_Print.term_to_string tf  in
-                              let uu____18252 =
+                              let uu____18093 =
                                 FStar_Syntax_Print.binders_to_string ", " bs1
                                  in
-                              let uu____18255 =
+                              let uu____18096 =
                                 FStar_Syntax_Print.comp_to_string c1  in
                               FStar_Util.print4
                                 "######tc_args of head %s @ %s with formals=%s and result type=%s\n"
-                                uu____18248 uu____18250 uu____18252
-                                uu____18255
+                                uu____18089 uu____18091 uu____18093
+                                uu____18096
                             else ());
                            tc_args head_info ([], [], [], guard, []) bs1 args))
-                 | FStar_Syntax_Syntax.Tm_refine (bv,uu____18301) ->
+                 | FStar_Syntax_Syntax.Tm_refine (bv,uu____18142) ->
                      check_function_app bv.FStar_Syntax_Syntax.sort guard
                  | FStar_Syntax_Syntax.Tm_ascribed
-                     (t,uu____18307,uu____18308) ->
+                     (t,uu____18148,uu____18149) ->
                      check_function_app t guard
-                 | uu____18349 ->
-                     let uu____18350 =
+                 | uu____18190 ->
+                     let uu____18191 =
                        FStar_TypeChecker_Err.expected_function_typ env tf  in
-                     FStar_Errors.raise_error uu____18350
+                     FStar_Errors.raise_error uu____18191
                        head.FStar_Syntax_Syntax.pos
                   in
                check_function_app thead FStar_TypeChecker_Env.trivial_guard)
@@ -6719,75 +6736,75 @@ and (check_short_circuit_args :
                     ((FStar_List.length bs) = (FStar_List.length args))
                   ->
                   let res_t = FStar_Syntax_Util.comp_result c  in
-                  let uu____18433 =
+                  let uu____18274 =
                     FStar_List.fold_left2
-                      (fun uu____18502  ->
-                         fun uu____18503  ->
-                           fun uu____18504  ->
-                             match (uu____18502, uu____18503, uu____18504)
+                      (fun uu____18343  ->
+                         fun uu____18344  ->
+                           fun uu____18345  ->
+                             match (uu____18343, uu____18344, uu____18345)
                              with
                              | ((seen,guard,ghost),(e,aq),(b,aq')) ->
-                                 ((let uu____18657 =
-                                     let uu____18659 =
+                                 ((let uu____18498 =
+                                     let uu____18500 =
                                        FStar_Syntax_Util.eq_aqual aq aq'  in
-                                     uu____18659 <> FStar_Syntax_Util.Equal
+                                     uu____18500 <> FStar_Syntax_Util.Equal
                                       in
-                                   if uu____18657
+                                   if uu____18498
                                    then
                                      FStar_Errors.raise_error
                                        (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                          "Inconsistent implicit qualifiers")
                                        e.FStar_Syntax_Syntax.pos
                                    else ());
-                                  (let uu____18665 =
+                                  (let uu____18506 =
                                      tc_check_tot_or_gtot_term env e
                                        b.FStar_Syntax_Syntax.sort
                                       in
-                                   match uu____18665 with
+                                   match uu____18506 with
                                    | (e1,c1,g) ->
                                        let short =
                                          FStar_TypeChecker_Util.short_circuit
                                            head seen
                                           in
                                        let g1 =
-                                         let uu____18694 =
+                                         let uu____18535 =
                                            FStar_TypeChecker_Env.guard_of_guard_formula
                                              short
                                             in
                                          FStar_TypeChecker_Env.imp_guard
-                                           uu____18694 g
+                                           uu____18535 g
                                           in
                                        let ghost1 =
                                          ghost ||
-                                           ((let uu____18699 =
+                                           ((let uu____18540 =
                                                FStar_TypeChecker_Common.is_total_lcomp
                                                  c1
                                                 in
-                                             Prims.op_Negation uu____18699)
+                                             Prims.op_Negation uu____18540)
                                               &&
-                                              (let uu____18702 =
+                                              (let uu____18543 =
                                                  FStar_TypeChecker_Util.is_pure_effect
                                                    env
                                                    c1.FStar_TypeChecker_Common.eff_name
                                                   in
-                                               Prims.op_Negation uu____18702))
+                                               Prims.op_Negation uu____18543))
                                           in
-                                       let uu____18704 =
-                                         let uu____18715 =
-                                           let uu____18726 =
+                                       let uu____18545 =
+                                         let uu____18556 =
+                                           let uu____18567 =
                                              FStar_Syntax_Syntax.as_arg e1
                                               in
-                                           [uu____18726]  in
-                                         FStar_List.append seen uu____18715
+                                           [uu____18567]  in
+                                         FStar_List.append seen uu____18556
                                           in
-                                       let uu____18759 =
+                                       let uu____18600 =
                                          FStar_TypeChecker_Env.conj_guard
                                            guard g1
                                           in
-                                       (uu____18704, uu____18759, ghost1))))
+                                       (uu____18545, uu____18600, ghost1))))
                       ([], g_head, false) args bs
                      in
-                  (match uu____18433 with
+                  (match uu____18274 with
                    | (args1,guard,ghost) ->
                        let e =
                          FStar_Syntax_Syntax.mk_Tm_app head args1
@@ -6796,17 +6813,17 @@ and (check_short_circuit_args :
                        let c1 =
                          if ghost
                          then
-                           let uu____18827 =
+                           let uu____18668 =
                              FStar_Syntax_Syntax.mk_GTotal res_t  in
-                           FStar_All.pipe_right uu____18827
+                           FStar_All.pipe_right uu____18668
                              FStar_TypeChecker_Common.lcomp_of_comp
                          else FStar_TypeChecker_Common.lcomp_of_comp c  in
-                       let uu____18830 =
+                       let uu____18671 =
                          FStar_TypeChecker_Util.strengthen_precondition
                            FStar_Pervasives_Native.None env e c1 guard
                           in
-                       (match uu____18830 with | (c2,g) -> (e, c2, g)))
-              | uu____18847 ->
+                       (match uu____18671 with | (c2,g) -> (e, c2, g)))
+              | uu____18688 ->
                   check_application_args env head chead g_head args
                     expected_topt
 
@@ -6830,25 +6847,25 @@ and (tc_pat :
         let expected_pat_typ env1 pos scrutinee_t =
           let rec aux norm1 t =
             let t1 = FStar_Syntax_Util.unrefine t  in
-            let uu____18945 = FStar_Syntax_Util.head_and_args t1  in
-            match uu____18945 with
+            let uu____18786 = FStar_Syntax_Util.head_and_args t1  in
+            match uu____18786 with
             | (head,args) ->
-                let uu____18988 =
-                  let uu____18989 = FStar_Syntax_Subst.compress head  in
-                  uu____18989.FStar_Syntax_Syntax.n  in
-                (match uu____18988 with
+                let uu____18829 =
+                  let uu____18830 = FStar_Syntax_Subst.compress head  in
+                  uu____18830.FStar_Syntax_Syntax.n  in
+                (match uu____18829 with
                  | FStar_Syntax_Syntax.Tm_uinst
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
-                        FStar_Syntax_Syntax.pos = uu____18993;
-                        FStar_Syntax_Syntax.vars = uu____18994;_},us)
+                        FStar_Syntax_Syntax.pos = uu____18834;
+                        FStar_Syntax_Syntax.vars = uu____18835;_},us)
                      -> unfold_once t1 f us args
                  | FStar_Syntax_Syntax.Tm_fvar f -> unfold_once t1 f [] args
-                 | uu____19001 ->
+                 | uu____18842 ->
                      if norm1
                      then t1
                      else
-                       (let uu____19005 =
+                       (let uu____18846 =
                           FStar_TypeChecker_Normalize.normalize
                             [FStar_TypeChecker_Env.HNF;
                             FStar_TypeChecker_Env.Unmeta;
@@ -6856,30 +6873,30 @@ and (tc_pat :
                             FStar_TypeChecker_Env.UnfoldUntil
                               FStar_Syntax_Syntax.delta_constant] env1 t1
                            in
-                        aux true uu____19005))
+                        aux true uu____18846))
           
           and unfold_once t f us args =
-            let uu____19023 =
+            let uu____18864 =
               FStar_TypeChecker_Env.is_type_constructor env1
                 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                in
-            if uu____19023
+            if uu____18864
             then t
             else
-              (let uu____19028 =
+              (let uu____18869 =
                  FStar_TypeChecker_Env.lookup_definition
                    [FStar_TypeChecker_Env.Unfold
                       FStar_Syntax_Syntax.delta_constant] env1
                    (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                   in
-               match uu____19028 with
+               match uu____18869 with
                | FStar_Pervasives_Native.None  -> t
                | FStar_Pervasives_Native.Some head_def_ts ->
-                   let uu____19048 =
+                   let uu____18889 =
                      FStar_TypeChecker_Env.inst_tscheme_with head_def_ts us
                       in
-                   (match uu____19048 with
-                    | (uu____19053,head_def) ->
+                   (match uu____18889 with
+                    | (uu____18894,head_def) ->
                         let t' =
                           FStar_Syntax_Syntax.mk_Tm_app head_def args
                             FStar_Pervasives_Native.None
@@ -6892,79 +6909,79 @@ and (tc_pat :
                            in
                         aux false t'1))
            in
-          let uu____19060 =
+          let uu____18901 =
             FStar_TypeChecker_Normalize.normalize
               [FStar_TypeChecker_Env.Beta; FStar_TypeChecker_Env.Iota] env1
               scrutinee_t
              in
-          aux false uu____19060  in
+          aux false uu____18901  in
         let pat_typ_ok env1 pat_t1 scrutinee_t =
-          (let uu____19079 =
+          (let uu____18920 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns")
               in
-           if uu____19079
+           if uu____18920
            then
-             let uu____19084 = FStar_Syntax_Print.term_to_string pat_t1  in
-             let uu____19086 = FStar_Syntax_Print.term_to_string scrutinee_t
+             let uu____18925 = FStar_Syntax_Print.term_to_string pat_t1  in
+             let uu____18927 = FStar_Syntax_Print.term_to_string scrutinee_t
                 in
              FStar_Util.print2 "$$$$$$$$$$$$pat_typ_ok? %s vs. %s\n"
-               uu____19084 uu____19086
+               uu____18925 uu____18927
            else ());
           (let fail1 msg =
              let msg1 =
-               let uu____19106 = FStar_Syntax_Print.term_to_string pat_t1  in
-               let uu____19108 =
+               let uu____18947 = FStar_Syntax_Print.term_to_string pat_t1  in
+               let uu____18949 =
                  FStar_Syntax_Print.term_to_string scrutinee_t  in
                FStar_Util.format3
                  "Type of pattern (%s) does not match type of scrutinee (%s)%s"
-                 uu____19106 uu____19108 msg
+                 uu____18947 uu____18949 msg
                 in
              FStar_Errors.raise_error
                (FStar_Errors.Fatal_MismatchedPatternType, msg1)
                p0.FStar_Syntax_Syntax.p
               in
-           let uu____19112 = FStar_Syntax_Util.head_and_args scrutinee_t  in
-           match uu____19112 with
+           let uu____18953 = FStar_Syntax_Util.head_and_args scrutinee_t  in
+           match uu____18953 with
            | (head_s,args_s) ->
                let pat_t2 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env1 pat_t1
                   in
-               let uu____19156 = FStar_Syntax_Util.un_uinst head_s  in
-               (match uu____19156 with
+               let uu____18997 = FStar_Syntax_Util.un_uinst head_s  in
+               (match uu____18997 with
                 | {
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
-                      uu____19157;
-                    FStar_Syntax_Syntax.pos = uu____19158;
-                    FStar_Syntax_Syntax.vars = uu____19159;_} ->
-                    let uu____19162 = FStar_Syntax_Util.head_and_args pat_t2
+                      uu____18998;
+                    FStar_Syntax_Syntax.pos = uu____18999;
+                    FStar_Syntax_Syntax.vars = uu____19000;_} ->
+                    let uu____19003 = FStar_Syntax_Util.head_and_args pat_t2
                        in
-                    (match uu____19162 with
+                    (match uu____19003 with
                      | (head_p,args_p) ->
-                         let uu____19205 =
+                         let uu____19046 =
                            FStar_TypeChecker_Rel.teq_nosmt_force env1 head_p
                              head_s
                             in
-                         if uu____19205
+                         if uu____19046
                          then
-                           let uu____19208 =
-                             let uu____19209 =
+                           let uu____19049 =
+                             let uu____19050 =
                                FStar_Syntax_Util.un_uinst head_p  in
-                             uu____19209.FStar_Syntax_Syntax.n  in
-                           (match uu____19208 with
+                             uu____19050.FStar_Syntax_Syntax.n  in
+                           (match uu____19049 with
                             | FStar_Syntax_Syntax.Tm_fvar f ->
-                                ((let uu____19214 =
-                                    let uu____19216 =
-                                      let uu____19218 =
+                                ((let uu____19055 =
+                                    let uu____19057 =
+                                      let uu____19059 =
                                         FStar_Syntax_Syntax.lid_of_fv f  in
                                       FStar_TypeChecker_Env.is_type_constructor
-                                        env1 uu____19218
+                                        env1 uu____19059
                                        in
                                     FStar_All.pipe_left Prims.op_Negation
-                                      uu____19216
+                                      uu____19057
                                      in
-                                  if uu____19214
+                                  if uu____19055
                                   then
                                     fail1
                                       "Pattern matching a non-inductive type"
@@ -6974,61 +6991,61 @@ and (tc_pat :
                                      (FStar_List.length args_s)
                                  then fail1 ""
                                  else ();
-                                 (let uu____19246 =
-                                    let uu____19271 =
-                                      let uu____19275 =
+                                 (let uu____19087 =
+                                    let uu____19112 =
+                                      let uu____19116 =
                                         FStar_Syntax_Syntax.lid_of_fv f  in
                                       FStar_TypeChecker_Env.num_inductive_ty_params
-                                        env1 uu____19275
+                                        env1 uu____19116
                                        in
-                                    match uu____19271 with
+                                    match uu____19112 with
                                     | FStar_Pervasives_Native.None  ->
                                         (args_p, args_s)
                                     | FStar_Pervasives_Native.Some n ->
-                                        let uu____19324 =
+                                        let uu____19165 =
                                           FStar_Util.first_N n args_p  in
-                                        (match uu____19324 with
-                                         | (params_p,uu____19382) ->
-                                             let uu____19423 =
+                                        (match uu____19165 with
+                                         | (params_p,uu____19223) ->
+                                             let uu____19264 =
                                                FStar_Util.first_N n args_s
                                                 in
-                                             (match uu____19423 with
-                                              | (params_s,uu____19481) ->
+                                             (match uu____19264 with
+                                              | (params_s,uu____19322) ->
                                                   (params_p, params_s)))
                                      in
-                                  match uu____19246 with
+                                  match uu____19087 with
                                   | (params_p,params_s) ->
                                       FStar_List.fold_left2
                                         (fun out  ->
-                                           fun uu____19610  ->
-                                             fun uu____19611  ->
-                                               match (uu____19610,
-                                                       uu____19611)
+                                           fun uu____19451  ->
+                                             fun uu____19452  ->
+                                               match (uu____19451,
+                                                       uu____19452)
                                                with
-                                               | ((p,uu____19645),(s,uu____19647))
+                                               | ((p,uu____19486),(s,uu____19488))
                                                    ->
-                                                   let uu____19680 =
+                                                   let uu____19521 =
                                                      FStar_TypeChecker_Rel.teq_nosmt
                                                        env1 p s
                                                       in
-                                                   (match uu____19680 with
+                                                   (match uu____19521 with
                                                     | FStar_Pervasives_Native.None
                                                          ->
-                                                        let uu____19683 =
-                                                          let uu____19685 =
+                                                        let uu____19524 =
+                                                          let uu____19526 =
                                                             FStar_Syntax_Print.term_to_string
                                                               p
                                                              in
-                                                          let uu____19687 =
+                                                          let uu____19528 =
                                                             FStar_Syntax_Print.term_to_string
                                                               s
                                                              in
                                                           FStar_Util.format2
                                                             "; parameter %s <> parameter %s"
-                                                            uu____19685
-                                                            uu____19687
+                                                            uu____19526
+                                                            uu____19528
                                                            in
-                                                        fail1 uu____19683
+                                                        fail1 uu____19524
                                                     | FStar_Pervasives_Native.Some
                                                         g ->
                                                         let g1 =
@@ -7039,23 +7056,23 @@ and (tc_pat :
                                                           g1 out))
                                         FStar_TypeChecker_Env.trivial_guard
                                         params_p params_s))
-                            | uu____19692 ->
+                            | uu____19533 ->
                                 fail1 "Pattern matching a non-inductive type")
                          else
-                           (let uu____19696 =
-                              let uu____19698 =
+                           (let uu____19537 =
+                              let uu____19539 =
                                 FStar_Syntax_Print.term_to_string head_p  in
-                              let uu____19700 =
+                              let uu____19541 =
                                 FStar_Syntax_Print.term_to_string head_s  in
                               FStar_Util.format2 "; head mismatch %s vs %s"
-                                uu____19698 uu____19700
+                                uu____19539 uu____19541
                                in
-                            fail1 uu____19696))
-                | uu____19703 ->
-                    let uu____19704 =
+                            fail1 uu____19537))
+                | uu____19544 ->
+                    let uu____19545 =
                       FStar_TypeChecker_Rel.teq_nosmt env1 pat_t2 scrutinee_t
                        in
-                    (match uu____19704 with
+                    (match uu____19545 with
                      | FStar_Pervasives_Native.None  -> fail1 ""
                      | FStar_Pervasives_Native.Some g ->
                          let g1 =
@@ -7065,20 +7082,20 @@ and (tc_pat :
                          g1)))
            in
         let type_of_simple_pat env1 e =
-          let uu____19747 = FStar_Syntax_Util.head_and_args e  in
-          match uu____19747 with
+          let uu____19588 = FStar_Syntax_Util.head_and_args e  in
+          match uu____19588 with
           | (head,args) ->
               (match head.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_fvar f ->
-                   let uu____19817 =
+                   let uu____19658 =
                      FStar_TypeChecker_Env.lookup_datacon env1
                        (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                       in
-                   (match uu____19817 with
+                   (match uu____19658 with
                     | (us,t_f) ->
-                        let uu____19837 = FStar_Syntax_Util.arrow_formals t_f
+                        let uu____19678 = FStar_Syntax_Util.arrow_formals t_f
                            in
-                        (match uu____19837 with
+                        (match uu____19678 with
                          | (formals,t) ->
                              let erasable =
                                FStar_TypeChecker_Env.non_informative env1 t
@@ -7090,8 +7107,8 @@ and (tc_pat :
                                 fail
                                   "Pattern is not a fully-applied data constructor"
                               else ();
-                              (let rec aux uu____19950 formals1 args1 =
-                                 match uu____19950 with
+                              (let rec aux uu____19791 formals1 args1 =
+                                 match uu____19791 with
                                  | (subst,args_out,bvs,guard) ->
                                      (match (formals1, args1) with
                                       | ([],[]) ->
@@ -7105,36 +7122,36 @@ and (tc_pat :
                                               FStar_Pervasives_Native.None
                                               e.FStar_Syntax_Syntax.pos
                                              in
-                                          let uu____20101 =
+                                          let uu____19942 =
                                             FStar_Syntax_Subst.subst subst t
                                              in
-                                          (pat_e, uu____20101, bvs, guard,
+                                          (pat_e, uu____19942, bvs, guard,
                                             erasable)
-                                      | ((f1,uu____20108)::formals2,(a,imp_a)::args2)
+                                      | ((f1,uu____19949)::formals2,(a,imp_a)::args2)
                                           ->
                                           let t_f1 =
                                             FStar_Syntax_Subst.subst subst
                                               f1.FStar_Syntax_Syntax.sort
                                              in
-                                          let uu____20166 =
-                                            let uu____20187 =
-                                              let uu____20188 =
+                                          let uu____20007 =
+                                            let uu____20028 =
+                                              let uu____20029 =
                                                 FStar_Syntax_Subst.compress a
                                                  in
-                                              uu____20188.FStar_Syntax_Syntax.n
+                                              uu____20029.FStar_Syntax_Syntax.n
                                                in
-                                            match uu____20187 with
+                                            match uu____20028 with
                                             | FStar_Syntax_Syntax.Tm_name x
                                                 ->
                                                 let x1 =
-                                                  let uu___2583_20213 = x  in
+                                                  let uu___2595_20054 = x  in
                                                   {
                                                     FStar_Syntax_Syntax.ppname
                                                       =
-                                                      (uu___2583_20213.FStar_Syntax_Syntax.ppname);
+                                                      (uu___2595_20054.FStar_Syntax_Syntax.ppname);
                                                     FStar_Syntax_Syntax.index
                                                       =
-                                                      (uu___2583_20213.FStar_Syntax_Syntax.index);
+                                                      (uu___2595_20054.FStar_Syntax_Syntax.index);
                                                     FStar_Syntax_Syntax.sort
                                                       = t_f1
                                                   }  in
@@ -7150,16 +7167,16 @@ and (tc_pat :
                                                   (FStar_List.append bvs [x1]),
                                                   FStar_TypeChecker_Env.trivial_guard)
                                             | FStar_Syntax_Syntax.Tm_uvar
-                                                uu____20236 ->
+                                                uu____20077 ->
                                                 let env2 =
                                                   FStar_TypeChecker_Env.set_expected_typ
                                                     env1 t_f1
                                                    in
-                                                let uu____20250 =
+                                                let uu____20091 =
                                                   tc_tot_or_gtot_term env2 a
                                                    in
-                                                (match uu____20250 with
-                                                 | (a1,uu____20278,g) ->
+                                                (match uu____20091 with
+                                                 | (a1,uu____20119,g) ->
                                                      let g1 =
                                                        FStar_TypeChecker_Rel.discharge_guard_no_smt
                                                          env2 g
@@ -7170,42 +7187,42 @@ and (tc_pat :
                                                        :: subst  in
                                                      ((a1, imp_a), subst1,
                                                        bvs, g1))
-                                            | uu____20302 ->
+                                            | uu____20143 ->
                                                 fail "Not a simple pattern"
                                              in
-                                          (match uu____20166 with
+                                          (match uu____20007 with
                                            | (a1,subst1,bvs1,g) ->
-                                               let uu____20367 =
-                                                 let uu____20390 =
+                                               let uu____20208 =
+                                                 let uu____20231 =
                                                    FStar_TypeChecker_Env.conj_guard
                                                      g guard
                                                     in
                                                  (subst1,
                                                    (FStar_List.append
                                                       args_out [a1]), bvs1,
-                                                   uu____20390)
+                                                   uu____20231)
                                                   in
-                                               aux uu____20367 formals2 args2)
-                                      | uu____20429 ->
+                                               aux uu____20208 formals2 args2)
+                                      | uu____20270 ->
                                           fail "Not a fully applued pattern")
                                   in
                                aux
                                  ([], [], [],
                                    FStar_TypeChecker_Env.trivial_guard)
                                  formals args))))
-               | uu____20488 -> fail "Not a simple pattern")
+               | uu____20329 -> fail "Not a simple pattern")
            in
         let rec check_nested_pattern env1 p t =
-          (let uu____20554 =
+          (let uu____20395 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns")
               in
-           if uu____20554
+           if uu____20395
            then
-             let uu____20559 = FStar_Syntax_Print.pat_to_string p  in
-             let uu____20561 = FStar_Syntax_Print.term_to_string t  in
-             FStar_Util.print2 "Checking pattern %s at type %s\n" uu____20559
-               uu____20561
+             let uu____20400 = FStar_Syntax_Print.pat_to_string p  in
+             let uu____20402 = FStar_Syntax_Print.term_to_string t  in
+             FStar_Util.print2 "Checking pattern %s at type %s\n" uu____20400
+               uu____20402
            else ());
           (let id =
              FStar_Syntax_Syntax.fvar FStar_Parser_Const.id_lid
@@ -7214,122 +7231,122 @@ and (tc_pat :
               in
            let mk_disc_t disc inner_t =
              let x_b =
-               let uu____20586 =
+               let uu____20427 =
                  FStar_Syntax_Syntax.gen_bv "x" FStar_Pervasives_Native.None
                    t
                   in
-               FStar_All.pipe_right uu____20586 FStar_Syntax_Syntax.mk_binder
+               FStar_All.pipe_right uu____20427 FStar_Syntax_Syntax.mk_binder
                 in
              let tm =
-               let uu____20597 =
-                 let uu____20602 =
-                   let uu____20603 =
-                     let uu____20612 =
-                       let uu____20613 =
+               let uu____20438 =
+                 let uu____20443 =
+                   let uu____20444 =
+                     let uu____20453 =
+                       let uu____20454 =
                          FStar_All.pipe_right x_b FStar_Pervasives_Native.fst
                           in
-                       FStar_All.pipe_right uu____20613
+                       FStar_All.pipe_right uu____20454
                          FStar_Syntax_Syntax.bv_to_name
                         in
-                     FStar_All.pipe_right uu____20612
+                     FStar_All.pipe_right uu____20453
                        FStar_Syntax_Syntax.as_arg
                       in
-                   [uu____20603]  in
-                 FStar_Syntax_Syntax.mk_Tm_app disc uu____20602  in
-               uu____20597 FStar_Pervasives_Native.None
+                   [uu____20444]  in
+                 FStar_Syntax_Syntax.mk_Tm_app disc uu____20443  in
+               uu____20438 FStar_Pervasives_Native.None
                  FStar_Range.dummyRange
                 in
              let tm1 =
-               let uu____20649 =
-                 let uu____20654 =
-                   let uu____20655 =
+               let uu____20490 =
+                 let uu____20495 =
+                   let uu____20496 =
                      FStar_All.pipe_right tm FStar_Syntax_Syntax.as_arg  in
-                   [uu____20655]  in
-                 FStar_Syntax_Syntax.mk_Tm_app inner_t uu____20654  in
-               uu____20649 FStar_Pervasives_Native.None
+                   [uu____20496]  in
+                 FStar_Syntax_Syntax.mk_Tm_app inner_t uu____20495  in
+               uu____20490 FStar_Pervasives_Native.None
                  FStar_Range.dummyRange
                 in
              FStar_Syntax_Util.abs [x_b] tm1 FStar_Pervasives_Native.None  in
            match p.FStar_Syntax_Syntax.v with
-           | FStar_Syntax_Syntax.Pat_dot_term uu____20717 ->
-               let uu____20724 =
-                 let uu____20726 = FStar_Syntax_Print.pat_to_string p  in
+           | FStar_Syntax_Syntax.Pat_dot_term uu____20558 ->
+               let uu____20565 =
+                 let uu____20567 = FStar_Syntax_Print.pat_to_string p  in
                  FStar_Util.format1
                    "Impossible: Expected an undecorated pattern, got %s"
-                   uu____20726
+                   uu____20567
                   in
-               failwith uu____20724
+               failwith uu____20565
            | FStar_Syntax_Syntax.Pat_wild x ->
                let x1 =
-                 let uu___2622_20748 = x  in
+                 let uu___2634_20589 = x  in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2622_20748.FStar_Syntax_Syntax.ppname);
+                     (uu___2634_20589.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2622_20748.FStar_Syntax_Syntax.index);
+                     (uu___2634_20589.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  }  in
-               let uu____20749 = FStar_Syntax_Syntax.bv_to_name x1  in
-               ([x1], [id], uu____20749,
-                 (let uu___2625_20756 = p  in
+               let uu____20590 = FStar_Syntax_Syntax.bv_to_name x1  in
+               ([x1], [id], uu____20590,
+                 (let uu___2637_20597 = p  in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
                     FStar_Syntax_Syntax.p =
-                      (uu___2625_20756.FStar_Syntax_Syntax.p)
+                      (uu___2637_20597.FStar_Syntax_Syntax.p)
                   }), FStar_TypeChecker_Env.trivial_guard, false)
            | FStar_Syntax_Syntax.Pat_var x ->
                let x1 =
-                 let uu___2629_20760 = x  in
+                 let uu___2641_20601 = x  in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2629_20760.FStar_Syntax_Syntax.ppname);
+                     (uu___2641_20601.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2629_20760.FStar_Syntax_Syntax.index);
+                     (uu___2641_20601.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  }  in
-               let uu____20761 = FStar_Syntax_Syntax.bv_to_name x1  in
-               ([x1], [id], uu____20761,
-                 (let uu___2632_20768 = p  in
+               let uu____20602 = FStar_Syntax_Syntax.bv_to_name x1  in
+               ([x1], [id], uu____20602,
+                 (let uu___2644_20609 = p  in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
                     FStar_Syntax_Syntax.p =
-                      (uu___2632_20768.FStar_Syntax_Syntax.p)
+                      (uu___2644_20609.FStar_Syntax_Syntax.p)
                   }), FStar_TypeChecker_Env.trivial_guard, false)
-           | FStar_Syntax_Syntax.Pat_constant uu____20770 ->
-               let uu____20771 =
+           | FStar_Syntax_Syntax.Pat_constant uu____20611 ->
+               let uu____20612 =
                  FStar_TypeChecker_PatternUtils.pat_as_exp false env1 p  in
-               (match uu____20771 with
-                | (uu____20800,e_c,uu____20802,uu____20803) ->
-                    let uu____20808 = tc_tot_or_gtot_term env1 e_c  in
-                    (match uu____20808 with
+               (match uu____20612 with
+                | (uu____20641,e_c,uu____20643,uu____20644) ->
+                    let uu____20649 = tc_tot_or_gtot_term env1 e_c  in
+                    (match uu____20649 with
                      | (e_c1,lc,g) ->
                          (FStar_TypeChecker_Rel.force_trivial_guard env1 g;
                           (let expected_t =
                              expected_pat_typ env1 p0.FStar_Syntax_Syntax.p t
                               in
-                           (let uu____20838 =
-                              let uu____20840 =
+                           (let uu____20679 =
+                              let uu____20681 =
                                 FStar_TypeChecker_Rel.teq_nosmt_force env1
                                   lc.FStar_TypeChecker_Common.res_typ
                                   expected_t
                                  in
-                              Prims.op_Negation uu____20840  in
-                            if uu____20838
+                              Prims.op_Negation uu____20681  in
+                            if uu____20679
                             then
-                              let uu____20843 =
-                                let uu____20845 =
+                              let uu____20684 =
+                                let uu____20686 =
                                   FStar_Syntax_Print.term_to_string
                                     lc.FStar_TypeChecker_Common.res_typ
                                    in
-                                let uu____20847 =
+                                let uu____20688 =
                                   FStar_Syntax_Print.term_to_string
                                     expected_t
                                    in
                                 FStar_Util.format2
                                   "Type of pattern (%s) does not match type of scrutinee (%s)"
-                                  uu____20845 uu____20847
+                                  uu____20686 uu____20688
                                  in
-                              fail uu____20843
+                              fail uu____20684
                             else ());
                            ([], [], e_c1, p,
                              FStar_TypeChecker_Env.trivial_guard, false)))))
@@ -7337,165 +7354,165 @@ and (tc_pat :
                let simple_pat =
                  let simple_sub_pats =
                    FStar_List.map
-                     (fun uu____20909  ->
-                        match uu____20909 with
+                     (fun uu____20750  ->
+                        match uu____20750 with
                         | (p1,b) ->
                             (match p1.FStar_Syntax_Syntax.v with
-                             | FStar_Syntax_Syntax.Pat_dot_term uu____20939
+                             | FStar_Syntax_Syntax.Pat_dot_term uu____20780
                                  -> (p1, b)
-                             | uu____20949 ->
-                                 let uu____20950 =
-                                   let uu____20953 =
-                                     let uu____20954 =
+                             | uu____20790 ->
+                                 let uu____20791 =
+                                   let uu____20794 =
+                                     let uu____20795 =
                                        FStar_Syntax_Syntax.new_bv
                                          (FStar_Pervasives_Native.Some
                                             (p1.FStar_Syntax_Syntax.p))
                                          FStar_Syntax_Syntax.tun
                                         in
-                                     FStar_Syntax_Syntax.Pat_var uu____20954
+                                     FStar_Syntax_Syntax.Pat_var uu____20795
                                       in
-                                   FStar_Syntax_Syntax.withinfo uu____20953
+                                   FStar_Syntax_Syntax.withinfo uu____20794
                                      p1.FStar_Syntax_Syntax.p
                                     in
-                                 (uu____20950, b))) sub_pats
+                                 (uu____20791, b))) sub_pats
                     in
-                 let uu___2660_20958 = p  in
+                 let uu___2672_20799 = p  in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons (fv, simple_sub_pats));
                    FStar_Syntax_Syntax.p =
-                     (uu___2660_20958.FStar_Syntax_Syntax.p)
+                     (uu___2672_20799.FStar_Syntax_Syntax.p)
                  }  in
                let sub_pats1 =
                  FStar_All.pipe_right sub_pats
                    (FStar_List.filter
-                      (fun uu____21003  ->
-                         match uu____21003 with
-                         | (x,uu____21013) ->
+                      (fun uu____20844  ->
+                         match uu____20844 with
+                         | (x,uu____20854) ->
                              (match x.FStar_Syntax_Syntax.v with
-                              | FStar_Syntax_Syntax.Pat_dot_term uu____21021
+                              | FStar_Syntax_Syntax.Pat_dot_term uu____20862
                                   -> false
-                              | uu____21029 -> true)))
+                              | uu____20870 -> true)))
                   in
-               let uu____21031 =
+               let uu____20872 =
                  FStar_TypeChecker_PatternUtils.pat_as_exp false env1
                    simple_pat
                   in
-               (match uu____21031 with
+               (match uu____20872 with
                 | (simple_bvs,simple_pat_e,g0,simple_pat_elab) ->
                     (if
                        (FStar_List.length simple_bvs) <>
                          (FStar_List.length sub_pats1)
                      then
-                       (let uu____21075 =
-                          let uu____21077 =
+                       (let uu____20916 =
+                          let uu____20918 =
                             FStar_Range.string_of_range
                               p.FStar_Syntax_Syntax.p
                              in
-                          let uu____21079 =
+                          let uu____20920 =
                             FStar_Syntax_Print.pat_to_string simple_pat  in
-                          let uu____21081 =
+                          let uu____20922 =
                             FStar_Util.string_of_int
                               (FStar_List.length sub_pats1)
                              in
-                          let uu____21088 =
+                          let uu____20929 =
                             FStar_Util.string_of_int
                               (FStar_List.length simple_bvs)
                              in
                           FStar_Util.format4
                             "(%s) Impossible: pattern bvar mismatch: %s; expected %s sub pats; got %s"
-                            uu____21077 uu____21079 uu____21081 uu____21088
+                            uu____20918 uu____20920 uu____20922 uu____20929
                            in
-                        failwith uu____21075)
+                        failwith uu____20916)
                      else ();
-                     (let uu____21093 =
-                        let uu____21105 =
+                     (let uu____20934 =
+                        let uu____20946 =
                           type_of_simple_pat env1 simple_pat_e  in
-                        match uu____21105 with
+                        match uu____20946 with
                         | (simple_pat_e1,simple_pat_t,simple_bvs1,guard,erasable)
                             ->
                             let g' =
-                              let uu____21142 =
+                              let uu____20983 =
                                 expected_pat_typ env1
                                   p0.FStar_Syntax_Syntax.p t
                                  in
-                              pat_typ_ok env1 simple_pat_t uu____21142  in
+                              pat_typ_ok env1 simple_pat_t uu____20983  in
                             let guard1 =
                               FStar_TypeChecker_Env.conj_guard guard g'  in
-                            ((let uu____21145 =
+                            ((let uu____20986 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env1)
                                   (FStar_Options.Other "Patterns")
                                  in
-                              if uu____21145
+                              if uu____20986
                               then
-                                let uu____21150 =
+                                let uu____20991 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_e1
                                    in
-                                let uu____21152 =
+                                let uu____20993 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_t
                                    in
-                                let uu____21154 =
-                                  let uu____21156 =
+                                let uu____20995 =
+                                  let uu____20997 =
                                     FStar_List.map
                                       (fun x  ->
-                                         let uu____21164 =
-                                           let uu____21166 =
+                                         let uu____21005 =
+                                           let uu____21007 =
                                              FStar_Syntax_Print.bv_to_string
                                                x
                                               in
-                                           let uu____21168 =
-                                             let uu____21170 =
-                                               let uu____21172 =
+                                           let uu____21009 =
+                                             let uu____21011 =
+                                               let uu____21013 =
                                                  FStar_Syntax_Print.term_to_string
                                                    x.FStar_Syntax_Syntax.sort
                                                   in
-                                               Prims.op_Hat uu____21172 ")"
+                                               Prims.op_Hat uu____21013 ")"
                                                 in
-                                             Prims.op_Hat " : " uu____21170
+                                             Prims.op_Hat " : " uu____21011
                                               in
-                                           Prims.op_Hat uu____21166
-                                             uu____21168
+                                           Prims.op_Hat uu____21007
+                                             uu____21009
                                             in
-                                         Prims.op_Hat "(" uu____21164)
+                                         Prims.op_Hat "(" uu____21005)
                                       simple_bvs1
                                      in
-                                  FStar_All.pipe_right uu____21156
+                                  FStar_All.pipe_right uu____20997
                                     (FStar_String.concat " ")
                                    in
                                 FStar_Util.print3
                                   "$$$$$$$$$$$$Checked simple pattern %s at type %s with bvs=%s\n"
-                                  uu____21150 uu____21152 uu____21154
+                                  uu____20991 uu____20993 uu____20995
                               else ());
                              (simple_pat_e1, simple_bvs1, guard1, erasable))
                          in
-                      match uu____21093 with
+                      match uu____20934 with
                       | (simple_pat_e1,simple_bvs1,g1,erasable) ->
-                          let uu____21215 =
-                            let uu____21247 =
-                              let uu____21279 =
+                          let uu____21056 =
+                            let uu____21088 =
+                              let uu____21120 =
                                 FStar_TypeChecker_Env.conj_guard g0 g1  in
-                              (env1, [], [], [], [], uu____21279, erasable,
+                              (env1, [], [], [], [], uu____21120, erasable,
                                 Prims.int_zero)
                                in
                             FStar_List.fold_left2
-                              (fun uu____21361  ->
-                                 fun uu____21362  ->
+                              (fun uu____21202  ->
+                                 fun uu____21203  ->
                                    fun x  ->
-                                     match (uu____21361, uu____21362) with
+                                     match (uu____21202, uu____21203) with
                                      | ((env2,bvs,tms,pats,subst,g,erasable1,i),
                                         (p1,b)) ->
                                          let expected_t =
                                            FStar_Syntax_Subst.subst subst
                                              x.FStar_Syntax_Syntax.sort
                                             in
-                                         let uu____21546 =
+                                         let uu____21387 =
                                            check_nested_pattern env2 p1
                                              expected_t
                                             in
-                                         (match uu____21546 with
+                                         (match uu____21387 with
                                           | (bvs_p,tms_p,e_p,p2,g',erasable_p)
                                               ->
                                               let env3 =
@@ -7504,29 +7521,29 @@ and (tc_pat :
                                                  in
                                               let tms_p1 =
                                                 let disc_tm =
-                                                  let uu____21616 =
+                                                  let uu____21457 =
                                                     FStar_Syntax_Syntax.lid_of_fv
                                                       fv
                                                      in
                                                   FStar_TypeChecker_Util.get_field_projector_name
-                                                    env3 uu____21616 i
+                                                    env3 uu____21457 i
                                                    in
-                                                let uu____21617 =
-                                                  let uu____21626 =
-                                                    let uu____21631 =
+                                                let uu____21458 =
+                                                  let uu____21467 =
+                                                    let uu____21472 =
                                                       FStar_Syntax_Syntax.fvar
                                                         disc_tm
                                                         (FStar_Syntax_Syntax.Delta_constant_at_level
                                                            Prims.int_one)
                                                         FStar_Pervasives_Native.None
                                                        in
-                                                    mk_disc_t uu____21631  in
-                                                  FStar_List.map uu____21626
+                                                    mk_disc_t uu____21472  in
+                                                  FStar_List.map uu____21467
                                                    in
                                                 FStar_All.pipe_right tms_p
-                                                  uu____21617
+                                                  uu____21458
                                                  in
-                                              let uu____21637 =
+                                              let uu____21478 =
                                                 FStar_TypeChecker_Env.conj_guard
                                                   g g'
                                                  in
@@ -7537,13 +7554,13 @@ and (tc_pat :
                                                    [(p2, b)]),
                                                 ((FStar_Syntax_Syntax.NT
                                                     (x, e_p)) :: subst),
-                                                uu____21637,
+                                                uu____21478,
                                                 (erasable1 || erasable_p),
                                                 (i + Prims.int_one))))
-                              uu____21247 sub_pats1 simple_bvs1
+                              uu____21088 sub_pats1 simple_bvs1
                              in
-                          (match uu____21215 with
-                           | (_env,bvs,tms,checked_sub_pats,subst,g,erasable1,uu____21696)
+                          (match uu____21056 with
+                           | (_env,bvs,tms,checked_sub_pats,subst,g,erasable1,uu____21537)
                                ->
                                let pat_e =
                                  FStar_Syntax_Subst.subst subst simple_pat_e1
@@ -7561,34 +7578,34 @@ and (tc_pat :
                                                 e
                                                in
                                             let hd1 =
-                                              let uu___2744_21872 = hd  in
+                                              let uu___2756_21713 = hd  in
                                               {
                                                 FStar_Syntax_Syntax.v =
                                                   (FStar_Syntax_Syntax.Pat_dot_term
                                                      (x, e1));
                                                 FStar_Syntax_Syntax.p =
-                                                  (uu___2744_21872.FStar_Syntax_Syntax.p)
+                                                  (uu___2756_21713.FStar_Syntax_Syntax.p)
                                               }  in
-                                            let uu____21877 =
+                                            let uu____21718 =
                                               aux simple_pats1 bvs1 sub_pats2
                                                in
-                                            (hd1, b) :: uu____21877
+                                            (hd1, b) :: uu____21718
                                         | FStar_Syntax_Syntax.Pat_var x ->
                                             (match (bvs1, sub_pats2) with
-                                             | (x'::bvs2,(hd1,uu____21921)::sub_pats3)
+                                             | (x'::bvs2,(hd1,uu____21762)::sub_pats3)
                                                  when
                                                  FStar_Syntax_Syntax.bv_eq x
                                                    x'
                                                  ->
-                                                 let uu____21958 =
+                                                 let uu____21799 =
                                                    aux simple_pats1 bvs2
                                                      sub_pats3
                                                     in
-                                                 (hd1, b) :: uu____21958
-                                             | uu____21978 ->
+                                                 (hd1, b) :: uu____21799
+                                             | uu____21819 ->
                                                  failwith
                                                    "Impossible: simple pat variable mismatch")
-                                        | uu____22004 ->
+                                        | uu____21845 ->
                                             failwith
                                               "Impossible: expected a simple pattern")
                                     in
@@ -7599,154 +7616,154 @@ and (tc_pat :
                                        aux simple_pats simple_bvs1
                                          checked_sub_pats
                                         in
-                                     let uu___2765_22047 = pat  in
+                                     let uu___2777_21888 = pat  in
                                      {
                                        FStar_Syntax_Syntax.v =
                                          (FStar_Syntax_Syntax.Pat_cons
                                             (fv1, nested_pats));
                                        FStar_Syntax_Syntax.p =
-                                         (uu___2765_22047.FStar_Syntax_Syntax.p)
+                                         (uu___2777_21888.FStar_Syntax_Syntax.p)
                                      }
-                                 | uu____22059 -> failwith "Impossible"  in
-                               let uu____22063 =
+                                 | uu____21900 -> failwith "Impossible"  in
+                               let uu____21904 =
                                  reconstruct_nested_pat simple_pat_elab  in
-                               (bvs, tms, pat_e, uu____22063, g, erasable1))))))
+                               (bvs, tms, pat_e, uu____21904, g, erasable1))))))
            in
-        (let uu____22070 =
+        (let uu____21911 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Patterns")
             in
-         if uu____22070
+         if uu____21911
          then
-           let uu____22075 = FStar_Syntax_Print.pat_to_string p0  in
-           FStar_Util.print1 "Checking pattern: %s\n" uu____22075
+           let uu____21916 = FStar_Syntax_Print.pat_to_string p0  in
+           FStar_Util.print1 "Checking pattern: %s\n" uu____21916
          else ());
-        (let uu____22080 =
-           let uu____22098 =
-             let uu___2770_22099 =
-               let uu____22100 = FStar_TypeChecker_Env.clear_expected_typ env
+        (let uu____21921 =
+           let uu____21939 =
+             let uu___2782_21940 =
+               let uu____21941 = FStar_TypeChecker_Env.clear_expected_typ env
                   in
-               FStar_All.pipe_right uu____22100 FStar_Pervasives_Native.fst
+               FStar_All.pipe_right uu____21941 FStar_Pervasives_Native.fst
                 in
              {
                FStar_TypeChecker_Env.solver =
-                 (uu___2770_22099.FStar_TypeChecker_Env.solver);
+                 (uu___2782_21940.FStar_TypeChecker_Env.solver);
                FStar_TypeChecker_Env.range =
-                 (uu___2770_22099.FStar_TypeChecker_Env.range);
+                 (uu___2782_21940.FStar_TypeChecker_Env.range);
                FStar_TypeChecker_Env.curmodule =
-                 (uu___2770_22099.FStar_TypeChecker_Env.curmodule);
+                 (uu___2782_21940.FStar_TypeChecker_Env.curmodule);
                FStar_TypeChecker_Env.gamma =
-                 (uu___2770_22099.FStar_TypeChecker_Env.gamma);
+                 (uu___2782_21940.FStar_TypeChecker_Env.gamma);
                FStar_TypeChecker_Env.gamma_sig =
-                 (uu___2770_22099.FStar_TypeChecker_Env.gamma_sig);
+                 (uu___2782_21940.FStar_TypeChecker_Env.gamma_sig);
                FStar_TypeChecker_Env.gamma_cache =
-                 (uu___2770_22099.FStar_TypeChecker_Env.gamma_cache);
+                 (uu___2782_21940.FStar_TypeChecker_Env.gamma_cache);
                FStar_TypeChecker_Env.modules =
-                 (uu___2770_22099.FStar_TypeChecker_Env.modules);
+                 (uu___2782_21940.FStar_TypeChecker_Env.modules);
                FStar_TypeChecker_Env.expected_typ =
-                 (uu___2770_22099.FStar_TypeChecker_Env.expected_typ);
+                 (uu___2782_21940.FStar_TypeChecker_Env.expected_typ);
                FStar_TypeChecker_Env.sigtab =
-                 (uu___2770_22099.FStar_TypeChecker_Env.sigtab);
+                 (uu___2782_21940.FStar_TypeChecker_Env.sigtab);
                FStar_TypeChecker_Env.attrtab =
-                 (uu___2770_22099.FStar_TypeChecker_Env.attrtab);
+                 (uu___2782_21940.FStar_TypeChecker_Env.attrtab);
                FStar_TypeChecker_Env.instantiate_imp =
-                 (uu___2770_22099.FStar_TypeChecker_Env.instantiate_imp);
+                 (uu___2782_21940.FStar_TypeChecker_Env.instantiate_imp);
                FStar_TypeChecker_Env.effects =
-                 (uu___2770_22099.FStar_TypeChecker_Env.effects);
+                 (uu___2782_21940.FStar_TypeChecker_Env.effects);
                FStar_TypeChecker_Env.generalize =
-                 (uu___2770_22099.FStar_TypeChecker_Env.generalize);
+                 (uu___2782_21940.FStar_TypeChecker_Env.generalize);
                FStar_TypeChecker_Env.letrecs =
-                 (uu___2770_22099.FStar_TypeChecker_Env.letrecs);
+                 (uu___2782_21940.FStar_TypeChecker_Env.letrecs);
                FStar_TypeChecker_Env.top_level =
-                 (uu___2770_22099.FStar_TypeChecker_Env.top_level);
+                 (uu___2782_21940.FStar_TypeChecker_Env.top_level);
                FStar_TypeChecker_Env.check_uvars =
-                 (uu___2770_22099.FStar_TypeChecker_Env.check_uvars);
+                 (uu___2782_21940.FStar_TypeChecker_Env.check_uvars);
                FStar_TypeChecker_Env.use_eq = true;
                FStar_TypeChecker_Env.use_eq_strict =
-                 (uu___2770_22099.FStar_TypeChecker_Env.use_eq_strict);
+                 (uu___2782_21940.FStar_TypeChecker_Env.use_eq_strict);
                FStar_TypeChecker_Env.is_iface =
-                 (uu___2770_22099.FStar_TypeChecker_Env.is_iface);
+                 (uu___2782_21940.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit =
-                 (uu___2770_22099.FStar_TypeChecker_Env.admit);
+                 (uu___2782_21940.FStar_TypeChecker_Env.admit);
                FStar_TypeChecker_Env.lax =
-                 (uu___2770_22099.FStar_TypeChecker_Env.lax);
+                 (uu___2782_21940.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
-                 (uu___2770_22099.FStar_TypeChecker_Env.lax_universes);
+                 (uu___2782_21940.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =
-                 (uu___2770_22099.FStar_TypeChecker_Env.phase1);
+                 (uu___2782_21940.FStar_TypeChecker_Env.phase1);
                FStar_TypeChecker_Env.failhard =
-                 (uu___2770_22099.FStar_TypeChecker_Env.failhard);
+                 (uu___2782_21940.FStar_TypeChecker_Env.failhard);
                FStar_TypeChecker_Env.nosynth =
-                 (uu___2770_22099.FStar_TypeChecker_Env.nosynth);
+                 (uu___2782_21940.FStar_TypeChecker_Env.nosynth);
                FStar_TypeChecker_Env.uvar_subtyping =
-                 (uu___2770_22099.FStar_TypeChecker_Env.uvar_subtyping);
+                 (uu___2782_21940.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.tc_term =
-                 (uu___2770_22099.FStar_TypeChecker_Env.tc_term);
+                 (uu___2782_21940.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.type_of =
-                 (uu___2770_22099.FStar_TypeChecker_Env.type_of);
+                 (uu___2782_21940.FStar_TypeChecker_Env.type_of);
                FStar_TypeChecker_Env.universe_of =
-                 (uu___2770_22099.FStar_TypeChecker_Env.universe_of);
+                 (uu___2782_21940.FStar_TypeChecker_Env.universe_of);
                FStar_TypeChecker_Env.check_type_of =
-                 (uu___2770_22099.FStar_TypeChecker_Env.check_type_of);
+                 (uu___2782_21940.FStar_TypeChecker_Env.check_type_of);
                FStar_TypeChecker_Env.use_bv_sorts =
-                 (uu___2770_22099.FStar_TypeChecker_Env.use_bv_sorts);
+                 (uu___2782_21940.FStar_TypeChecker_Env.use_bv_sorts);
                FStar_TypeChecker_Env.qtbl_name_and_index =
-                 (uu___2770_22099.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 (uu___2782_21940.FStar_TypeChecker_Env.qtbl_name_and_index);
                FStar_TypeChecker_Env.normalized_eff_names =
-                 (uu___2770_22099.FStar_TypeChecker_Env.normalized_eff_names);
+                 (uu___2782_21940.FStar_TypeChecker_Env.normalized_eff_names);
                FStar_TypeChecker_Env.fv_delta_depths =
-                 (uu___2770_22099.FStar_TypeChecker_Env.fv_delta_depths);
+                 (uu___2782_21940.FStar_TypeChecker_Env.fv_delta_depths);
                FStar_TypeChecker_Env.proof_ns =
-                 (uu___2770_22099.FStar_TypeChecker_Env.proof_ns);
+                 (uu___2782_21940.FStar_TypeChecker_Env.proof_ns);
                FStar_TypeChecker_Env.synth_hook =
-                 (uu___2770_22099.FStar_TypeChecker_Env.synth_hook);
+                 (uu___2782_21940.FStar_TypeChecker_Env.synth_hook);
                FStar_TypeChecker_Env.try_solve_implicits_hook =
-                 (uu___2770_22099.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                 (uu___2782_21940.FStar_TypeChecker_Env.try_solve_implicits_hook);
                FStar_TypeChecker_Env.splice =
-                 (uu___2770_22099.FStar_TypeChecker_Env.splice);
+                 (uu___2782_21940.FStar_TypeChecker_Env.splice);
                FStar_TypeChecker_Env.mpreprocess =
-                 (uu___2770_22099.FStar_TypeChecker_Env.mpreprocess);
+                 (uu___2782_21940.FStar_TypeChecker_Env.mpreprocess);
                FStar_TypeChecker_Env.postprocess =
-                 (uu___2770_22099.FStar_TypeChecker_Env.postprocess);
+                 (uu___2782_21940.FStar_TypeChecker_Env.postprocess);
                FStar_TypeChecker_Env.is_native_tactic =
-                 (uu___2770_22099.FStar_TypeChecker_Env.is_native_tactic);
+                 (uu___2782_21940.FStar_TypeChecker_Env.is_native_tactic);
                FStar_TypeChecker_Env.identifier_info =
-                 (uu___2770_22099.FStar_TypeChecker_Env.identifier_info);
+                 (uu___2782_21940.FStar_TypeChecker_Env.identifier_info);
                FStar_TypeChecker_Env.tc_hooks =
-                 (uu___2770_22099.FStar_TypeChecker_Env.tc_hooks);
+                 (uu___2782_21940.FStar_TypeChecker_Env.tc_hooks);
                FStar_TypeChecker_Env.dsenv =
-                 (uu___2770_22099.FStar_TypeChecker_Env.dsenv);
+                 (uu___2782_21940.FStar_TypeChecker_Env.dsenv);
                FStar_TypeChecker_Env.nbe =
-                 (uu___2770_22099.FStar_TypeChecker_Env.nbe);
+                 (uu___2782_21940.FStar_TypeChecker_Env.nbe);
                FStar_TypeChecker_Env.strict_args_tab =
-                 (uu___2770_22099.FStar_TypeChecker_Env.strict_args_tab);
+                 (uu___2782_21940.FStar_TypeChecker_Env.strict_args_tab);
                FStar_TypeChecker_Env.erasable_types_tab =
-                 (uu___2770_22099.FStar_TypeChecker_Env.erasable_types_tab)
+                 (uu___2782_21940.FStar_TypeChecker_Env.erasable_types_tab)
              }  in
-           let uu____22116 =
+           let uu____21957 =
              FStar_TypeChecker_PatternUtils.elaborate_pat env p0  in
-           check_nested_pattern uu____22098 uu____22116 pat_t  in
-         match uu____22080 with
+           check_nested_pattern uu____21939 uu____21957 pat_t  in
+         match uu____21921 with
          | (bvs,tms,pat_e,pat,g,erasable) ->
-             ((let uu____22155 =
+             ((let uu____21996 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Patterns")
                   in
-               if uu____22155
+               if uu____21996
                then
-                 let uu____22160 = FStar_Syntax_Print.pat_to_string pat  in
-                 let uu____22162 = FStar_Syntax_Print.term_to_string pat_e
+                 let uu____22001 = FStar_Syntax_Print.pat_to_string pat  in
+                 let uu____22003 = FStar_Syntax_Print.term_to_string pat_e
                     in
                  FStar_Util.print2
-                   "Done checking pattern %s as expression %s\n" uu____22160
-                   uu____22162
+                   "Done checking pattern %s as expression %s\n" uu____22001
+                   uu____22003
                else ());
-              (let uu____22167 = FStar_TypeChecker_Env.push_bvs env bvs  in
-               let uu____22168 =
+              (let uu____22008 = FStar_TypeChecker_Env.push_bvs env bvs  in
+               let uu____22009 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env pat_e
                   in
-               (pat, bvs, tms, uu____22167, pat_e, uu____22168, g, erasable))))
+               (pat, bvs, tms, uu____22008, pat_e, uu____22009, g, erasable))))
 
 and (tc_eqn :
   FStar_Syntax_Syntax.bv ->
@@ -7762,89 +7779,89 @@ and (tc_eqn :
   fun scrutinee  ->
     fun env  ->
       fun branch  ->
-        let uu____22206 = FStar_Syntax_Subst.open_branch branch  in
-        match uu____22206 with
+        let uu____22047 = FStar_Syntax_Subst.open_branch branch  in
+        match uu____22047 with
         | (pattern,when_clause,branch_exp) ->
-            let uu____22255 = branch  in
-            (match uu____22255 with
-             | (cpat,uu____22286,cbr) ->
+            let uu____22096 = branch  in
+            (match uu____22096 with
+             | (cpat,uu____22127,cbr) ->
                  let pat_t = scrutinee.FStar_Syntax_Syntax.sort  in
                  let scrutinee_tm = FStar_Syntax_Syntax.bv_to_name scrutinee
                     in
-                 let uu____22308 =
-                   let uu____22315 =
+                 let uu____22149 =
+                   let uu____22156 =
                      FStar_TypeChecker_Env.push_bv env scrutinee  in
-                   FStar_All.pipe_right uu____22315
+                   FStar_All.pipe_right uu____22156
                      FStar_TypeChecker_Env.clear_expected_typ
                     in
-                 (match uu____22308 with
-                  | (scrutinee_env,uu____22352) ->
-                      let uu____22357 = tc_pat env pat_t pattern  in
-                      (match uu____22357 with
+                 (match uu____22149 with
+                  | (scrutinee_env,uu____22193) ->
+                      let uu____22198 = tc_pat env pat_t pattern  in
+                      (match uu____22198 with
                        | (pattern1,pat_bvs,pat_bv_tms,pat_env,pat_exp,norm_pat_exp,guard_pat,erasable)
                            ->
-                           ((let uu____22427 =
+                           ((let uu____22268 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug env)
                                  FStar_Options.Extreme
                                 in
-                             if uu____22427
+                             if uu____22268
                              then
-                               let uu____22431 =
+                               let uu____22272 =
                                  FStar_Syntax_Print.pat_to_string pattern1
                                   in
-                               let uu____22433 =
+                               let uu____22274 =
                                  FStar_Syntax_Print.bvs_to_string ";" pat_bvs
                                   in
-                               let uu____22436 =
+                               let uu____22277 =
                                  FStar_List.fold_left
                                    (fun s  ->
                                       fun t  ->
-                                        let uu____22445 =
-                                          let uu____22447 =
+                                        let uu____22286 =
+                                          let uu____22288 =
                                             FStar_Syntax_Print.term_to_string
                                               t
                                              in
-                                          Prims.op_Hat ";" uu____22447  in
-                                        Prims.op_Hat s uu____22445) ""
+                                          Prims.op_Hat ";" uu____22288  in
+                                        Prims.op_Hat s uu____22286) ""
                                    pat_bv_tms
                                   in
                                FStar_Util.print3
                                  "tc_eqn: typechecked pattern %s with bvs %s and pat_bv_tms %s"
-                                 uu____22431 uu____22433 uu____22436
+                                 uu____22272 uu____22274 uu____22277
                              else ());
-                            (let uu____22454 =
+                            (let uu____22295 =
                                match when_clause with
                                | FStar_Pervasives_Native.None  ->
                                    (FStar_Pervasives_Native.None,
                                      FStar_TypeChecker_Env.trivial_guard)
                                | FStar_Pervasives_Native.Some e ->
-                                   let uu____22484 =
+                                   let uu____22325 =
                                      FStar_TypeChecker_Env.should_verify env
                                       in
-                                   if uu____22484
+                                   if uu____22325
                                    then
                                      FStar_Errors.raise_error
                                        (FStar_Errors.Fatal_WhenClauseNotSupported,
                                          "When clauses are not yet supported in --verify mode; they will be some day")
                                        e.FStar_Syntax_Syntax.pos
                                    else
-                                     (let uu____22507 =
-                                        let uu____22514 =
+                                     (let uu____22348 =
+                                        let uu____22355 =
                                           FStar_TypeChecker_Env.set_expected_typ
                                             pat_env FStar_Syntax_Util.t_bool
                                            in
-                                        tc_term uu____22514 e  in
-                                      match uu____22507 with
+                                        tc_term uu____22355 e  in
+                                      match uu____22348 with
                                       | (e1,c,g) ->
                                           ((FStar_Pervasives_Native.Some e1),
                                             g))
                                 in
-                             match uu____22454 with
+                             match uu____22295 with
                              | (when_clause1,g_when) ->
-                                 let uu____22571 = tc_term pat_env branch_exp
+                                 let uu____22412 = tc_term pat_env branch_exp
                                     in
-                                 (match uu____22571 with
+                                 (match uu____22412 with
                                   | (branch_exp1,c,g_branch) ->
                                       (FStar_TypeChecker_Env.def_check_guard_wf
                                          cbr.FStar_Syntax_Syntax.pos
@@ -7854,25 +7871,25 @@ and (tc_eqn :
                                           | FStar_Pervasives_Native.None  ->
                                               FStar_Pervasives_Native.None
                                           | FStar_Pervasives_Native.Some w ->
-                                              let uu____22630 =
+                                              let uu____22471 =
                                                 FStar_Syntax_Util.mk_eq2
                                                   FStar_Syntax_Syntax.U_zero
                                                   FStar_Syntax_Util.t_bool w
                                                   FStar_Syntax_Util.exp_true_bool
                                                  in
                                               FStar_All.pipe_left
-                                                (fun uu____22641  ->
+                                                (fun uu____22482  ->
                                                    FStar_Pervasives_Native.Some
-                                                     uu____22641) uu____22630
+                                                     uu____22482) uu____22471
                                            in
                                         let branch_guard =
-                                          let uu____22645 =
-                                            let uu____22647 =
+                                          let uu____22486 =
+                                            let uu____22488 =
                                               FStar_TypeChecker_Env.should_verify
                                                 env
                                                in
-                                            Prims.op_Negation uu____22647  in
-                                          if uu____22645
+                                            Prims.op_Negation uu____22488  in
+                                          if uu____22486
                                           then FStar_Syntax_Util.t_true
                                           else
                                             (let rec build_branch_guard
@@ -7880,16 +7897,16 @@ and (tc_eqn :
                                                pat_exp1 =
                                                let discriminate scrutinee_tm2
                                                  f =
-                                                 let uu____22703 =
-                                                   let uu____22711 =
+                                                 let uu____22544 =
+                                                   let uu____22552 =
                                                      FStar_TypeChecker_Env.typ_of_datacon
                                                        env
                                                        f.FStar_Syntax_Syntax.v
                                                       in
                                                    FStar_TypeChecker_Env.datacons_of_typ
-                                                     env uu____22711
+                                                     env uu____22552
                                                     in
-                                                 match uu____22703 with
+                                                 match uu____22544 with
                                                  | (is_induc,datacons) ->
                                                      if
                                                        (Prims.op_Negation
@@ -7903,15 +7920,15 @@ and (tc_eqn :
                                                          FStar_Syntax_Util.mk_discriminator
                                                            f.FStar_Syntax_Syntax.v
                                                           in
-                                                       let uu____22727 =
+                                                       let uu____22568 =
                                                          FStar_TypeChecker_Env.try_lookup_lid
                                                            env discriminator
                                                           in
-                                                       (match uu____22727
+                                                       (match uu____22568
                                                         with
                                                         | FStar_Pervasives_Native.None
                                                              -> []
-                                                        | uu____22748 ->
+                                                        | uu____22589 ->
                                                             let disc =
                                                               FStar_Syntax_Syntax.fvar
                                                                 discriminator
@@ -7920,55 +7937,55 @@ and (tc_eqn :
                                                                 FStar_Pervasives_Native.None
                                                                in
                                                             let disc1 =
-                                                              let uu____22764
+                                                              let uu____22605
                                                                 =
-                                                                let uu____22769
+                                                                let uu____22610
                                                                   =
-                                                                  let uu____22770
+                                                                  let uu____22611
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     scrutinee_tm2
                                                                      in
-                                                                  [uu____22770]
+                                                                  [uu____22611]
                                                                    in
                                                                 FStar_Syntax_Syntax.mk_Tm_app
                                                                   disc
-                                                                  uu____22769
+                                                                  uu____22610
                                                                  in
-                                                              uu____22764
+                                                              uu____22605
                                                                 FStar_Pervasives_Native.None
                                                                 scrutinee_tm2.FStar_Syntax_Syntax.pos
                                                                in
-                                                            let uu____22795 =
+                                                            let uu____22636 =
                                                               FStar_Syntax_Util.mk_eq2
                                                                 FStar_Syntax_Syntax.U_zero
                                                                 FStar_Syntax_Util.t_bool
                                                                 disc1
                                                                 FStar_Syntax_Util.exp_true_bool
                                                                in
-                                                            [uu____22795])
+                                                            [uu____22636])
                                                      else []
                                                   in
-                                               let fail uu____22803 =
-                                                 let uu____22804 =
-                                                   let uu____22806 =
+                                               let fail uu____22644 =
+                                                 let uu____22645 =
+                                                   let uu____22647 =
                                                      FStar_Range.string_of_range
                                                        pat_exp1.FStar_Syntax_Syntax.pos
                                                       in
-                                                   let uu____22808 =
+                                                   let uu____22649 =
                                                      FStar_Syntax_Print.term_to_string
                                                        pat_exp1
                                                       in
-                                                   let uu____22810 =
+                                                   let uu____22651 =
                                                      FStar_Syntax_Print.tag_of_term
                                                        pat_exp1
                                                       in
                                                    FStar_Util.format3
                                                      "tc_eqn: Impossible (%s) %s (%s)"
-                                                     uu____22806 uu____22808
-                                                     uu____22810
+                                                     uu____22647 uu____22649
+                                                     uu____22651
                                                     in
-                                                 failwith uu____22804  in
+                                                 failwith uu____22645  in
                                                let rec head_constructor t =
                                                  match t.FStar_Syntax_Syntax.n
                                                  with
@@ -7976,171 +7993,171 @@ and (tc_eqn :
                                                      fv ->
                                                      fv.FStar_Syntax_Syntax.fv_name
                                                  | FStar_Syntax_Syntax.Tm_uinst
-                                                     (t1,uu____22825) ->
+                                                     (t1,uu____22666) ->
                                                      head_constructor t1
-                                                 | uu____22830 -> fail ()  in
+                                                 | uu____22671 -> fail ()  in
                                                let force_scrutinee
-                                                 uu____22836 =
+                                                 uu____22677 =
                                                  match scrutinee_tm1 with
                                                  | FStar_Pervasives_Native.None
                                                       ->
-                                                     let uu____22837 =
-                                                       let uu____22839 =
+                                                     let uu____22678 =
+                                                       let uu____22680 =
                                                          FStar_Range.string_of_range
                                                            pattern2.FStar_Syntax_Syntax.p
                                                           in
-                                                       let uu____22841 =
+                                                       let uu____22682 =
                                                          FStar_Syntax_Print.pat_to_string
                                                            pattern2
                                                           in
                                                        FStar_Util.format2
                                                          "Impossible (%s): scrutinee of match is not defined %s"
-                                                         uu____22839
-                                                         uu____22841
+                                                         uu____22680
+                                                         uu____22682
                                                         in
-                                                     failwith uu____22837
+                                                     failwith uu____22678
                                                  | FStar_Pervasives_Native.Some
                                                      t -> t
                                                   in
                                                let pat_exp2 =
-                                                 let uu____22848 =
+                                                 let uu____22689 =
                                                    FStar_Syntax_Subst.compress
                                                      pat_exp1
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____22848
+                                                   uu____22689
                                                    FStar_Syntax_Util.unmeta
                                                   in
                                                match ((pattern2.FStar_Syntax_Syntax.v),
                                                        (pat_exp2.FStar_Syntax_Syntax.n))
                                                with
-                                               | (uu____22853,FStar_Syntax_Syntax.Tm_name
-                                                  uu____22854) -> []
-                                               | (uu____22855,FStar_Syntax_Syntax.Tm_constant
+                                               | (uu____22694,FStar_Syntax_Syntax.Tm_name
+                                                  uu____22695) -> []
+                                               | (uu____22696,FStar_Syntax_Syntax.Tm_constant
                                                   (FStar_Const.Const_unit ))
                                                    -> []
                                                | (FStar_Syntax_Syntax.Pat_constant
                                                   _c,FStar_Syntax_Syntax.Tm_constant
                                                   c1) ->
-                                                   let uu____22858 =
-                                                     let uu____22859 =
+                                                   let uu____22699 =
+                                                     let uu____22700 =
                                                        tc_constant env
                                                          pat_exp2.FStar_Syntax_Syntax.pos
                                                          c1
                                                         in
-                                                     let uu____22860 =
+                                                     let uu____22701 =
                                                        force_scrutinee ()  in
                                                      FStar_Syntax_Util.mk_eq2
                                                        FStar_Syntax_Syntax.U_zero
-                                                       uu____22859
-                                                       uu____22860 pat_exp2
+                                                       uu____22700
+                                                       uu____22701 pat_exp2
                                                       in
-                                                   [uu____22858]
+                                                   [uu____22699]
                                                | (FStar_Syntax_Syntax.Pat_constant
                                                   (FStar_Const.Const_int
-                                                  (uu____22861,FStar_Pervasives_Native.Some
-                                                   uu____22862)),uu____22863)
+                                                  (uu____22702,FStar_Pervasives_Native.Some
+                                                   uu____22703)),uu____22704)
                                                    ->
-                                                   let uu____22880 =
-                                                     let uu____22887 =
+                                                   let uu____22721 =
+                                                     let uu____22728 =
                                                        FStar_TypeChecker_Env.clear_expected_typ
                                                          env
                                                         in
-                                                     match uu____22887 with
-                                                     | (env1,uu____22901) ->
+                                                     match uu____22728 with
+                                                     | (env1,uu____22742) ->
                                                          env1.FStar_TypeChecker_Env.type_of
                                                            env1 pat_exp2
                                                       in
-                                                   (match uu____22880 with
-                                                    | (uu____22908,t,uu____22910)
+                                                   (match uu____22721 with
+                                                    | (uu____22749,t,uu____22751)
                                                         ->
-                                                        let uu____22911 =
-                                                          let uu____22912 =
+                                                        let uu____22752 =
+                                                          let uu____22753 =
                                                             force_scrutinee
                                                               ()
                                                              in
                                                           FStar_Syntax_Util.mk_eq2
                                                             FStar_Syntax_Syntax.U_zero
-                                                            t uu____22912
+                                                            t uu____22753
                                                             pat_exp2
                                                            in
-                                                        [uu____22911])
+                                                        [uu____22752])
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22913,[]),FStar_Syntax_Syntax.Tm_uinst
-                                                  uu____22914) ->
+                                                  (uu____22754,[]),FStar_Syntax_Syntax.Tm_uinst
+                                                  uu____22755) ->
                                                    let f =
                                                      head_constructor
                                                        pat_exp2
                                                       in
-                                                   let uu____22938 =
-                                                     let uu____22940 =
+                                                   let uu____22779 =
+                                                     let uu____22781 =
                                                        FStar_TypeChecker_Env.is_datacon
                                                          env
                                                          f.FStar_Syntax_Syntax.v
                                                         in
                                                      Prims.op_Negation
-                                                       uu____22940
+                                                       uu____22781
                                                       in
-                                                   if uu____22938
+                                                   if uu____22779
                                                    then
                                                      failwith
                                                        "Impossible: nullary patterns must be data constructors"
                                                    else
-                                                     (let uu____22950 =
+                                                     (let uu____22791 =
                                                         force_scrutinee ()
                                                          in
-                                                      let uu____22953 =
+                                                      let uu____22794 =
                                                         head_constructor
                                                           pat_exp2
                                                          in
                                                       discriminate
-                                                        uu____22950
-                                                        uu____22953)
+                                                        uu____22791
+                                                        uu____22794)
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22956,[]),FStar_Syntax_Syntax.Tm_fvar
-                                                  uu____22957) ->
+                                                  (uu____22797,[]),FStar_Syntax_Syntax.Tm_fvar
+                                                  uu____22798) ->
                                                    let f =
                                                      head_constructor
                                                        pat_exp2
                                                       in
-                                                   let uu____22975 =
-                                                     let uu____22977 =
+                                                   let uu____22816 =
+                                                     let uu____22818 =
                                                        FStar_TypeChecker_Env.is_datacon
                                                          env
                                                          f.FStar_Syntax_Syntax.v
                                                         in
                                                      Prims.op_Negation
-                                                       uu____22977
+                                                       uu____22818
                                                       in
-                                                   if uu____22975
+                                                   if uu____22816
                                                    then
                                                      failwith
                                                        "Impossible: nullary patterns must be data constructors"
                                                    else
-                                                     (let uu____22987 =
+                                                     (let uu____22828 =
                                                         force_scrutinee ()
                                                          in
-                                                      let uu____22990 =
+                                                      let uu____22831 =
                                                         head_constructor
                                                           pat_exp2
                                                          in
                                                       discriminate
-                                                        uu____22987
-                                                        uu____22990)
+                                                        uu____22828
+                                                        uu____22831)
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22993,pat_args),FStar_Syntax_Syntax.Tm_app
+                                                  (uu____22834,pat_args),FStar_Syntax_Syntax.Tm_app
                                                   (head,args)) ->
                                                    let f =
                                                      head_constructor head
                                                       in
-                                                   let uu____23040 =
-                                                     (let uu____23044 =
+                                                   let uu____22881 =
+                                                     (let uu____22885 =
                                                         FStar_TypeChecker_Env.is_datacon
                                                           env
                                                           f.FStar_Syntax_Syntax.v
                                                          in
                                                       Prims.op_Negation
-                                                        uu____23044)
+                                                        uu____22885)
                                                        ||
                                                        ((FStar_List.length
                                                            pat_args)
@@ -8148,29 +8165,29 @@ and (tc_eqn :
                                                           (FStar_List.length
                                                              args))
                                                       in
-                                                   if uu____23040
+                                                   if uu____22881
                                                    then
                                                      failwith
                                                        "Impossible: application patterns must be fully-applied data constructors"
                                                    else
                                                      (let sub_term_guards =
-                                                        let uu____23072 =
-                                                          let uu____23077 =
+                                                        let uu____22913 =
+                                                          let uu____22918 =
                                                             FStar_List.zip
                                                               pat_args args
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____23077
+                                                            uu____22918
                                                             (FStar_List.mapi
                                                                (fun i  ->
                                                                   fun
-                                                                    uu____23163
+                                                                    uu____23004
                                                                      ->
-                                                                    match uu____23163
+                                                                    match uu____23004
                                                                     with
                                                                     | 
-                                                                    ((pi,uu____23185),
-                                                                    (ei,uu____23187))
+                                                                    ((pi,uu____23026),
+                                                                    (ei,uu____23028))
                                                                     ->
                                                                     let projector
                                                                     =
@@ -8180,139 +8197,139 @@ and (tc_eqn :
                                                                     i  in
                                                                     let scrutinee_tm2
                                                                     =
-                                                                    let uu____23215
+                                                                    let uu____23056
                                                                     =
                                                                     FStar_TypeChecker_Env.try_lookup_lid
                                                                     env
                                                                     projector
                                                                      in
-                                                                    match uu____23215
+                                                                    match uu____23056
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
                                                                      ->
                                                                     FStar_Pervasives_Native.None
                                                                     | 
-                                                                    uu____23236
+                                                                    uu____23077
                                                                     ->
                                                                     let proj
                                                                     =
-                                                                    let uu____23248
+                                                                    let uu____23089
                                                                     =
                                                                     FStar_Ident.set_lid_range
                                                                     projector
                                                                     f.FStar_Syntax_Syntax.p
                                                                      in
                                                                     FStar_Syntax_Syntax.fvar
-                                                                    uu____23248
+                                                                    uu____23089
                                                                     (FStar_Syntax_Syntax.Delta_equational_at_level
                                                                     Prims.int_one)
                                                                     FStar_Pervasives_Native.None
                                                                      in
-                                                                    let uu____23250
+                                                                    let uu____23091
                                                                     =
-                                                                    let uu____23251
+                                                                    let uu____23092
                                                                     =
-                                                                    let uu____23256
+                                                                    let uu____23097
                                                                     =
-                                                                    let uu____23257
+                                                                    let uu____23098
                                                                     =
-                                                                    let uu____23266
+                                                                    let uu____23107
                                                                     =
                                                                     force_scrutinee
                                                                     ()  in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu____23266
+                                                                    uu____23107
                                                                      in
-                                                                    [uu____23257]
+                                                                    [uu____23098]
                                                                      in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     proj
-                                                                    uu____23256
+                                                                    uu____23097
                                                                      in
-                                                                    uu____23251
+                                                                    uu____23092
                                                                     FStar_Pervasives_Native.None
                                                                     f.FStar_Syntax_Syntax.p
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____23250
+                                                                    uu____23091
                                                                      in
                                                                     build_branch_guard
                                                                     scrutinee_tm2
                                                                     pi ei))
                                                            in
                                                         FStar_All.pipe_right
-                                                          uu____23072
+                                                          uu____22913
                                                           FStar_List.flatten
                                                          in
-                                                      let uu____23289 =
-                                                        let uu____23292 =
+                                                      let uu____23130 =
+                                                        let uu____23133 =
                                                           force_scrutinee ()
                                                            in
                                                         discriminate
-                                                          uu____23292 f
+                                                          uu____23133 f
                                                          in
                                                       FStar_List.append
-                                                        uu____23289
+                                                        uu____23130
                                                         sub_term_guards)
                                                | (FStar_Syntax_Syntax.Pat_dot_term
-                                                  uu____23295,uu____23296) ->
+                                                  uu____23136,uu____23137) ->
                                                    []
-                                               | uu____23303 ->
-                                                   let uu____23308 =
-                                                     let uu____23310 =
+                                               | uu____23144 ->
+                                                   let uu____23149 =
+                                                     let uu____23151 =
                                                        FStar_Syntax_Print.pat_to_string
                                                          pattern2
                                                         in
-                                                     let uu____23312 =
+                                                     let uu____23153 =
                                                        FStar_Syntax_Print.term_to_string
                                                          pat_exp2
                                                         in
                                                      FStar_Util.format2
                                                        "Internal error: unexpected elaborated pattern: %s and pattern expression %s"
-                                                       uu____23310
-                                                       uu____23312
+                                                       uu____23151
+                                                       uu____23153
                                                       in
-                                                   failwith uu____23308
+                                                   failwith uu____23149
                                                 in
                                              let build_and_check_branch_guard
                                                scrutinee_tm1 pattern2 pat =
-                                               let uu____23341 =
-                                                 let uu____23343 =
+                                               let uu____23182 =
+                                                 let uu____23184 =
                                                    FStar_TypeChecker_Env.should_verify
                                                      env
                                                     in
                                                  Prims.op_Negation
-                                                   uu____23343
+                                                   uu____23184
                                                   in
-                                               if uu____23341
+                                               if uu____23182
                                                then
                                                  FStar_TypeChecker_Util.fvar_const
                                                    env
                                                    FStar_Parser_Const.true_lid
                                                else
                                                  (let t =
-                                                    let uu____23349 =
+                                                    let uu____23190 =
                                                       build_branch_guard
                                                         scrutinee_tm1
                                                         pattern2 pat
                                                        in
                                                     FStar_All.pipe_left
                                                       FStar_Syntax_Util.mk_conj_l
-                                                      uu____23349
+                                                      uu____23190
                                                      in
-                                                  let uu____23358 =
+                                                  let uu____23199 =
                                                     FStar_Syntax_Util.type_u
                                                       ()
                                                      in
-                                                  match uu____23358 with
-                                                  | (k,uu____23364) ->
-                                                      let uu____23365 =
+                                                  match uu____23199 with
+                                                  | (k,uu____23205) ->
+                                                      let uu____23206 =
                                                         tc_check_tot_or_gtot_term
                                                           scrutinee_env t k
                                                          in
-                                                      (match uu____23365 with
-                                                       | (t1,uu____23373,uu____23374)
+                                                      (match uu____23206 with
+                                                       | (t1,uu____23214,uu____23215)
                                                            -> t1))
                                                 in
                                              let branch_guard =
@@ -8332,16 +8349,16 @@ and (tc_eqn :
                                                 in
                                              branch_guard1)
                                            in
-                                        let uu____23388 =
+                                        let uu____23229 =
                                           let eqs =
-                                            let uu____23408 =
-                                              let uu____23410 =
+                                            let uu____23249 =
+                                              let uu____23251 =
                                                 FStar_TypeChecker_Env.should_verify
                                                   env
                                                  in
-                                              Prims.op_Negation uu____23410
+                                              Prims.op_Negation uu____23251
                                                in
-                                            if uu____23408
+                                            if uu____23249
                                             then FStar_Pervasives_Native.None
                                             else
                                               (let e =
@@ -8351,56 +8368,56 @@ and (tc_eqn :
                                                match e.FStar_Syntax_Syntax.n
                                                with
                                                | FStar_Syntax_Syntax.Tm_uvar
-                                                   uu____23420 ->
+                                                   uu____23261 ->
                                                    FStar_Pervasives_Native.None
                                                | FStar_Syntax_Syntax.Tm_constant
-                                                   uu____23433 ->
+                                                   uu____23274 ->
                                                    FStar_Pervasives_Native.None
                                                | FStar_Syntax_Syntax.Tm_fvar
-                                                   uu____23434 ->
+                                                   uu____23275 ->
                                                    FStar_Pervasives_Native.None
-                                               | uu____23435 ->
-                                                   let uu____23436 =
-                                                     let uu____23437 =
+                                               | uu____23276 ->
+                                                   let uu____23277 =
+                                                     let uu____23278 =
                                                        env.FStar_TypeChecker_Env.universe_of
                                                          env pat_t
                                                         in
                                                      FStar_Syntax_Util.mk_eq2
-                                                       uu____23437 pat_t
+                                                       uu____23278 pat_t
                                                        scrutinee_tm e
                                                       in
                                                    FStar_Pervasives_Native.Some
-                                                     uu____23436)
+                                                     uu____23277)
                                              in
-                                          let uu____23438 =
+                                          let uu____23279 =
                                             FStar_TypeChecker_Util.strengthen_precondition
                                               FStar_Pervasives_Native.None
                                               env branch_exp1 c g_branch
                                              in
-                                          match uu____23438 with
+                                          match uu____23279 with
                                           | (c1,g_branch1) ->
                                               let branch_has_layered_effect =
-                                                let uu____23467 =
+                                                let uu____23308 =
                                                   FStar_All.pipe_right
                                                     c1.FStar_TypeChecker_Common.eff_name
                                                     (FStar_TypeChecker_Env.norm_eff_name
                                                        env)
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____23467
+                                                  uu____23308
                                                   (FStar_TypeChecker_Env.is_layered_effect
                                                      env)
                                                  in
-                                              let uu____23469 =
+                                              let uu____23310 =
                                                 let env1 =
-                                                  let uu____23475 =
+                                                  let uu____23316 =
                                                     FStar_All.pipe_right
                                                       pat_bvs
                                                       (FStar_List.map
                                                          FStar_Syntax_Syntax.mk_binder)
                                                      in
                                                   FStar_TypeChecker_Env.push_binders
-                                                    scrutinee_env uu____23475
+                                                    scrutinee_env uu____23316
                                                    in
                                                 if branch_has_layered_effect
                                                 then
@@ -8416,13 +8433,13 @@ and (tc_eqn :
                                                   (match (eqs,
                                                            when_condition)
                                                    with
-                                                   | uu____23496 when
-                                                       let uu____23507 =
+                                                   | uu____23337 when
+                                                       let uu____23348 =
                                                          FStar_TypeChecker_Env.should_verify
                                                            env1
                                                           in
                                                        Prims.op_Negation
-                                                         uu____23507
+                                                         uu____23348
                                                        -> (c1, g_when)
                                                    | (FStar_Pervasives_Native.None
                                                       ,FStar_Pervasives_Native.None
@@ -8438,16 +8455,16 @@ and (tc_eqn :
                                                          FStar_TypeChecker_Env.guard_of_guard_formula
                                                            gf
                                                           in
-                                                       let uu____23528 =
+                                                       let uu____23369 =
                                                          FStar_TypeChecker_Util.weaken_precondition
                                                            env1 c1 gf
                                                           in
-                                                       let uu____23529 =
+                                                       let uu____23370 =
                                                          FStar_TypeChecker_Env.imp_guard
                                                            g g_when
                                                           in
-                                                       (uu____23528,
-                                                         uu____23529)
+                                                       (uu____23369,
+                                                         uu____23370)
                                                    | (FStar_Pervasives_Native.Some
                                                       f,FStar_Pervasives_Native.Some
                                                       w) ->
@@ -8456,27 +8473,27 @@ and (tc_eqn :
                                                            f
                                                           in
                                                        let g_fw =
-                                                         let uu____23544 =
+                                                         let uu____23385 =
                                                            FStar_Syntax_Util.mk_conj
                                                              f w
                                                             in
                                                          FStar_TypeChecker_Common.NonTrivial
-                                                           uu____23544
+                                                           uu____23385
                                                           in
-                                                       let uu____23545 =
+                                                       let uu____23386 =
                                                          FStar_TypeChecker_Util.weaken_precondition
                                                            env1 c1 g_fw
                                                           in
-                                                       let uu____23546 =
-                                                         let uu____23547 =
+                                                       let uu____23387 =
+                                                         let uu____23388 =
                                                            FStar_TypeChecker_Env.guard_of_guard_formula
                                                              g_f
                                                             in
                                                          FStar_TypeChecker_Env.imp_guard
-                                                           uu____23547 g_when
+                                                           uu____23388 g_when
                                                           in
-                                                       (uu____23545,
-                                                         uu____23546)
+                                                       (uu____23386,
+                                                         uu____23387)
                                                    | (FStar_Pervasives_Native.None
                                                       ,FStar_Pervasives_Native.Some
                                                       w) ->
@@ -8488,13 +8505,13 @@ and (tc_eqn :
                                                          FStar_TypeChecker_Env.guard_of_guard_formula
                                                            g_w
                                                           in
-                                                       let uu____23561 =
+                                                       let uu____23402 =
                                                          FStar_TypeChecker_Util.weaken_precondition
                                                            env1 c1 g_w
                                                           in
-                                                       (uu____23561, g_when))
+                                                       (uu____23402, g_when))
                                                  in
-                                              (match uu____23469 with
+                                              (match uu____23310 with
                                                | (c_weak,g_when_weak) ->
                                                    let binders =
                                                      FStar_List.map
@@ -8504,12 +8521,12 @@ and (tc_eqn :
                                                    let maybe_return_c_weak
                                                      should_return =
                                                      let c_weak1 =
-                                                       let uu____23604 =
+                                                       let uu____23445 =
                                                          should_return &&
                                                            (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                               c_weak)
                                                           in
-                                                       if uu____23604
+                                                       if uu____23445
                                                        then
                                                          FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                                            env branch_exp1
@@ -8518,14 +8535,14 @@ and (tc_eqn :
                                                      if
                                                        branch_has_layered_effect
                                                      then
-                                                       ((let uu____23611 =
+                                                       ((let uu____23452 =
                                                            FStar_All.pipe_left
                                                              (FStar_TypeChecker_Env.debug
                                                                 env)
                                                              (FStar_Options.Other
                                                                 "LayeredEffects")
                                                             in
-                                                         if uu____23611
+                                                         if uu____23452
                                                          then
                                                            FStar_Util.print_string
                                                              "Typechecking pat_bv_tms ...\n"
@@ -8537,29 +8554,29 @@ and (tc_eqn :
                                                                 (fun
                                                                    pat_bv_tm 
                                                                    ->
-                                                                   let uu____23631
+                                                                   let uu____23472
                                                                     =
-                                                                    let uu____23636
+                                                                    let uu____23477
                                                                     =
-                                                                    let uu____23637
+                                                                    let uu____23478
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     scrutinee_tm
                                                                     FStar_Syntax_Syntax.as_arg
                                                                      in
-                                                                    [uu____23637]
+                                                                    [uu____23478]
                                                                      in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     pat_bv_tm
-                                                                    uu____23636
+                                                                    uu____23477
                                                                      in
-                                                                   uu____23631
+                                                                   uu____23472
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Range.dummyRange))
                                                             in
                                                          let pat_bv_tms2 =
                                                            let env1 =
-                                                             let uu___3010_23674
+                                                             let uu___3022_23515
                                                                =
                                                                FStar_TypeChecker_Env.push_bv
                                                                  env
@@ -8568,158 +8585,158 @@ and (tc_eqn :
                                                              {
                                                                FStar_TypeChecker_Env.solver
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.solver);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.solver);
                                                                FStar_TypeChecker_Env.range
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.range);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.range);
                                                                FStar_TypeChecker_Env.curmodule
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.curmodule);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.curmodule);
                                                                FStar_TypeChecker_Env.gamma
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.gamma);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.gamma);
                                                                FStar_TypeChecker_Env.gamma_sig
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.gamma_sig);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.gamma_sig);
                                                                FStar_TypeChecker_Env.gamma_cache
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.gamma_cache);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.gamma_cache);
                                                                FStar_TypeChecker_Env.modules
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.modules);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.modules);
                                                                FStar_TypeChecker_Env.expected_typ
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.expected_typ);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.expected_typ);
                                                                FStar_TypeChecker_Env.sigtab
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.sigtab);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.sigtab);
                                                                FStar_TypeChecker_Env.attrtab
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.attrtab);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.attrtab);
                                                                FStar_TypeChecker_Env.instantiate_imp
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.instantiate_imp);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.instantiate_imp);
                                                                FStar_TypeChecker_Env.effects
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.effects);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.effects);
                                                                FStar_TypeChecker_Env.generalize
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.generalize);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.generalize);
                                                                FStar_TypeChecker_Env.letrecs
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.letrecs);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.letrecs);
                                                                FStar_TypeChecker_Env.top_level
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.top_level);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.top_level);
                                                                FStar_TypeChecker_Env.check_uvars
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.check_uvars);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.check_uvars);
                                                                FStar_TypeChecker_Env.use_eq
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.use_eq);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.use_eq);
                                                                FStar_TypeChecker_Env.use_eq_strict
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.use_eq_strict);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.use_eq_strict);
                                                                FStar_TypeChecker_Env.is_iface
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.is_iface);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.is_iface);
                                                                FStar_TypeChecker_Env.admit
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.admit);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.admit);
                                                                FStar_TypeChecker_Env.lax
                                                                  = true;
                                                                FStar_TypeChecker_Env.lax_universes
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.lax_universes);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.lax_universes);
                                                                FStar_TypeChecker_Env.phase1
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.phase1);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.phase1);
                                                                FStar_TypeChecker_Env.failhard
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.failhard);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.failhard);
                                                                FStar_TypeChecker_Env.nosynth
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.nosynth);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.nosynth);
                                                                FStar_TypeChecker_Env.uvar_subtyping
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.uvar_subtyping);
                                                                FStar_TypeChecker_Env.tc_term
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.tc_term);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.tc_term);
                                                                FStar_TypeChecker_Env.type_of
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.type_of);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.type_of);
                                                                FStar_TypeChecker_Env.universe_of
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.universe_of);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.universe_of);
                                                                FStar_TypeChecker_Env.check_type_of
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.check_type_of);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.check_type_of);
                                                                FStar_TypeChecker_Env.use_bv_sorts
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.use_bv_sorts);
                                                                FStar_TypeChecker_Env.qtbl_name_and_index
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                FStar_TypeChecker_Env.normalized_eff_names
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.normalized_eff_names);
                                                                FStar_TypeChecker_Env.fv_delta_depths
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.fv_delta_depths);
                                                                FStar_TypeChecker_Env.proof_ns
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.proof_ns);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.proof_ns);
                                                                FStar_TypeChecker_Env.synth_hook
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.synth_hook);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.synth_hook);
                                                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                FStar_TypeChecker_Env.splice
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.splice);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.splice);
                                                                FStar_TypeChecker_Env.mpreprocess
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.mpreprocess);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.mpreprocess);
                                                                FStar_TypeChecker_Env.postprocess
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.postprocess);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.postprocess);
                                                                FStar_TypeChecker_Env.is_native_tactic
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.is_native_tactic);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.is_native_tactic);
                                                                FStar_TypeChecker_Env.identifier_info
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.identifier_info);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.identifier_info);
                                                                FStar_TypeChecker_Env.tc_hooks
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.tc_hooks);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.tc_hooks);
                                                                FStar_TypeChecker_Env.dsenv
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.dsenv);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.dsenv);
                                                                FStar_TypeChecker_Env.nbe
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.nbe);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.nbe);
                                                                FStar_TypeChecker_Env.strict_args_tab
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.strict_args_tab);
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.strict_args_tab);
                                                                FStar_TypeChecker_Env.erasable_types_tab
                                                                  =
-                                                                 (uu___3010_23674.FStar_TypeChecker_Env.erasable_types_tab)
+                                                                 (uu___3022_23515.FStar_TypeChecker_Env.erasable_types_tab)
                                                              }  in
-                                                           let uu____23676 =
-                                                             let uu____23679
+                                                           let uu____23517 =
+                                                             let uu____23520
                                                                =
                                                                FStar_List.fold_left2
                                                                  (fun
-                                                                    uu____23707
+                                                                    uu____23548
                                                                      ->
                                                                     fun
                                                                     pat_bv_tm
                                                                      ->
                                                                     fun bv 
                                                                     ->
-                                                                    match uu____23707
+                                                                    match uu____23548
                                                                     with
                                                                     | 
                                                                     (substs,acc)
@@ -8732,32 +8749,32 @@ and (tc_eqn :
                                                                      in
                                                                     let pat_bv_tm1
                                                                     =
-                                                                    let uu____23748
+                                                                    let uu____23589
                                                                     =
-                                                                    let uu____23755
+                                                                    let uu____23596
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     pat_bv_tm
                                                                     (FStar_Syntax_Subst.subst
                                                                     substs)
                                                                      in
-                                                                    let uu____23756
+                                                                    let uu____23597
                                                                     =
-                                                                    let uu____23767
+                                                                    let uu____23608
                                                                     =
                                                                     FStar_TypeChecker_Env.set_expected_typ
                                                                     env1
                                                                     expected_t
                                                                      in
                                                                     tc_trivial_guard
-                                                                    uu____23767
+                                                                    uu____23608
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____23755
-                                                                    uu____23756
+                                                                    uu____23596
+                                                                    uu____23597
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____23748
+                                                                    uu____23589
                                                                     FStar_Pervasives_Native.fst
                                                                      in
                                                                     ((FStar_List.append
@@ -8774,70 +8791,70 @@ and (tc_eqn :
                                                                  pat_bvs
                                                                 in
                                                              FStar_All.pipe_right
-                                                               uu____23679
+                                                               uu____23520
                                                                FStar_Pervasives_Native.snd
                                                               in
                                                            FStar_All.pipe_right
-                                                             uu____23676
+                                                             uu____23517
                                                              (FStar_List.map
                                                                 (FStar_TypeChecker_Normalize.normalize
                                                                    [FStar_TypeChecker_Env.Beta]
                                                                    env1))
                                                             in
-                                                         (let uu____23829 =
+                                                         (let uu____23670 =
                                                             FStar_All.pipe_left
                                                               (FStar_TypeChecker_Env.debug
                                                                  env)
                                                               (FStar_Options.Other
                                                                  "LayeredEffects")
                                                              in
-                                                          if uu____23829
+                                                          if uu____23670
                                                           then
-                                                            let uu____23834 =
+                                                            let uu____23675 =
                                                               FStar_List.fold_left
                                                                 (fun s  ->
                                                                    fun t  ->
-                                                                    let uu____23843
+                                                                    let uu____23684
                                                                     =
-                                                                    let uu____23845
+                                                                    let uu____23686
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t  in
                                                                     Prims.op_Hat
                                                                     ";"
-                                                                    uu____23845
+                                                                    uu____23686
                                                                      in
                                                                     Prims.op_Hat
                                                                     s
-                                                                    uu____23843)
+                                                                    uu____23684)
                                                                 ""
                                                                 pat_bv_tms2
                                                                in
-                                                            let uu____23849 =
+                                                            let uu____23690 =
                                                               FStar_List.fold_left
                                                                 (fun s  ->
                                                                    fun t  ->
-                                                                    let uu____23858
+                                                                    let uu____23699
                                                                     =
-                                                                    let uu____23860
+                                                                    let uu____23701
                                                                     =
                                                                     FStar_Syntax_Print.bv_to_string
                                                                     t  in
                                                                     Prims.op_Hat
                                                                     ";"
-                                                                    uu____23860
+                                                                    uu____23701
                                                                      in
                                                                     Prims.op_Hat
                                                                     s
-                                                                    uu____23858)
+                                                                    uu____23699)
                                                                 "" pat_bvs
                                                                in
                                                             FStar_Util.print2
                                                               "tc_eqn: typechecked pat_bv_tms %s (pat_bvs : %s)\n"
-                                                              uu____23834
-                                                              uu____23849
+                                                              uu____23675
+                                                              uu____23690
                                                           else ());
-                                                         (let uu____23867 =
+                                                         (let uu____23708 =
                                                             FStar_All.pipe_right
                                                               c_weak1
                                                               (FStar_TypeChecker_Common.apply_lcomp
@@ -8855,77 +8872,77 @@ and (tc_eqn :
                                                                     FStar_TypeChecker_Common.weaken_guard_formula
                                                                     g eqs1))
                                                              in
-                                                          let uu____23874 =
-                                                            let uu____23879 =
+                                                          let uu____23715 =
+                                                            let uu____23720 =
                                                               FStar_TypeChecker_Env.push_bv
                                                                 env scrutinee
                                                                in
                                                             FStar_TypeChecker_Util.close_layered_lcomp
-                                                              uu____23879
+                                                              uu____23720
                                                               pat_bvs
                                                               pat_bv_tms2
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____23867
-                                                            uu____23874)))
+                                                            uu____23708
+                                                            uu____23715)))
                                                      else
                                                        FStar_TypeChecker_Util.close_wp_lcomp
                                                          env pat_bvs c_weak1
                                                       in
-                                                   let uu____23882 =
+                                                   let uu____23723 =
                                                      FStar_TypeChecker_Env.close_guard
                                                        env binders
                                                        g_when_weak
                                                       in
-                                                   let uu____23883 =
+                                                   let uu____23724 =
                                                      FStar_TypeChecker_Env.conj_guard
                                                        guard_pat g_branch1
                                                       in
                                                    ((c_weak.FStar_TypeChecker_Common.eff_name),
                                                      (c_weak.FStar_TypeChecker_Common.cflags),
                                                      maybe_return_c_weak,
-                                                     uu____23882,
-                                                     uu____23883))
+                                                     uu____23723,
+                                                     uu____23724))
                                            in
-                                        match uu____23388 with
+                                        match uu____23229 with
                                         | (effect_label,cflags,maybe_return_c,g_when1,g_branch1)
                                             ->
                                             let guard =
                                               FStar_TypeChecker_Env.conj_guard
                                                 g_when1 g_branch1
                                                in
-                                            ((let uu____23938 =
+                                            ((let uu____23779 =
                                                 FStar_TypeChecker_Env.debug
                                                   env FStar_Options.High
                                                  in
-                                              if uu____23938
+                                              if uu____23779
                                               then
-                                                let uu____23941 =
+                                                let uu____23782 =
                                                   FStar_TypeChecker_Rel.guard_to_string
                                                     env guard
                                                    in
                                                 FStar_All.pipe_left
                                                   (FStar_Util.print1
                                                      "Carrying guard from match: %s\n")
-                                                  uu____23941
+                                                  uu____23782
                                               else ());
-                                             (let uu____23947 =
+                                             (let uu____23788 =
                                                 FStar_Syntax_Subst.close_branch
                                                   (pattern1, when_clause1,
                                                     branch_exp1)
                                                  in
-                                              let uu____23964 =
-                                                let uu____23965 =
+                                              let uu____23805 =
+                                                let uu____23806 =
                                                   FStar_List.map
                                                     FStar_Syntax_Syntax.mk_binder
                                                     pat_bvs
                                                    in
                                                 FStar_TypeChecker_Util.close_guard_implicits
-                                                  env false uu____23965 guard
+                                                  env false uu____23806 guard
                                                  in
-                                              (uu____23947, branch_guard,
+                                              (uu____23788, branch_guard,
                                                 effect_label, cflags,
-                                                maybe_return_c, uu____23964,
+                                                maybe_return_c, uu____23805,
                                                 erasable)))))))))))
 
 and (check_top_level_let :
@@ -8939,42 +8956,42 @@ and (check_top_level_let :
       let env1 = instantiate_both env  in
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
-          let uu____24014 = check_let_bound_def true env1 lb  in
-          (match uu____24014 with
+          let uu____23855 = check_let_bound_def true env1 lb  in
+          (match uu____23855 with
            | (e1,univ_vars,c1,g1,annotated) ->
-               let uu____24040 =
+               let uu____23881 =
                  if
                    annotated &&
                      (Prims.op_Negation env1.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____24062 =
+                   let uu____23903 =
                      FStar_TypeChecker_Normalize.reduce_uvar_solutions env1
                        e1
                       in
-                   (g1, uu____24062, univ_vars, c1)
+                   (g1, uu____23903, univ_vars, c1)
                  else
                    (let g11 =
-                      let uu____24068 =
+                      let uu____23909 =
                         FStar_TypeChecker_Rel.solve_deferred_constraints env1
                           g1
                          in
-                      FStar_All.pipe_right uu____24068
+                      FStar_All.pipe_right uu____23909
                         (FStar_TypeChecker_Rel.resolve_implicits env1)
                        in
-                    let uu____24069 = FStar_TypeChecker_Common.lcomp_comp c1
+                    let uu____23910 = FStar_TypeChecker_Common.lcomp_comp c1
                        in
-                    match uu____24069 with
+                    match uu____23910 with
                     | (comp1,g_comp1) ->
                         let g12 =
                           FStar_TypeChecker_Env.conj_guard g11 g_comp1  in
-                        let uu____24087 =
-                          let uu____24100 =
+                        let uu____23928 =
+                          let uu____23941 =
                             FStar_TypeChecker_Util.generalize env1 false
                               [((lb.FStar_Syntax_Syntax.lbname), e1, comp1)]
                              in
-                          FStar_List.hd uu____24100  in
-                        (match uu____24087 with
-                         | (uu____24150,univs,e11,c11,gvs) ->
+                          FStar_List.hd uu____23941  in
+                        (match uu____23928 with
+                         | (uu____23991,univs,e11,c11,gvs) ->
                              let g13 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.map_guard g12)
@@ -8989,30 +9006,30 @@ and (check_top_level_let :
                              let g14 =
                                FStar_TypeChecker_Env.abstract_guard_n gvs g13
                                 in
-                             let uu____24164 =
+                             let uu____24005 =
                                FStar_TypeChecker_Common.lcomp_of_comp c11  in
-                             (g14, e11, univs, uu____24164)))
+                             (g14, e11, univs, uu____24005)))
                   in
-               (match uu____24040 with
+               (match uu____23881 with
                 | (g11,e11,univ_vars1,c11) ->
-                    let uu____24181 =
-                      let uu____24190 =
+                    let uu____24022 =
+                      let uu____24031 =
                         FStar_TypeChecker_Env.should_verify env1  in
-                      if uu____24190
+                      if uu____24031
                       then
-                        let uu____24201 =
+                        let uu____24042 =
                           FStar_TypeChecker_Util.check_top_level env1 g11 c11
                            in
-                        match uu____24201 with
+                        match uu____24042 with
                         | (ok,c12) ->
                             (if ok
                              then (e2, c12)
                              else
-                               ((let uu____24235 =
+                               ((let uu____24076 =
                                    FStar_TypeChecker_Env.get_range env1  in
-                                 FStar_Errors.log_issue uu____24235
+                                 FStar_Errors.log_issue uu____24076
                                    FStar_TypeChecker_Err.top_level_effect);
-                                (let uu____24236 =
+                                (let uu____24077 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_meta
                                         (e2,
@@ -9021,12 +9038,12 @@ and (check_top_level_let :
                                      FStar_Pervasives_Native.None
                                      e2.FStar_Syntax_Syntax.pos
                                     in
-                                 (uu____24236, c12))))
+                                 (uu____24077, c12))))
                       else
                         (FStar_TypeChecker_Rel.force_trivial_guard env1 g11;
-                         (let uu____24248 =
+                         (let uu____24089 =
                             FStar_TypeChecker_Common.lcomp_comp c11  in
-                          match uu____24248 with
+                          match uu____24089 with
                           | (comp1,g_comp1) ->
                               (FStar_TypeChecker_Rel.force_trivial_guard env1
                                  g_comp1;
@@ -9039,15 +9056,15 @@ and (check_top_level_let :
                                        env1)
                                    in
                                 let e21 =
-                                  let uu____24272 =
+                                  let uu____24113 =
                                     FStar_Syntax_Util.is_pure_comp c  in
-                                  if uu____24272
+                                  if uu____24113
                                   then e2
                                   else
-                                    ((let uu____24280 =
+                                    ((let uu____24121 =
                                         FStar_TypeChecker_Env.get_range env1
                                          in
-                                      FStar_Errors.log_issue uu____24280
+                                      FStar_Errors.log_issue uu____24121
                                         FStar_TypeChecker_Err.top_level_effect);
                                      FStar_Syntax_Syntax.mk
                                        (FStar_Syntax_Syntax.Tm_meta
@@ -9059,22 +9076,22 @@ and (check_top_level_let :
                                    in
                                 (e21, c)))))
                        in
-                    (match uu____24181 with
+                    (match uu____24022 with
                      | (e21,c12) ->
-                         ((let uu____24304 =
+                         ((let uu____24145 =
                              FStar_TypeChecker_Env.debug env1
                                FStar_Options.Medium
                               in
-                           if uu____24304
+                           if uu____24145
                            then
-                             let uu____24307 =
+                             let uu____24148 =
                                FStar_Syntax_Print.term_to_string e11  in
                              FStar_Util.print1
-                               "Let binding BEFORE tcnorm: %s\n" uu____24307
+                               "Let binding BEFORE tcnorm: %s\n" uu____24148
                            else ());
                           (let e12 =
-                             let uu____24313 = FStar_Options.tcnorm ()  in
-                             if uu____24313
+                             let uu____24154 = FStar_Options.tcnorm ()  in
+                             if uu____24154
                              then
                                FStar_TypeChecker_Normalize.normalize
                                  [FStar_TypeChecker_Env.UnfoldAttr
@@ -9087,22 +9104,22 @@ and (check_top_level_let :
                                  FStar_TypeChecker_Env.DoNotUnfoldPureLets]
                                  env1 e11
                              else e11  in
-                           (let uu____24319 =
+                           (let uu____24160 =
                               FStar_TypeChecker_Env.debug env1
                                 FStar_Options.Medium
                                in
-                            if uu____24319
+                            if uu____24160
                             then
-                              let uu____24322 =
+                              let uu____24163 =
                                 FStar_Syntax_Print.term_to_string e12  in
                               FStar_Util.print1
-                                "Let binding AFTER tcnorm: %s\n" uu____24322
+                                "Let binding AFTER tcnorm: %s\n" uu____24163
                             else ());
                            (let cres =
-                              let uu____24328 =
+                              let uu____24169 =
                                 FStar_Syntax_Util.is_pure_or_ghost_comp c12
                                  in
-                              if uu____24328
+                              if uu____24169
                               then
                                 FStar_Syntax_Syntax.mk_Total'
                                   FStar_Syntax_Syntax.t_unit
@@ -9117,8 +9134,8 @@ and (check_top_level_let :
                                  let c1_wp =
                                    match c1_comp_typ.FStar_Syntax_Syntax.effect_args
                                    with
-                                   | (wp,uu____24336)::[] -> wp
-                                   | uu____24361 ->
+                                   | (wp,uu____24177)::[] -> wp
+                                   | uu____24202 ->
                                        failwith
                                          "Impossible! check_top_level_let: got unexpected effect args"
                                     in
@@ -9131,28 +9148,28 @@ and (check_top_level_let :
                                      FStar_All.pipe_right c1_eff_decl
                                        FStar_Syntax_Util.get_return_vc_combinator
                                       in
-                                   let uu____24378 =
-                                     let uu____24383 =
+                                   let uu____24219 =
+                                     let uu____24224 =
                                        FStar_TypeChecker_Env.inst_effect_fun_with
                                          [FStar_Syntax_Syntax.U_zero] env1
                                          c1_eff_decl ret
                                         in
-                                     let uu____24384 =
-                                       let uu____24385 =
+                                     let uu____24225 =
+                                       let uu____24226 =
                                          FStar_Syntax_Syntax.as_arg
                                            FStar_Syntax_Syntax.t_unit
                                           in
-                                       let uu____24394 =
-                                         let uu____24405 =
+                                       let uu____24235 =
+                                         let uu____24246 =
                                            FStar_Syntax_Syntax.as_arg
                                              FStar_Syntax_Syntax.unit_const
                                             in
-                                         [uu____24405]  in
-                                       uu____24385 :: uu____24394  in
+                                         [uu____24246]  in
+                                       uu____24226 :: uu____24235  in
                                      FStar_Syntax_Syntax.mk_Tm_app
-                                       uu____24383 uu____24384
+                                       uu____24224 uu____24225
                                       in
-                                   uu____24378 FStar_Pervasives_Native.None
+                                   uu____24219 FStar_Pervasives_Native.None
                                      e21.FStar_Syntax_Syntax.pos
                                     in
                                  let wp =
@@ -9160,17 +9177,17 @@ and (check_top_level_let :
                                      FStar_All.pipe_right c1_eff_decl
                                        FStar_Syntax_Util.get_bind_vc_combinator
                                       in
-                                   let uu____24442 =
-                                     let uu____24447 =
+                                   let uu____24283 =
+                                     let uu____24288 =
                                        FStar_TypeChecker_Env.inst_effect_fun_with
                                          (FStar_List.append
                                             c1_comp_typ.FStar_Syntax_Syntax.comp_univs
                                             [FStar_Syntax_Syntax.U_zero])
                                          env1 c1_eff_decl bind
                                         in
-                                     let uu____24448 =
-                                       let uu____24449 =
-                                         let uu____24458 =
+                                     let uu____24289 =
+                                       let uu____24290 =
+                                         let uu____24299 =
                                            FStar_Syntax_Syntax.mk
                                              (FStar_Syntax_Syntax.Tm_constant
                                                 (FStar_Const.Const_range
@@ -9180,35 +9197,35 @@ and (check_top_level_let :
                                             in
                                          FStar_All.pipe_left
                                            FStar_Syntax_Syntax.as_arg
-                                           uu____24458
+                                           uu____24299
                                           in
-                                       let uu____24467 =
-                                         let uu____24478 =
+                                       let uu____24308 =
+                                         let uu____24319 =
                                            FStar_All.pipe_left
                                              FStar_Syntax_Syntax.as_arg
                                              c1_comp_typ.FStar_Syntax_Syntax.result_typ
                                             in
-                                         let uu____24495 =
-                                           let uu____24506 =
+                                         let uu____24336 =
+                                           let uu____24347 =
                                              FStar_Syntax_Syntax.as_arg
                                                FStar_Syntax_Syntax.t_unit
                                               in
-                                           let uu____24515 =
-                                             let uu____24526 =
+                                           let uu____24356 =
+                                             let uu____24367 =
                                                FStar_Syntax_Syntax.as_arg
                                                  c1_wp
                                                 in
-                                             let uu____24535 =
-                                               let uu____24546 =
-                                                 let uu____24555 =
-                                                   let uu____24556 =
-                                                     let uu____24557 =
+                                             let uu____24376 =
+                                               let uu____24387 =
+                                                 let uu____24396 =
+                                                   let uu____24397 =
+                                                     let uu____24398 =
                                                        FStar_Syntax_Syntax.null_binder
                                                          c1_comp_typ.FStar_Syntax_Syntax.result_typ
                                                         in
-                                                     [uu____24557]  in
+                                                     [uu____24398]  in
                                                    FStar_Syntax_Util.abs
-                                                     uu____24556 wp2
+                                                     uu____24397 wp2
                                                      (FStar_Pervasives_Native.Some
                                                         (FStar_Syntax_Util.mk_residual_comp
                                                            FStar_Parser_Const.effect_Tot_lid
@@ -9217,24 +9234,24 @@ and (check_top_level_let :
                                                     in
                                                  FStar_All.pipe_left
                                                    FStar_Syntax_Syntax.as_arg
-                                                   uu____24555
+                                                   uu____24396
                                                   in
-                                               [uu____24546]  in
-                                             uu____24526 :: uu____24535  in
-                                           uu____24506 :: uu____24515  in
-                                         uu____24478 :: uu____24495  in
-                                       uu____24449 :: uu____24467  in
+                                               [uu____24387]  in
+                                             uu____24367 :: uu____24376  in
+                                           uu____24347 :: uu____24356  in
+                                         uu____24319 :: uu____24336  in
+                                       uu____24290 :: uu____24308  in
                                      FStar_Syntax_Syntax.mk_Tm_app
-                                       uu____24447 uu____24448
+                                       uu____24288 uu____24289
                                       in
-                                   uu____24442 FStar_Pervasives_Native.None
+                                   uu____24283 FStar_Pervasives_Native.None
                                      lb.FStar_Syntax_Syntax.lbpos
                                     in
-                                 let uu____24634 =
-                                   let uu____24635 =
-                                     let uu____24646 =
+                                 let uu____24475 =
+                                   let uu____24476 =
+                                     let uu____24487 =
                                        FStar_Syntax_Syntax.as_arg wp  in
-                                     [uu____24646]  in
+                                     [uu____24487]  in
                                    {
                                      FStar_Syntax_Syntax.comp_univs =
                                        [FStar_Syntax_Syntax.U_zero];
@@ -9243,10 +9260,10 @@ and (check_top_level_let :
                                      FStar_Syntax_Syntax.result_typ =
                                        FStar_Syntax_Syntax.t_unit;
                                      FStar_Syntax_Syntax.effect_args =
-                                       uu____24635;
+                                       uu____24476;
                                      FStar_Syntax_Syntax.flags = []
                                    }  in
-                                 FStar_Syntax_Syntax.mk_Comp uu____24634)
+                                 FStar_Syntax_Syntax.mk_Comp uu____24475)
                                in
                             let lb1 =
                               FStar_Syntax_Util.close_univs_and_mk_letbinding
@@ -9257,18 +9274,18 @@ and (check_top_level_let :
                                 lb.FStar_Syntax_Syntax.lbattrs
                                 lb.FStar_Syntax_Syntax.lbpos
                                in
-                            let uu____24674 =
+                            let uu____24515 =
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_let
                                    ((false, [lb1]), e21))
                                 FStar_Pervasives_Native.None
                                 e.FStar_Syntax_Syntax.pos
                                in
-                            let uu____24688 =
+                            let uu____24529 =
                               FStar_TypeChecker_Common.lcomp_of_comp cres  in
-                            (uu____24674, uu____24688,
+                            (uu____24515, uu____24529,
                               FStar_TypeChecker_Env.trivial_guard)))))))
-      | uu____24689 -> failwith "Impossible"
+      | uu____24530 -> failwith "Impossible"
 
 and (maybe_intro_smt_lemma :
   FStar_TypeChecker_Env.env ->
@@ -9278,15 +9295,15 @@ and (maybe_intro_smt_lemma :
   fun env  ->
     fun lem_typ  ->
       fun c2  ->
-        let uu____24700 = FStar_Syntax_Util.is_smt_lemma lem_typ  in
-        if uu____24700
+        let uu____24541 = FStar_Syntax_Util.is_smt_lemma lem_typ  in
+        if uu____24541
         then
           let universe_of_binders bs =
-            let uu____24727 =
+            let uu____24568 =
               FStar_List.fold_left
-                (fun uu____24752  ->
+                (fun uu____24593  ->
                    fun b  ->
-                     match uu____24752 with
+                     match uu____24593 with
                      | (env1,us) ->
                          let u =
                            env1.FStar_TypeChecker_Env.universe_of env1
@@ -9296,7 +9313,7 @@ and (maybe_intro_smt_lemma :
                            FStar_TypeChecker_Env.push_binders env1 [b]  in
                          (env2, (u :: us))) (env, []) bs
                in
-            match uu____24727 with | (uu____24800,us) -> FStar_List.rev us
+            match uu____24568 with | (uu____24641,us) -> FStar_List.rev us
              in
           let quant =
             FStar_Syntax_Util.smt_lemma_as_forall lem_typ universe_of_binders
@@ -9317,111 +9334,111 @@ and (check_inner_let :
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
           let env2 =
-            let uu___3142_24836 = env1  in
+            let uu___3154_24677 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___3142_24836.FStar_TypeChecker_Env.solver);
+                (uu___3154_24677.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___3142_24836.FStar_TypeChecker_Env.range);
+                (uu___3154_24677.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___3142_24836.FStar_TypeChecker_Env.curmodule);
+                (uu___3154_24677.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___3142_24836.FStar_TypeChecker_Env.gamma);
+                (uu___3154_24677.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___3142_24836.FStar_TypeChecker_Env.gamma_sig);
+                (uu___3154_24677.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___3142_24836.FStar_TypeChecker_Env.gamma_cache);
+                (uu___3154_24677.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___3142_24836.FStar_TypeChecker_Env.modules);
+                (uu___3154_24677.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___3142_24836.FStar_TypeChecker_Env.expected_typ);
+                (uu___3154_24677.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___3142_24836.FStar_TypeChecker_Env.sigtab);
+                (uu___3154_24677.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___3142_24836.FStar_TypeChecker_Env.attrtab);
+                (uu___3154_24677.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___3142_24836.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___3154_24677.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___3142_24836.FStar_TypeChecker_Env.effects);
+                (uu___3154_24677.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___3142_24836.FStar_TypeChecker_Env.generalize);
+                (uu___3154_24677.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___3142_24836.FStar_TypeChecker_Env.letrecs);
+                (uu___3154_24677.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level = false;
               FStar_TypeChecker_Env.check_uvars =
-                (uu___3142_24836.FStar_TypeChecker_Env.check_uvars);
+                (uu___3154_24677.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___3142_24836.FStar_TypeChecker_Env.use_eq);
+                (uu___3154_24677.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___3142_24836.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___3154_24677.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___3142_24836.FStar_TypeChecker_Env.is_iface);
+                (uu___3154_24677.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___3142_24836.FStar_TypeChecker_Env.admit);
+                (uu___3154_24677.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___3142_24836.FStar_TypeChecker_Env.lax);
+                (uu___3154_24677.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___3142_24836.FStar_TypeChecker_Env.lax_universes);
+                (uu___3154_24677.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___3142_24836.FStar_TypeChecker_Env.phase1);
+                (uu___3154_24677.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___3142_24836.FStar_TypeChecker_Env.failhard);
+                (uu___3154_24677.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___3142_24836.FStar_TypeChecker_Env.nosynth);
+                (uu___3154_24677.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___3142_24836.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___3154_24677.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___3142_24836.FStar_TypeChecker_Env.tc_term);
+                (uu___3154_24677.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___3142_24836.FStar_TypeChecker_Env.type_of);
+                (uu___3154_24677.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___3142_24836.FStar_TypeChecker_Env.universe_of);
+                (uu___3154_24677.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___3142_24836.FStar_TypeChecker_Env.check_type_of);
+                (uu___3154_24677.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___3142_24836.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___3154_24677.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___3142_24836.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___3154_24677.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___3142_24836.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___3154_24677.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___3142_24836.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___3154_24677.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___3142_24836.FStar_TypeChecker_Env.proof_ns);
+                (uu___3154_24677.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___3142_24836.FStar_TypeChecker_Env.synth_hook);
+                (uu___3154_24677.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___3142_24836.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___3154_24677.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___3142_24836.FStar_TypeChecker_Env.splice);
+                (uu___3154_24677.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___3142_24836.FStar_TypeChecker_Env.mpreprocess);
+                (uu___3154_24677.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___3142_24836.FStar_TypeChecker_Env.postprocess);
+                (uu___3154_24677.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.is_native_tactic =
-                (uu___3142_24836.FStar_TypeChecker_Env.is_native_tactic);
+                (uu___3154_24677.FStar_TypeChecker_Env.is_native_tactic);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___3142_24836.FStar_TypeChecker_Env.identifier_info);
+                (uu___3154_24677.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___3142_24836.FStar_TypeChecker_Env.tc_hooks);
+                (uu___3154_24677.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___3142_24836.FStar_TypeChecker_Env.dsenv);
+                (uu___3154_24677.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___3142_24836.FStar_TypeChecker_Env.nbe);
+                (uu___3154_24677.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___3142_24836.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___3154_24677.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___3142_24836.FStar_TypeChecker_Env.erasable_types_tab)
+                (uu___3154_24677.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let uu____24838 =
-            let uu____24850 =
-              let uu____24851 = FStar_TypeChecker_Env.clear_expected_typ env2
+          let uu____24679 =
+            let uu____24691 =
+              let uu____24692 = FStar_TypeChecker_Env.clear_expected_typ env2
                  in
-              FStar_All.pipe_right uu____24851 FStar_Pervasives_Native.fst
+              FStar_All.pipe_right uu____24692 FStar_Pervasives_Native.fst
                in
-            check_let_bound_def false uu____24850 lb  in
-          (match uu____24838 with
-           | (e1,uu____24874,c1,g1,annotated) ->
+            check_let_bound_def false uu____24691 lb  in
+          (match uu____24679 with
+           | (e1,uu____24715,c1,g1,annotated) ->
                let pure_or_ghost =
                  FStar_TypeChecker_Common.is_pure_or_ghost_lcomp c1  in
                let is_inline_let =
@@ -9432,76 +9449,76 @@ and (check_inner_let :
                   in
                (if is_inline_let && (Prims.op_Negation pure_or_ghost)
                 then
-                  (let uu____24888 =
-                     let uu____24894 =
-                       let uu____24896 = FStar_Syntax_Print.term_to_string e1
+                  (let uu____24729 =
+                     let uu____24735 =
+                       let uu____24737 = FStar_Syntax_Print.term_to_string e1
                           in
-                       let uu____24898 =
+                       let uu____24739 =
                          FStar_Syntax_Print.lid_to_string
                            c1.FStar_TypeChecker_Common.eff_name
                           in
                        FStar_Util.format2
                          "Definitions marked @inline_let are expected to be pure or ghost; got an expression \"%s\" with effect \"%s\""
-                         uu____24896 uu____24898
+                         uu____24737 uu____24739
                         in
-                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____24894)
+                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____24735)
                       in
-                   FStar_Errors.raise_error uu____24888
+                   FStar_Errors.raise_error uu____24729
                      e1.FStar_Syntax_Syntax.pos)
                 else ();
                 (let attrs =
-                   let uu____24909 =
+                   let uu____24750 =
                      (pure_or_ghost && (Prims.op_Negation is_inline_let)) &&
                        (FStar_Syntax_Util.is_unit
                           c1.FStar_TypeChecker_Common.res_typ)
                       in
-                   if uu____24909
+                   if uu____24750
                    then FStar_Syntax_Util.inline_let_attr ::
                      (lb.FStar_Syntax_Syntax.lbattrs)
                    else lb.FStar_Syntax_Syntax.lbattrs  in
                  let x =
-                   let uu___3157_24921 =
+                   let uu___3169_24762 =
                      FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
                    {
                      FStar_Syntax_Syntax.ppname =
-                       (uu___3157_24921.FStar_Syntax_Syntax.ppname);
+                       (uu___3169_24762.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
-                       (uu___3157_24921.FStar_Syntax_Syntax.index);
+                       (uu___3169_24762.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort =
                        (c1.FStar_TypeChecker_Common.res_typ)
                    }  in
-                 let uu____24922 =
-                   let uu____24927 =
-                     let uu____24928 = FStar_Syntax_Syntax.mk_binder x  in
-                     [uu____24928]  in
-                   FStar_Syntax_Subst.open_term uu____24927 e2  in
-                 match uu____24922 with
+                 let uu____24763 =
+                   let uu____24768 =
+                     let uu____24769 = FStar_Syntax_Syntax.mk_binder x  in
+                     [uu____24769]  in
+                   FStar_Syntax_Subst.open_term uu____24768 e2  in
+                 match uu____24763 with
                  | (xb,e21) ->
                      let xbinder = FStar_List.hd xb  in
                      let x1 = FStar_Pervasives_Native.fst xbinder  in
                      let env_x = FStar_TypeChecker_Env.push_bv env2 x1  in
-                     let uu____24972 =
-                       let uu____24979 = tc_term env_x e21  in
-                       FStar_All.pipe_right uu____24979
-                         (fun uu____25005  ->
-                            match uu____25005 with
+                     let uu____24813 =
+                       let uu____24820 = tc_term env_x e21  in
+                       FStar_All.pipe_right uu____24820
+                         (fun uu____24846  ->
+                            match uu____24846 with
                             | (e22,c2,g2) ->
-                                let uu____25021 =
-                                  let uu____25026 =
+                                let uu____24862 =
+                                  let uu____24867 =
                                     FStar_All.pipe_right
-                                      (fun uu____25044  ->
+                                      (fun uu____24885  ->
                                          "folding guard g2 of e2 in the lcomp")
-                                      (fun uu____25050  ->
+                                      (fun uu____24891  ->
                                          FStar_Pervasives_Native.Some
-                                           uu____25050)
+                                           uu____24891)
                                      in
                                   FStar_TypeChecker_Util.strengthen_precondition
-                                    uu____25026 env_x e22 c2 g2
+                                    uu____24867 env_x e22 c2 g2
                                    in
-                                (match uu____25021 with
+                                (match uu____24862 with
                                  | (c21,g21) -> (e22, c21, g21)))
                         in
-                     (match uu____24972 with
+                     (match uu____24813 with
                       | (e22,c2,g2) ->
                           let c21 =
                             maybe_intro_smt_lemma env_x
@@ -9533,15 +9550,15 @@ and (check_inner_let :
                               attrs lb.FStar_Syntax_Syntax.lbpos
                              in
                           let e3 =
-                            let uu____25078 =
-                              let uu____25085 =
-                                let uu____25086 =
-                                  let uu____25100 =
+                            let uu____24919 =
+                              let uu____24926 =
+                                let uu____24927 =
+                                  let uu____24941 =
                                     FStar_Syntax_Subst.close xb e23  in
-                                  ((false, [lb1]), uu____25100)  in
-                                FStar_Syntax_Syntax.Tm_let uu____25086  in
-                              FStar_Syntax_Syntax.mk uu____25085  in
-                            uu____25078 FStar_Pervasives_Native.None
+                                  ((false, [lb1]), uu____24941)  in
+                                FStar_Syntax_Syntax.Tm_let uu____24927  in
+                              FStar_Syntax_Syntax.mk uu____24926  in
+                            uu____24919 FStar_Pervasives_Native.None
                               e.FStar_Syntax_Syntax.pos
                              in
                           let e4 =
@@ -9550,92 +9567,92 @@ and (check_inner_let :
                               cres.FStar_TypeChecker_Common.res_typ
                              in
                           let g21 =
-                            let uu____25118 =
-                              let uu____25120 =
+                            let uu____24959 =
+                              let uu____24961 =
                                 FStar_All.pipe_right
                                   cres.FStar_TypeChecker_Common.eff_name
                                   (FStar_TypeChecker_Env.norm_eff_name env2)
                                  in
-                              FStar_All.pipe_right uu____25120
+                              FStar_All.pipe_right uu____24961
                                 (FStar_TypeChecker_Env.is_layered_effect env2)
                                in
                             FStar_TypeChecker_Util.close_guard_implicits env2
-                              uu____25118 xb g2
+                              uu____24959 xb g2
                              in
                           let guard = FStar_TypeChecker_Env.conj_guard g1 g21
                              in
-                          let uu____25123 =
-                            let uu____25125 =
+                          let uu____24964 =
+                            let uu____24966 =
                               FStar_TypeChecker_Env.expected_typ env2  in
-                            FStar_Option.isSome uu____25125  in
-                          if uu____25123
+                            FStar_Option.isSome uu____24966  in
+                          if uu____24964
                           then
                             let tt =
-                              let uu____25136 =
+                              let uu____24977 =
                                 FStar_TypeChecker_Env.expected_typ env2  in
-                              FStar_All.pipe_right uu____25136
+                              FStar_All.pipe_right uu____24977
                                 FStar_Option.get
                                in
-                            ((let uu____25142 =
+                            ((let uu____24983 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env2)
                                   (FStar_Options.Other "Exports")
                                  in
-                              if uu____25142
+                              if uu____24983
                               then
-                                let uu____25147 =
+                                let uu____24988 =
                                   FStar_Syntax_Print.term_to_string tt  in
-                                let uu____25149 =
+                                let uu____24990 =
                                   FStar_Syntax_Print.term_to_string
                                     cres.FStar_TypeChecker_Common.res_typ
                                    in
                                 FStar_Util.print2
                                   "Got expected type from env %s\ncres.res_typ=%s\n"
-                                  uu____25147 uu____25149
+                                  uu____24988 uu____24990
                               else ());
                              (e4, cres, guard))
                           else
-                            (let uu____25156 =
+                            (let uu____24997 =
                                check_no_escape FStar_Pervasives_Native.None
                                  env2 [x1]
                                  cres.FStar_TypeChecker_Common.res_typ
                                 in
-                             match uu____25156 with
+                             match uu____24997 with
                              | (t,g_ex) ->
-                                 ((let uu____25170 =
+                                 ((let uu____25011 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env2)
                                        (FStar_Options.Other "Exports")
                                       in
-                                   if uu____25170
+                                   if uu____25011
                                    then
-                                     let uu____25175 =
+                                     let uu____25016 =
                                        FStar_Syntax_Print.term_to_string
                                          cres.FStar_TypeChecker_Common.res_typ
                                         in
-                                     let uu____25177 =
+                                     let uu____25018 =
                                        FStar_Syntax_Print.term_to_string t
                                         in
                                      FStar_Util.print2
                                        "Checked %s has no escaping types; normalized to %s\n"
-                                       uu____25175 uu____25177
+                                       uu____25016 uu____25018
                                    else ());
-                                  (let uu____25182 =
+                                  (let uu____25023 =
                                      FStar_TypeChecker_Env.conj_guard g_ex
                                        guard
                                       in
                                    (e4,
-                                     (let uu___3196_25184 = cres  in
+                                     (let uu___3208_25025 = cres  in
                                       {
                                         FStar_TypeChecker_Common.eff_name =
-                                          (uu___3196_25184.FStar_TypeChecker_Common.eff_name);
+                                          (uu___3208_25025.FStar_TypeChecker_Common.eff_name);
                                         FStar_TypeChecker_Common.res_typ = t;
                                         FStar_TypeChecker_Common.cflags =
-                                          (uu___3196_25184.FStar_TypeChecker_Common.cflags);
+                                          (uu___3208_25025.FStar_TypeChecker_Common.cflags);
                                         FStar_TypeChecker_Common.comp_thunk =
-                                          (uu___3196_25184.FStar_TypeChecker_Common.comp_thunk)
-                                      }), uu____25182))))))))
-      | uu____25185 ->
+                                          (uu___3208_25025.FStar_TypeChecker_Common.comp_thunk)
+                                      }), uu____25023))))))))
+      | uu____25026 ->
           failwith "Impossible (inner let with more than one lb)"
 
 and (check_top_level_let_rec :
@@ -9649,44 +9666,44 @@ and (check_top_level_let_rec :
       let env1 = instantiate_both env  in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____25221 = FStar_Syntax_Subst.open_let_rec lbs e2  in
-          (match uu____25221 with
+          let uu____25062 = FStar_Syntax_Subst.open_let_rec lbs e2  in
+          (match uu____25062 with
            | (lbs1,e21) ->
-               let uu____25240 =
+               let uu____25081 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____25240 with
+               (match uu____25081 with
                 | (env0,topt) ->
-                    let uu____25259 = build_let_rec_env true env0 lbs1  in
-                    (match uu____25259 with
+                    let uu____25100 = build_let_rec_env true env0 lbs1  in
+                    (match uu____25100 with
                      | (lbs2,rec_env,g_t) ->
-                         let uu____25282 = check_let_recs rec_env lbs2  in
-                         (match uu____25282 with
+                         let uu____25123 = check_let_recs rec_env lbs2  in
+                         (match uu____25123 with
                           | (lbs3,g_lbs) ->
                               let g_lbs1 =
-                                let uu____25302 =
-                                  let uu____25303 =
+                                let uu____25143 =
+                                  let uu____25144 =
                                     FStar_TypeChecker_Env.conj_guard g_t
                                       g_lbs
                                      in
-                                  FStar_All.pipe_right uu____25303
+                                  FStar_All.pipe_right uu____25144
                                     (FStar_TypeChecker_Rel.solve_deferred_constraints
                                        env1)
                                    in
-                                FStar_All.pipe_right uu____25302
+                                FStar_All.pipe_right uu____25143
                                   (FStar_TypeChecker_Rel.resolve_implicits
                                      env1)
                                  in
                               let all_lb_names =
-                                let uu____25309 =
+                                let uu____25150 =
                                   FStar_All.pipe_right lbs3
                                     (FStar_List.map
                                        (fun lb  ->
                                           FStar_Util.right
                                             lb.FStar_Syntax_Syntax.lbname))
                                    in
-                                FStar_All.pipe_right uu____25309
-                                  (fun uu____25326  ->
-                                     FStar_Pervasives_Native.Some uu____25326)
+                                FStar_All.pipe_right uu____25150
+                                  (fun uu____25167  ->
+                                     FStar_Pervasives_Native.Some uu____25167)
                                  in
                               let lbs4 =
                                 if
@@ -9717,25 +9734,25 @@ and (check_top_level_let_rec :
                                               lb.FStar_Syntax_Syntax.lbpos))
                                 else
                                   (let ecs =
-                                     let uu____25363 =
+                                     let uu____25204 =
                                        FStar_All.pipe_right lbs3
                                          (FStar_List.map
                                             (fun lb  ->
-                                               let uu____25397 =
+                                               let uu____25238 =
                                                  FStar_Syntax_Syntax.mk_Total
                                                    lb.FStar_Syntax_Syntax.lbtyp
                                                   in
                                                ((lb.FStar_Syntax_Syntax.lbname),
                                                  (lb.FStar_Syntax_Syntax.lbdef),
-                                                 uu____25397)))
+                                                 uu____25238)))
                                         in
                                      FStar_TypeChecker_Util.generalize env1
-                                       true uu____25363
+                                       true uu____25204
                                       in
                                    FStar_List.map2
-                                     (fun uu____25432  ->
+                                     (fun uu____25273  ->
                                         fun lb  ->
-                                          match uu____25432 with
+                                          match uu____25273 with
                                           | (x,uvs,e,c,gvs) ->
                                               FStar_Syntax_Util.close_univs_and_mk_letbinding
                                                 all_lb_names x uvs
@@ -9748,35 +9765,35 @@ and (check_top_level_let_rec :
                                      ecs lbs3)
                                  in
                               let cres =
-                                let uu____25480 =
+                                let uu____25321 =
                                   FStar_Syntax_Syntax.mk_Total
                                     FStar_Syntax_Syntax.t_unit
                                    in
                                 FStar_All.pipe_left
                                   FStar_TypeChecker_Common.lcomp_of_comp
-                                  uu____25480
+                                  uu____25321
                                  in
-                              let uu____25481 =
+                              let uu____25322 =
                                 FStar_Syntax_Subst.close_let_rec lbs4 e21  in
-                              (match uu____25481 with
+                              (match uu____25322 with
                                | (lbs5,e22) ->
-                                   ((let uu____25501 =
+                                   ((let uu____25342 =
                                        FStar_TypeChecker_Rel.discharge_guard
                                          env1 g_lbs1
                                         in
-                                     FStar_All.pipe_right uu____25501
+                                     FStar_All.pipe_right uu____25342
                                        (FStar_TypeChecker_Rel.force_trivial_guard
                                           env1));
-                                    (let uu____25502 =
+                                    (let uu____25343 =
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_let
                                             ((true, lbs5), e22))
                                          FStar_Pervasives_Native.None
                                          top.FStar_Syntax_Syntax.pos
                                         in
-                                     (uu____25502, cres,
+                                     (uu____25343, cres,
                                        FStar_TypeChecker_Env.trivial_guard))))))))
-      | uu____25516 -> failwith "Impossible"
+      | uu____25357 -> failwith "Impossible"
 
 and (check_inner_let_rec :
   FStar_TypeChecker_Env.env ->
@@ -9789,64 +9806,64 @@ and (check_inner_let_rec :
       let env1 = instantiate_both env  in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____25552 = FStar_Syntax_Subst.open_let_rec lbs e2  in
-          (match uu____25552 with
+          let uu____25393 = FStar_Syntax_Subst.open_let_rec lbs e2  in
+          (match uu____25393 with
            | (lbs1,e21) ->
-               let uu____25571 =
+               let uu____25412 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____25571 with
+               (match uu____25412 with
                 | (env0,topt) ->
-                    let uu____25590 = build_let_rec_env false env0 lbs1  in
-                    (match uu____25590 with
+                    let uu____25431 = build_let_rec_env false env0 lbs1  in
+                    (match uu____25431 with
                      | (lbs2,rec_env,g_t) ->
-                         let uu____25613 =
-                           let uu____25620 = check_let_recs rec_env lbs2  in
-                           FStar_All.pipe_right uu____25620
-                             (fun uu____25643  ->
-                                match uu____25643 with
+                         let uu____25454 =
+                           let uu____25461 = check_let_recs rec_env lbs2  in
+                           FStar_All.pipe_right uu____25461
+                             (fun uu____25484  ->
+                                match uu____25484 with
                                 | (lbs3,g) ->
-                                    let uu____25662 =
+                                    let uu____25503 =
                                       FStar_TypeChecker_Env.conj_guard g_t g
                                        in
-                                    (lbs3, uu____25662))
+                                    (lbs3, uu____25503))
                             in
-                         (match uu____25613 with
+                         (match uu____25454 with
                           | (lbs3,g_lbs) ->
-                              let uu____25677 =
+                              let uu____25518 =
                                 FStar_All.pipe_right lbs3
                                   (FStar_Util.fold_map
                                      (fun env2  ->
                                         fun lb  ->
                                           let x =
-                                            let uu___3271_25700 =
+                                            let uu___3283_25541 =
                                               FStar_Util.left
                                                 lb.FStar_Syntax_Syntax.lbname
                                                in
                                             {
                                               FStar_Syntax_Syntax.ppname =
-                                                (uu___3271_25700.FStar_Syntax_Syntax.ppname);
+                                                (uu___3283_25541.FStar_Syntax_Syntax.ppname);
                                               FStar_Syntax_Syntax.index =
-                                                (uu___3271_25700.FStar_Syntax_Syntax.index);
+                                                (uu___3283_25541.FStar_Syntax_Syntax.index);
                                               FStar_Syntax_Syntax.sort =
                                                 (lb.FStar_Syntax_Syntax.lbtyp)
                                             }  in
                                           let lb1 =
-                                            let uu___3274_25702 = lb  in
+                                            let uu___3286_25543 = lb  in
                                             {
                                               FStar_Syntax_Syntax.lbname =
                                                 (FStar_Util.Inl x);
                                               FStar_Syntax_Syntax.lbunivs =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbunivs);
+                                                (uu___3286_25543.FStar_Syntax_Syntax.lbunivs);
                                               FStar_Syntax_Syntax.lbtyp =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbtyp);
+                                                (uu___3286_25543.FStar_Syntax_Syntax.lbtyp);
                                               FStar_Syntax_Syntax.lbeff =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbeff);
+                                                (uu___3286_25543.FStar_Syntax_Syntax.lbeff);
                                               FStar_Syntax_Syntax.lbdef =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbdef);
+                                                (uu___3286_25543.FStar_Syntax_Syntax.lbdef);
                                               FStar_Syntax_Syntax.lbattrs =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbattrs);
+                                                (uu___3286_25543.FStar_Syntax_Syntax.lbattrs);
                                               FStar_Syntax_Syntax.lbpos =
-                                                (uu___3274_25702.FStar_Syntax_Syntax.lbpos)
+                                                (uu___3286_25543.FStar_Syntax_Syntax.lbpos)
                                             }  in
                                           let env3 =
                                             FStar_TypeChecker_Env.push_let_binding
@@ -9857,7 +9874,7 @@ and (check_inner_let_rec :
                                              in
                                           (env3, lb1)) env1)
                                  in
-                              (match uu____25677 with
+                              (match uu____25518 with
                                | (env2,lbs4) ->
                                    let bvs =
                                      FStar_All.pipe_right lbs4
@@ -9866,8 +9883,8 @@ and (check_inner_let_rec :
                                              FStar_Util.left
                                                lb.FStar_Syntax_Syntax.lbname))
                                       in
-                                   let uu____25729 = tc_term env2 e21  in
-                                   (match uu____25729 with
+                                   let uu____25570 = tc_term env2 e21  in
+                                   (match uu____25570 with
                                     | (e22,cres,g2) ->
                                         let cres1 =
                                           FStar_List.fold_right
@@ -9887,17 +9904,17 @@ and (check_inner_let_rec :
                                             [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
                                            in
                                         let guard =
-                                          let uu____25753 =
-                                            let uu____25754 =
+                                          let uu____25594 =
+                                            let uu____25595 =
                                               FStar_List.map
                                                 FStar_Syntax_Syntax.mk_binder
                                                 bvs
                                                in
                                             FStar_TypeChecker_Env.close_guard
-                                              env2 uu____25754 g2
+                                              env2 uu____25595 g2
                                              in
                                           FStar_TypeChecker_Env.conj_guard
-                                            g_lbs uu____25753
+                                            g_lbs uu____25594
                                            in
                                         let cres4 =
                                           FStar_TypeChecker_Util.close_wp_lcomp
@@ -9908,39 +9925,39 @@ and (check_inner_let_rec :
                                             cres4.FStar_TypeChecker_Common.res_typ
                                            in
                                         let cres5 =
-                                          let uu___3295_25764 = cres4  in
+                                          let uu___3307_25605 = cres4  in
                                           {
                                             FStar_TypeChecker_Common.eff_name
                                               =
-                                              (uu___3295_25764.FStar_TypeChecker_Common.eff_name);
+                                              (uu___3307_25605.FStar_TypeChecker_Common.eff_name);
                                             FStar_TypeChecker_Common.res_typ
                                               = tres;
                                             FStar_TypeChecker_Common.cflags =
-                                              (uu___3295_25764.FStar_TypeChecker_Common.cflags);
+                                              (uu___3307_25605.FStar_TypeChecker_Common.cflags);
                                             FStar_TypeChecker_Common.comp_thunk
                                               =
-                                              (uu___3295_25764.FStar_TypeChecker_Common.comp_thunk)
+                                              (uu___3307_25605.FStar_TypeChecker_Common.comp_thunk)
                                           }  in
                                         let guard1 =
                                           let bs =
                                             FStar_All.pipe_right lbs4
                                               (FStar_List.map
                                                  (fun lb  ->
-                                                    let uu____25772 =
+                                                    let uu____25613 =
                                                       FStar_Util.left
                                                         lb.FStar_Syntax_Syntax.lbname
                                                        in
                                                     FStar_Syntax_Syntax.mk_binder
-                                                      uu____25772))
+                                                      uu____25613))
                                              in
                                           FStar_TypeChecker_Util.close_guard_implicits
                                             env2 false bs guard
                                            in
-                                        let uu____25774 =
+                                        let uu____25615 =
                                           FStar_Syntax_Subst.close_let_rec
                                             lbs4 e22
                                            in
-                                        (match uu____25774 with
+                                        (match uu____25615 with
                                          | (lbs5,e23) ->
                                              let e =
                                                FStar_Syntax_Syntax.mk
@@ -9951,40 +9968,40 @@ and (check_inner_let_rec :
                                                 in
                                              (match topt with
                                               | FStar_Pervasives_Native.Some
-                                                  uu____25815 ->
+                                                  uu____25656 ->
                                                   (e, cres5, guard1)
                                               | FStar_Pervasives_Native.None 
                                                   ->
-                                                  let uu____25816 =
+                                                  let uu____25657 =
                                                     check_no_escape
                                                       FStar_Pervasives_Native.None
                                                       env2 bvs tres
                                                      in
-                                                  (match uu____25816 with
+                                                  (match uu____25657 with
                                                    | (tres1,g_ex) ->
                                                        let cres6 =
-                                                         let uu___3311_25830
+                                                         let uu___3323_25671
                                                            = cres5  in
                                                          {
                                                            FStar_TypeChecker_Common.eff_name
                                                              =
-                                                             (uu___3311_25830.FStar_TypeChecker_Common.eff_name);
+                                                             (uu___3323_25671.FStar_TypeChecker_Common.eff_name);
                                                            FStar_TypeChecker_Common.res_typ
                                                              = tres1;
                                                            FStar_TypeChecker_Common.cflags
                                                              =
-                                                             (uu___3311_25830.FStar_TypeChecker_Common.cflags);
+                                                             (uu___3323_25671.FStar_TypeChecker_Common.cflags);
                                                            FStar_TypeChecker_Common.comp_thunk
                                                              =
-                                                             (uu___3311_25830.FStar_TypeChecker_Common.comp_thunk)
+                                                             (uu___3323_25671.FStar_TypeChecker_Common.comp_thunk)
                                                          }  in
-                                                       let uu____25831 =
+                                                       let uu____25672 =
                                                          FStar_TypeChecker_Env.conj_guard
                                                            g_ex guard1
                                                           in
                                                        (e, cres6,
-                                                         uu____25831))))))))))
-      | uu____25832 -> failwith "Impossible"
+                                                         uu____25672))))))))))
+      | uu____25673 -> failwith "Impossible"
 
 and (build_let_rec_env :
   Prims.bool ->
@@ -9998,43 +10015,43 @@ and (build_let_rec_env :
       fun lbs  ->
         let env0 = env  in
         let termination_check_enabled lbname lbdef lbtyp =
-          let uu____25880 = FStar_Options.ml_ish ()  in
-          if uu____25880
+          let uu____25721 = FStar_Options.ml_ish ()  in
+          if uu____25721
           then false
           else
             (let t = FStar_TypeChecker_Normalize.unfold_whnf env lbtyp  in
-             let uu____25888 = FStar_Syntax_Util.arrow_formals_comp t  in
-             match uu____25888 with
+             let uu____25729 = FStar_Syntax_Util.arrow_formals_comp t  in
+             match uu____25729 with
              | (formals,c) ->
-                 let uu____25896 = FStar_Syntax_Util.abs_formals lbdef  in
-                 (match uu____25896 with
-                  | (actuals,uu____25907,uu____25908) ->
+                 let uu____25737 = FStar_Syntax_Util.abs_formals lbdef  in
+                 (match uu____25737 with
+                  | (actuals,uu____25748,uu____25749) ->
                       if
                         ((FStar_List.length formals) < Prims.int_one) ||
                           ((FStar_List.length actuals) < Prims.int_one)
                       then
-                        let uu____25929 =
-                          let uu____25935 =
-                            let uu____25937 =
+                        let uu____25770 =
+                          let uu____25776 =
+                            let uu____25778 =
                               FStar_Syntax_Print.term_to_string lbdef  in
-                            let uu____25939 =
+                            let uu____25780 =
                               FStar_Syntax_Print.term_to_string lbtyp  in
                             FStar_Util.format2
                               "Only function literals with arrow types can be defined recursively; got %s : %s"
-                              uu____25937 uu____25939
+                              uu____25778 uu____25780
                              in
                           (FStar_Errors.Fatal_RecursiveFunctionLiteral,
-                            uu____25935)
+                            uu____25776)
                            in
-                        FStar_Errors.raise_error uu____25929
+                        FStar_Errors.raise_error uu____25770
                           lbtyp.FStar_Syntax_Syntax.pos
                       else
                         (let actuals1 =
-                           let uu____25947 =
+                           let uu____25788 =
                              FStar_TypeChecker_Env.set_expected_typ env lbtyp
                               in
                            FStar_TypeChecker_Util.maybe_add_implicit_binders
-                             uu____25947 actuals
+                             uu____25788 actuals
                             in
                          if
                            (FStar_List.length formals) <>
@@ -10045,30 +10062,30 @@ and (build_let_rec_env :
                               if n = Prims.int_one
                               then "1 argument was found"
                               else
-                                (let uu____25978 = FStar_Util.string_of_int n
+                                (let uu____25819 = FStar_Util.string_of_int n
                                     in
                                  FStar_Util.format1 "%s arguments were found"
-                                   uu____25978)
+                                   uu____25819)
                                in
                             let formals_msg =
                               let n = FStar_List.length formals  in
                               if n = Prims.int_one
                               then "1 argument"
                               else
-                                (let uu____25997 = FStar_Util.string_of_int n
+                                (let uu____25838 = FStar_Util.string_of_int n
                                     in
                                  FStar_Util.format1 "%s arguments"
-                                   uu____25997)
+                                   uu____25838)
                                in
                             let msg =
-                              let uu____26002 =
+                              let uu____25843 =
                                 FStar_Syntax_Print.term_to_string lbtyp  in
-                              let uu____26004 =
+                              let uu____25845 =
                                 FStar_Syntax_Print.lbname_to_string lbname
                                  in
                               FStar_Util.format4
                                 "From its type %s, the definition of `let rec %s` expects a function with %s, but %s"
-                                uu____26002 uu____26004 formals_msg
+                                uu____25843 uu____25845 formals_msg
                                 actuals_msg
                                in
                             FStar_Errors.raise_error
@@ -10083,17 +10100,17 @@ and (build_let_rec_env :
                             (FStar_List.contains
                                FStar_Syntax_Syntax.TotalEffect)))))
            in
-        let uu____26016 =
+        let uu____25857 =
           FStar_List.fold_left
-            (fun uu____26049  ->
+            (fun uu____25890  ->
                fun lb  ->
-                 match uu____26049 with
+                 match uu____25890 with
                  | (lbs1,env1,g_acc) ->
-                     let uu____26074 =
+                     let uu____25915 =
                        FStar_TypeChecker_Util.extract_let_rec_annotation env1
                          lb
                         in
-                     (match uu____26074 with
+                     (match uu____25915 with
                       | (univ_vars,t,check_t) ->
                           let env2 =
                             FStar_TypeChecker_Env.push_univ_vars env1
@@ -10103,7 +10120,7 @@ and (build_let_rec_env :
                             FStar_Syntax_Util.unascribe
                               lb.FStar_Syntax_Syntax.lbdef
                              in
-                          let uu____26097 =
+                          let uu____25938 =
                             if Prims.op_Negation check_t
                             then (g_acc, t)
                             else
@@ -10111,247 +10128,247 @@ and (build_let_rec_env :
                                  FStar_TypeChecker_Env.push_univ_vars env0
                                    univ_vars
                                   in
-                               let uu____26116 =
-                                 let uu____26123 =
-                                   let uu____26124 =
+                               let uu____25957 =
+                                 let uu____25964 =
+                                   let uu____25965 =
                                      FStar_Syntax_Util.type_u ()  in
                                    FStar_All.pipe_left
-                                     FStar_Pervasives_Native.fst uu____26124
+                                     FStar_Pervasives_Native.fst uu____25965
                                     in
                                  tc_check_tot_or_gtot_term
-                                   (let uu___3357_26135 = env01  in
+                                   (let uu___3369_25976 = env01  in
                                     {
                                       FStar_TypeChecker_Env.solver =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.solver);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.solver);
                                       FStar_TypeChecker_Env.range =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.range);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.range);
                                       FStar_TypeChecker_Env.curmodule =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.curmodule);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.curmodule);
                                       FStar_TypeChecker_Env.gamma =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.gamma);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.gamma);
                                       FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.gamma_sig);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.gamma_sig);
                                       FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.gamma_cache);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.gamma_cache);
                                       FStar_TypeChecker_Env.modules =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.modules);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.modules);
                                       FStar_TypeChecker_Env.expected_typ =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.expected_typ);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.expected_typ);
                                       FStar_TypeChecker_Env.sigtab =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.sigtab);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.sigtab);
                                       FStar_TypeChecker_Env.attrtab =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.attrtab);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.attrtab);
                                       FStar_TypeChecker_Env.instantiate_imp =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.instantiate_imp);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.instantiate_imp);
                                       FStar_TypeChecker_Env.effects =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.effects);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.effects);
                                       FStar_TypeChecker_Env.generalize =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.generalize);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.generalize);
                                       FStar_TypeChecker_Env.letrecs =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.letrecs);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.letrecs);
                                       FStar_TypeChecker_Env.top_level =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.top_level);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.top_level);
                                       FStar_TypeChecker_Env.check_uvars =
                                         true;
                                       FStar_TypeChecker_Env.use_eq =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.use_eq);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.use_eq);
                                       FStar_TypeChecker_Env.use_eq_strict =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.use_eq_strict);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.use_eq_strict);
                                       FStar_TypeChecker_Env.is_iface =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.is_iface);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.is_iface);
                                       FStar_TypeChecker_Env.admit =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.admit);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.admit);
                                       FStar_TypeChecker_Env.lax =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.lax);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.lax);
                                       FStar_TypeChecker_Env.lax_universes =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.lax_universes);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.phase1);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.phase1);
                                       FStar_TypeChecker_Env.failhard =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.failhard);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.failhard);
                                       FStar_TypeChecker_Env.nosynth =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.nosynth);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.nosynth);
                                       FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.uvar_subtyping);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.tc_term =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.tc_term);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.type_of =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.type_of);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.type_of);
                                       FStar_TypeChecker_Env.universe_of =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.universe_of);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.universe_of);
                                       FStar_TypeChecker_Env.check_type_of =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.check_type_of);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.check_type_of);
                                       FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.use_bv_sorts);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.use_bv_sorts);
                                       FStar_TypeChecker_Env.qtbl_name_and_index
                                         =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.qtbl_name_and_index);
                                       FStar_TypeChecker_Env.normalized_eff_names
                                         =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.normalized_eff_names);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.normalized_eff_names);
                                       FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.fv_delta_depths);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.fv_delta_depths);
                                       FStar_TypeChecker_Env.proof_ns =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.proof_ns);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.proof_ns);
                                       FStar_TypeChecker_Env.synth_hook =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.synth_hook);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.synth_hook);
                                       FStar_TypeChecker_Env.try_solve_implicits_hook
                                         =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                       FStar_TypeChecker_Env.splice =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.splice);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.splice);
                                       FStar_TypeChecker_Env.mpreprocess =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.mpreprocess);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.mpreprocess);
                                       FStar_TypeChecker_Env.postprocess =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.postprocess);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.postprocess);
                                       FStar_TypeChecker_Env.is_native_tactic
                                         =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.is_native_tactic);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.is_native_tactic);
                                       FStar_TypeChecker_Env.identifier_info =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.identifier_info);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.identifier_info);
                                       FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.tc_hooks);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.tc_hooks);
                                       FStar_TypeChecker_Env.dsenv =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.dsenv);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.nbe =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.nbe);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.strict_args_tab);
+                                        (uu___3369_25976.FStar_TypeChecker_Env.strict_args_tab);
                                       FStar_TypeChecker_Env.erasable_types_tab
                                         =
-                                        (uu___3357_26135.FStar_TypeChecker_Env.erasable_types_tab)
-                                    }) t uu____26123
+                                        (uu___3369_25976.FStar_TypeChecker_Env.erasable_types_tab)
+                                    }) t uu____25964
                                   in
-                               match uu____26116 with
-                               | (t1,uu____26144,g) ->
-                                   let uu____26146 =
-                                     let uu____26147 =
-                                       let uu____26148 =
+                               match uu____25957 with
+                               | (t1,uu____25985,g) ->
+                                   let uu____25987 =
+                                     let uu____25988 =
+                                       let uu____25989 =
                                          FStar_All.pipe_right g
                                            (FStar_TypeChecker_Rel.resolve_implicits
                                               env2)
                                           in
-                                       FStar_All.pipe_right uu____26148
+                                       FStar_All.pipe_right uu____25989
                                          (FStar_TypeChecker_Rel.discharge_guard
                                             env2)
                                         in
                                      FStar_TypeChecker_Env.conj_guard g_acc
-                                       uu____26147
+                                       uu____25988
                                       in
-                                   let uu____26149 = norm env01 t1  in
-                                   (uu____26146, uu____26149))
+                                   let uu____25990 = norm env01 t1  in
+                                   (uu____25987, uu____25990))
                              in
-                          (match uu____26097 with
+                          (match uu____25938 with
                            | (g,t1) ->
                                let env3 =
-                                 let uu____26169 =
+                                 let uu____26010 =
                                    termination_check_enabled
                                      lb.FStar_Syntax_Syntax.lbname e t1
                                     in
-                                 if uu____26169
+                                 if uu____26010
                                  then
-                                   let uu___3367_26172 = env2  in
+                                   let uu___3379_26013 = env2  in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.solver);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.range);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.curmodule);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.gamma);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.modules);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.sigtab);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.attrtab);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.effects);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.generalize);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
                                        (((lb.FStar_Syntax_Syntax.lbname), t1,
                                           univ_vars) ::
                                        (env2.FStar_TypeChecker_Env.letrecs));
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.top_level);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.use_eq);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.use_eq);
                                      FStar_TypeChecker_Env.use_eq_strict =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.use_eq_strict);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.use_eq_strict);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.is_iface);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.admit);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.lax);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.phase1);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.failhard);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.nosynth);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.tc_term);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.type_of);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.universe_of);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.try_solve_implicits_hook
                                        =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.splice);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.mpreprocess =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.mpreprocess);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.mpreprocess);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.postprocess);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.is_native_tactic =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.is_native_tactic);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.is_native_tactic);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.dsenv);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.nbe);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.strict_args_tab);
+                                       (uu___3379_26013.FStar_TypeChecker_Env.strict_args_tab);
                                      FStar_TypeChecker_Env.erasable_types_tab
                                        =
-                                       (uu___3367_26172.FStar_TypeChecker_Env.erasable_types_tab)
+                                       (uu___3379_26013.FStar_TypeChecker_Env.erasable_types_tab)
                                    }
                                  else
                                    FStar_TypeChecker_Env.push_let_binding
@@ -10359,24 +10376,24 @@ and (build_let_rec_env :
                                      (univ_vars, t1)
                                   in
                                let lb1 =
-                                 let uu___3370_26186 = lb  in
+                                 let uu___3382_26027 = lb  in
                                  {
                                    FStar_Syntax_Syntax.lbname =
-                                     (uu___3370_26186.FStar_Syntax_Syntax.lbname);
+                                     (uu___3382_26027.FStar_Syntax_Syntax.lbname);
                                    FStar_Syntax_Syntax.lbunivs = univ_vars;
                                    FStar_Syntax_Syntax.lbtyp = t1;
                                    FStar_Syntax_Syntax.lbeff =
-                                     (uu___3370_26186.FStar_Syntax_Syntax.lbeff);
+                                     (uu___3382_26027.FStar_Syntax_Syntax.lbeff);
                                    FStar_Syntax_Syntax.lbdef = e;
                                    FStar_Syntax_Syntax.lbattrs =
-                                     (uu___3370_26186.FStar_Syntax_Syntax.lbattrs);
+                                     (uu___3382_26027.FStar_Syntax_Syntax.lbattrs);
                                    FStar_Syntax_Syntax.lbpos =
-                                     (uu___3370_26186.FStar_Syntax_Syntax.lbpos)
+                                     (uu___3382_26027.FStar_Syntax_Syntax.lbpos)
                                  }  in
                                ((lb1 :: lbs1), env3, g))))
             ([], env, FStar_TypeChecker_Env.trivial_guard) lbs
            in
-        match uu____26016 with
+        match uu____25857 with
         | (lbs1,env1,g) -> ((FStar_List.rev lbs1), env1, g)
 
 and (check_let_recs :
@@ -10387,64 +10404,64 @@ and (check_let_recs :
   =
   fun env  ->
     fun lbs  ->
-      let uu____26212 =
-        let uu____26221 =
+      let uu____26053 =
+        let uu____26062 =
           FStar_All.pipe_right lbs
             (FStar_List.map
                (fun lb  ->
-                  let uu____26247 =
+                  let uu____26088 =
                     FStar_Syntax_Util.abs_formals
                       lb.FStar_Syntax_Syntax.lbdef
                      in
-                  match uu____26247 with
+                  match uu____26088 with
                   | (bs,t,lcomp) ->
                       (match bs with
                        | [] ->
-                           let uu____26277 =
+                           let uu____26118 =
                              FStar_Syntax_Syntax.range_of_lbname
                                lb.FStar_Syntax_Syntax.lbname
                               in
                            FStar_Errors.raise_error
                              (FStar_Errors.Fatal_RecursiveFunctionLiteral,
                                "Only function literals may be defined recursively")
-                             uu____26277
-                       | uu____26284 ->
+                             uu____26118
+                       | uu____26125 ->
                            let lb1 =
-                             let uu___3387_26287 = lb  in
-                             let uu____26288 =
+                             let uu___3399_26128 = lb  in
+                             let uu____26129 =
                                FStar_Syntax_Util.abs bs t lcomp  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbname);
+                                 (uu___3399_26128.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___3399_26128.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___3399_26128.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = uu____26288;
+                                 (uu___3399_26128.FStar_Syntax_Syntax.lbeff);
+                               FStar_Syntax_Syntax.lbdef = uu____26129;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___3399_26128.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___3387_26287.FStar_Syntax_Syntax.lbpos)
+                                 (uu___3399_26128.FStar_Syntax_Syntax.lbpos)
                              }  in
-                           let uu____26291 =
-                             let uu____26298 =
+                           let uu____26132 =
+                             let uu____26139 =
                                FStar_TypeChecker_Env.set_expected_typ env
                                  lb1.FStar_Syntax_Syntax.lbtyp
                                 in
-                             tc_tot_or_gtot_term uu____26298
+                             tc_tot_or_gtot_term uu____26139
                                lb1.FStar_Syntax_Syntax.lbdef
                               in
-                           (match uu____26291 with
+                           (match uu____26132 with
                             | (e,c,g) ->
-                                ((let uu____26307 =
-                                    let uu____26309 =
+                                ((let uu____26148 =
+                                    let uu____26150 =
                                       FStar_TypeChecker_Common.is_total_lcomp
                                         c
                                        in
-                                    Prims.op_Negation uu____26309  in
-                                  if uu____26307
+                                    Prims.op_Negation uu____26150  in
+                                  if uu____26148
                                   then
                                     FStar_Errors.raise_error
                                       (FStar_Errors.Fatal_UnexpectedGTotForLetRec,
@@ -10462,8 +10479,8 @@ and (check_let_recs :
                                      in
                                   (lb2, g)))))))
            in
-        FStar_All.pipe_right uu____26221 FStar_List.unzip  in
-      match uu____26212 with
+        FStar_All.pipe_right uu____26062 FStar_List.unzip  in
+      match uu____26053 with
       | (lbs1,gs) ->
           let g_lbs =
             FStar_List.fold_right FStar_TypeChecker_Env.conj_guard gs
@@ -10482,12 +10499,12 @@ and (check_let_bound_def :
   fun top_level  ->
     fun env  ->
       fun lb  ->
-        let uu____26365 = FStar_TypeChecker_Env.clear_expected_typ env  in
-        match uu____26365 with
-        | (env1,uu____26384) ->
+        let uu____26206 = FStar_TypeChecker_Env.clear_expected_typ env  in
+        match uu____26206 with
+        | (env1,uu____26225) ->
             let e1 = lb.FStar_Syntax_Syntax.lbdef  in
-            let uu____26392 = check_lbtyp top_level env lb  in
-            (match uu____26392 with
+            let uu____26233 = check_lbtyp top_level env lb  in
+            (match uu____26233 with
              | (topt,wf_annot,univ_vars,univ_opening,env11) ->
                  (if (Prims.op_Negation top_level) && (univ_vars <> [])
                   then
@@ -10497,144 +10514,144 @@ and (check_let_bound_def :
                       e1.FStar_Syntax_Syntax.pos
                   else ();
                   (let e11 = FStar_Syntax_Subst.subst univ_opening e1  in
-                   let uu____26441 =
+                   let uu____26282 =
                      tc_maybe_toplevel_term
-                       (let uu___3418_26450 = env11  in
+                       (let uu___3430_26291 = env11  in
                         {
                           FStar_TypeChecker_Env.solver =
-                            (uu___3418_26450.FStar_TypeChecker_Env.solver);
+                            (uu___3430_26291.FStar_TypeChecker_Env.solver);
                           FStar_TypeChecker_Env.range =
-                            (uu___3418_26450.FStar_TypeChecker_Env.range);
+                            (uu___3430_26291.FStar_TypeChecker_Env.range);
                           FStar_TypeChecker_Env.curmodule =
-                            (uu___3418_26450.FStar_TypeChecker_Env.curmodule);
+                            (uu___3430_26291.FStar_TypeChecker_Env.curmodule);
                           FStar_TypeChecker_Env.gamma =
-                            (uu___3418_26450.FStar_TypeChecker_Env.gamma);
+                            (uu___3430_26291.FStar_TypeChecker_Env.gamma);
                           FStar_TypeChecker_Env.gamma_sig =
-                            (uu___3418_26450.FStar_TypeChecker_Env.gamma_sig);
+                            (uu___3430_26291.FStar_TypeChecker_Env.gamma_sig);
                           FStar_TypeChecker_Env.gamma_cache =
-                            (uu___3418_26450.FStar_TypeChecker_Env.gamma_cache);
+                            (uu___3430_26291.FStar_TypeChecker_Env.gamma_cache);
                           FStar_TypeChecker_Env.modules =
-                            (uu___3418_26450.FStar_TypeChecker_Env.modules);
+                            (uu___3430_26291.FStar_TypeChecker_Env.modules);
                           FStar_TypeChecker_Env.expected_typ =
-                            (uu___3418_26450.FStar_TypeChecker_Env.expected_typ);
+                            (uu___3430_26291.FStar_TypeChecker_Env.expected_typ);
                           FStar_TypeChecker_Env.sigtab =
-                            (uu___3418_26450.FStar_TypeChecker_Env.sigtab);
+                            (uu___3430_26291.FStar_TypeChecker_Env.sigtab);
                           FStar_TypeChecker_Env.attrtab =
-                            (uu___3418_26450.FStar_TypeChecker_Env.attrtab);
+                            (uu___3430_26291.FStar_TypeChecker_Env.attrtab);
                           FStar_TypeChecker_Env.instantiate_imp =
-                            (uu___3418_26450.FStar_TypeChecker_Env.instantiate_imp);
+                            (uu___3430_26291.FStar_TypeChecker_Env.instantiate_imp);
                           FStar_TypeChecker_Env.effects =
-                            (uu___3418_26450.FStar_TypeChecker_Env.effects);
+                            (uu___3430_26291.FStar_TypeChecker_Env.effects);
                           FStar_TypeChecker_Env.generalize =
-                            (uu___3418_26450.FStar_TypeChecker_Env.generalize);
+                            (uu___3430_26291.FStar_TypeChecker_Env.generalize);
                           FStar_TypeChecker_Env.letrecs =
-                            (uu___3418_26450.FStar_TypeChecker_Env.letrecs);
+                            (uu___3430_26291.FStar_TypeChecker_Env.letrecs);
                           FStar_TypeChecker_Env.top_level = top_level;
                           FStar_TypeChecker_Env.check_uvars =
-                            (uu___3418_26450.FStar_TypeChecker_Env.check_uvars);
+                            (uu___3430_26291.FStar_TypeChecker_Env.check_uvars);
                           FStar_TypeChecker_Env.use_eq =
-                            (uu___3418_26450.FStar_TypeChecker_Env.use_eq);
+                            (uu___3430_26291.FStar_TypeChecker_Env.use_eq);
                           FStar_TypeChecker_Env.use_eq_strict =
-                            (uu___3418_26450.FStar_TypeChecker_Env.use_eq_strict);
+                            (uu___3430_26291.FStar_TypeChecker_Env.use_eq_strict);
                           FStar_TypeChecker_Env.is_iface =
-                            (uu___3418_26450.FStar_TypeChecker_Env.is_iface);
+                            (uu___3430_26291.FStar_TypeChecker_Env.is_iface);
                           FStar_TypeChecker_Env.admit =
-                            (uu___3418_26450.FStar_TypeChecker_Env.admit);
+                            (uu___3430_26291.FStar_TypeChecker_Env.admit);
                           FStar_TypeChecker_Env.lax =
-                            (uu___3418_26450.FStar_TypeChecker_Env.lax);
+                            (uu___3430_26291.FStar_TypeChecker_Env.lax);
                           FStar_TypeChecker_Env.lax_universes =
-                            (uu___3418_26450.FStar_TypeChecker_Env.lax_universes);
+                            (uu___3430_26291.FStar_TypeChecker_Env.lax_universes);
                           FStar_TypeChecker_Env.phase1 =
-                            (uu___3418_26450.FStar_TypeChecker_Env.phase1);
+                            (uu___3430_26291.FStar_TypeChecker_Env.phase1);
                           FStar_TypeChecker_Env.failhard =
-                            (uu___3418_26450.FStar_TypeChecker_Env.failhard);
+                            (uu___3430_26291.FStar_TypeChecker_Env.failhard);
                           FStar_TypeChecker_Env.nosynth =
-                            (uu___3418_26450.FStar_TypeChecker_Env.nosynth);
+                            (uu___3430_26291.FStar_TypeChecker_Env.nosynth);
                           FStar_TypeChecker_Env.uvar_subtyping =
-                            (uu___3418_26450.FStar_TypeChecker_Env.uvar_subtyping);
+                            (uu___3430_26291.FStar_TypeChecker_Env.uvar_subtyping);
                           FStar_TypeChecker_Env.tc_term =
-                            (uu___3418_26450.FStar_TypeChecker_Env.tc_term);
+                            (uu___3430_26291.FStar_TypeChecker_Env.tc_term);
                           FStar_TypeChecker_Env.type_of =
-                            (uu___3418_26450.FStar_TypeChecker_Env.type_of);
+                            (uu___3430_26291.FStar_TypeChecker_Env.type_of);
                           FStar_TypeChecker_Env.universe_of =
-                            (uu___3418_26450.FStar_TypeChecker_Env.universe_of);
+                            (uu___3430_26291.FStar_TypeChecker_Env.universe_of);
                           FStar_TypeChecker_Env.check_type_of =
-                            (uu___3418_26450.FStar_TypeChecker_Env.check_type_of);
+                            (uu___3430_26291.FStar_TypeChecker_Env.check_type_of);
                           FStar_TypeChecker_Env.use_bv_sorts =
-                            (uu___3418_26450.FStar_TypeChecker_Env.use_bv_sorts);
+                            (uu___3430_26291.FStar_TypeChecker_Env.use_bv_sorts);
                           FStar_TypeChecker_Env.qtbl_name_and_index =
-                            (uu___3418_26450.FStar_TypeChecker_Env.qtbl_name_and_index);
+                            (uu___3430_26291.FStar_TypeChecker_Env.qtbl_name_and_index);
                           FStar_TypeChecker_Env.normalized_eff_names =
-                            (uu___3418_26450.FStar_TypeChecker_Env.normalized_eff_names);
+                            (uu___3430_26291.FStar_TypeChecker_Env.normalized_eff_names);
                           FStar_TypeChecker_Env.fv_delta_depths =
-                            (uu___3418_26450.FStar_TypeChecker_Env.fv_delta_depths);
+                            (uu___3430_26291.FStar_TypeChecker_Env.fv_delta_depths);
                           FStar_TypeChecker_Env.proof_ns =
-                            (uu___3418_26450.FStar_TypeChecker_Env.proof_ns);
+                            (uu___3430_26291.FStar_TypeChecker_Env.proof_ns);
                           FStar_TypeChecker_Env.synth_hook =
-                            (uu___3418_26450.FStar_TypeChecker_Env.synth_hook);
+                            (uu___3430_26291.FStar_TypeChecker_Env.synth_hook);
                           FStar_TypeChecker_Env.try_solve_implicits_hook =
-                            (uu___3418_26450.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                            (uu___3430_26291.FStar_TypeChecker_Env.try_solve_implicits_hook);
                           FStar_TypeChecker_Env.splice =
-                            (uu___3418_26450.FStar_TypeChecker_Env.splice);
+                            (uu___3430_26291.FStar_TypeChecker_Env.splice);
                           FStar_TypeChecker_Env.mpreprocess =
-                            (uu___3418_26450.FStar_TypeChecker_Env.mpreprocess);
+                            (uu___3430_26291.FStar_TypeChecker_Env.mpreprocess);
                           FStar_TypeChecker_Env.postprocess =
-                            (uu___3418_26450.FStar_TypeChecker_Env.postprocess);
+                            (uu___3430_26291.FStar_TypeChecker_Env.postprocess);
                           FStar_TypeChecker_Env.is_native_tactic =
-                            (uu___3418_26450.FStar_TypeChecker_Env.is_native_tactic);
+                            (uu___3430_26291.FStar_TypeChecker_Env.is_native_tactic);
                           FStar_TypeChecker_Env.identifier_info =
-                            (uu___3418_26450.FStar_TypeChecker_Env.identifier_info);
+                            (uu___3430_26291.FStar_TypeChecker_Env.identifier_info);
                           FStar_TypeChecker_Env.tc_hooks =
-                            (uu___3418_26450.FStar_TypeChecker_Env.tc_hooks);
+                            (uu___3430_26291.FStar_TypeChecker_Env.tc_hooks);
                           FStar_TypeChecker_Env.dsenv =
-                            (uu___3418_26450.FStar_TypeChecker_Env.dsenv);
+                            (uu___3430_26291.FStar_TypeChecker_Env.dsenv);
                           FStar_TypeChecker_Env.nbe =
-                            (uu___3418_26450.FStar_TypeChecker_Env.nbe);
+                            (uu___3430_26291.FStar_TypeChecker_Env.nbe);
                           FStar_TypeChecker_Env.strict_args_tab =
-                            (uu___3418_26450.FStar_TypeChecker_Env.strict_args_tab);
+                            (uu___3430_26291.FStar_TypeChecker_Env.strict_args_tab);
                           FStar_TypeChecker_Env.erasable_types_tab =
-                            (uu___3418_26450.FStar_TypeChecker_Env.erasable_types_tab)
+                            (uu___3430_26291.FStar_TypeChecker_Env.erasable_types_tab)
                         }) e11
                       in
-                   match uu____26441 with
+                   match uu____26282 with
                    | (e12,c1,g1) ->
-                       let uu____26465 =
-                         let uu____26470 =
+                       let uu____26306 =
+                         let uu____26311 =
                            FStar_TypeChecker_Env.set_range env11
                              e12.FStar_Syntax_Syntax.pos
                             in
                          FStar_TypeChecker_Util.strengthen_precondition
                            (FStar_Pervasives_Native.Some
-                              (fun uu____26476  ->
+                              (fun uu____26317  ->
                                  FStar_Util.return_all
                                    FStar_TypeChecker_Err.ill_kinded_type))
-                           uu____26470 e12 c1 wf_annot
+                           uu____26311 e12 c1 wf_annot
                           in
-                       (match uu____26465 with
+                       (match uu____26306 with
                         | (c11,guard_f) ->
                             let g11 =
                               FStar_TypeChecker_Env.conj_guard g1 guard_f  in
-                            ((let uu____26493 =
+                            ((let uu____26334 =
                                 FStar_TypeChecker_Env.debug env
                                   FStar_Options.Extreme
                                  in
-                              if uu____26493
+                              if uu____26334
                               then
-                                let uu____26496 =
+                                let uu____26337 =
                                   FStar_Syntax_Print.lbname_to_string
                                     lb.FStar_Syntax_Syntax.lbname
                                    in
-                                let uu____26498 =
+                                let uu____26339 =
                                   FStar_TypeChecker_Common.lcomp_to_string
                                     c11
                                    in
-                                let uu____26500 =
+                                let uu____26341 =
                                   FStar_TypeChecker_Rel.guard_to_string env
                                     g11
                                    in
                                 FStar_Util.print3
                                   "checked let-bound def %s : %s guard is %s\n"
-                                  uu____26496 uu____26498 uu____26500
+                                  uu____26337 uu____26339 uu____26341
                               else ());
                              (e12, univ_vars, c11, g11,
                                (FStar_Option.isSome topt)))))))
@@ -10654,23 +10671,23 @@ and (check_lbtyp :
         let t = FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp  in
         match t.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_unknown  ->
-            let uu____26539 =
+            let uu____26380 =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs
                in
-            (match uu____26539 with
+            (match uu____26380 with
              | (univ_opening,univ_vars) ->
-                 let uu____26572 =
+                 let uu____26413 =
                    FStar_TypeChecker_Env.push_univ_vars env univ_vars  in
                  (FStar_Pervasives_Native.None,
                    FStar_TypeChecker_Env.trivial_guard, univ_vars,
-                   univ_opening, uu____26572))
-        | uu____26577 ->
-            let uu____26578 =
+                   univ_opening, uu____26413))
+        | uu____26418 ->
+            let uu____26419 =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs
                in
-            (match uu____26578 with
+            (match uu____26419 with
              | (univ_opening,univ_vars) ->
                  let t1 = FStar_Syntax_Subst.subst univ_opening t  in
                  let env1 =
@@ -10679,45 +10696,45 @@ and (check_lbtyp :
                    top_level &&
                      (Prims.op_Negation env.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____26628 =
+                   let uu____26469 =
                      FStar_TypeChecker_Env.set_expected_typ env1 t1  in
                    ((FStar_Pervasives_Native.Some t1),
                      FStar_TypeChecker_Env.trivial_guard, univ_vars,
-                     univ_opening, uu____26628)
+                     univ_opening, uu____26469)
                  else
-                   (let uu____26635 = FStar_Syntax_Util.type_u ()  in
-                    match uu____26635 with
-                    | (k,uu____26655) ->
-                        let uu____26656 = tc_check_tot_or_gtot_term env1 t1 k
+                   (let uu____26476 = FStar_Syntax_Util.type_u ()  in
+                    match uu____26476 with
+                    | (k,uu____26496) ->
+                        let uu____26497 = tc_check_tot_or_gtot_term env1 t1 k
                            in
-                        (match uu____26656 with
-                         | (t2,uu____26678,g) ->
-                             ((let uu____26681 =
+                        (match uu____26497 with
+                         | (t2,uu____26519,g) ->
+                             ((let uu____26522 =
                                  FStar_TypeChecker_Env.debug env
                                    FStar_Options.Medium
                                   in
-                               if uu____26681
+                               if uu____26522
                                then
-                                 let uu____26684 =
-                                   let uu____26686 =
+                                 let uu____26525 =
+                                   let uu____26527 =
                                      FStar_Syntax_Util.range_of_lbname
                                        lb.FStar_Syntax_Syntax.lbname
                                       in
-                                   FStar_Range.string_of_range uu____26686
+                                   FStar_Range.string_of_range uu____26527
                                     in
-                                 let uu____26687 =
+                                 let uu____26528 =
                                    FStar_Syntax_Print.term_to_string t2  in
                                  FStar_Util.print2
                                    "(%s) Checked type annotation %s\n"
-                                   uu____26684 uu____26687
+                                   uu____26525 uu____26528
                                else ());
                               (let t3 = norm env1 t2  in
-                               let uu____26693 =
+                               let uu____26534 =
                                  FStar_TypeChecker_Env.set_expected_typ env1
                                    t3
                                   in
                                ((FStar_Pervasives_Native.Some t3), g,
-                                 univ_vars, univ_opening, uu____26693))))))
+                                 univ_vars, univ_opening, uu____26534))))))
 
 and (tc_binder :
   FStar_TypeChecker_Env.env ->
@@ -10728,76 +10745,76 @@ and (tc_binder :
         FStar_TypeChecker_Env.guard_t * FStar_Syntax_Syntax.universe))
   =
   fun env  ->
-    fun uu____26699  ->
-      match uu____26699 with
+    fun uu____26540  ->
+      match uu____26540 with
       | (x,imp) ->
-          let uu____26726 = FStar_Syntax_Util.type_u ()  in
-          (match uu____26726 with
+          let uu____26567 = FStar_Syntax_Util.type_u ()  in
+          (match uu____26567 with
            | (tu,u) ->
-               ((let uu____26748 =
+               ((let uu____26589 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Extreme  in
-                 if uu____26748
+                 if uu____26589
                  then
-                   let uu____26751 = FStar_Syntax_Print.bv_to_string x  in
-                   let uu____26753 =
+                   let uu____26592 = FStar_Syntax_Print.bv_to_string x  in
+                   let uu____26594 =
                      FStar_Syntax_Print.term_to_string
                        x.FStar_Syntax_Syntax.sort
                       in
-                   let uu____26755 = FStar_Syntax_Print.term_to_string tu  in
+                   let uu____26596 = FStar_Syntax_Print.term_to_string tu  in
                    FStar_Util.print3 "Checking binder %s:%s at type %s\n"
-                     uu____26751 uu____26753 uu____26755
+                     uu____26592 uu____26594 uu____26596
                  else ());
-                (let uu____26760 =
+                (let uu____26601 =
                    tc_check_tot_or_gtot_term env x.FStar_Syntax_Syntax.sort
                      tu
                     in
-                 match uu____26760 with
-                 | (t,uu____26782,g) ->
-                     let uu____26784 =
+                 match uu____26601 with
+                 | (t,uu____26623,g) ->
+                     let uu____26625 =
                        match imp with
                        | FStar_Pervasives_Native.Some
                            (FStar_Syntax_Syntax.Meta tau) ->
-                           let uu____26800 =
+                           let uu____26641 =
                              tc_tactic FStar_Syntax_Syntax.t_unit
                                FStar_Syntax_Syntax.t_unit env tau
                               in
-                           (match uu____26800 with
-                            | (tau1,uu____26814,g1) ->
+                           (match uu____26641 with
+                            | (tau1,uu____26655,g1) ->
                                 ((FStar_Pervasives_Native.Some
                                     (FStar_Syntax_Syntax.Meta tau1)), g1))
-                       | uu____26818 ->
+                       | uu____26659 ->
                            (imp, FStar_TypeChecker_Env.trivial_guard)
                         in
-                     (match uu____26784 with
+                     (match uu____26625 with
                       | (imp1,g') ->
                           let x1 =
-                            ((let uu___3480_26853 = x  in
+                            ((let uu___3492_26694 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___3480_26853.FStar_Syntax_Syntax.ppname);
+                                  (uu___3492_26694.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___3480_26853.FStar_Syntax_Syntax.index);
+                                  (uu___3492_26694.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t
                               }), imp1)
                              in
-                          ((let uu____26855 =
+                          ((let uu____26696 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.High
                                in
-                            if uu____26855
+                            if uu____26696
                             then
-                              let uu____26858 =
+                              let uu____26699 =
                                 FStar_Syntax_Print.bv_to_string
                                   (FStar_Pervasives_Native.fst x1)
                                  in
-                              let uu____26862 =
+                              let uu____26703 =
                                 FStar_Syntax_Print.term_to_string t  in
                               FStar_Util.print2
-                                "Pushing binder %s at type %s\n" uu____26858
-                                uu____26862
+                                "Pushing binder %s at type %s\n" uu____26699
+                                uu____26703
                             else ());
-                           (let uu____26867 = push_binding env x1  in
-                            (x1, uu____26867, g, u)))))))
+                           (let uu____26708 = push_binding env x1  in
+                            (x1, uu____26708, g, u)))))))
 
 and (tc_binders :
   FStar_TypeChecker_Env.env ->
@@ -10807,30 +10824,30 @@ and (tc_binders :
   =
   fun env  ->
     fun bs  ->
-      (let uu____26879 =
+      (let uu____26720 =
          FStar_TypeChecker_Env.debug env FStar_Options.Extreme  in
-       if uu____26879
+       if uu____26720
        then
-         let uu____26882 = FStar_Syntax_Print.binders_to_string ", " bs  in
-         FStar_Util.print1 "Checking binders %s\n" uu____26882
+         let uu____26723 = FStar_Syntax_Print.binders_to_string ", " bs  in
+         FStar_Util.print1 "Checking binders %s\n" uu____26723
        else ());
       (let rec aux env1 bs1 =
          match bs1 with
          | [] -> ([], env1, FStar_TypeChecker_Env.trivial_guard, [])
          | b::bs2 ->
-             let uu____26995 = tc_binder env1 b  in
-             (match uu____26995 with
+             let uu____26836 = tc_binder env1 b  in
+             (match uu____26836 with
               | (b1,env',g,u) ->
-                  let uu____27044 = aux env' bs2  in
-                  (match uu____27044 with
+                  let uu____26885 = aux env' bs2  in
+                  (match uu____26885 with
                    | (bs3,env'1,g',us) ->
-                       let uu____27105 =
-                         let uu____27106 =
+                       let uu____26946 =
+                         let uu____26947 =
                            FStar_TypeChecker_Env.close_guard_univs [u] 
                              [b1] g'
                             in
-                         FStar_TypeChecker_Env.conj_guard g uu____27106  in
-                       ((b1 :: bs3), env'1, uu____27105, (u :: us))))
+                         FStar_TypeChecker_Env.conj_guard g uu____26947  in
+                       ((b1 :: bs3), env'1, uu____26946, (u :: us))))
           in
        aux env bs)
 
@@ -10847,30 +10864,30 @@ and (tc_smt_pats :
     fun pats  ->
       let tc_args en1 args =
         FStar_List.fold_right
-          (fun uu____27214  ->
-             fun uu____27215  ->
-               match (uu____27214, uu____27215) with
+          (fun uu____27055  ->
+             fun uu____27056  ->
+               match (uu____27055, uu____27056) with
                | ((t,imp),(args1,g)) ->
                    (FStar_All.pipe_right t (check_no_smt_theory_symbols en1);
-                    (let uu____27307 = tc_term en1 t  in
-                     match uu____27307 with
-                     | (t1,uu____27327,g') ->
-                         let uu____27329 =
+                    (let uu____27148 = tc_term en1 t  in
+                     match uu____27148 with
+                     | (t1,uu____27168,g') ->
+                         let uu____27170 =
                            FStar_TypeChecker_Env.conj_guard g g'  in
-                         (((t1, imp) :: args1), uu____27329)))) args
+                         (((t1, imp) :: args1), uu____27170)))) args
           ([], FStar_TypeChecker_Env.trivial_guard)
          in
       FStar_List.fold_right
         (fun p  ->
-           fun uu____27383  ->
-             match uu____27383 with
+           fun uu____27224  ->
+             match uu____27224 with
              | (pats1,g) ->
-                 let uu____27410 = tc_args en p  in
-                 (match uu____27410 with
+                 let uu____27251 = tc_args en p  in
+                 (match uu____27251 with
                   | (args,g') ->
-                      let uu____27423 = FStar_TypeChecker_Env.conj_guard g g'
+                      let uu____27264 = FStar_TypeChecker_Env.conj_guard g g'
                          in
-                      ((args :: pats1), uu____27423))) pats
+                      ((args :: pats1), uu____27264))) pats
         ([], FStar_TypeChecker_Env.trivial_guard)
 
 and (tc_tot_or_gtot_term :
@@ -10881,70 +10898,70 @@ and (tc_tot_or_gtot_term :
   =
   fun env  ->
     fun e  ->
-      let uu____27436 = tc_maybe_toplevel_term env e  in
-      match uu____27436 with
+      let uu____27277 = tc_maybe_toplevel_term env e  in
+      match uu____27277 with
       | (e1,c,g) ->
-          let uu____27452 = FStar_TypeChecker_Common.is_tot_or_gtot_lcomp c
+          let uu____27293 = FStar_TypeChecker_Common.is_tot_or_gtot_lcomp c
              in
-          if uu____27452
+          if uu____27293
           then (e1, c, g)
           else
             (let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g
                 in
-             let uu____27464 = FStar_TypeChecker_Common.lcomp_comp c  in
-             match uu____27464 with
+             let uu____27305 = FStar_TypeChecker_Common.lcomp_comp c  in
+             match uu____27305 with
              | (c1,g_c) ->
                  let c2 = norm_c env c1  in
-                 let uu____27478 =
-                   let uu____27484 =
+                 let uu____27319 =
+                   let uu____27325 =
                      FStar_TypeChecker_Util.is_pure_effect env
                        (FStar_Syntax_Util.comp_effect_name c2)
                       in
-                   if uu____27484
+                   if uu____27325
                    then
-                     let uu____27492 =
+                     let uu____27333 =
                        FStar_Syntax_Syntax.mk_Total
                          (FStar_Syntax_Util.comp_result c2)
                         in
-                     (uu____27492, false)
+                     (uu____27333, false)
                    else
-                     (let uu____27497 =
+                     (let uu____27338 =
                         FStar_Syntax_Syntax.mk_GTotal
                           (FStar_Syntax_Util.comp_result c2)
                          in
-                      (uu____27497, true))
+                      (uu____27338, true))
                     in
-                 (match uu____27478 with
+                 (match uu____27319 with
                   | (target_comp,allow_ghost) ->
-                      let uu____27510 =
+                      let uu____27351 =
                         FStar_TypeChecker_Rel.sub_comp env c2 target_comp  in
-                      (match uu____27510 with
+                      (match uu____27351 with
                        | FStar_Pervasives_Native.Some g' ->
-                           let uu____27520 =
+                           let uu____27361 =
                              FStar_TypeChecker_Common.lcomp_of_comp
                                target_comp
                               in
-                           let uu____27521 =
-                             let uu____27522 =
+                           let uu____27362 =
+                             let uu____27363 =
                                FStar_TypeChecker_Env.conj_guard g_c g'  in
-                             FStar_TypeChecker_Env.conj_guard g1 uu____27522
+                             FStar_TypeChecker_Env.conj_guard g1 uu____27363
                               in
-                           (e1, uu____27520, uu____27521)
-                       | uu____27523 ->
+                           (e1, uu____27361, uu____27362)
+                       | uu____27364 ->
                            if allow_ghost
                            then
-                             let uu____27533 =
+                             let uu____27374 =
                                FStar_TypeChecker_Err.expected_ghost_expression
                                  e1 c2
                                 in
-                             FStar_Errors.raise_error uu____27533
+                             FStar_Errors.raise_error uu____27374
                                e1.FStar_Syntax_Syntax.pos
                            else
-                             (let uu____27547 =
+                             (let uu____27388 =
                                 FStar_TypeChecker_Err.expected_pure_expression
                                   e1 c2
                                  in
-                              FStar_Errors.raise_error uu____27547
+                              FStar_Errors.raise_error uu____27388
                                 e1.FStar_Syntax_Syntax.pos))))
 
 and (tc_check_tot_or_gtot_term :
@@ -10967,8 +10984,8 @@ and (tc_trivial_guard :
   =
   fun env  ->
     fun t  ->
-      let uu____27571 = tc_tot_or_gtot_term env t  in
-      match uu____27571 with
+      let uu____27412 = tc_tot_or_gtot_term env t  in
+      match uu____27412 with
       | (t1,c,g) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env g; (t1, c))
 
@@ -10980,9 +10997,9 @@ let (tc_check_trivial_guard :
   fun env  ->
     fun t  ->
       fun k  ->
-        let uu____27602 = tc_check_tot_or_gtot_term env t k  in
-        match uu____27602 with
-        | (t1,uu____27610,g) ->
+        let uu____27443 = tc_check_tot_or_gtot_term env t k  in
+        match uu____27443 with
+        | (t1,uu____27451,g) ->
             (FStar_TypeChecker_Rel.force_trivial_guard env g; t1)
   
 let (type_of_tot_term :
@@ -10993,157 +11010,157 @@ let (type_of_tot_term :
   =
   fun env  ->
     fun e  ->
-      (let uu____27631 =
+      (let uu____27472 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "RelCheck")
           in
-       if uu____27631
+       if uu____27472
        then
-         let uu____27636 = FStar_Syntax_Print.term_to_string e  in
-         FStar_Util.print1 "Checking term %s\n" uu____27636
+         let uu____27477 = FStar_Syntax_Print.term_to_string e  in
+         FStar_Util.print1 "Checking term %s\n" uu____27477
        else ());
       (let env1 =
-         let uu___3572_27642 = env  in
+         let uu___3584_27483 = env  in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___3572_27642.FStar_TypeChecker_Env.solver);
+             (uu___3584_27483.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___3572_27642.FStar_TypeChecker_Env.range);
+             (uu___3584_27483.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___3572_27642.FStar_TypeChecker_Env.curmodule);
+             (uu___3584_27483.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
-             (uu___3572_27642.FStar_TypeChecker_Env.gamma);
+             (uu___3584_27483.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___3572_27642.FStar_TypeChecker_Env.gamma_sig);
+             (uu___3584_27483.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___3572_27642.FStar_TypeChecker_Env.gamma_cache);
+             (uu___3584_27483.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___3572_27642.FStar_TypeChecker_Env.modules);
+             (uu___3584_27483.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___3572_27642.FStar_TypeChecker_Env.expected_typ);
+             (uu___3584_27483.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___3572_27642.FStar_TypeChecker_Env.sigtab);
+             (uu___3584_27483.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___3572_27642.FStar_TypeChecker_Env.attrtab);
+             (uu___3584_27483.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___3572_27642.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___3584_27483.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___3572_27642.FStar_TypeChecker_Env.effects);
+             (uu___3584_27483.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___3572_27642.FStar_TypeChecker_Env.generalize);
+             (uu___3584_27483.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs = [];
            FStar_TypeChecker_Env.top_level = false;
            FStar_TypeChecker_Env.check_uvars =
-             (uu___3572_27642.FStar_TypeChecker_Env.check_uvars);
+             (uu___3584_27483.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___3572_27642.FStar_TypeChecker_Env.use_eq);
+             (uu___3584_27483.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___3572_27642.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___3584_27483.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
-             (uu___3572_27642.FStar_TypeChecker_Env.is_iface);
+             (uu___3584_27483.FStar_TypeChecker_Env.is_iface);
            FStar_TypeChecker_Env.admit =
-             (uu___3572_27642.FStar_TypeChecker_Env.admit);
+             (uu___3584_27483.FStar_TypeChecker_Env.admit);
            FStar_TypeChecker_Env.lax =
-             (uu___3572_27642.FStar_TypeChecker_Env.lax);
+             (uu___3584_27483.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___3572_27642.FStar_TypeChecker_Env.lax_universes);
+             (uu___3584_27483.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___3572_27642.FStar_TypeChecker_Env.phase1);
+             (uu___3584_27483.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___3572_27642.FStar_TypeChecker_Env.failhard);
+             (uu___3584_27483.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___3572_27642.FStar_TypeChecker_Env.nosynth);
+             (uu___3584_27483.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___3572_27642.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___3584_27483.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___3572_27642.FStar_TypeChecker_Env.tc_term);
+             (uu___3584_27483.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___3572_27642.FStar_TypeChecker_Env.type_of);
+             (uu___3584_27483.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___3572_27642.FStar_TypeChecker_Env.universe_of);
+             (uu___3584_27483.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___3572_27642.FStar_TypeChecker_Env.check_type_of);
+             (uu___3584_27483.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___3572_27642.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___3584_27483.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___3572_27642.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___3584_27483.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___3572_27642.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___3584_27483.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___3572_27642.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___3584_27483.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___3572_27642.FStar_TypeChecker_Env.proof_ns);
+             (uu___3584_27483.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___3572_27642.FStar_TypeChecker_Env.synth_hook);
+             (uu___3584_27483.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___3572_27642.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___3584_27483.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___3572_27642.FStar_TypeChecker_Env.splice);
+             (uu___3584_27483.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___3572_27642.FStar_TypeChecker_Env.mpreprocess);
+             (uu___3584_27483.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___3572_27642.FStar_TypeChecker_Env.postprocess);
+             (uu___3584_27483.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.is_native_tactic =
-             (uu___3572_27642.FStar_TypeChecker_Env.is_native_tactic);
+             (uu___3584_27483.FStar_TypeChecker_Env.is_native_tactic);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___3572_27642.FStar_TypeChecker_Env.identifier_info);
+             (uu___3584_27483.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___3572_27642.FStar_TypeChecker_Env.tc_hooks);
+             (uu___3584_27483.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___3572_27642.FStar_TypeChecker_Env.dsenv);
+             (uu___3584_27483.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___3572_27642.FStar_TypeChecker_Env.nbe);
+             (uu___3584_27483.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___3572_27642.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___3584_27483.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___3572_27642.FStar_TypeChecker_Env.erasable_types_tab)
+             (uu___3584_27483.FStar_TypeChecker_Env.erasable_types_tab)
          }  in
-       let uu____27650 =
+       let uu____27491 =
          try
-           (fun uu___3576_27664  ->
+           (fun uu___3588_27505  ->
               match () with | () -> tc_tot_or_gtot_term env1 e) ()
          with
-         | FStar_Errors.Error (e1,msg,uu____27685) ->
-             let uu____27688 = FStar_TypeChecker_Env.get_range env1  in
-             FStar_Errors.raise_error (e1, msg) uu____27688
+         | FStar_Errors.Error (e1,msg,uu____27526) ->
+             let uu____27529 = FStar_TypeChecker_Env.get_range env1  in
+             FStar_Errors.raise_error (e1, msg) uu____27529
           in
-       match uu____27650 with
+       match uu____27491 with
        | (t,c,g) ->
            let c1 = FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env1 c
               in
-           let uu____27706 = FStar_TypeChecker_Common.is_total_lcomp c1  in
-           if uu____27706
+           let uu____27547 = FStar_TypeChecker_Common.is_total_lcomp c1  in
+           if uu____27547
            then (t, (c1.FStar_TypeChecker_Common.res_typ), g)
            else
-             (let uu____27717 =
-                let uu____27723 =
-                  let uu____27725 = FStar_Syntax_Print.term_to_string e  in
+             (let uu____27558 =
+                let uu____27564 =
+                  let uu____27566 = FStar_Syntax_Print.term_to_string e  in
                   FStar_Util.format1
                     "Implicit argument: Expected a total term; got a ghost term: %s"
-                    uu____27725
+                    uu____27566
                    in
-                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____27723)
+                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____27564)
                  in
-              let uu____27729 = FStar_TypeChecker_Env.get_range env1  in
-              FStar_Errors.raise_error uu____27717 uu____27729))
+              let uu____27570 = FStar_TypeChecker_Env.get_range env1  in
+              FStar_Errors.raise_error uu____27558 uu____27570))
   
 let level_of_type_fail :
-  'uuuuuu27745 .
+  'uuuuuu27586 .
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> Prims.string -> 'uuuuuu27745
+      FStar_Syntax_Syntax.term -> Prims.string -> 'uuuuuu27586
   =
   fun env  ->
     fun e  ->
       fun t  ->
-        let uu____27763 =
-          let uu____27769 =
-            let uu____27771 = FStar_Syntax_Print.term_to_string e  in
+        let uu____27604 =
+          let uu____27610 =
+            let uu____27612 = FStar_Syntax_Print.term_to_string e  in
             FStar_Util.format2 "Expected a term of type 'Type'; got %s : %s"
-              uu____27771 t
+              uu____27612 t
              in
-          (FStar_Errors.Fatal_UnexpectedTermType, uu____27769)  in
-        let uu____27775 = FStar_TypeChecker_Env.get_range env  in
-        FStar_Errors.raise_error uu____27763 uu____27775
+          (FStar_Errors.Fatal_UnexpectedTermType, uu____27610)  in
+        let uu____27616 = FStar_TypeChecker_Env.get_range env  in
+        FStar_Errors.raise_error uu____27604 uu____27616
   
 let (level_of_type :
   FStar_TypeChecker_Env.env ->
@@ -11154,12 +11171,12 @@ let (level_of_type :
     fun e  ->
       fun t  ->
         let rec aux retry t1 =
-          let uu____27809 =
-            let uu____27810 = FStar_Syntax_Util.unrefine t1  in
-            uu____27810.FStar_Syntax_Syntax.n  in
-          match uu____27809 with
+          let uu____27650 =
+            let uu____27651 = FStar_Syntax_Util.unrefine t1  in
+            uu____27651.FStar_Syntax_Syntax.n  in
+          match uu____27650 with
           | FStar_Syntax_Syntax.Tm_type u -> u
-          | uu____27814 ->
+          | uu____27655 ->
               if retry
               then
                 let t2 =
@@ -11169,113 +11186,113 @@ let (level_of_type :
                    in
                 aux false t2
               else
-                (let uu____27820 = FStar_Syntax_Util.type_u ()  in
-                 match uu____27820 with
+                (let uu____27661 = FStar_Syntax_Util.type_u ()  in
+                 match uu____27661 with
                  | (t_u,u) ->
                      let env1 =
-                       let uu___3608_27828 = env  in
+                       let uu___3620_27669 = env  in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3608_27828.FStar_TypeChecker_Env.solver);
+                           (uu___3620_27669.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3608_27828.FStar_TypeChecker_Env.range);
+                           (uu___3620_27669.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3608_27828.FStar_TypeChecker_Env.curmodule);
+                           (uu___3620_27669.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3608_27828.FStar_TypeChecker_Env.gamma);
+                           (uu___3620_27669.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3608_27828.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___3620_27669.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3608_27828.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___3620_27669.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3608_27828.FStar_TypeChecker_Env.modules);
+                           (uu___3620_27669.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3608_27828.FStar_TypeChecker_Env.expected_typ);
+                           (uu___3620_27669.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3608_27828.FStar_TypeChecker_Env.sigtab);
+                           (uu___3620_27669.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3608_27828.FStar_TypeChecker_Env.attrtab);
+                           (uu___3620_27669.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3608_27828.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___3620_27669.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3608_27828.FStar_TypeChecker_Env.effects);
+                           (uu___3620_27669.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3608_27828.FStar_TypeChecker_Env.generalize);
+                           (uu___3620_27669.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3608_27828.FStar_TypeChecker_Env.letrecs);
+                           (uu___3620_27669.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level =
-                           (uu___3608_27828.FStar_TypeChecker_Env.top_level);
+                           (uu___3620_27669.FStar_TypeChecker_Env.top_level);
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3608_27828.FStar_TypeChecker_Env.check_uvars);
+                           (uu___3620_27669.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3608_27828.FStar_TypeChecker_Env.use_eq);
+                           (uu___3620_27669.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.use_eq_strict =
-                           (uu___3608_27828.FStar_TypeChecker_Env.use_eq_strict);
+                           (uu___3620_27669.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3608_27828.FStar_TypeChecker_Env.is_iface);
+                           (uu___3620_27669.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3608_27828.FStar_TypeChecker_Env.admit);
+                           (uu___3620_27669.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3608_27828.FStar_TypeChecker_Env.lax_universes);
+                           (uu___3620_27669.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3608_27828.FStar_TypeChecker_Env.phase1);
+                           (uu___3620_27669.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3608_27828.FStar_TypeChecker_Env.failhard);
+                           (uu___3620_27669.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3608_27828.FStar_TypeChecker_Env.nosynth);
+                           (uu___3620_27669.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3608_27828.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___3620_27669.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3608_27828.FStar_TypeChecker_Env.tc_term);
+                           (uu___3620_27669.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3608_27828.FStar_TypeChecker_Env.type_of);
+                           (uu___3620_27669.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3608_27828.FStar_TypeChecker_Env.universe_of);
+                           (uu___3620_27669.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3608_27828.FStar_TypeChecker_Env.check_type_of);
+                           (uu___3620_27669.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts =
-                           (uu___3608_27828.FStar_TypeChecker_Env.use_bv_sorts);
+                           (uu___3620_27669.FStar_TypeChecker_Env.use_bv_sorts);
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3608_27828.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___3620_27669.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3608_27828.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___3620_27669.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3608_27828.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___3620_27669.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3608_27828.FStar_TypeChecker_Env.proof_ns);
+                           (uu___3620_27669.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3608_27828.FStar_TypeChecker_Env.synth_hook);
+                           (uu___3620_27669.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                           (uu___3608_27828.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                           (uu___3620_27669.FStar_TypeChecker_Env.try_solve_implicits_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3608_27828.FStar_TypeChecker_Env.splice);
+                           (uu___3620_27669.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.mpreprocess =
-                           (uu___3608_27828.FStar_TypeChecker_Env.mpreprocess);
+                           (uu___3620_27669.FStar_TypeChecker_Env.mpreprocess);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3608_27828.FStar_TypeChecker_Env.postprocess);
+                           (uu___3620_27669.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.is_native_tactic =
-                           (uu___3608_27828.FStar_TypeChecker_Env.is_native_tactic);
+                           (uu___3620_27669.FStar_TypeChecker_Env.is_native_tactic);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3608_27828.FStar_TypeChecker_Env.identifier_info);
+                           (uu___3620_27669.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3608_27828.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___3620_27669.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3608_27828.FStar_TypeChecker_Env.dsenv);
+                           (uu___3620_27669.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3608_27828.FStar_TypeChecker_Env.nbe);
+                           (uu___3620_27669.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3608_27828.FStar_TypeChecker_Env.strict_args_tab);
+                           (uu___3620_27669.FStar_TypeChecker_Env.strict_args_tab);
                          FStar_TypeChecker_Env.erasable_types_tab =
-                           (uu___3608_27828.FStar_TypeChecker_Env.erasable_types_tab)
+                           (uu___3620_27669.FStar_TypeChecker_Env.erasable_types_tab)
                        }  in
                      let g = FStar_TypeChecker_Rel.teq env1 t1 t_u  in
                      ((match g.FStar_TypeChecker_Common.guard_f with
                        | FStar_TypeChecker_Common.NonTrivial f ->
-                           let uu____27833 =
+                           let uu____27674 =
                              FStar_Syntax_Print.term_to_string t1  in
-                           level_of_type_fail env1 e uu____27833
-                       | uu____27835 ->
+                           level_of_type_fail env1 e uu____27674
+                       | uu____27676 ->
                            FStar_TypeChecker_Rel.force_trivial_guard env1 g);
                       u))
            in
@@ -11288,61 +11305,61 @@ let rec (universe_of_aux :
   =
   fun env  ->
     fun e  ->
-      let uu____27852 =
-        let uu____27853 = FStar_Syntax_Subst.compress e  in
-        uu____27853.FStar_Syntax_Syntax.n  in
-      match uu____27852 with
-      | FStar_Syntax_Syntax.Tm_bvar uu____27856 -> failwith "Impossible"
+      let uu____27693 =
+        let uu____27694 = FStar_Syntax_Subst.compress e  in
+        uu____27694.FStar_Syntax_Syntax.n  in
+      match uu____27693 with
+      | FStar_Syntax_Syntax.Tm_bvar uu____27697 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____27859 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_let uu____27875 ->
+      | FStar_Syntax_Syntax.Tm_delayed uu____27700 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_let uu____27716 ->
           let e1 = FStar_TypeChecker_Normalize.normalize [] env e  in
           universe_of_aux env e1
-      | FStar_Syntax_Syntax.Tm_abs (bs,t,uu____27892) ->
+      | FStar_Syntax_Syntax.Tm_abs (bs,t,uu____27733) ->
           level_of_type_fail env e "arrow type"
       | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
           FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
-      | FStar_Syntax_Syntax.Tm_meta (t,uu____27937) -> universe_of_aux env t
+      | FStar_Syntax_Syntax.Tm_meta (t,uu____27778) -> universe_of_aux env t
       | FStar_Syntax_Syntax.Tm_name n -> n.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____27944 =
+          let uu____27785 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____27944 with | ((uu____27953,t),uu____27955) -> t)
+          (match uu____27785 with | ((uu____27794,t),uu____27796) -> t)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____27961 = FStar_Syntax_Util.unfold_lazy i  in
-          universe_of_aux env uu____27961
+          let uu____27802 = FStar_Syntax_Util.unfold_lazy i  in
+          universe_of_aux env uu____27802
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____27964,(FStar_Util.Inl t,uu____27966),uu____27967) -> t
+          (uu____27805,(FStar_Util.Inl t,uu____27807),uu____27808) -> t
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____28014,(FStar_Util.Inr c,uu____28016),uu____28017) ->
+          (uu____27855,(FStar_Util.Inr c,uu____27857),uu____27858) ->
           FStar_Syntax_Util.comp_result c
       | FStar_Syntax_Syntax.Tm_type u ->
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ u))
             FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
-      | FStar_Syntax_Syntax.Tm_quoted uu____28065 -> FStar_Syntax_Util.ktype0
+      | FStar_Syntax_Syntax.Tm_quoted uu____27906 -> FStar_Syntax_Util.ktype0
       | FStar_Syntax_Syntax.Tm_constant sc ->
           tc_constant env e.FStar_Syntax_Syntax.pos sc
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____28074;
-             FStar_Syntax_Syntax.vars = uu____28075;_},us)
+             FStar_Syntax_Syntax.pos = uu____27915;
+             FStar_Syntax_Syntax.vars = uu____27916;_},us)
           ->
-          let uu____28081 =
+          let uu____27922 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____28081 with
-           | ((us',t),uu____28092) ->
+          (match uu____27922 with
+           | ((us',t),uu____27933) ->
                (if (FStar_List.length us) <> (FStar_List.length us')
                 then
-                  (let uu____28099 = FStar_TypeChecker_Env.get_range env  in
+                  (let uu____27940 = FStar_TypeChecker_Env.get_range env  in
                    FStar_Errors.raise_error
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
                        "Unexpected number of universe instantiations")
-                     uu____28099)
+                     uu____27940)
                 else
                   FStar_List.iter2
                     (fun u'  ->
@@ -11350,31 +11367,31 @@ let rec (universe_of_aux :
                          match u' with
                          | FStar_Syntax_Syntax.U_unif u'' ->
                              FStar_Syntax_Unionfind.univ_change u'' u
-                         | uu____28118 -> failwith "Impossible") us' us;
+                         | uu____27959 -> failwith "Impossible") us' us;
                 t))
-      | FStar_Syntax_Syntax.Tm_uinst uu____28120 ->
+      | FStar_Syntax_Syntax.Tm_uinst uu____27961 ->
           failwith "Impossible: Tm_uinst's head must be an fvar"
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____28129) ->
+      | FStar_Syntax_Syntax.Tm_refine (x,uu____27970) ->
           universe_of_aux env x.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____28156 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____28156 with
+          let uu____27997 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____27997 with
            | (bs1,c1) ->
                let us =
                  FStar_List.map
-                   (fun uu____28176  ->
-                      match uu____28176 with
-                      | (b,uu____28184) ->
-                          let uu____28189 =
+                   (fun uu____28017  ->
+                      match uu____28017 with
+                      | (b,uu____28025) ->
+                          let uu____28030 =
                             universe_of_aux env b.FStar_Syntax_Syntax.sort
                              in
                           level_of_type env b.FStar_Syntax_Syntax.sort
-                            uu____28189) bs1
+                            uu____28030) bs1
                   in
                let u_res =
                  let res = FStar_Syntax_Util.comp_result c1  in
-                 let uu____28194 = universe_of_aux env res  in
-                 level_of_type env res uu____28194  in
+                 let uu____28035 = universe_of_aux env res  in
+                 level_of_type env res uu____28035  in
                let u_c =
                  FStar_All.pipe_right c1
                    (FStar_TypeChecker_Util.universe_of_comp env u_res)
@@ -11390,204 +11407,204 @@ let rec (universe_of_aux :
             let hd2 = FStar_Syntax_Subst.compress hd1  in
             match hd2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_bvar uu____28305 ->
+            | FStar_Syntax_Syntax.Tm_bvar uu____28146 ->
                 failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_delayed uu____28321 ->
+            | FStar_Syntax_Syntax.Tm_delayed uu____28162 ->
                 failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_fvar uu____28351 ->
-                let uu____28352 = universe_of_aux env hd2  in
-                (uu____28352, args1)
-            | FStar_Syntax_Syntax.Tm_name uu____28363 ->
-                let uu____28364 = universe_of_aux env hd2  in
-                (uu____28364, args1)
-            | FStar_Syntax_Syntax.Tm_uvar uu____28375 ->
-                let uu____28388 = universe_of_aux env hd2  in
-                (uu____28388, args1)
-            | FStar_Syntax_Syntax.Tm_uinst uu____28399 ->
-                let uu____28406 = universe_of_aux env hd2  in
-                (uu____28406, args1)
-            | FStar_Syntax_Syntax.Tm_ascribed uu____28417 ->
-                let uu____28444 = universe_of_aux env hd2  in
-                (uu____28444, args1)
-            | FStar_Syntax_Syntax.Tm_refine uu____28455 ->
-                let uu____28462 = universe_of_aux env hd2  in
-                (uu____28462, args1)
-            | FStar_Syntax_Syntax.Tm_constant uu____28473 ->
-                let uu____28474 = universe_of_aux env hd2  in
-                (uu____28474, args1)
-            | FStar_Syntax_Syntax.Tm_arrow uu____28485 ->
-                let uu____28500 = universe_of_aux env hd2  in
-                (uu____28500, args1)
-            | FStar_Syntax_Syntax.Tm_meta uu____28511 ->
-                let uu____28518 = universe_of_aux env hd2  in
-                (uu____28518, args1)
-            | FStar_Syntax_Syntax.Tm_type uu____28529 ->
-                let uu____28530 = universe_of_aux env hd2  in
-                (uu____28530, args1)
-            | FStar_Syntax_Syntax.Tm_match (uu____28541,hd3::uu____28543) ->
-                let uu____28608 = FStar_Syntax_Subst.open_branch hd3  in
-                (match uu____28608 with
-                 | (uu____28623,uu____28624,hd4) ->
-                     let uu____28642 = FStar_Syntax_Util.head_and_args hd4
+            | FStar_Syntax_Syntax.Tm_fvar uu____28192 ->
+                let uu____28193 = universe_of_aux env hd2  in
+                (uu____28193, args1)
+            | FStar_Syntax_Syntax.Tm_name uu____28204 ->
+                let uu____28205 = universe_of_aux env hd2  in
+                (uu____28205, args1)
+            | FStar_Syntax_Syntax.Tm_uvar uu____28216 ->
+                let uu____28229 = universe_of_aux env hd2  in
+                (uu____28229, args1)
+            | FStar_Syntax_Syntax.Tm_uinst uu____28240 ->
+                let uu____28247 = universe_of_aux env hd2  in
+                (uu____28247, args1)
+            | FStar_Syntax_Syntax.Tm_ascribed uu____28258 ->
+                let uu____28285 = universe_of_aux env hd2  in
+                (uu____28285, args1)
+            | FStar_Syntax_Syntax.Tm_refine uu____28296 ->
+                let uu____28303 = universe_of_aux env hd2  in
+                (uu____28303, args1)
+            | FStar_Syntax_Syntax.Tm_constant uu____28314 ->
+                let uu____28315 = universe_of_aux env hd2  in
+                (uu____28315, args1)
+            | FStar_Syntax_Syntax.Tm_arrow uu____28326 ->
+                let uu____28341 = universe_of_aux env hd2  in
+                (uu____28341, args1)
+            | FStar_Syntax_Syntax.Tm_meta uu____28352 ->
+                let uu____28359 = universe_of_aux env hd2  in
+                (uu____28359, args1)
+            | FStar_Syntax_Syntax.Tm_type uu____28370 ->
+                let uu____28371 = universe_of_aux env hd2  in
+                (uu____28371, args1)
+            | FStar_Syntax_Syntax.Tm_match (uu____28382,hd3::uu____28384) ->
+                let uu____28449 = FStar_Syntax_Subst.open_branch hd3  in
+                (match uu____28449 with
+                 | (uu____28464,uu____28465,hd4) ->
+                     let uu____28483 = FStar_Syntax_Util.head_and_args hd4
                         in
-                     (match uu____28642 with
+                     (match uu____28483 with
                       | (hd5,args') ->
                           type_of_head retry hd5
                             (FStar_List.append args' args1)))
-            | uu____28707 when retry ->
+            | uu____28548 when retry ->
                 let e1 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Env.Beta;
                     FStar_TypeChecker_Env.DoNotUnfoldPureLets] env e
                    in
-                let uu____28709 = FStar_Syntax_Util.head_and_args e1  in
-                (match uu____28709 with
+                let uu____28550 = FStar_Syntax_Util.head_and_args e1  in
+                (match uu____28550 with
                  | (hd3,args2) -> type_of_head false hd3 args2)
-            | uu____28767 ->
-                let uu____28768 =
+            | uu____28608 ->
+                let uu____28609 =
                   FStar_TypeChecker_Env.clear_expected_typ env  in
-                (match uu____28768 with
-                 | (env1,uu____28790) ->
+                (match uu____28609 with
+                 | (env1,uu____28631) ->
                      let env2 =
-                       let uu___3769_28796 = env1  in
+                       let uu___3781_28637 = env1  in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3769_28796.FStar_TypeChecker_Env.solver);
+                           (uu___3781_28637.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3769_28796.FStar_TypeChecker_Env.range);
+                           (uu___3781_28637.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3769_28796.FStar_TypeChecker_Env.curmodule);
+                           (uu___3781_28637.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3769_28796.FStar_TypeChecker_Env.gamma);
+                           (uu___3781_28637.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3769_28796.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___3781_28637.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3769_28796.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___3781_28637.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3769_28796.FStar_TypeChecker_Env.modules);
+                           (uu___3781_28637.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3769_28796.FStar_TypeChecker_Env.expected_typ);
+                           (uu___3781_28637.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3769_28796.FStar_TypeChecker_Env.sigtab);
+                           (uu___3781_28637.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3769_28796.FStar_TypeChecker_Env.attrtab);
+                           (uu___3781_28637.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3769_28796.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___3781_28637.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3769_28796.FStar_TypeChecker_Env.effects);
+                           (uu___3781_28637.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3769_28796.FStar_TypeChecker_Env.generalize);
+                           (uu___3781_28637.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3769_28796.FStar_TypeChecker_Env.letrecs);
+                           (uu___3781_28637.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level = false;
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3769_28796.FStar_TypeChecker_Env.check_uvars);
+                           (uu___3781_28637.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3769_28796.FStar_TypeChecker_Env.use_eq);
+                           (uu___3781_28637.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.use_eq_strict =
-                           (uu___3769_28796.FStar_TypeChecker_Env.use_eq_strict);
+                           (uu___3781_28637.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3769_28796.FStar_TypeChecker_Env.is_iface);
+                           (uu___3781_28637.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3769_28796.FStar_TypeChecker_Env.admit);
+                           (uu___3781_28637.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3769_28796.FStar_TypeChecker_Env.lax_universes);
+                           (uu___3781_28637.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3769_28796.FStar_TypeChecker_Env.phase1);
+                           (uu___3781_28637.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3769_28796.FStar_TypeChecker_Env.failhard);
+                           (uu___3781_28637.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3769_28796.FStar_TypeChecker_Env.nosynth);
+                           (uu___3781_28637.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3769_28796.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___3781_28637.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3769_28796.FStar_TypeChecker_Env.tc_term);
+                           (uu___3781_28637.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3769_28796.FStar_TypeChecker_Env.type_of);
+                           (uu___3781_28637.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3769_28796.FStar_TypeChecker_Env.universe_of);
+                           (uu___3781_28637.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3769_28796.FStar_TypeChecker_Env.check_type_of);
+                           (uu___3781_28637.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts = true;
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3769_28796.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___3781_28637.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3769_28796.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___3781_28637.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3769_28796.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___3781_28637.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3769_28796.FStar_TypeChecker_Env.proof_ns);
+                           (uu___3781_28637.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3769_28796.FStar_TypeChecker_Env.synth_hook);
+                           (uu___3781_28637.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                           (uu___3769_28796.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                           (uu___3781_28637.FStar_TypeChecker_Env.try_solve_implicits_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3769_28796.FStar_TypeChecker_Env.splice);
+                           (uu___3781_28637.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.mpreprocess =
-                           (uu___3769_28796.FStar_TypeChecker_Env.mpreprocess);
+                           (uu___3781_28637.FStar_TypeChecker_Env.mpreprocess);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3769_28796.FStar_TypeChecker_Env.postprocess);
+                           (uu___3781_28637.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.is_native_tactic =
-                           (uu___3769_28796.FStar_TypeChecker_Env.is_native_tactic);
+                           (uu___3781_28637.FStar_TypeChecker_Env.is_native_tactic);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3769_28796.FStar_TypeChecker_Env.identifier_info);
+                           (uu___3781_28637.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3769_28796.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___3781_28637.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3769_28796.FStar_TypeChecker_Env.dsenv);
+                           (uu___3781_28637.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3769_28796.FStar_TypeChecker_Env.nbe);
+                           (uu___3781_28637.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3769_28796.FStar_TypeChecker_Env.strict_args_tab);
+                           (uu___3781_28637.FStar_TypeChecker_Env.strict_args_tab);
                          FStar_TypeChecker_Env.erasable_types_tab =
-                           (uu___3769_28796.FStar_TypeChecker_Env.erasable_types_tab)
+                           (uu___3781_28637.FStar_TypeChecker_Env.erasable_types_tab)
                        }  in
-                     ((let uu____28801 =
+                     ((let uu____28642 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env2)
                            (FStar_Options.Other "UniverseOf")
                           in
-                       if uu____28801
+                       if uu____28642
                        then
-                         let uu____28806 =
-                           let uu____28808 =
+                         let uu____28647 =
+                           let uu____28649 =
                              FStar_TypeChecker_Env.get_range env2  in
-                           FStar_Range.string_of_range uu____28808  in
-                         let uu____28809 =
+                           FStar_Range.string_of_range uu____28649  in
+                         let uu____28650 =
                            FStar_Syntax_Print.term_to_string hd2  in
                          FStar_Util.print2 "%s: About to type-check %s\n"
-                           uu____28806 uu____28809
+                           uu____28647 uu____28650
                        else ());
-                      (let uu____28814 = tc_term env2 hd2  in
-                       match uu____28814 with
-                       | (uu____28835,{
+                      (let uu____28655 = tc_term env2 hd2  in
+                       match uu____28655 with
+                       | (uu____28676,{
                                         FStar_TypeChecker_Common.eff_name =
-                                          uu____28836;
+                                          uu____28677;
                                         FStar_TypeChecker_Common.res_typ = t;
                                         FStar_TypeChecker_Common.cflags =
-                                          uu____28838;
+                                          uu____28679;
                                         FStar_TypeChecker_Common.comp_thunk =
-                                          uu____28839;_},g)
+                                          uu____28680;_},g)
                            ->
-                           ((let uu____28857 =
+                           ((let uu____28698 =
                                FStar_TypeChecker_Rel.solve_deferred_constraints
                                  env2 g
                                 in
-                             FStar_All.pipe_right uu____28857
-                               (fun uu____28858  -> ()));
+                             FStar_All.pipe_right uu____28698
+                               (fun uu____28699  -> ()));
                             (t, args1)))))
              in
-          let uu____28869 = type_of_head true hd args  in
-          (match uu____28869 with
+          let uu____28710 = type_of_head true hd args  in
+          (match uu____28710 with
            | (t,args1) ->
                let t1 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.UnfoldUntil
                       FStar_Syntax_Syntax.delta_constant] env t
                   in
-               let uu____28908 = FStar_Syntax_Util.arrow_formals_comp t1  in
-               (match uu____28908 with
+               let uu____28749 = FStar_Syntax_Util.arrow_formals_comp t1  in
+               (match uu____28749 with
                 | (bs,res) ->
                     let res1 = FStar_Syntax_Util.comp_result res  in
                     if (FStar_List.length bs) = (FStar_List.length args1)
@@ -11596,14 +11613,14 @@ let rec (universe_of_aux :
                          in
                       FStar_Syntax_Subst.subst subst res1
                     else
-                      (let uu____28936 =
+                      (let uu____28777 =
                          FStar_Syntax_Print.term_to_string res1  in
-                       level_of_type_fail env e uu____28936)))
-      | FStar_Syntax_Syntax.Tm_match (uu____28938,hd::uu____28940) ->
-          let uu____29005 = FStar_Syntax_Subst.open_branch hd  in
-          (match uu____29005 with
-           | (uu____29006,uu____29007,hd1) -> universe_of_aux env hd1)
-      | FStar_Syntax_Syntax.Tm_match (uu____29025,[]) ->
+                       level_of_type_fail env e uu____28777)))
+      | FStar_Syntax_Syntax.Tm_match (uu____28779,hd::uu____28781) ->
+          let uu____28846 = FStar_Syntax_Subst.open_branch hd  in
+          (match uu____28846 with
+           | (uu____28847,uu____28848,hd1) -> universe_of_aux env hd1)
+      | FStar_Syntax_Syntax.Tm_match (uu____28866,[]) ->
           level_of_type_fail env e "empty match cases"
   
 let (universe_of :
@@ -11612,8 +11629,8 @@ let (universe_of :
   =
   fun env  ->
     fun e  ->
-      let uu____29072 = universe_of_aux env e  in
-      level_of_type env e uu____29072
+      let uu____28913 = universe_of_aux env e  in
+      level_of_type env e uu____28913
   
 let (tc_tparams :
   FStar_TypeChecker_Env.env_t ->
@@ -11623,8 +11640,8 @@ let (tc_tparams :
   =
   fun env0  ->
     fun tps  ->
-      let uu____29096 = tc_binders env0 tps  in
-      match uu____29096 with
+      let uu____28937 = tc_binders env0 tps  in
+      match uu____28937 with
       | (tps1,env,g,us) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env0 g; (tps1, env, us))
   
@@ -11641,142 +11658,142 @@ let rec (type_of_well_typed_term :
          in
       let t1 = FStar_Syntax_Subst.compress t  in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____29154 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_bvar uu____29172 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____28995 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_bvar uu____29013 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name x ->
           FStar_Pervasives_Native.Some (x.FStar_Syntax_Syntax.sort)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____29178 = FStar_Syntax_Util.unfold_lazy i  in
-          type_of_well_typed_term env uu____29178
+          let uu____29019 = FStar_Syntax_Util.unfold_lazy i  in
+          type_of_well_typed_term env uu____29019
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____29180 =
+          let uu____29021 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env []
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          FStar_Util.bind_opt uu____29180
-            (fun uu____29194  ->
-               match uu____29194 with
-               | (t2,uu____29202) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu____29021
+            (fun uu____29035  ->
+               match uu____29035 with
+               | (t2,uu____29043) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____29204;
-             FStar_Syntax_Syntax.vars = uu____29205;_},us)
+             FStar_Syntax_Syntax.pos = uu____29045;
+             FStar_Syntax_Syntax.vars = uu____29046;_},us)
           ->
-          let uu____29211 =
+          let uu____29052 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env us
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          FStar_Util.bind_opt uu____29211
-            (fun uu____29225  ->
-               match uu____29225 with
-               | (t2,uu____29233) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu____29052
+            (fun uu____29066  ->
+               match uu____29066 with
+               | (t2,uu____29074) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify ) ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect
-          uu____29234) -> FStar_Pervasives_Native.None
+          uu____29075) -> FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_constant sc ->
-          let uu____29236 = tc_constant env t1.FStar_Syntax_Syntax.pos sc  in
-          FStar_Pervasives_Native.Some uu____29236
+          let uu____29077 = tc_constant env t1.FStar_Syntax_Syntax.pos sc  in
+          FStar_Pervasives_Native.Some uu____29077
       | FStar_Syntax_Syntax.Tm_type u ->
-          let uu____29238 = mk_tm_type (FStar_Syntax_Syntax.U_succ u)  in
-          FStar_Pervasives_Native.Some uu____29238
+          let uu____29079 = mk_tm_type (FStar_Syntax_Syntax.U_succ u)  in
+          FStar_Pervasives_Native.Some uu____29079
       | FStar_Syntax_Syntax.Tm_abs
           (bs,body,FStar_Pervasives_Native.Some
            { FStar_Syntax_Syntax.residual_effect = eff;
              FStar_Syntax_Syntax.residual_typ = FStar_Pervasives_Native.Some
                tbody;
-             FStar_Syntax_Syntax.residual_flags = uu____29243;_})
+             FStar_Syntax_Syntax.residual_flags = uu____29084;_})
           ->
           let mk_comp =
-            let uu____29287 =
+            let uu____29128 =
               FStar_Ident.lid_equals eff FStar_Parser_Const.effect_Tot_lid
                in
-            if uu____29287
+            if uu____29128
             then FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_Total'
             else
-              (let uu____29318 =
+              (let uu____29159 =
                  FStar_Ident.lid_equals eff
                    FStar_Parser_Const.effect_GTot_lid
                   in
-               if uu____29318
+               if uu____29159
                then
                  FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_GTotal'
                else FStar_Pervasives_Native.None)
              in
           FStar_Util.bind_opt mk_comp
             (fun f  ->
-               let uu____29388 = universe_of_well_typed_term env tbody  in
-               FStar_Util.bind_opt uu____29388
+               let uu____29229 = universe_of_well_typed_term env tbody  in
+               FStar_Util.bind_opt uu____29229
                  (fun u  ->
-                    let uu____29396 =
-                      let uu____29399 =
-                        let uu____29406 =
-                          let uu____29407 =
-                            let uu____29422 =
+                    let uu____29237 =
+                      let uu____29240 =
+                        let uu____29247 =
+                          let uu____29248 =
+                            let uu____29263 =
                               f tbody (FStar_Pervasives_Native.Some u)  in
-                            (bs, uu____29422)  in
-                          FStar_Syntax_Syntax.Tm_arrow uu____29407  in
-                        FStar_Syntax_Syntax.mk uu____29406  in
-                      uu____29399 FStar_Pervasives_Native.None
+                            (bs, uu____29263)  in
+                          FStar_Syntax_Syntax.Tm_arrow uu____29248  in
+                        FStar_Syntax_Syntax.mk uu____29247  in
+                      uu____29240 FStar_Pervasives_Native.None
                         t1.FStar_Syntax_Syntax.pos
                        in
-                    FStar_Pervasives_Native.Some uu____29396))
+                    FStar_Pervasives_Native.Some uu____29237))
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____29459 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____29459 with
+          let uu____29300 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____29300 with
            | (bs1,c1) ->
                let rec aux env1 us bs2 =
                  match bs2 with
                  | [] ->
-                     let uu____29518 =
+                     let uu____29359 =
                        universe_of_well_typed_term env1
                          (FStar_Syntax_Util.comp_result c1)
                         in
-                     FStar_Util.bind_opt uu____29518
+                     FStar_Util.bind_opt uu____29359
                        (fun uc  ->
-                          let uu____29526 =
+                          let uu____29367 =
                             mk_tm_type (FStar_Syntax_Syntax.U_max (uc :: us))
                              in
-                          FStar_Pervasives_Native.Some uu____29526)
+                          FStar_Pervasives_Native.Some uu____29367)
                  | (x,imp)::bs3 ->
-                     let uu____29552 =
+                     let uu____29393 =
                        universe_of_well_typed_term env1
                          x.FStar_Syntax_Syntax.sort
                         in
-                     FStar_Util.bind_opt uu____29552
+                     FStar_Util.bind_opt uu____29393
                        (fun u_x  ->
                           let env2 = FStar_TypeChecker_Env.push_bv env1 x  in
                           aux env2 (u_x :: us) bs3)
                   in
                aux env [] bs1)
-      | FStar_Syntax_Syntax.Tm_abs uu____29561 ->
+      | FStar_Syntax_Syntax.Tm_abs uu____29402 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____29581) ->
-          let uu____29586 =
+      | FStar_Syntax_Syntax.Tm_refine (x,uu____29422) ->
+          let uu____29427 =
             universe_of_well_typed_term env x.FStar_Syntax_Syntax.sort  in
-          FStar_Util.bind_opt uu____29586
+          FStar_Util.bind_opt uu____29427
             (fun u_x  ->
-               let uu____29594 = mk_tm_type u_x  in
-               FStar_Pervasives_Native.Some uu____29594)
+               let uu____29435 = mk_tm_type u_x  in
+               FStar_Pervasives_Native.Some uu____29435)
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____29599;
-             FStar_Syntax_Syntax.vars = uu____29600;_},a::hd::rest)
+             FStar_Syntax_Syntax.pos = uu____29440;
+             FStar_Syntax_Syntax.vars = uu____29441;_},a::hd::rest)
           ->
           let rest1 = hd :: rest  in
-          let uu____29679 = FStar_Syntax_Util.head_and_args t1  in
-          (match uu____29679 with
-           | (unary_op,uu____29699) ->
+          let uu____29520 = FStar_Syntax_Util.head_and_args t1  in
+          (match uu____29520 with
+           | (unary_op,uu____29540) ->
                let head =
-                 let uu____29727 =
+                 let uu____29568 =
                    FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
                     in
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))
-                   FStar_Pervasives_Native.None uu____29727
+                   FStar_Pervasives_Native.None uu____29568
                   in
                let t2 =
                  FStar_Syntax_Syntax.mk
@@ -11788,21 +11805,21 @@ let rec (type_of_well_typed_term :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____29775;
-             FStar_Syntax_Syntax.vars = uu____29776;_},a1::a2::hd::rest)
+             FStar_Syntax_Syntax.pos = uu____29616;
+             FStar_Syntax_Syntax.vars = uu____29617;_},a1::a2::hd::rest)
           ->
           let rest1 = hd :: rest  in
-          let uu____29872 = FStar_Syntax_Util.head_and_args t1  in
-          (match uu____29872 with
-           | (unary_op,uu____29892) ->
+          let uu____29713 = FStar_Syntax_Util.head_and_args t1  in
+          (match uu____29713 with
+           | (unary_op,uu____29733) ->
                let head =
-                 let uu____29920 =
+                 let uu____29761 =
                    FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos
                     in
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))
-                   FStar_Pervasives_Native.None uu____29920
+                   FStar_Pervasives_Native.None uu____29761
                   in
                let t2 =
                  FStar_Syntax_Syntax.mk
@@ -11814,32 +11831,32 @@ let rec (type_of_well_typed_term :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____29976;
-             FStar_Syntax_Syntax.vars = uu____29977;_},uu____29978::[])
+             FStar_Syntax_Syntax.pos = uu____29817;
+             FStar_Syntax_Syntax.vars = uu____29818;_},uu____29819::[])
           -> FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_range
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____30017;
-             FStar_Syntax_Syntax.vars = uu____30018;_},(t2,uu____30020)::uu____30021::[])
+             FStar_Syntax_Syntax.pos = uu____29858;
+             FStar_Syntax_Syntax.vars = uu____29859;_},(t2,uu____29861)::uu____29862::[])
           -> type_of_well_typed_term env t2
       | FStar_Syntax_Syntax.Tm_app (hd,args) ->
           let t_hd = type_of_well_typed_term env hd  in
           let rec aux t_hd1 =
-            let uu____30117 =
-              let uu____30118 =
+            let uu____29958 =
+              let uu____29959 =
                 FStar_TypeChecker_Normalize.unfold_whnf env t_hd1  in
-              uu____30118.FStar_Syntax_Syntax.n  in
-            match uu____30117 with
+              uu____29959.FStar_Syntax_Syntax.n  in
+            match uu____29958 with
             | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                 let n_args = FStar_List.length args  in
                 let n_bs = FStar_List.length bs  in
                 let bs_t_opt =
                   if n_args < n_bs
                   then
-                    let uu____30191 = FStar_Util.first_N n_args bs  in
-                    match uu____30191 with
+                    let uu____30032 = FStar_Util.first_N n_args bs  in
+                    match uu____30032 with
                     | (bs1,rest) ->
                         let t2 =
                           FStar_Syntax_Syntax.mk
@@ -11847,24 +11864,24 @@ let rec (type_of_well_typed_term :
                             FStar_Pervasives_Native.None
                             t_hd1.FStar_Syntax_Syntax.pos
                            in
-                        let uu____30279 =
-                          let uu____30284 = FStar_Syntax_Syntax.mk_Total t2
+                        let uu____30120 =
+                          let uu____30125 = FStar_Syntax_Syntax.mk_Total t2
                              in
-                          FStar_Syntax_Subst.open_comp bs1 uu____30284  in
-                        (match uu____30279 with
+                          FStar_Syntax_Subst.open_comp bs1 uu____30125  in
+                        (match uu____30120 with
                          | (bs2,c1) ->
                              FStar_Pervasives_Native.Some
                                (bs2, (FStar_Syntax_Util.comp_result c1)))
                   else
                     if n_args = n_bs
                     then
-                      (let uu____30338 = FStar_Syntax_Subst.open_comp bs c
+                      (let uu____30179 = FStar_Syntax_Subst.open_comp bs c
                           in
-                       match uu____30338 with
+                       match uu____30179 with
                        | (bs1,c1) ->
-                           let uu____30359 =
+                           let uu____30200 =
                              FStar_Syntax_Util.is_tot_or_gtot_comp c1  in
-                           if uu____30359
+                           if uu____30200
                            then
                              FStar_Pervasives_Native.Some
                                (bs1, (FStar_Syntax_Util.comp_result c1))
@@ -11872,8 +11889,8 @@ let rec (type_of_well_typed_term :
                     else FStar_Pervasives_Native.None
                    in
                 FStar_Util.bind_opt bs_t_opt
-                  (fun uu____30441  ->
-                     match uu____30441 with
+                  (fun uu____30282  ->
+                     match uu____30282 with
                      | (bs1,t2) ->
                          let subst =
                            FStar_List.map2
@@ -11884,36 +11901,36 @@ let rec (type_of_well_typed_term :
                                       (FStar_Pervasives_Native.fst a))) bs1
                              args
                             in
-                         let uu____30517 = FStar_Syntax_Subst.subst subst t2
+                         let uu____30358 = FStar_Syntax_Subst.subst subst t2
                             in
-                         FStar_Pervasives_Native.Some uu____30517)
-            | FStar_Syntax_Syntax.Tm_refine (x,uu____30519) ->
+                         FStar_Pervasives_Native.Some uu____30358)
+            | FStar_Syntax_Syntax.Tm_refine (x,uu____30360) ->
                 aux x.FStar_Syntax_Syntax.sort
-            | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____30525,uu____30526) ->
+            | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____30366,uu____30367) ->
                 aux t2
-            | uu____30567 -> FStar_Pervasives_Native.None  in
+            | uu____30408 -> FStar_Pervasives_Native.None  in
           FStar_Util.bind_opt t_hd aux
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____30568,(FStar_Util.Inl t2,uu____30570),uu____30571) ->
+          (uu____30409,(FStar_Util.Inl t2,uu____30411),uu____30412) ->
           FStar_Pervasives_Native.Some t2
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____30618,(FStar_Util.Inr c,uu____30620),uu____30621) ->
+          (uu____30459,(FStar_Util.Inr c,uu____30461),uu____30462) ->
           FStar_Pervasives_Native.Some (FStar_Syntax_Util.comp_result c)
       | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
-          let uu____30686 =
+          let uu____30527 =
             FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
              in
-          FStar_Pervasives_Native.Some uu____30686
+          FStar_Pervasives_Native.Some uu____30527
       | FStar_Syntax_Syntax.Tm_quoted (tm,qi) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_term
-      | FStar_Syntax_Syntax.Tm_meta (t2,uu____30694) ->
+      | FStar_Syntax_Syntax.Tm_meta (t2,uu____30535) ->
           type_of_well_typed_term env t2
-      | FStar_Syntax_Syntax.Tm_match uu____30699 ->
+      | FStar_Syntax_Syntax.Tm_match uu____30540 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_let uu____30722 ->
+      | FStar_Syntax_Syntax.Tm_let uu____30563 ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uinst uu____30736 ->
+      | FStar_Syntax_Syntax.Tm_uinst uu____30577 ->
           FStar_Pervasives_Native.None
 
 and (universe_of_well_typed_term :
@@ -11923,14 +11940,14 @@ and (universe_of_well_typed_term :
   =
   fun env  ->
     fun t  ->
-      let uu____30747 = type_of_well_typed_term env t  in
-      match uu____30747 with
+      let uu____30588 = type_of_well_typed_term env t  in
+      match uu____30588 with
       | FStar_Pervasives_Native.Some
           { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_type u;
-            FStar_Syntax_Syntax.pos = uu____30753;
-            FStar_Syntax_Syntax.vars = uu____30754;_}
+            FStar_Syntax_Syntax.pos = uu____30594;
+            FStar_Syntax_Syntax.vars = uu____30595;_}
           -> FStar_Pervasives_Native.Some u
-      | uu____30757 -> FStar_Pervasives_Native.None
+      | uu____30598 -> FStar_Pervasives_Native.None
 
 let (check_type_of_well_typed_term' :
   Prims.bool ->
@@ -11944,148 +11961,148 @@ let (check_type_of_well_typed_term' :
         fun k  ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k  in
           let env2 =
-            let uu___4048_30785 = env1  in
+            let uu___4060_30626 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___4048_30785.FStar_TypeChecker_Env.solver);
+                (uu___4060_30626.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___4048_30785.FStar_TypeChecker_Env.range);
+                (uu___4060_30626.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___4048_30785.FStar_TypeChecker_Env.curmodule);
+                (uu___4060_30626.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___4048_30785.FStar_TypeChecker_Env.gamma);
+                (uu___4060_30626.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___4048_30785.FStar_TypeChecker_Env.gamma_sig);
+                (uu___4060_30626.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___4048_30785.FStar_TypeChecker_Env.gamma_cache);
+                (uu___4060_30626.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___4048_30785.FStar_TypeChecker_Env.modules);
+                (uu___4060_30626.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___4048_30785.FStar_TypeChecker_Env.expected_typ);
+                (uu___4060_30626.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___4048_30785.FStar_TypeChecker_Env.sigtab);
+                (uu___4060_30626.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___4048_30785.FStar_TypeChecker_Env.attrtab);
+                (uu___4060_30626.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___4048_30785.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___4060_30626.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___4048_30785.FStar_TypeChecker_Env.effects);
+                (uu___4060_30626.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___4048_30785.FStar_TypeChecker_Env.generalize);
+                (uu___4060_30626.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___4048_30785.FStar_TypeChecker_Env.letrecs);
+                (uu___4060_30626.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___4048_30785.FStar_TypeChecker_Env.top_level);
+                (uu___4060_30626.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___4048_30785.FStar_TypeChecker_Env.check_uvars);
+                (uu___4060_30626.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___4048_30785.FStar_TypeChecker_Env.use_eq);
+                (uu___4060_30626.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___4048_30785.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___4060_30626.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___4048_30785.FStar_TypeChecker_Env.is_iface);
+                (uu___4060_30626.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___4048_30785.FStar_TypeChecker_Env.admit);
+                (uu___4060_30626.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___4048_30785.FStar_TypeChecker_Env.lax);
+                (uu___4060_30626.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___4048_30785.FStar_TypeChecker_Env.lax_universes);
+                (uu___4060_30626.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___4048_30785.FStar_TypeChecker_Env.phase1);
+                (uu___4060_30626.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___4048_30785.FStar_TypeChecker_Env.failhard);
+                (uu___4060_30626.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___4048_30785.FStar_TypeChecker_Env.nosynth);
+                (uu___4060_30626.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___4048_30785.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___4060_30626.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___4048_30785.FStar_TypeChecker_Env.tc_term);
+                (uu___4060_30626.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___4048_30785.FStar_TypeChecker_Env.type_of);
+                (uu___4060_30626.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___4048_30785.FStar_TypeChecker_Env.universe_of);
+                (uu___4060_30626.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___4048_30785.FStar_TypeChecker_Env.check_type_of);
+                (uu___4060_30626.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___4048_30785.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___4060_30626.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___4048_30785.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___4060_30626.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___4048_30785.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___4060_30626.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___4048_30785.FStar_TypeChecker_Env.proof_ns);
+                (uu___4060_30626.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___4048_30785.FStar_TypeChecker_Env.synth_hook);
+                (uu___4060_30626.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___4048_30785.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___4060_30626.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___4048_30785.FStar_TypeChecker_Env.splice);
+                (uu___4060_30626.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___4048_30785.FStar_TypeChecker_Env.mpreprocess);
+                (uu___4060_30626.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___4048_30785.FStar_TypeChecker_Env.postprocess);
+                (uu___4060_30626.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.is_native_tactic =
-                (uu___4048_30785.FStar_TypeChecker_Env.is_native_tactic);
+                (uu___4060_30626.FStar_TypeChecker_Env.is_native_tactic);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___4048_30785.FStar_TypeChecker_Env.identifier_info);
+                (uu___4060_30626.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___4048_30785.FStar_TypeChecker_Env.tc_hooks);
+                (uu___4060_30626.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___4048_30785.FStar_TypeChecker_Env.dsenv);
+                (uu___4060_30626.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___4048_30785.FStar_TypeChecker_Env.nbe);
+                (uu___4060_30626.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___4048_30785.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___4060_30626.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___4048_30785.FStar_TypeChecker_Env.erasable_types_tab)
+                (uu___4060_30626.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let slow_check uu____30792 =
+          let slow_check uu____30633 =
             if must_total
             then
-              let uu____30794 = env2.FStar_TypeChecker_Env.type_of env2 t  in
-              match uu____30794 with | (uu____30801,uu____30802,g) -> g
+              let uu____30635 = env2.FStar_TypeChecker_Env.type_of env2 t  in
+              match uu____30635 with | (uu____30642,uu____30643,g) -> g
             else
-              (let uu____30806 = env2.FStar_TypeChecker_Env.tc_term env2 t
+              (let uu____30647 = env2.FStar_TypeChecker_Env.tc_term env2 t
                   in
-               match uu____30806 with | (uu____30813,uu____30814,g) -> g)
+               match uu____30647 with | (uu____30654,uu____30655,g) -> g)
              in
-          let uu____30816 = type_of_well_typed_term env2 t  in
-          match uu____30816 with
+          let uu____30657 = type_of_well_typed_term env2 t  in
+          match uu____30657 with
           | FStar_Pervasives_Native.None  -> slow_check ()
           | FStar_Pervasives_Native.Some k' ->
-              ((let uu____30821 =
+              ((let uu____30662 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                     (FStar_Options.Other "FastImplicits")
                    in
-                if uu____30821
+                if uu____30662
                 then
-                  let uu____30826 =
+                  let uu____30667 =
                     FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos  in
-                  let uu____30828 = FStar_Syntax_Print.term_to_string t  in
-                  let uu____30830 = FStar_Syntax_Print.term_to_string k'  in
-                  let uu____30832 = FStar_Syntax_Print.term_to_string k  in
+                  let uu____30669 = FStar_Syntax_Print.term_to_string t  in
+                  let uu____30671 = FStar_Syntax_Print.term_to_string k'  in
+                  let uu____30673 = FStar_Syntax_Print.term_to_string k  in
                   FStar_Util.print4 "(%s) Fast check  %s : %s <:? %s\n"
-                    uu____30826 uu____30828 uu____30830 uu____30832
+                    uu____30667 uu____30669 uu____30671 uu____30673
                 else ());
                (let g = FStar_TypeChecker_Rel.subtype_nosmt env2 k' k  in
-                (let uu____30841 =
+                (let uu____30682 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                      (FStar_Options.Other "FastImplicits")
                     in
-                 if uu____30841
+                 if uu____30682
                  then
-                   let uu____30846 =
+                   let uu____30687 =
                      FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos
                       in
-                   let uu____30848 = FStar_Syntax_Print.term_to_string t  in
-                   let uu____30850 = FStar_Syntax_Print.term_to_string k'  in
-                   let uu____30852 = FStar_Syntax_Print.term_to_string k  in
+                   let uu____30689 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____30691 = FStar_Syntax_Print.term_to_string k'  in
+                   let uu____30693 = FStar_Syntax_Print.term_to_string k  in
                    FStar_Util.print5 "(%s) Fast check %s: %s : %s <: %s\n"
-                     uu____30846
+                     uu____30687
                      (if FStar_Option.isSome g
                       then "succeeded with guard"
-                      else "failed") uu____30848 uu____30850 uu____30852
+                      else "failed") uu____30689 uu____30691 uu____30693
                  else ());
                 (match g with
                  | FStar_Pervasives_Native.None  -> slow_check ()
@@ -12103,116 +12120,116 @@ let (check_type_of_well_typed_term :
         fun k  ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k  in
           let env2 =
-            let uu___4079_30889 = env1  in
+            let uu___4091_30730 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___4079_30889.FStar_TypeChecker_Env.solver);
+                (uu___4091_30730.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___4079_30889.FStar_TypeChecker_Env.range);
+                (uu___4091_30730.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___4079_30889.FStar_TypeChecker_Env.curmodule);
+                (uu___4091_30730.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___4079_30889.FStar_TypeChecker_Env.gamma);
+                (uu___4091_30730.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___4079_30889.FStar_TypeChecker_Env.gamma_sig);
+                (uu___4091_30730.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___4079_30889.FStar_TypeChecker_Env.gamma_cache);
+                (uu___4091_30730.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___4079_30889.FStar_TypeChecker_Env.modules);
+                (uu___4091_30730.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___4079_30889.FStar_TypeChecker_Env.expected_typ);
+                (uu___4091_30730.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___4079_30889.FStar_TypeChecker_Env.sigtab);
+                (uu___4091_30730.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___4079_30889.FStar_TypeChecker_Env.attrtab);
+                (uu___4091_30730.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___4079_30889.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___4091_30730.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___4079_30889.FStar_TypeChecker_Env.effects);
+                (uu___4091_30730.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___4079_30889.FStar_TypeChecker_Env.generalize);
+                (uu___4091_30730.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___4079_30889.FStar_TypeChecker_Env.letrecs);
+                (uu___4091_30730.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___4079_30889.FStar_TypeChecker_Env.top_level);
+                (uu___4091_30730.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___4079_30889.FStar_TypeChecker_Env.check_uvars);
+                (uu___4091_30730.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___4079_30889.FStar_TypeChecker_Env.use_eq);
+                (uu___4091_30730.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___4079_30889.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___4091_30730.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___4079_30889.FStar_TypeChecker_Env.is_iface);
+                (uu___4091_30730.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___4079_30889.FStar_TypeChecker_Env.admit);
+                (uu___4091_30730.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___4079_30889.FStar_TypeChecker_Env.lax);
+                (uu___4091_30730.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___4079_30889.FStar_TypeChecker_Env.lax_universes);
+                (uu___4091_30730.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___4079_30889.FStar_TypeChecker_Env.phase1);
+                (uu___4091_30730.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___4079_30889.FStar_TypeChecker_Env.failhard);
+                (uu___4091_30730.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___4079_30889.FStar_TypeChecker_Env.nosynth);
+                (uu___4091_30730.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___4079_30889.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___4091_30730.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___4079_30889.FStar_TypeChecker_Env.tc_term);
+                (uu___4091_30730.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___4079_30889.FStar_TypeChecker_Env.type_of);
+                (uu___4091_30730.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___4079_30889.FStar_TypeChecker_Env.universe_of);
+                (uu___4091_30730.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___4079_30889.FStar_TypeChecker_Env.check_type_of);
+                (uu___4091_30730.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___4079_30889.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___4091_30730.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___4079_30889.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___4091_30730.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___4079_30889.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___4091_30730.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___4079_30889.FStar_TypeChecker_Env.proof_ns);
+                (uu___4091_30730.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___4079_30889.FStar_TypeChecker_Env.synth_hook);
+                (uu___4091_30730.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___4079_30889.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___4091_30730.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___4079_30889.FStar_TypeChecker_Env.splice);
+                (uu___4091_30730.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___4079_30889.FStar_TypeChecker_Env.mpreprocess);
+                (uu___4091_30730.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___4079_30889.FStar_TypeChecker_Env.postprocess);
+                (uu___4091_30730.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.is_native_tactic =
-                (uu___4079_30889.FStar_TypeChecker_Env.is_native_tactic);
+                (uu___4091_30730.FStar_TypeChecker_Env.is_native_tactic);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___4079_30889.FStar_TypeChecker_Env.identifier_info);
+                (uu___4091_30730.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___4079_30889.FStar_TypeChecker_Env.tc_hooks);
+                (uu___4091_30730.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___4079_30889.FStar_TypeChecker_Env.dsenv);
+                (uu___4091_30730.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___4079_30889.FStar_TypeChecker_Env.nbe);
+                (uu___4091_30730.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___4079_30889.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___4091_30730.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___4079_30889.FStar_TypeChecker_Env.erasable_types_tab)
+                (uu___4091_30730.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let slow_check uu____30896 =
+          let slow_check uu____30737 =
             if must_total
             then
-              let uu____30898 = env2.FStar_TypeChecker_Env.type_of env2 t  in
-              match uu____30898 with | (uu____30905,uu____30906,g) -> g
+              let uu____30739 = env2.FStar_TypeChecker_Env.type_of env2 t  in
+              match uu____30739 with | (uu____30746,uu____30747,g) -> g
             else
-              (let uu____30910 = env2.FStar_TypeChecker_Env.tc_term env2 t
+              (let uu____30751 = env2.FStar_TypeChecker_Env.tc_term env2 t
                   in
-               match uu____30910 with | (uu____30917,uu____30918,g) -> g)
+               match uu____30751 with | (uu____30758,uu____30759,g) -> g)
              in
-          let uu____30920 =
-            let uu____30922 = FStar_Options.__temp_fast_implicits ()  in
-            FStar_All.pipe_left Prims.op_Negation uu____30922  in
-          if uu____30920
+          let uu____30761 =
+            let uu____30763 = FStar_Options.__temp_fast_implicits ()  in
+            FStar_All.pipe_left Prims.op_Negation uu____30763  in
+          if uu____30761
           then slow_check ()
           else check_type_of_well_typed_term' must_total env2 t k
   

--- a/src/syntax/FStar.Syntax.Syntax.fs
+++ b/src/syntax/FStar.Syntax.Syntax.fs
@@ -622,6 +622,7 @@ let freenames_of_binders (bs:binders) : freenames =
 let binders_of_list fvs : binders = (fvs |> List.map (fun t -> t, None))
 let binders_of_freenames (fvs:freenames) = Util.set_elements fvs |> binders_of_list
 let is_implicit = function Some (Implicit _) -> true | _ -> false
+let is_implicit_or_meta = function Some (Implicit _) | Some (Meta _) -> true | _ -> false
 let as_implicit = function true -> Some imp_tag | _ -> None
 
 let pat_bvs (p:pat) : list<bv> =

--- a/src/syntax/FStar.Syntax.Syntax.fsi
+++ b/src/syntax/FStar.Syntax.Syntax.fsi
@@ -575,6 +575,7 @@ val is_null_binder: binder -> bool
 val argpos:         arg -> Range.range
 val pat_bvs:        pat -> list<bv>
 val is_implicit:    aqual -> bool
+val is_implicit_or_meta: aqual -> bool
 val as_implicit:    bool -> aqual
 val is_top_level:   list<letbinding> -> bool
 

--- a/tests/micro-benchmarks/LambdaImplicits.fst
+++ b/tests/micro-benchmarks/LambdaImplicits.fst
@@ -1,0 +1,75 @@
+module LambdaImplicits
+
+val id0 : #a:Type -> a -> a
+let id0 #a x = x
+
+val id1 : #a:Type -> a -> a
+let id1 x = x
+
+val id2 : a:Type -> a -> a
+[@(expect_failure [189])]
+let id2 x = x
+
+val id3 : a:Type -> a -> a
+[@(expect_failure [91])]
+let id3 #a x = x
+
+val id4 : #a:Type -> a -> a
+
+(* This should fail, but the error is awful:
+ *
+ * Test.fst(22,14-22,15): (Error 66) Failed to resolve implicit argument ?1 of
+ * type Type introduced for user-provided implicit term at Test.fst(22,14-22,15)
+ *
+ * Coming from the fact that `fun #_ a x -> x <: #a:Type -> a -> a`
+ * (almost) succeeds phase 1 checking, but then the implicit type
+ * for `x` cannot be solved. This is the case even before allowing
+ * implicit instantiation in lambdas. *)
+[@(expect_failure [66])]
+let id4 a x = x
+
+val fst0 : #a:Type -> a & a -> a
+let fst0 (x, _) = x
+
+val fst : #a:Type -> #b:Type -> a & b -> a
+let fst (x, _) = x
+
+val safe_hd : #a:Type -> list a -> option a
+let safe_hd = function
+              | [] -> None
+              | h::_ -> Some h
+
+val bind_opt : #a:Type -> #b:Type -> option a -> (a -> option b) -> option b
+let bind_opt o f =
+  match o with
+  | None -> None
+  | Some x -> f x
+
+val bind_opt' : #a:_ -> #b:_ -> (option a & (a -> option b)) -> option b
+let bind_opt' =
+  function
+  | None, _ -> None
+  | Some x, f -> f x
+
+(* Can't have a val, see #604 *)
+let poly2 (f : (#a:Type -> a -> list a)) : list int & list bool = f 1, f true
+
+let call_poly2 = poly2 (fun x -> [x])
+
+val dep : #a:Type -> (#l : list a) -> unit -> int
+let dep () = 1
+
+val app_pure : #a:Type -> #req:_ -> #ens:_
+               -> (unit -> Pure a req ens) -> squash req -> Tot a
+let app_pure f _ = f ()
+
+val app_pure2 : #a:Type -> #req:_ -> #ens:_
+               -> (unit -> Pure a req ens) -> Tot a
+let app_pure2 #_ #req f = assume req; f ()
+
+(* Doesn't work due to the arity check for let recs *)
+(* val rev : #a:Type -> list a -> list a *)
+(* let rec rev xs = *)
+(*     match xs with *)
+(*     | h :: t-> rev t @ [h] *)
+(*     | [] -> [] *)


### PR DESCRIPTION
This PR makes the typechecker introduce (nameless) implicit arguments on lambdas where an implicit was expected but an explicit binder was given.

This makes the following work:
```fstar
val id : #a:Type -> a -> a
let id x = x
```
without having to add a `#a` binder. See the test file added for many more examples.