### PR TITLE
Better UF errors + defensive RO mode

### DIFF
--- a/src/basic/FStar.Errors.fs
+++ b/src/basic/FStar.Errors.fs
@@ -344,6 +344,7 @@ type raw_error =
   | Warning_IgnoredBinding
   | Warning_AbstractQualifier
   | Warning_CouldNotReadHints
+  | Fatal_BadUvar
 
 type flag = error_flag
 
@@ -685,6 +686,7 @@ let default_flags =
   (Warning_IgnoredBinding                            , CWarning);
   (Warning_AbstractQualifier                         , CWarning);
   (Warning_CouldNotReadHints                         , CWarning); // 333
+  (Fatal_BadUvar                                     , CFatal);
   ]
   (* Protip: if we keep the semicolon at the end, we modify exactly one
    * line for each error we add. This means we get a cleaner git history/blame *)

--- a/src/extraction/FStar.Extraction.ML.Modul.fs
+++ b/src/extraction/FStar.Extraction.ML.Modul.fs
@@ -34,6 +34,7 @@ module MLS = FStar.Extraction.ML.Syntax
 module BU = FStar.Util
 module S  = FStar.Syntax.Syntax
 module SS = FStar.Syntax.Subst
+module UF = FStar.Syntax.Unionfind
 module U  = FStar.Syntax.Util
 module TC = FStar.TypeChecker.Tc
 module N  = FStar.TypeChecker.Normalize
@@ -653,14 +654,15 @@ let extract_iface' (g:env_t) modul =
     res
 
 let extract_iface (g:env_t) modul =
