### PR TITLE
Allow "ticked" variables at any type

### DIFF
--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -226,19 +226,19 @@ let sort_ftv ftv =
   BU.sort_with (fun x y -> String.compare (text_of_id x) (text_of_id y)) <|
       BU.remove_dups (fun x y -> (text_of_id x) = (text_of_id y)) ftv
 
-let rec free_type_vars_b env binder = match binder.b with
+let rec free_tick_vars_b env binder = match binder.b with
   | Variable _ -> env, []
   | TVariable x ->
     let env, _ = Env.push_bv env x in
     (env, [x])
   | Annotated(_, term) ->
-    (env, free_type_vars env term)
+    (env, free_tick_vars env term)
   | TAnnotated(id, _) ->
     let env, _ = Env.push_bv env id in
     (env, [])
   | NoName t ->
-    (env, free_type_vars env t)
-and free_type_vars env t = match (unparen t).tm with
+    (env, free_tick_vars env t)
+and free_tick_vars env t = match (unparen t).tm with
   | Labeled _ -> failwith "Impossible --- labeled source term"
 
   | Tvar a ->
@@ -256,51 +256,51 @@ and free_type_vars env t = match (unparen t).tm with
 
   | Requires (t, _)
   | Ensures (t, _)
-  | NamedTyp(_, t) -> free_type_vars env t
+  | NamedTyp(_, t) -> free_tick_vars env t
   | Paren t -> failwith "impossible"
   | Ascribed(t, t', tacopt) ->
     let ts = t::t'::(match tacopt with None -> [] | Some t -> [t]) in
-    List.collect (free_type_vars env) ts
+    List.collect (free_tick_vars env) ts
 
-  | Construct(_, ts) -> List.collect (fun (t, _) -> free_type_vars env t) ts
+  | Construct(_, ts) -> List.collect (fun (t, _) -> free_tick_vars env t) ts
 
-  | Op(_, ts) -> List.collect (free_type_vars env) ts
+  | Op(_, ts) -> List.collect (free_tick_vars env) ts
 
-  | App(t1,t2,_) -> free_type_vars env t1@free_type_vars env t2
+  | App(t1,t2,_) -> free_tick_vars env t1@free_tick_vars env t2
 
   | Refine (b, t) ->
-    let env, f = free_type_vars_b env b in
-    f@free_type_vars env t
+    let env, f = free_tick_vars_b env b in
+    f@free_tick_vars env t
 
   | Sum(binders, body) ->
     let env, free = List.fold_left (fun (env, free) bt ->
       let env, f =
         match bt with
-        | Inl binder -> free_type_vars_b env binder
-        | Inr t -> env, free_type_vars env body
+        | Inl binder -> free_tick_vars_b env binder
+        | Inr t -> env, free_tick_vars env body
       in
       env, f@free) (env, []) binders in
-    free@free_type_vars env body
+    free@free_tick_vars env body
 
   | Product(binders, body) ->
     let env, free = List.fold_left (fun (env, free) binder ->
-      let env, f = free_type_vars_b env binder in
+      let env, f = free_tick_vars_b env binder in
       env, f@free) (env, []) binders in
-    free@free_type_vars env body
+    free@free_tick_vars env body
 
-  | Project(t, _) -> free_type_vars env t
+  | Project(t, _) -> free_tick_vars env t
 
   | Attributes cattributes ->
       (* attributes should be closed but better safe than sorry *)
-      List.collect (free_type_vars env) cattributes
+      List.collect (free_tick_vars env) cattributes
 
   | CalcProof (rel, init, steps) ->
-    free_type_vars env rel
-    @ free_type_vars env init
+    free_tick_vars env rel
+    @ free_tick_vars env init
     @ List.collect (fun (CalcStep (rel, just, next)) ->
-                            free_type_vars env rel
-                            @ free_type_vars env just
-                            @ free_type_vars env next) steps
+                            free_tick_vars env rel
+                            @ free_tick_vars env just
+                            @ free_tick_vars env next) steps
 
   | Abs _  (* not closing implicitly over free vars in all these forms: TODO: Fixme! *)
   | Let _
@@ -325,7 +325,7 @@ let head_and_args t =
     aux [] t
 
 let close env t =
-  let ftv = sort_ftv <| free_type_vars env t in
+  let ftv = sort_ftv <| free_tick_vars env t in
   if List.length ftv = 0
   then t
   else let binders = ftv |> List.map (fun x -> mk_binder (TAnnotated(x, tm_type (range_of_id x))) (range_of_id x) Type_level (Some Implicit)) in
@@ -333,7 +333,7 @@ let close env t =
        result
 
 let close_fun env t =