-    let g, iface =
+  let g, iface =
+    UF.with_uf_enabled (fun () ->
       if Options.debug_any()
       then FStar.Util.measure_execution_time
              (BU.format1 "Extracted interface of %s" (string_of_lid modul.name))
              (fun () -> extract_iface' g modul)
-      else extract_iface' g modul
-    in
-    UEnv.exit_module g, iface
+      else extract_iface' g modul)
+  in
+  UEnv.exit_module g, iface
 
 (********************************************************************************************)
 (* Extract Implementations *)
@@ -982,12 +984,14 @@ let extract (g:uenv) (m:modul) =
   ignore <| Options.restore_cmd_line_options true;
   if not (Options.should_extract (string_of_lid m.name))
   then failwith (BU.format1 "Extract called on a module %s that should not be extracted" (Ident.string_of_lid m.name));
-  if Options.interactive() then g, None else
+  if Options.interactive() then g, None else begin
   let g, mllib =
+    UF.with_uf_enabled (fun () ->
       if Options.debug_any ()
       then let msg = BU.format1 "Extracting module %s" (Print.lid_to_string m.name) in
            BU.measure_execution_time msg (fun () -> extract' g m)
-      else extract' g m
+      else extract' g m)
   in
   ignore <| Options.restore_cmd_line_options true;
   exit_module g, mllib
+  end

--- a/src/fstar/FStar.CheckedFiles.fs
+++ b/src/fstar/FStar.CheckedFiles.fs
@@ -42,7 +42,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It need to be kept in sync with prims.fst
  *)
-let cache_version_number = 21
+let cache_version_number = 22
 
 type tc_result = {
   checked_module: Syntax.modul; //persisted

--- a/src/fstar/FStar.Main.fs
+++ b/src/fstar/FStar.Main.fs
@@ -23,6 +23,7 @@ open FStar.Ident
 open FStar.CheckedFiles
 open FStar.Universal
 module E = FStar.Errors
+module UF = FStar.Syntax.Unionfind
 
 let _ = FStar.Version.dummy ()
 
@@ -115,6 +116,11 @@ let go _ =
 
     | Success ->
         fstar_files := Some filenames;
+
+        (* Set the unionfind graph to read-only mode.
+         * This will be unset by the typechecker and other pieces
+         * of code that intend to use it. It helps us catch errors. *)
+        UF.set_ro ();
 
         (* --dep: Just compute and print the transitive dependency graph;
                   don't verify anything *)

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fs
@@ -32,6 +32,7 @@ open FStar.SMTEncoding
 open FStar.SMTEncoding.Util
 module S = FStar.Syntax.Syntax
 module SS = FStar.Syntax.Subst
+module UF = FStar.Syntax.Unionfind
 module N = FStar.TypeChecker.Normalize
 module BU = FStar.Util
 module U = FStar.Syntax.Util
@@ -1703,6 +1704,7 @@ let give_decls_to_z3_and_set_env (env:env_t) (name:string) (decls:decls_t) :unit
 let encode_modul tcenv modul =
   if Options.lax() && Options.ml_ish() then [], []
   else begin
+    UF.with_uf_enabled (fun () ->
     varops.reset_fresh ();
     let name = BU.format2 "%s %s" (if modul.is_interface then "interface" else "module")  (string_of_lid modul.name) in
     if Env.debug tcenv Options.Medium
@@ -1717,7 +1719,7 @@ let encode_modul tcenv modul =
     give_decls_to_z3_and_set_env env name decls;
     if Env.debug tcenv Options.Medium then BU.print1 "Done encoding externals for %s\n" name;
     decls, env |> get_current_module_fvbs
-  end
+  ) end
 
 let encode_modul_from_cache tcenv tcmod (decls, fvbs) =
   if Options.lax () && Options.ml_ish () then ()

--- a/src/syntax/FStar.Syntax.Print.fs
+++ b/src/syntax/FStar.Syntax.Print.fs
@@ -158,7 +158,8 @@ let version_to_string v = U.format2 "%s.%s" (U.string_of_int v.major) (U.string_
 let univ_uvar_to_string u =
     if (Options.hide_uvar_nums())
     then "?"
-    else "?" ^ (Unionfind.univ_uvar_id u |> string_of_int) ^ ":" ^ (version_to_string (snd u))
+    else "?" ^ (Unionfind.univ_uvar_id u |> string_of_int)
+            ^ ":" ^ (u |> (fun (_, u, _) -> version_to_string u))
 
 let rec int_of_univ n u = match Subst.compress_univ u with
     | U_zero -> n, None

--- a/src/syntax/FStar.Syntax.Syntax.fs
+++ b/src/syntax/FStar.Syntax.Syntax.fs
@@ -82,7 +82,7 @@ type universe =
   | U_unif  of universe_uvar
   | U_unknown
 and univ_name = ident
-and universe_uvar = Unionfind.p_uvar<option<universe>> * version
+and universe_uvar = Unionfind.p_uvar<option<universe>> * version * Range.range
 
 
 // IN F*: [@ PpxDerivingYoJson PpxDerivingShow ]
@@ -148,7 +148,7 @@ and ctx_uvar = {                                                 (* (G |- ?u : t
     ctx_uvar_meta: option<(dyn * term)>; (* the dyn is an FStar.TypeChecker.Env.env *)
 }
 and ctx_uvar_and_subst = ctx_uvar * subst_ts
-and uvar = Unionfind.p_uvar<option<term>> * version
+and uvar = Unionfind.p_uvar<option<term>> * version * Range.range
 and uvars = set<ctx_uvar>
 and branch = pat * option<term> * term                           (* optional when clause in each branch *)
 and ascription = either<term, comp> * option<term>               (* e <: t [by tac] or e <: C [by tac] *)

--- a/src/syntax/FStar.Syntax.Syntax.fsi
+++ b/src/syntax/FStar.Syntax.Syntax.fsi
@@ -75,7 +75,7 @@ type universe =
   | U_unif  of universe_uvar
   | U_unknown
 and univ_name = ident
-and universe_uvar = Unionfind.p_uvar<option<universe>> * version
+and universe_uvar = Unionfind.p_uvar<option<universe>> * version * Range.range
 
 type univ_names    = list<univ_name>
 type universes     = list<universe>
@@ -131,7 +131,7 @@ and ctx_uvar = {                                                 (* (G |- ?u : t
     ctx_uvar_meta: option<(dyn * term)>; (* the dyn is an FStar.TypeChecker.Env.env *)
 }
 and ctx_uvar_and_subst = ctx_uvar * subst_ts
-and uvar = Unionfind.p_uvar<option<term>> * version
+and uvar = Unionfind.p_uvar<option<term>> * version * Range.range
 and uvars = set<ctx_uvar>
 and branch = pat * option<term> * term                           (* optional when clause in each branch *)
 and ascription = either<term, comp> * option<term>               (* e <: t [by tac] or e <: C [by tac] *)

--- a/src/syntax/FStar.Syntax.Unionfind.fs
+++ b/src/syntax/FStar.Syntax.Unionfind.fs
@@ -100,7 +100,6 @@ let chk_v_t (u, v) =
                         (version_to_string v))
 
 let uvar_id u  = PU.puf_id (get_term_graph()) (chk_v_t u)
-let from_id n  = PU.puf_fromid (get_term_graph()) n, get_version()
 let fresh ()   = PU.puf_fresh (get_term_graph()) None, get_version()
 let find u     = PU.puf_find (get_term_graph()) (chk_v_t u)
 let change u t = set_term_graph (PU.puf_change (get_term_graph()) (chk_v_t u) (Some t))
@@ -132,7 +131,6 @@ let set_univ_graph (ug:ugraph) =
   set ({get() with univ_graph = ug})
 
 let univ_uvar_id u  = PU.puf_id (get_univ_graph()) (chk_v_u u)
-let univ_from_id n  = PU.puf_fromid (get_univ_graph()) n, get_version()
 let univ_fresh ()   = PU.puf_fresh (get_univ_graph()) None, get_version()
 let univ_find u     = PU.puf_find (get_univ_graph()) (chk_v_u u)
 let univ_change u t = set_univ_graph (PU.puf_change (get_univ_graph()) (chk_v_u u) (Some t))

--- a/src/syntax/FStar.Syntax.Unionfind.fs
+++ b/src/syntax/FStar.Syntax.Unionfind.fs
@@ -1,7 +1,9 @@
 #light "off"
 module FStar.Syntax.Unionfind
 open FStar.All
+open FStar.Errors
 open FStar.Syntax.Syntax
+
 module S = FStar.Syntax.Syntax
 module PU = FStar.Unionfind
 module BU = FStar.Util
@@ -93,11 +95,13 @@ let chk_v_t (u, v) =
     if v.major = expected.major
     && v.minor <= expected.minor
     then u
-    else failwith (BU.format3
-                        "Incompatible version for term unification variable %s: current version is %s; got version %s"
+    else
+      raise_error (Fatal_BadUvar,
+                   BU.format3 "Internal error: incompatible version for term unification variable %s: current version is %s; got version %s"
                         (uvar_to_string u)
                         (version_to_string expected)
                         (version_to_string v))
+                  Range.dummyRange
 
 let uvar_id u  = PU.puf_id (get_term_graph()) (chk_v_t u)
 let fresh ()   = PU.puf_fresh (get_term_graph()) None, get_version()
@@ -120,11 +124,13 @@ let chk_v_u (u, v) =
     if v.major = expected.major
     && v.minor <= expected.minor
     then u
-    else failwith (BU.format3
-                        "Incompatible version for universe unification variable %s: current version is %s; got version %s"
+    else
+      raise_error (Fatal_BadUvar,
+                   BU.format3 "Internal error: incompatible version for universe unification variable %s: current version is %s; got version %s"
                         (uvar_to_string u)
                         (version_to_string expected)
                         (version_to_string v))
+                  Range.dummyRange
 
 (*private*)
 let set_univ_graph (ug:ugraph) =

--- a/src/syntax/FStar.Syntax.Unionfind.fs
+++ b/src/syntax/FStar.Syntax.Unionfind.fs
@@ -89,7 +89,7 @@ let set_term_graph tg =
   set ({get() with term_graph = tg})
 
 (*private*)
-let chk_v_t (u, v) =
+let chk_v_t (u, v, rng) =
     let uvar_to_string u = "?" ^ (PU.puf_id (get_term_graph ()) u |> BU.string_of_int) in
     let expected = get_version () in
     if v.major = expected.major
@@ -101,10 +101,10 @@ let chk_v_t (u, v) =
                         (uvar_to_string u)
                         (version_to_string expected)
                         (version_to_string v))
-                  Range.dummyRange
+                  rng
 
 let uvar_id u  = PU.puf_id (get_term_graph()) (chk_v_t u)
-let fresh ()   = PU.puf_fresh (get_term_graph()) None, get_version()
+let fresh rng  = PU.puf_fresh (get_term_graph()) None, get_version(), rng
 let find u     = PU.puf_find (get_term_graph()) (chk_v_t u)
 let change u t = set_term_graph (PU.puf_change (get_term_graph()) (chk_v_t u) (Some t))
 let equiv u v  = PU.puf_equivalent (get_term_graph()) (chk_v_t u) (chk_v_t v)
@@ -118,7 +118,7 @@ let union  u v = set_term_graph (PU.puf_union (get_term_graph()) (chk_v_t u) (ch
 let get_univ_graph () = (get()).univ_graph
 
 (*private*)
-let chk_v_u (u, v) =
+let chk_v_u (u, v, rng) =
     let uvar_to_string u = "?" ^ (PU.puf_id (get_univ_graph ()) u |> BU.string_of_int) in
     let expected = get_version () in
     if v.major = expected.major
@@ -130,14 +130,14 @@ let chk_v_u (u, v) =
                         (uvar_to_string u)
                         (version_to_string expected)
                         (version_to_string v))
-                  Range.dummyRange
+                  rng
 
 (*private*)
 let set_univ_graph (ug:ugraph) =
   set ({get() with univ_graph = ug})
 
 let univ_uvar_id u  = PU.puf_id (get_univ_graph()) (chk_v_u u)
-let univ_fresh ()   = PU.puf_fresh (get_univ_graph()) None, get_version()
+let univ_fresh rng  = PU.puf_fresh (get_univ_graph()) None, get_version(), rng
 let univ_find u     = PU.puf_find (get_univ_graph()) (chk_v_u u)
 let univ_change u t = set_univ_graph (PU.puf_change (get_univ_graph()) (chk_v_u u) (Some t))
 let univ_equiv  u v = PU.puf_equivalent (get_univ_graph()) (chk_v_u u) (chk_v_u v)

--- a/src/syntax/FStar.Syntax.Unionfind.fsi
+++ b/src/syntax/FStar.Syntax.Unionfind.fsi
@@ -20,7 +20,6 @@ val update_in_tx   : ref<'a> -> 'a -> unit
 
 val fresh  : unit -> S.uvar
 val uvar_id: S.uvar -> int
-val from_id : int -> S.uvar
 val find   : S.uvar -> option<S.term>
 val change : S.uvar -> S.term -> unit
 val equiv  : S.uvar -> S.uvar -> bool
@@ -28,7 +27,6 @@ val union  : S.uvar -> S.uvar -> unit
 
 val univ_fresh  : unit -> S.universe_uvar
 val univ_uvar_id: S.universe_uvar -> int
-val univ_from_id : int -> S.universe_uvar
 val univ_find   : S.universe_uvar -> option<S.universe>
 val univ_change : S.universe_uvar -> S.universe -> unit
 val univ_equiv  : S.universe_uvar -> S.universe_uvar -> bool

--- a/src/syntax/FStar.Syntax.Unionfind.fsi
+++ b/src/syntax/FStar.Syntax.Unionfind.fsi
@@ -13,21 +13,21 @@ val set : uf -> unit
 val reset : unit -> unit
 
 type tx
-val new_transaction: (unit -> tx)
-val rollback       : tx -> unit
-val commit         : tx -> unit
-val update_in_tx   : ref<'a> -> 'a -> unit
+val new_transaction    : (unit -> tx)
+val rollback           : tx -> unit
+val commit             : tx -> unit
+val update_in_tx       : ref<'a> -> 'a -> unit
 
-val fresh  : unit -> S.uvar
-val uvar_id: S.uvar -> int
-val find   : S.uvar -> option<S.term>
-val change : S.uvar -> S.term -> unit
-val equiv  : S.uvar -> S.uvar -> bool
-val union  : S.uvar -> S.uvar -> unit
+val fresh              : Range.range -> S.uvar
+val uvar_id            : S.uvar -> int
+val find               : S.uvar -> option<S.term>
+val change             : S.uvar -> S.term -> unit
+val equiv              : S.uvar -> S.uvar -> bool
+val union              : S.uvar -> S.uvar -> unit
 
-val univ_fresh  : unit -> S.universe_uvar
-val univ_uvar_id: S.universe_uvar -> int
-val univ_find   : S.universe_uvar -> option<S.universe>
-val univ_change : S.universe_uvar -> S.universe -> unit
-val univ_equiv  : S.universe_uvar -> S.universe_uvar -> bool
-val univ_union  : S.universe_uvar -> S.universe_uvar -> unit
+val univ_fresh         : Range.range -> S.universe_uvar
+val univ_uvar_id       : S.universe_uvar -> int
+val univ_find          : S.universe_uvar -> option<S.universe>
+val univ_change        : S.universe_uvar -> S.universe -> unit
+val univ_equiv         : S.universe_uvar -> S.universe_uvar -> bool
+val univ_union         : S.universe_uvar -> S.universe_uvar -> unit

--- a/src/syntax/FStar.Syntax.Unionfind.fsi
+++ b/src/syntax/FStar.Syntax.Unionfind.fsi
@@ -5,12 +5,22 @@ module FStar.Syntax.Unionfind
  * universes on top of the existing union-find implementation. *)
 
 open FStar.All
+module Range = FStar.Range
 module S = FStar.Syntax.Syntax
 
 type uf
 val get : unit -> uf
 val set : uf -> unit
 val reset : unit -> unit
+
+(* Set read-only mode *)
+val set_ro : unit -> unit
+
+(* Set read-write mode *)
+val set_rw : unit -> unit
+
+(* Run a function with rw mode enabled *)
+val with_uf_enabled : (unit -> 'a) -> 'a
 
 type tx
 val new_transaction    : (unit -> tx)

--- a/src/syntax/FStar.Syntax.Util.fs
+++ b/src/syntax/FStar.Syntax.Util.fs
@@ -1078,7 +1078,7 @@ let ktype0 : term = mk (Tm_type(U_zero)) None dummyRange
 
 //Type(u), where u is a new universe unification variable
 let type_u () : typ * universe =
-    let u = U_unif <| Unionfind.univ_fresh () in
+    let u = U_unif <| Unionfind.univ_fresh Range.dummyRange in
     mk (Tm_type u) None dummyRange, u
 
 // works on anything, really

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -436,7 +436,7 @@ let variable_not_found v =
   (Errors.Fatal_VariableNotFound, (format1 "Variable \"%s\" not found" (Print.bv_to_string v)))
 
 //Construct a new universe unification variable
-let new_u_univ () = U_unif (Unionfind.univ_fresh ())
+let new_u_univ () = U_unif (Unionfind.univ_fresh Range.dummyRange)
 
 let mk_univ_subst (formals : list<univ_name>) (us : universes) : list<subst_elt> =
     assert (List.length us = List.length formals);
@@ -1730,7 +1730,7 @@ let new_implicit_var_aux reason r env k should_check meta =
       let binders = all_binders env in
       let gamma = env.gamma in
       let ctx_uvar = {
-          ctx_uvar_head=FStar.Syntax.Unionfind.fresh();
+          ctx_uvar_head=FStar.Syntax.Unionfind.fresh r;
           ctx_uvar_gamma=gamma;
           ctx_uvar_binders=binders;
           ctx_uvar_typ=k;

--- a/src/typechecker/FStar.TypeChecker.Rel.fs
+++ b/src/typechecker/FStar.TypeChecker.Rel.fs
@@ -88,7 +88,7 @@ type worklist = {
 (* --------------------------------------------------------- *)
 let new_uvar reason wl r gamma binders k should_check meta : ctx_uvar * term * worklist =
     let ctx_uvar = {
-         ctx_uvar_head=UF.fresh();
+         ctx_uvar_head=UF.fresh r;
          ctx_uvar_gamma=gamma;
          ctx_uvar_binders=binders;
          ctx_uvar_typ=k;

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -36,6 +36,7 @@ open FStar.TypeChecker.TcTerm
 module S  = FStar.Syntax.Syntax
 module SP  = FStar.Syntax.Print
 module SS = FStar.Syntax.Subst
+module UF = FStar.Syntax.Unionfind
 module N  = FStar.TypeChecker.Normalize
 module TcComm = FStar.TypeChecker.Common
 module TcUtil = FStar.TypeChecker.Util
@@ -1001,7 +1002,7 @@ let tc_decls env ses =
               env
               t); //update the id_info table after having removed their uvars
     let env = ses' |> List.fold_left (fun env se -> add_sigelt_to_env env se false) env in
-    FStar.Syntax.Unionfind.reset();
+    UF.reset();
 
     if Options.log_types() || Env.debug env <| Options.Other "LogTypes"
     then begin
@@ -1041,7 +1042,9 @@ let tc_decls env ses =
     end;
     r
   in
-  let ses, exports, env, _ = BU.fold_flatten process_one_decl_timed ([], [], env, []) ses in
+  let ses, exports, env, _ =
+    UF.with_uf_enabled (fun () ->
+      BU.fold_flatten process_one_decl_timed ([], [], env, []) ses) in
   List.rev_append ses [], List.rev_append exports [], env
 
 let _ =
@@ -1340,7 +1343,9 @@ and finish_partial_modul (loading_from_cache:bool) (iface_exists:bool) (en:env) 
     if not (Options.lax())
     && not loading_from_cache
     && not (Options.use_extracted_interfaces ())
-    then check_exports env modul exports;
+    then begin
+      UF.with_uf_enabled (fun () -> check_exports env modul exports)
+    end;
 
     //pop BUT ignore the old env
     pop_context env ("Ending modul " ^ string_of_lid modul.name) |> ignore;

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -1076,8 +1076,8 @@ let check_exports env (modul:modul) exports : unit =
     let check_term lid univs t =
         let _ = Errors.message_prefix.set_prefix
                 (BU.format2 "Interface of %s violates its abstraction (add a 'private' qualifier to '%s'?)"
-                        (Print.lid_to_string modul.name)
-                        (Print.lid_to_string lid)) in
+                        (string_of_lid modul.name)
+                        (string_of_lid lid)) in
         check_term lid univs t;
         Errors.message_prefix.clear_prefix()
     in

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -698,4 +698,4 @@ let labeled (r: range) (msg: string) (b: Type) : Type = b
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 21
+let __cache_version_number__ = 22


### PR DESCRIPTION
After fixing #2001 I thought we should have some kind of mechanism to prevent these weird bugs from popping up in the future.

This PR implements a "read-only" mode for the unionfind graph. The RO mode is set very early in `FStar.Main.go` and only selectively disabled by code that is expected to have a unionfind effect (the typechecker, encoding, extraction[*]). This excludes desugaring, so #2001 would have failed with a message like `Internal error: UF graph was in read-only mode`.

The first commits are some improvements to error messages and the addition of ranges to uvars (not ctx_uvars, they already have one) so we can report good locations. That's less controversial but could use a set of eyes too.

[*] Though I'm not sure I expected the last two to be in the list. They currently do have an UF effect since (at least in one point) they lookup fvars, which get their type schemes instantiated. That probably shouldn't be the case, right?

This PR involves a cache version bump.