-  let ftv = sort_ftv <| free_type_vars env t in
+  let ftv = sort_ftv <| free_tick_vars env t in
   if List.length ftv = 0
   then t
   else let binders = ftv |> List.map (fun x -> mk_binder (TAnnotated(x, tm_type (range_of_id x))) (range_of_id x) Type_level (Some Implicit)) in
@@ -1187,8 +1187,8 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
       let binders = binders |> List.map replace_unit_pattern in
       let _, ftv = List.fold_left (fun (env, ftvs) pat ->
         match pat.pat with
-          | PatAscribed(_, (t, None)) -> env, free_type_vars env t@ftvs
-          | PatAscribed(_, (t, Some tac)) -> env, free_type_vars env t@free_type_vars env tac@ftvs
+          | PatAscribed(_, (t, None)) -> env, free_tick_vars env t@ftvs
+          | PatAscribed(_, (t, Some tac)) -> env, free_tick_vars env t@free_tick_vars env tac@ftvs
           | _ -> env, ftvs) (env, []) binders in
       let ftv = sort_ftv ftv in
       let binders = (ftv |> List.map (fun a ->

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -328,7 +328,7 @@ let close env t =
   let ftv = sort_ftv <| free_tick_vars env t in
   if List.length ftv = 0
   then t
-  else let binders = ftv |> List.map (fun x -> mk_binder (TAnnotated(x, tm_type (range_of_id x))) (range_of_id x) Type_level (Some Implicit)) in
+  else let binders = ftv |> List.map (fun x -> mk_binder (TAnnotated(x, mk_term Wild (range_of_id x) Type_level)) (range_of_id x) Type_level (Some Implicit)) in
        let result = mk_term (Product(binders, t)) t.range t.level in
        result
 
@@ -336,7 +336,7 @@ let close_fun env t =
   let ftv = sort_ftv <| free_tick_vars env t in
   if List.length ftv = 0
   then t
-  else let binders = ftv |> List.map (fun x -> mk_binder (TAnnotated(x, tm_type (range_of_id x))) (range_of_id x) Type_level (Some Implicit)) in
+  else let binders = ftv |> List.map (fun x -> mk_binder (TAnnotated(x, mk_term Wild (range_of_id x) Type_level)) (range_of_id x) Type_level (Some Implicit)) in
        let t = match (unparen t).tm with
         | Product _ -> t
         | _ -> mk_term (App(mk_term (Name C.effect_Tot_lid) t.range t.level, t, Nothing)) t.range t.level in

--- a/tests/micro-benchmarks/Tick.fst
+++ b/tests/micro-benchmarks/Tick.fst
@@ -1,0 +1,35 @@
+module Tick
+
+open FStar.Seq
+
+(* 'a is Type _ *)
+val id : 'a -> 'a
+let id x = x
+
+val fst : 'a & 'b -> 'a
+let fst (x, y) = x
+
+(* Never worked: Identifier not found 'a *)
+//let fst' (p : 'a & 'b) = fun (x, _) -> x
+
+(* This does *)
+let id' (x : 'a) = x
+
+(* 'a is Type_, 'l1 and 'l2 are nat *)
+val concat_lseq : lseq 'a 'l1 -> lseq 'a 'l2 -> lseq 'a ('l1 + 'l2)
+let concat_lseq s1 s2 = append s1 s2
+
+let concat_lseq' (s1 : lseq 'a 'l1) (s2 : lseq 'a 'l2) : lseq 'a ('l1 + 'l2) = append s1 s2
+
+(* Can't infer the type of 'a, should it be generalized? *)
+(* This was previously working (!!!) by making 'a:Type *)
+[@(expect_failure [66])]
+val _lem : unit -> Lemma ('a == 'a)
+
+(* Same thing *)
+[@(expect_failure [66])]
+val _lem2 : #a:_ -> unit -> Lemma (a == a)
+
+(* Need to annotate #int *)
+val lem : unit -> Lemma (List.Tot.rev #int ['a; 'b; 'c] == ['c; 'b; 'a])
+let lem () = ()


### PR DESCRIPTION
(Work in progress, posting for discussion.)

This PR extends the meaning of `'a` variables from `Type` variables, useful e.g. in
```fstar
val id : 'a -> 'a
let f x = x
```
to any type, so one can write things like:
```fstar
val concat_lseq : lseq 'a 'l1 -> lseq 'a 'l2 -> lseq 'a ('l1 + 'l2)
let concat_lseq s1 s2 = append s1 s2
```
Without needing to explicitly bind the `'l1` and `'l2`. There's an example file with a handful of examples.

The change to remove the `Type` restriction is easy enough and did not trigger any regression across everest (though it could, there's an example in the file, though one that's unlikely anyone would write.)

What I'm concerned about is that I don't know the precise semantics of these variables, e.g. where they are allowed to appear. One cannot explicitly bind them it seems. #681 is related, where the discussions seems to conclude in that mixing these variables with regular implicits is an anti-pattern.